### PR TITLE
Only store `local.get` on the provider stack out-of-place when necessary

### DIFF
--- a/crates/wasmi/src/engine/translator/stack/provider.rs
+++ b/crates/wasmi/src/engine/translator/stack/provider.rs
@@ -88,7 +88,6 @@ impl ProviderStack {
     ///
     /// This is required to initialize usage of the attack-immune [`LocalRefs`] before first use.
     fn sync_local_refs(&mut self) {
-        self.locals.reset();
         self.use_locals = true;
         for (index, provider) in self.providers.iter().enumerate() {
             let TaggedProvider::Local(local) = provider else {


### PR DESCRIPTION
Closes https://github.com/paritytech/wasmi/issues/809.

Local translation benchmarks indicate up to 5% performance improvement.
Performance gains on Wasm are between 5-10%. 🎉 