### PR TITLE
Rename `wasmi_arena::Index` => `ArenaIndex`

### DIFF
--- a/crates/arena/src/dedup.rs
+++ b/crates/arena/src/dedup.rs
@@ -1,6 +1,6 @@
-use super::{Arena, Index, Iter, IterMut};
+use super::{Arena, ArenaIndex, Iter, IterMut};
 use alloc::collections::BTreeMap;
-use core::ops;
+use core::ops::{Index, IndexMut};
 
 /// A deduplicating arena allocator with a given index and entity type.
 ///
@@ -68,7 +68,7 @@ impl<Idx, T> DedupArena<Idx, T> {
 
 impl<Idx, T> DedupArena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
     T: Ord + Clone,
 {
     /// Returns the next entity index.
@@ -108,7 +108,7 @@ where
 
 impl<Idx, T> FromIterator<T> for DedupArena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
     T: Clone + Ord,
 {
     fn from_iter<I>(iter: I) -> Self
@@ -129,7 +129,7 @@ where
 
 impl<'a, Idx, T> IntoIterator for &'a DedupArena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     type Item = (Idx, &'a T);
     type IntoIter = Iter<'a, Idx, T>;
@@ -141,7 +141,7 @@ where
 
 impl<'a, Idx, T> IntoIterator for &'a mut DedupArena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     type Item = (Idx, &'a mut T);
     type IntoIter = IterMut<'a, Idx, T>;
@@ -151,9 +151,9 @@ where
     }
 }
 
-impl<Idx, T> ops::Index<Idx> for DedupArena<Idx, T>
+impl<Idx, T> Index<Idx> for DedupArena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     type Output = T;
 
@@ -163,9 +163,9 @@ where
     }
 }
 
-impl<Idx, T> ops::IndexMut<Idx> for DedupArena<Idx, T>
+impl<Idx, T> IndexMut<Idx> for DedupArena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     #[inline]
     fn index_mut(&mut self, index: Idx) -> &mut Self::Output {

--- a/crates/arena/src/guarded.rs
+++ b/crates/arena/src/guarded.rs
@@ -1,4 +1,4 @@
-use crate::Index;
+use crate::ArenaIndex;
 
 /// A guarded entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -19,8 +19,8 @@ impl<GuardIdx, EntityIdx> GuardedEntity<GuardIdx, EntityIdx> {
 
 impl<GuardIdx, EntityIdx> GuardedEntity<GuardIdx, EntityIdx>
 where
-    GuardIdx: Index,
-    EntityIdx: Index,
+    GuardIdx: ArenaIndex,
+    EntityIdx: ArenaIndex,
 {
     /// Returns the entity index of the [`GuardedEntity`].
     ///

--- a/crates/arena/src/lib.rs
+++ b/crates/arena/src/lib.rs
@@ -33,15 +33,15 @@ use alloc::vec::Vec;
 use core::{
     iter::{DoubleEndedIterator, Enumerate, ExactSizeIterator},
     marker::PhantomData,
-    ops,
+    ops::{Index, IndexMut},
     slice,
 };
 
 /// Types that can be used as indices for arenas.
-pub trait Index: Copy {
-    /// Converts the [`Index`] into the underlying `usize` value.
+pub trait ArenaIndex: Copy {
+    /// Converts the [`ArenaIndex`] into the underlying `usize` value.
     fn into_usize(self) -> usize;
-    /// Converts the `usize` value into the associated [`Index`].
+    /// Converts the `usize` value into the associated [`ArenaIndex`].
     fn from_usize(value: usize) -> Self;
 }
 
@@ -122,7 +122,7 @@ impl<Idx, T> Arena<Idx, T> {
 
 impl<Idx, T> Arena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     /// Returns the next entity index.
     fn next_index(&self) -> Idx {
@@ -164,7 +164,7 @@ impl<Idx, T> FromIterator<T> for Arena<Idx, T> {
 
 impl<'a, Idx, T> IntoIterator for &'a Arena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     type Item = (Idx, &'a T);
     type IntoIter = Iter<'a, Idx, T>;
@@ -176,7 +176,7 @@ where
 
 impl<'a, Idx, T> IntoIterator for &'a mut Arena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     type Item = (Idx, &'a mut T);
     type IntoIter = IterMut<'a, Idx, T>;
@@ -195,7 +195,7 @@ pub struct Iter<'a, Idx, T> {
 
 impl<'a, Idx, T> Iterator for Iter<'a, Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     type Item = (Idx, &'a T);
 
@@ -214,7 +214,7 @@ where
 
 impl<'a, Idx, T> DoubleEndedIterator for Iter<'a, Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -226,7 +226,7 @@ where
 
 impl<'a, Idx, T> ExactSizeIterator for Iter<'a, Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     fn len(&self) -> usize {
         self.iter.len()
@@ -242,7 +242,7 @@ pub struct IterMut<'a, Idx, T> {
 
 impl<'a, Idx, T> Iterator for IterMut<'a, Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     type Item = (Idx, &'a mut T);
 
@@ -261,7 +261,7 @@ where
 
 impl<'a, Idx, T> DoubleEndedIterator for IterMut<'a, Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -273,7 +273,7 @@ where
 
 impl<'a, Idx, T> ExactSizeIterator for IterMut<'a, Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     #[inline]
     fn len(&self) -> usize {
@@ -288,9 +288,9 @@ impl<Idx, T> Arena<Idx, T> {
     }
 }
 
-impl<Idx, T> ops::Index<Idx> for Arena<Idx, T>
+impl<Idx, T> Index<Idx> for Arena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     type Output = T;
 
@@ -301,9 +301,9 @@ where
     }
 }
 
-impl<Idx, T> ops::IndexMut<Idx> for Arena<Idx, T>
+impl<Idx, T> IndexMut<Idx> for Arena<Idx, T>
 where
-    Idx: Index,
+    Idx: ArenaIndex,
 {
     #[inline]
     fn index_mut(&mut self, index: Idx) -> &mut Self::Output {

--- a/crates/arena/src/tests.rs
+++ b/crates/arena/src/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl Index for usize {
+impl ArenaIndex for usize {
     fn into_usize(self) -> usize {
         self
     }

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -2,13 +2,13 @@
 
 use super::Instruction;
 use alloc::vec::Vec;
-use wasmi_arena::Index;
+use wasmi_arena::ArenaIndex;
 
 /// A reference to a Wasm function body stored in the [`CodeMap`].
 #[derive(Debug, Copy, Clone)]
 pub struct FuncBody(usize);
 
-impl Index for FuncBody {
+impl ArenaIndex for FuncBody {
     fn into_usize(self) -> usize {
         self.0
     }

--- a/crates/wasmi/src/engine/func_types.rs
+++ b/crates/wasmi/src/engine/func_types.rs
@@ -1,12 +1,12 @@
 use super::{EngineIdx, Guarded};
 use crate::FuncType;
-use wasmi_arena::{DedupArena, GuardedEntity, Index};
+use wasmi_arena::{ArenaIndex, DedupArena, GuardedEntity};
 
 /// A raw index to a function signature entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DedupFuncTypeIdx(u32);
 
-impl Index for DedupFuncTypeIdx {
+impl ArenaIndex for DedupFuncTypeIdx {
     fn into_usize(self) -> usize {
         self.0 as _
     }
@@ -93,7 +93,7 @@ impl FuncTypeRegistry {
     /// If the guarded entity is not owned by the engine.
     fn unwrap_index<Idx>(&self, func_type: Guarded<Idx>) -> Idx
     where
-        Idx: Index,
+        Idx: ArenaIndex,
     {
         func_type.entity_index(self.engine_idx).unwrap_or_else(|| {
             panic!(

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -46,7 +46,7 @@ use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU32, Ordering};
 pub use func_types::DedupFuncType;
 use spin::mutex::Mutex;
-use wasmi_arena::{GuardedEntity, Index};
+use wasmi_arena::{ArenaIndex, GuardedEntity};
 
 /// The outcome of a `wasmi` function execution.
 #[derive(Debug, Copy, Clone)]
@@ -65,7 +65,7 @@ pub enum CallOutcome {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EngineIdx(u32);
 
-impl Index for EngineIdx {
+impl ArenaIndex for EngineIdx {
     fn into_usize(self) -> usize {
         self.0 as _
     }

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -24,13 +24,13 @@ use crate::{
 };
 use alloc::sync::Arc;
 use core::{fmt, fmt::Debug};
-use wasmi_arena::Index;
+use wasmi_arena::ArenaIndex;
 
 /// A raw index to a function entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FuncIdx(u32);
 
-impl Index for FuncIdx {
+impl ArenaIndex for FuncIdx {
     fn into_usize(self) -> usize {
         self.0 as usize
     }

--- a/crates/wasmi/src/global.rs
+++ b/crates/wasmi/src/global.rs
@@ -1,14 +1,14 @@
 use super::{AsContext, AsContextMut, Stored};
 use crate::core::{Value, ValueType};
 use core::{fmt, fmt::Display, ptr::NonNull};
-use wasmi_arena::Index;
+use wasmi_arena::ArenaIndex;
 use wasmi_core::UntypedValue;
 
 /// A raw index to a global variable entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GlobalIdx(u32);
 
-impl Index for GlobalIdx {
+impl ArenaIndex for GlobalIdx {
     fn into_usize(self) -> usize {
         self.0 as usize
     }

--- a/crates/wasmi/src/instance.rs
+++ b/crates/wasmi/src/instance.rs
@@ -18,13 +18,13 @@ use alloc::{
     vec::Vec,
 };
 use core::iter::FusedIterator;
-use wasmi_arena::Index;
+use wasmi_arena::ArenaIndex;
 
 /// A raw index to a module instance entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct InstanceIdx(u32);
 
-impl Index for InstanceIdx {
+impl ArenaIndex for InstanceIdx {
     fn into_usize(self) -> usize {
         self.0 as usize
     }

--- a/crates/wasmi/src/memory/mod.rs
+++ b/crates/wasmi/src/memory/mod.rs
@@ -3,14 +3,14 @@ mod byte_buffer;
 use self::byte_buffer::ByteBuffer;
 use super::{AsContext, AsContextMut, StoreContext, StoreContextMut, Stored};
 use core::{fmt, fmt::Display};
-use wasmi_arena::Index;
+use wasmi_arena::ArenaIndex;
 use wasmi_core::Pages;
 
 /// A raw index to a linear memory entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MemoryIdx(u32);
 
-impl Index for MemoryIdx {
+impl ArenaIndex for MemoryIdx {
     fn into_usize(self) -> usize {
         self.0 as usize
     }

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -19,7 +19,7 @@ use super::{
     TableIdx,
 };
 use core::sync::atomic::{AtomicU32, Ordering};
-use wasmi_arena::{Arena, GuardedEntity, Index};
+use wasmi_arena::{Arena, ArenaIndex, GuardedEntity};
 
 /// A unique store index.
 ///
@@ -29,7 +29,7 @@ use wasmi_arena::{Arena, GuardedEntity, Index};
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StoreIdx(u32);
 
-impl Index for StoreIdx {
+impl ArenaIndex for StoreIdx {
     fn into_usize(self) -> usize {
         self.0 as usize
     }
@@ -199,7 +199,7 @@ impl<T> Store<T> {
     /// If the stored entity does not originate from this store.
     fn unwrap_index<Idx>(&self, stored: Stored<Idx>) -> Idx
     where
-        Idx: Index,
+        Idx: ArenaIndex,
     {
         stored.entity_index(self.store_idx).unwrap_or_else(|| {
             panic!(

--- a/crates/wasmi/src/table.rs
+++ b/crates/wasmi/src/table.rs
@@ -3,13 +3,13 @@
 use super::{AsContext, AsContextMut, Func, Stored};
 use alloc::vec::Vec;
 use core::{fmt, fmt::Display};
-use wasmi_arena::Index;
+use wasmi_arena::ArenaIndex;
 
 /// A raw index to a table entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TableIdx(u32);
 
-impl Index for TableIdx {
+impl ArenaIndex for TableIdx {
     fn into_usize(self) -> usize {
         self.0 as usize
     }


### PR DESCRIPTION
This helps to differentiate this trait from Rust's `core::ops::Index[Mut]` traits.

Carved out PR from: https://github.com/paritytech/wasmi/pull/590