### PR TITLE
Cleanup bytecode constructor codegen

### DIFF
--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -31,111 +31,6 @@ use super::{
 };
 use core::num::{NonZeroI32, NonZeroI64, NonZeroU32, NonZeroU64};
 
-impl Instruction {
-    /// Creates a new [`Instruction::BranchCmpFallback`].
-    pub fn branch_cmp_fallback(lhs: Register, rhs: Register, params: Register) -> Self {
-        Self::BranchCmpFallback { lhs, rhs, params }
-    }
-}
-
-macro_rules! constructor_for_branch_binop {
-    ( $( fn $name:ident() -> Self::$op_code:ident; )* ) => {
-        impl Instruction {
-            $(
-                #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-                pub fn $name(lhs: Register, rhs: Register, offset: BranchOffset16) -> Self {
-                    Self::$op_code(BranchBinOpInstr::new(lhs, rhs, offset))
-                }
-            )*
-        }
-    }
-}
-constructor_for_branch_binop! {
-    fn branch_i32_and() -> Self::BranchI32And;
-    fn branch_i32_or() -> Self::BranchI32Or;
-    fn branch_i32_xor() -> Self::BranchI32Xor;
-    fn branch_i32_and_eqz() -> Self::BranchI32AndEqz;
-    fn branch_i32_or_eqz() -> Self::BranchI32OrEqz;
-    fn branch_i32_xor_eqz() -> Self::BranchI32XorEqz;
-    fn branch_i32_eq() -> Self::BranchI32Eq;
-    fn branch_i32_ne() -> Self::BranchI32Ne;
-    fn branch_i32_lt_s() -> Self::BranchI32LtS;
-    fn branch_i32_lt_u() -> Self::BranchI32LtU;
-    fn branch_i32_le_s() -> Self::BranchI32LeS;
-    fn branch_i32_le_u() -> Self::BranchI32LeU;
-    fn branch_i32_gt_s() -> Self::BranchI32GtS;
-    fn branch_i32_gt_u() -> Self::BranchI32GtU;
-    fn branch_i32_ge_s() -> Self::BranchI32GeS;
-    fn branch_i32_ge_u() -> Self::BranchI32GeU;
-
-    fn branch_i64_eq() -> Self::BranchI64Eq;
-    fn branch_i64_ne() -> Self::BranchI64Ne;
-    fn branch_i64_lt_s() -> Self::BranchI64LtS;
-    fn branch_i64_lt_u() -> Self::BranchI64LtU;
-    fn branch_i64_le_s() -> Self::BranchI64LeS;
-    fn branch_i64_le_u() -> Self::BranchI64LeU;
-    fn branch_i64_gt_s() -> Self::BranchI64GtS;
-    fn branch_i64_gt_u() -> Self::BranchI64GtU;
-    fn branch_i64_ge_s() -> Self::BranchI64GeS;
-    fn branch_i64_ge_u() -> Self::BranchI64GeU;
-
-    fn branch_f32_eq() -> Self::BranchF32Eq;
-    fn branch_f32_ne() -> Self::BranchF32Ne;
-    fn branch_f32_lt() -> Self::BranchF32Lt;
-    fn branch_f32_le() -> Self::BranchF32Le;
-    fn branch_f32_gt() -> Self::BranchF32Gt;
-    fn branch_f32_ge() -> Self::BranchF32Ge;
-
-    fn branch_f64_eq() -> Self::BranchF64Eq;
-    fn branch_f64_ne() -> Self::BranchF64Ne;
-    fn branch_f64_lt() -> Self::BranchF64Lt;
-    fn branch_f64_le() -> Self::BranchF64Le;
-    fn branch_f64_gt() -> Self::BranchF64Gt;
-    fn branch_f64_ge() -> Self::BranchF64Ge;
-}
-
-macro_rules! constructor_for_branch_binop_imm {
-    ( $( fn $name:ident($ty:ty) -> Self::$op_code:ident; )* ) => {
-        impl Instruction {
-            $(
-                #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-                pub fn $name(lhs: Register, rhs: impl Into<Const16<$ty>>, offset: BranchOffset16) -> Self {
-                    Self::$op_code(BranchBinOpInstrImm16::new(lhs, rhs.into(), offset))
-                }
-            )*
-        }
-    }
-}
-constructor_for_branch_binop_imm! {
-    fn branch_i32_and_imm(i32) -> Self::BranchI32AndImm;
-    fn branch_i32_or_imm(i32) -> Self::BranchI32OrImm;
-    fn branch_i32_xor_imm(i32) -> Self::BranchI32XorImm;
-    fn branch_i32_and_eqz_imm(i32) -> Self::BranchI32AndEqzImm;
-    fn branch_i32_or_eqz_imm(i32) -> Self::BranchI32OrEqzImm;
-    fn branch_i32_xor_eqz_imm(i32) -> Self::BranchI32XorEqzImm;
-    fn branch_i32_eq_imm(i32) -> Self::BranchI32EqImm;
-    fn branch_i32_ne_imm(i32) -> Self::BranchI32NeImm;
-    fn branch_i32_lt_s_imm(i32) -> Self::BranchI32LtSImm;
-    fn branch_i32_lt_u_imm(u32) -> Self::BranchI32LtUImm;
-    fn branch_i32_le_s_imm(i32) -> Self::BranchI32LeSImm;
-    fn branch_i32_le_u_imm(u32) -> Self::BranchI32LeUImm;
-    fn branch_i32_gt_s_imm(i32) -> Self::BranchI32GtSImm;
-    fn branch_i32_gt_u_imm(u32) -> Self::BranchI32GtUImm;
-    fn branch_i32_ge_s_imm(i32) -> Self::BranchI32GeSImm;
-    fn branch_i32_ge_u_imm(u32) -> Self::BranchI32GeUImm;
-
-    fn branch_i64_eq_imm(i64) -> Self::BranchI64EqImm;
-    fn branch_i64_ne_imm(i64) -> Self::BranchI64NeImm;
-    fn branch_i64_lt_s_imm(i64) -> Self::BranchI64LtSImm;
-    fn branch_i64_lt_u_imm(u64) -> Self::BranchI64LtUImm;
-    fn branch_i64_le_s_imm(i64) -> Self::BranchI64LeSImm;
-    fn branch_i64_le_u_imm(u64) -> Self::BranchI64LeUImm;
-    fn branch_i64_gt_s_imm(i64) -> Self::BranchI64GtSImm;
-    fn branch_i64_gt_u_imm(u64) -> Self::BranchI64GtUImm;
-    fn branch_i64_ge_s_imm(i64) -> Self::BranchI64GeSImm;
-    fn branch_i64_ge_u_imm(u64) -> Self::BranchI64GeUImm;
-}
-
 macro_rules! constructor_for_branch_binop_imm {
     ( $( fn $name:ident($ty:ty) -> Self::$op_code:ident; )* ) => {
         impl Instruction {
@@ -1748,4 +1643,109 @@ constructor_for_store_instrs! {
     fn f64_store() -> Self::F64Store;
     fn f64_store_offset16(offset16) -> Self::F64StoreOffset16;
     fn f64_store_at(at) -> Self::F64StoreAt;
+}
+
+impl Instruction {
+    /// Creates a new [`Instruction::BranchCmpFallback`].
+    pub fn branch_cmp_fallback(lhs: Register, rhs: Register, params: Register) -> Self {
+        Self::BranchCmpFallback { lhs, rhs, params }
+    }
+}
+
+macro_rules! constructor_for_branch_cmp_instrs {
+    ( $( fn $name:ident() -> Self::$op_code:ident; )* ) => {
+        impl Instruction {
+            $(
+                #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+                pub fn $name(lhs: Register, rhs: Register, offset: BranchOffset16) -> Self {
+                    Self::$op_code(BranchBinOpInstr::new(lhs, rhs, offset))
+                }
+            )*
+        }
+    }
+}
+constructor_for_branch_cmp_instrs! {
+    fn branch_i32_and() -> Self::BranchI32And;
+    fn branch_i32_or() -> Self::BranchI32Or;
+    fn branch_i32_xor() -> Self::BranchI32Xor;
+    fn branch_i32_and_eqz() -> Self::BranchI32AndEqz;
+    fn branch_i32_or_eqz() -> Self::BranchI32OrEqz;
+    fn branch_i32_xor_eqz() -> Self::BranchI32XorEqz;
+    fn branch_i32_eq() -> Self::BranchI32Eq;
+    fn branch_i32_ne() -> Self::BranchI32Ne;
+    fn branch_i32_lt_s() -> Self::BranchI32LtS;
+    fn branch_i32_lt_u() -> Self::BranchI32LtU;
+    fn branch_i32_le_s() -> Self::BranchI32LeS;
+    fn branch_i32_le_u() -> Self::BranchI32LeU;
+    fn branch_i32_gt_s() -> Self::BranchI32GtS;
+    fn branch_i32_gt_u() -> Self::BranchI32GtU;
+    fn branch_i32_ge_s() -> Self::BranchI32GeS;
+    fn branch_i32_ge_u() -> Self::BranchI32GeU;
+
+    fn branch_i64_eq() -> Self::BranchI64Eq;
+    fn branch_i64_ne() -> Self::BranchI64Ne;
+    fn branch_i64_lt_s() -> Self::BranchI64LtS;
+    fn branch_i64_lt_u() -> Self::BranchI64LtU;
+    fn branch_i64_le_s() -> Self::BranchI64LeS;
+    fn branch_i64_le_u() -> Self::BranchI64LeU;
+    fn branch_i64_gt_s() -> Self::BranchI64GtS;
+    fn branch_i64_gt_u() -> Self::BranchI64GtU;
+    fn branch_i64_ge_s() -> Self::BranchI64GeS;
+    fn branch_i64_ge_u() -> Self::BranchI64GeU;
+
+    fn branch_f32_eq() -> Self::BranchF32Eq;
+    fn branch_f32_ne() -> Self::BranchF32Ne;
+    fn branch_f32_lt() -> Self::BranchF32Lt;
+    fn branch_f32_le() -> Self::BranchF32Le;
+    fn branch_f32_gt() -> Self::BranchF32Gt;
+    fn branch_f32_ge() -> Self::BranchF32Ge;
+
+    fn branch_f64_eq() -> Self::BranchF64Eq;
+    fn branch_f64_ne() -> Self::BranchF64Ne;
+    fn branch_f64_lt() -> Self::BranchF64Lt;
+    fn branch_f64_le() -> Self::BranchF64Le;
+    fn branch_f64_gt() -> Self::BranchF64Gt;
+    fn branch_f64_ge() -> Self::BranchF64Ge;
+}
+
+macro_rules! constructor_for_branch_cmp_imm_instrs {
+    ( $( fn $name:ident($ty:ty) -> Self::$op_code:ident; )* ) => {
+        impl Instruction {
+            $(
+                #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+                pub fn $name(lhs: Register, rhs: impl Into<Const16<$ty>>, offset: BranchOffset16) -> Self {
+                    Self::$op_code(BranchBinOpInstrImm16::new(lhs, rhs.into(), offset))
+                }
+            )*
+        }
+    }
+}
+constructor_for_branch_cmp_imm_instrs! {
+    fn branch_i32_and_imm(i32) -> Self::BranchI32AndImm;
+    fn branch_i32_or_imm(i32) -> Self::BranchI32OrImm;
+    fn branch_i32_xor_imm(i32) -> Self::BranchI32XorImm;
+    fn branch_i32_and_eqz_imm(i32) -> Self::BranchI32AndEqzImm;
+    fn branch_i32_or_eqz_imm(i32) -> Self::BranchI32OrEqzImm;
+    fn branch_i32_xor_eqz_imm(i32) -> Self::BranchI32XorEqzImm;
+    fn branch_i32_eq_imm(i32) -> Self::BranchI32EqImm;
+    fn branch_i32_ne_imm(i32) -> Self::BranchI32NeImm;
+    fn branch_i32_lt_s_imm(i32) -> Self::BranchI32LtSImm;
+    fn branch_i32_lt_u_imm(u32) -> Self::BranchI32LtUImm;
+    fn branch_i32_le_s_imm(i32) -> Self::BranchI32LeSImm;
+    fn branch_i32_le_u_imm(u32) -> Self::BranchI32LeUImm;
+    fn branch_i32_gt_s_imm(i32) -> Self::BranchI32GtSImm;
+    fn branch_i32_gt_u_imm(u32) -> Self::BranchI32GtUImm;
+    fn branch_i32_ge_s_imm(i32) -> Self::BranchI32GeSImm;
+    fn branch_i32_ge_u_imm(u32) -> Self::BranchI32GeUImm;
+
+    fn branch_i64_eq_imm(i64) -> Self::BranchI64EqImm;
+    fn branch_i64_ne_imm(i64) -> Self::BranchI64NeImm;
+    fn branch_i64_lt_s_imm(i64) -> Self::BranchI64LtSImm;
+    fn branch_i64_lt_u_imm(u64) -> Self::BranchI64LtUImm;
+    fn branch_i64_le_s_imm(i64) -> Self::BranchI64LeSImm;
+    fn branch_i64_le_u_imm(u64) -> Self::BranchI64LeUImm;
+    fn branch_i64_gt_s_imm(i64) -> Self::BranchI64GtSImm;
+    fn branch_i64_gt_u_imm(u64) -> Self::BranchI64GtUImm;
+    fn branch_i64_ge_s_imm(i64) -> Self::BranchI64GeSImm;
+    fn branch_i64_ge_u_imm(u64) -> Self::BranchI64GeUImm;
 }

--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -1556,30 +1556,30 @@ constructor_for_unary_instrs! {
 macro_rules! constructor_for_load_instrs {
     (
         $(
-            fn $fn_name:ident($mode:ident) -> Self::$op_code:ident;
+            fn $fn_name:ident($($mode:ident)?) -> Self::$op_code:ident;
         )* $(,)?
     ) => {
         impl Instruction {
             $(
                 constructor_for_load_instrs! {
-                    @impl fn $fn_name($mode) -> Self::$op_code
+                    @impl fn $fn_name($($mode)?) -> Self::$op_code
                 }
             )*
         }
     };
-    ( @impl fn $fn_name:ident(load) -> Self::$op_code:ident ) => {
+    ( @impl fn $fn_name:ident() -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(result: Register, ptr: Register) -> Self {
             Self::$op_code(LoadInstr::new(result, ptr))
         }
     };
-    ( @impl fn $fn_name:ident(load_at) -> Self::$op_code:ident ) => {
+    ( @impl fn $fn_name:ident(at) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(result: Register, address: Const32<u32>) -> Self {
             Self::$op_code(LoadAtInstr::new(result, address))
         }
     };
-    ( @impl fn $fn_name:ident(load_offset16) -> Self::$op_code:ident ) => {
+    ( @impl fn $fn_name:ident(offset16) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(result: Register, ptr: Register, offset: Const16<u32>) -> Self {
             Self::$op_code(LoadOffset16Instr::new(result, ptr, offset))
@@ -1587,61 +1587,61 @@ macro_rules! constructor_for_load_instrs {
     };
 }
 constructor_for_load_instrs! {
-    fn i32_load(load) -> Self::I32Load;
-    fn i32_load_at(load_at) -> Self::I32LoadAt;
-    fn i32_load_offset16(load_offset16) -> Self::I32LoadOffset16;
+    fn i32_load() -> Self::I32Load;
+    fn i32_load_at(at) -> Self::I32LoadAt;
+    fn i32_load_offset16(offset16) -> Self::I32LoadOffset16;
 
-    fn i32_load8_s(load) -> Self::I32Load8s;
-    fn i32_load8_s_at(load_at) -> Self::I32Load8sAt;
-    fn i32_load8_s_offset16(load_offset16) -> Self::I32Load8sOffset16;
+    fn i32_load8_s() -> Self::I32Load8s;
+    fn i32_load8_s_at(at) -> Self::I32Load8sAt;
+    fn i32_load8_s_offset16(offset16) -> Self::I32Load8sOffset16;
 
-    fn i32_load8_u(load) -> Self::I32Load8u;
-    fn i32_load8_u_at(load_at) -> Self::I32Load8uAt;
-    fn i32_load8_u_offset16(load_offset16) -> Self::I32Load8uOffset16;
+    fn i32_load8_u() -> Self::I32Load8u;
+    fn i32_load8_u_at(at) -> Self::I32Load8uAt;
+    fn i32_load8_u_offset16(offset16) -> Self::I32Load8uOffset16;
 
-    fn i32_load16_s(load) -> Self::I32Load16s;
-    fn i32_load16_s_at(load_at) -> Self::I32Load16sAt;
-    fn i32_load16_s_offset16(load_offset16) -> Self::I32Load16sOffset16;
+    fn i32_load16_s() -> Self::I32Load16s;
+    fn i32_load16_s_at(at) -> Self::I32Load16sAt;
+    fn i32_load16_s_offset16(offset16) -> Self::I32Load16sOffset16;
 
-    fn i32_load16_u(load) -> Self::I32Load16u;
-    fn i32_load16_u_at(load_at) -> Self::I32Load16uAt;
-    fn i32_load16_u_offset16(load_offset16) -> Self::I32Load16uOffset16;
+    fn i32_load16_u() -> Self::I32Load16u;
+    fn i32_load16_u_at(at) -> Self::I32Load16uAt;
+    fn i32_load16_u_offset16(offset16) -> Self::I32Load16uOffset16;
 
-    fn i64_load(load) -> Self::I64Load;
-    fn i64_load_at(load_at) -> Self::I64LoadAt;
-    fn i64_load_offset16(load_offset16) -> Self::I64LoadOffset16;
+    fn i64_load() -> Self::I64Load;
+    fn i64_load_at(at) -> Self::I64LoadAt;
+    fn i64_load_offset16(offset16) -> Self::I64LoadOffset16;
 
-    fn i64_load8_s(load) -> Self::I64Load8s;
-    fn i64_load8_s_at(load_at) -> Self::I64Load8sAt;
-    fn i64_load8_s_offset16(load_offset16) -> Self::I64Load8sOffset16;
+    fn i64_load8_s() -> Self::I64Load8s;
+    fn i64_load8_s_at(at) -> Self::I64Load8sAt;
+    fn i64_load8_s_offset16(offset16) -> Self::I64Load8sOffset16;
 
-    fn i64_load8_u(load) -> Self::I64Load8u;
-    fn i64_load8_u_at(load_at) -> Self::I64Load8uAt;
-    fn i64_load8_u_offset16(load_offset16) -> Self::I64Load8uOffset16;
+    fn i64_load8_u() -> Self::I64Load8u;
+    fn i64_load8_u_at(at) -> Self::I64Load8uAt;
+    fn i64_load8_u_offset16(offset16) -> Self::I64Load8uOffset16;
 
-    fn i64_load16_s(load) -> Self::I64Load16s;
-    fn i64_load16_s_at(load_at) -> Self::I64Load16sAt;
-    fn i64_load16_s_offset16(load_offset16) -> Self::I64Load16sOffset16;
+    fn i64_load16_s() -> Self::I64Load16s;
+    fn i64_load16_s_at(at) -> Self::I64Load16sAt;
+    fn i64_load16_s_offset16(offset16) -> Self::I64Load16sOffset16;
 
-    fn i64_load16_u(load) -> Self::I64Load16u;
-    fn i64_load16_u_at(load_at) -> Self::I64Load16uAt;
-    fn i64_load16_u_offset16(load_offset16) -> Self::I64Load16uOffset16;
+    fn i64_load16_u() -> Self::I64Load16u;
+    fn i64_load16_u_at(at) -> Self::I64Load16uAt;
+    fn i64_load16_u_offset16(offset16) -> Self::I64Load16uOffset16;
 
-    fn i64_load32_s(load) -> Self::I64Load32s;
-    fn i64_load32_s_at(load_at) -> Self::I64Load32sAt;
-    fn i64_load32_s_offset16(load_offset16) -> Self::I64Load32sOffset16;
+    fn i64_load32_s() -> Self::I64Load32s;
+    fn i64_load32_s_at(at) -> Self::I64Load32sAt;
+    fn i64_load32_s_offset16(offset16) -> Self::I64Load32sOffset16;
 
-    fn i64_load32_u(load) -> Self::I64Load32u;
-    fn i64_load32_u_at(load_at) -> Self::I64Load32uAt;
-    fn i64_load32_u_offset16(load_offset16) -> Self::I64Load32uOffset16;
+    fn i64_load32_u() -> Self::I64Load32u;
+    fn i64_load32_u_at(at) -> Self::I64Load32uAt;
+    fn i64_load32_u_offset16(offset16) -> Self::I64Load32uOffset16;
 
-    fn f32_load(load) -> Self::F32Load;
-    fn f32_load_at(load_at) -> Self::F32LoadAt;
-    fn f32_load_offset16(load_offset16) -> Self::F32LoadOffset16;
+    fn f32_load() -> Self::F32Load;
+    fn f32_load_at(at) -> Self::F32LoadAt;
+    fn f32_load_offset16(offset16) -> Self::F32LoadOffset16;
 
-    fn f64_load(load) -> Self::F64Load;
-    fn f64_load_at(load_at) -> Self::F64LoadAt;
-    fn f64_load_offset16(load_offset16) -> Self::F64LoadOffset16;
+    fn f64_load() -> Self::F64Load;
+    fn f64_load_at(at) -> Self::F64LoadAt;
+    fn f64_load_offset16(offset16) -> Self::F64LoadOffset16;
 }
 
 macro_rules! constructor_for_store_instrs {

--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -39,12 +39,6 @@ macro_rules! constructor_for {
     ) => {
         $( constructor_for! { @impl fn $fn_name($mode) -> Self::$op_code } )*
     };
-    ( @impl fn $fn_name:ident(unary) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(result: Register, input: Register) -> Self {
-            Self::$op_code(UnaryInstr::new(result, input))
-        }
-    };
     ( @impl fn $fn_name:ident(binary) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(result: Register, lhs: Register, rhs: Register) -> Self {
@@ -1432,34 +1426,6 @@ impl Instruction {
         fn f64_store_offset16(store_offset16) -> Self::F64StoreOffset16;
         fn f64_store_at(store_at) -> Self::F64StoreAt;
 
-        // Integer Unary
-
-        fn i32_clz(unary) -> Self::I32Clz;
-        fn i32_ctz(unary) -> Self::I32Ctz;
-        fn i32_popcnt(unary) -> Self::I32Popcnt;
-
-        fn i64_clz(unary) -> Self::I64Clz;
-        fn i64_ctz(unary) -> Self::I64Ctz;
-        fn i64_popcnt(unary) -> Self::I64Popcnt;
-
-        // Float Unary
-
-        fn f32_abs(unary) -> Self::F32Abs;
-        fn f32_neg(unary) -> Self::F32Neg;
-        fn f32_ceil(unary) -> Self::F32Ceil;
-        fn f32_floor(unary) -> Self::F32Floor;
-        fn f32_trunc(unary) -> Self::F32Trunc;
-        fn f32_nearest(unary) -> Self::F32Nearest;
-        fn f32_sqrt(unary) -> Self::F32Sqrt;
-
-        fn f64_abs(unary) -> Self::F64Abs;
-        fn f64_neg(unary) -> Self::F64Neg;
-        fn f64_ceil(unary) -> Self::F64Ceil;
-        fn f64_floor(unary) -> Self::F64Floor;
-        fn f64_trunc(unary) -> Self::F64Trunc;
-        fn f64_nearest(unary) -> Self::F64Nearest;
-        fn f64_sqrt(unary) -> Self::F64Sqrt;
-
         // Float Arithmetic
 
         fn f32_add(binary) -> Self::F32Add;
@@ -1667,50 +1633,92 @@ impl Instruction {
         fn i64_rotr(binary) -> Self::I64Rotr;
         fn i64_rotr_imm(binary_i64imm16) -> Self::I64RotrImm;
         fn i64_rotr_imm16_rev(binary_i64imm16_rev) -> Self::I64RotrImm16Rev;
-
-        // Conversions
-
-        fn i32_extend8_s(unary) -> Self::I32Extend8S;
-        fn i32_extend16_s(unary) -> Self::I32Extend16S;
-        fn i64_extend8_s(unary) -> Self::I64Extend8S;
-        fn i64_extend16_s(unary) -> Self::I64Extend16S;
-        fn i64_extend32_s(unary) -> Self::I64Extend32S;
-
-        fn i32_wrap_i64(unary) -> Self::I32WrapI64;
-        fn i64_extend_i32_s(unary) -> Self::I64ExtendI32S;
-        fn i64_extend_i32_u(unary) -> Self::I64ExtendI32U;
-
-        fn f32_demote_f64(unary) -> Self::F32DemoteF64;
-        fn f64_promote_f32(unary) -> Self::F64PromoteF32;
-
-        fn i32_trunc_f32_s(unary) -> Self::I32TruncF32S;
-        fn i32_trunc_f32_u(unary) -> Self::I32TruncF32U;
-        fn i32_trunc_f64_s(unary) -> Self::I32TruncF64S;
-        fn i32_trunc_f64_u(unary) -> Self::I32TruncF64U;
-
-        fn i64_trunc_f32_s(unary) -> Self::I64TruncF32S;
-        fn i64_trunc_f32_u(unary) -> Self::I64TruncF32U;
-        fn i64_trunc_f64_s(unary) -> Self::I64TruncF64S;
-        fn i64_trunc_f64_u(unary) -> Self::I64TruncF64U;
-
-        fn i32_trunc_sat_f32_s(unary) -> Self::I32TruncSatF32S;
-        fn i32_trunc_sat_f32_u(unary) -> Self::I32TruncSatF32U;
-        fn i32_trunc_sat_f64_s(unary) -> Self::I32TruncSatF64S;
-        fn i32_trunc_sat_f64_u(unary) -> Self::I32TruncSatF64U;
-
-        fn i64_trunc_sat_f32_s(unary) -> Self::I64TruncSatF32S;
-        fn i64_trunc_sat_f32_u(unary) -> Self::I64TruncSatF32U;
-        fn i64_trunc_sat_f64_s(unary) -> Self::I64TruncSatF64S;
-        fn i64_trunc_sat_f64_u(unary) -> Self::I64TruncSatF64U;
-
-        fn f32_convert_i32_s(unary) -> Self::F32ConvertI32S;
-        fn f32_convert_i32_u(unary) -> Self::F32ConvertI32U;
-        fn f32_convert_i64_s(unary) -> Self::F32ConvertI64S;
-        fn f32_convert_i64_u(unary) -> Self::F32ConvertI64U;
-
-        fn f64_convert_i32_s(unary) -> Self::F64ConvertI32S;
-        fn f64_convert_i32_u(unary) -> Self::F64ConvertI32U;
-        fn f64_convert_i64_s(unary) -> Self::F64ConvertI64S;
-        fn f64_convert_i64_u(unary) -> Self::F64ConvertI64U;
     }
+}
+
+macro_rules! constructor_for_unary_instrs {
+    ( $( fn $constructor_name:ident() -> Self::$instr_name:ident; )* ) => {
+        impl Instruction {
+            $(
+                #[doc = concat!("Creates a new [`Instruction::", stringify!($instr_name), "`].")]
+                pub fn $constructor_name(result: Register, input: Register) -> Self {
+                    Self::$instr_name(UnaryInstr::new(result, input))
+                }
+            )*
+        }
+    }
+}
+constructor_for_unary_instrs! {
+    // Integer Unary
+
+    fn i32_clz() -> Self::I32Clz;
+    fn i32_ctz() -> Self::I32Ctz;
+    fn i32_popcnt() -> Self::I32Popcnt;
+
+    fn i64_clz() -> Self::I64Clz;
+    fn i64_ctz() -> Self::I64Ctz;
+    fn i64_popcnt() -> Self::I64Popcnt;
+
+    // Float Unary
+
+    fn f32_abs() -> Self::F32Abs;
+    fn f32_neg() -> Self::F32Neg;
+    fn f32_ceil() -> Self::F32Ceil;
+    fn f32_floor() -> Self::F32Floor;
+    fn f32_trunc() -> Self::F32Trunc;
+    fn f32_nearest() -> Self::F32Nearest;
+    fn f32_sqrt() -> Self::F32Sqrt;
+
+    fn f64_abs() -> Self::F64Abs;
+    fn f64_neg() -> Self::F64Neg;
+    fn f64_ceil() -> Self::F64Ceil;
+    fn f64_floor() -> Self::F64Floor;
+    fn f64_trunc() -> Self::F64Trunc;
+    fn f64_nearest() -> Self::F64Nearest;
+    fn f64_sqrt() -> Self::F64Sqrt;
+
+    // Conversion
+
+    fn i32_extend8_s() -> Self::I32Extend8S;
+    fn i32_extend16_s() -> Self::I32Extend16S;
+    fn i64_extend8_s() -> Self::I64Extend8S;
+    fn i64_extend16_s() -> Self::I64Extend16S;
+    fn i64_extend32_s() -> Self::I64Extend32S;
+
+    fn i32_wrap_i64() -> Self::I32WrapI64;
+    fn i64_extend_i32_s() -> Self::I64ExtendI32S;
+    fn i64_extend_i32_u() -> Self::I64ExtendI32U;
+
+    fn f32_demote_f64() -> Self::F32DemoteF64;
+    fn f64_promote_f32() -> Self::F64PromoteF32;
+
+    fn i32_trunc_f32_s() -> Self::I32TruncF32S;
+    fn i32_trunc_f32_u() -> Self::I32TruncF32U;
+    fn i32_trunc_f64_s() -> Self::I32TruncF64S;
+    fn i32_trunc_f64_u() -> Self::I32TruncF64U;
+
+    fn i64_trunc_f32_s() -> Self::I64TruncF32S;
+    fn i64_trunc_f32_u() -> Self::I64TruncF32U;
+    fn i64_trunc_f64_s() -> Self::I64TruncF64S;
+    fn i64_trunc_f64_u() -> Self::I64TruncF64U;
+
+    fn i32_trunc_sat_f32_s() -> Self::I32TruncSatF32S;
+    fn i32_trunc_sat_f32_u() -> Self::I32TruncSatF32U;
+    fn i32_trunc_sat_f64_s() -> Self::I32TruncSatF64S;
+    fn i32_trunc_sat_f64_u() -> Self::I32TruncSatF64U;
+
+    fn i64_trunc_sat_f32_s() -> Self::I64TruncSatF32S;
+    fn i64_trunc_sat_f32_u() -> Self::I64TruncSatF32U;
+    fn i64_trunc_sat_f64_s() -> Self::I64TruncSatF64S;
+    fn i64_trunc_sat_f64_u() -> Self::I64TruncSatF64U;
+
+    fn f32_convert_i32_s() -> Self::F32ConvertI32S;
+    fn f32_convert_i32_u() -> Self::F32ConvertI32U;
+    fn f32_convert_i64_s() -> Self::F32ConvertI64S;
+    fn f32_convert_i64_u() -> Self::F32ConvertI64U;
+
+    fn f64_convert_i32_s() -> Self::F64ConvertI32S;
+    fn f64_convert_i32_u() -> Self::F64ConvertI32U;
+    fn f64_convert_i64_s() -> Self::F64ConvertI64S;
+    fn f64_convert_i64_u() -> Self::F64ConvertI64U;
 }

--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -31,30 +31,6 @@ use super::{
 };
 use core::num::{NonZeroI32, NonZeroI64, NonZeroU32, NonZeroU64};
 
-macro_rules! constructor_for_branch_binop_imm {
-    ( $( fn $name:ident($ty:ty) -> Self::$op_code:ident; )* ) => {
-        impl Instruction {
-            $(
-                #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-                pub fn $name(result: Register, lhs: Register, rhs: impl Into<Const16<$ty>>) -> Self {
-                    Self::$op_code(BinInstrImm16::new(result, lhs, rhs.into()))
-                }
-            )*
-        }
-    }
-}
-constructor_for_branch_binop_imm! {
-    fn i32_div_s_imm16(NonZeroI32) -> Self::I32DivSImm16;
-    fn i32_div_u_imm16(NonZeroU32) -> Self::I32DivUImm16;
-    fn i32_rem_s_imm16(NonZeroI32) -> Self::I32RemSImm16;
-    fn i32_rem_u_imm16(NonZeroU32) -> Self::I32RemUImm16;
-
-    fn i64_div_s_imm16(NonZeroI64) -> Self::I64DivSImm16;
-    fn i64_div_u_imm16(NonZeroU64) -> Self::I64DivUImm16;
-    fn i64_rem_s_imm16(NonZeroI64) -> Self::I64RemSImm16;
-    fn i64_rem_u_imm16(NonZeroU64) -> Self::I64RemUImm16;
-}
-
 impl Instruction {
     /// Creates a new [`Instruction::Const32`] from the given `value`.
     pub fn const32(value: impl Into<AnyConst32>) -> Self {
@@ -1748,4 +1724,28 @@ constructor_for_branch_cmp_imm_instrs! {
     fn branch_i64_gt_u_imm(u64) -> Self::BranchI64GtUImm;
     fn branch_i64_ge_s_imm(i64) -> Self::BranchI64GeSImm;
     fn branch_i64_ge_u_imm(u64) -> Self::BranchI64GeUImm;
+}
+
+macro_rules! constructor_for_divrem_imm_instrs {
+    ( $( fn $name:ident($ty:ty) -> Self::$op_code:ident; )* ) => {
+        impl Instruction {
+            $(
+                #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+                pub fn $name(result: Register, lhs: Register, rhs: impl Into<Const16<$ty>>) -> Self {
+                    Self::$op_code(BinInstrImm16::new(result, lhs, rhs.into()))
+                }
+            )*
+        }
+    }
+}
+constructor_for_divrem_imm_instrs! {
+    fn i32_div_s_imm16(NonZeroI32) -> Self::I32DivSImm16;
+    fn i32_div_u_imm16(NonZeroU32) -> Self::I32DivUImm16;
+    fn i32_rem_s_imm16(NonZeroI32) -> Self::I32RemSImm16;
+    fn i32_rem_u_imm16(NonZeroU32) -> Self::I32RemUImm16;
+
+    fn i64_div_s_imm16(NonZeroI64) -> Self::I64DivSImm16;
+    fn i64_div_u_imm16(NonZeroU64) -> Self::I64DivUImm16;
+    fn i64_rem_s_imm16(NonZeroI64) -> Self::I64RemSImm16;
+    fn i64_rem_u_imm16(NonZeroU64) -> Self::I64RemUImm16;
 }

--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -1646,53 +1646,53 @@ constructor_for_load_instrs! {
 
 macro_rules! constructor_for_store_instrs {
     (
-        $( fn $fn_name:ident($mode:ident) -> Self::$op_code:ident; )* $(,)?
+        $( fn $fn_name:ident($($mode:tt)?) -> Self::$op_code:ident; )* $(,)?
     ) => {
         impl Instruction {
             $(
                 constructor_for_store_instrs! {
-                    @impl fn $fn_name($mode) -> Self::$op_code
+                    @impl fn $fn_name($($mode)?) -> Self::$op_code
                 }
             )*
         }
     };
-    ( @impl fn $fn_name:ident(store) -> Self::$op_code:ident ) => {
+    ( @impl fn $fn_name:ident() -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(ptr: Register, offset: Const32<u32>) -> Self {
             Self::$op_code(StoreInstr::new(ptr, offset))
         }
     };
-    ( @impl fn $fn_name:ident(store_at) -> Self::$op_code:ident ) => {
+    ( @impl fn $fn_name:ident(at) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(address: Const32<u32>, value: Register) -> Self {
             Self::$op_code(StoreAtInstr::new(address, value))
         }
     };
-    ( @impl fn $fn_name:ident(store_offset16) -> Self::$op_code:ident ) => {
+    ( @impl fn $fn_name:ident(offset16) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(ptr: Register, offset: u16, value: Register) -> Self {
             Self::$op_code(StoreOffset16Instr::new(ptr, offset.into(), value))
         }
     };
-    ( @impl fn $fn_name:ident(store_offset16_imm8) -> Self::$op_code:ident ) => {
+    ( @impl fn $fn_name:ident({offset16_imm<i8>}) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(ptr: Register, offset: u16, value: i8) -> Self {
             Self::$op_code(StoreOffset16Instr::new(ptr, offset.into(), value.into()))
         }
     };
-    ( @impl fn $fn_name:ident(store_offset16_imm16) -> Self::$op_code:ident ) => {
+    ( @impl fn $fn_name:ident({offset16_imm<i16>}) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(ptr: Register, offset: u16, value: i16) -> Self {
             Self::$op_code(StoreOffset16Instr::new(ptr, offset.into(), value.into()))
         }
     };
-    ( @impl fn $fn_name:ident(store_at_imm8) -> Self::$op_code:ident ) => {
+    ( @impl fn $fn_name:ident({at_imm<i8>}) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(address: Const32<u32>, value: i8) -> Self {
             Self::$op_code(StoreAtInstr::new(address, value.into()))
         }
     };
-    ( @impl fn $fn_name:ident(store_at_imm16) -> Self::$op_code:ident ) => {
+    ( @impl fn $fn_name:ident({at_imm<i16>}) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(address: Const32<u32>, value: i16) -> Self {
             Self::$op_code(StoreAtInstr::new(address, value.into()))
@@ -1700,53 +1700,53 @@ macro_rules! constructor_for_store_instrs {
     };
 }
 constructor_for_store_instrs! {
-    fn i32_store(store) -> Self::I32Store;
-    fn i32_store_offset16(store_offset16) -> Self::I32StoreOffset16;
-    fn i32_store_offset16_imm16(store_offset16_imm16) -> Self::I32StoreOffset16Imm16;
-    fn i32_store_at(store_at) -> Self::I32StoreAt;
-    fn i32_store_at_imm16(store_at_imm16) -> Self::I32StoreAtImm16;
+    fn i32_store() -> Self::I32Store;
+    fn i32_store_offset16(offset16) -> Self::I32StoreOffset16;
+    fn i32_store_offset16_imm16({offset16_imm<i16>}) -> Self::I32StoreOffset16Imm16;
+    fn i32_store_at(at) -> Self::I32StoreAt;
+    fn i32_store_at_imm16({at_imm<i16>}) -> Self::I32StoreAtImm16;
 
-    fn i32_store8(store) -> Self::I32Store8;
-    fn i32_store8_offset16(store_offset16) -> Self::I32Store8Offset16;
-    fn i32_store8_offset16_imm(store_offset16_imm8) -> Self::I32Store8Offset16Imm;
-    fn i32_store8_at(store_at) -> Self::I32Store8At;
-    fn i32_store8_at_imm(store_at_imm8) -> Self::I32Store8AtImm;
+    fn i32_store8() -> Self::I32Store8;
+    fn i32_store8_offset16(offset16) -> Self::I32Store8Offset16;
+    fn i32_store8_offset16_imm({offset16_imm<i8>}) -> Self::I32Store8Offset16Imm;
+    fn i32_store8_at(at) -> Self::I32Store8At;
+    fn i32_store8_at_imm({at_imm<i8>}) -> Self::I32Store8AtImm;
 
-    fn i32_store16(store) -> Self::I32Store16;
-    fn i32_store16_offset16(store_offset16) -> Self::I32Store16Offset16;
-    fn i32_store16_offset16_imm(store_offset16_imm16) -> Self::I32Store16Offset16Imm;
-    fn i32_store16_at(store_at) -> Self::I32Store16At;
-    fn i32_store16_at_imm(store_at_imm16) -> Self::I32Store16AtImm;
+    fn i32_store16() -> Self::I32Store16;
+    fn i32_store16_offset16(offset16) -> Self::I32Store16Offset16;
+    fn i32_store16_offset16_imm({offset16_imm<i16>}) -> Self::I32Store16Offset16Imm;
+    fn i32_store16_at(at) -> Self::I32Store16At;
+    fn i32_store16_at_imm({at_imm<i16>}) -> Self::I32Store16AtImm;
 
-    fn i64_store(store) -> Self::I64Store;
-    fn i64_store_offset16(store_offset16) -> Self::I64StoreOffset16;
-    fn i64_store_offset16_imm16(store_offset16_imm16) -> Self::I64StoreOffset16Imm16;
-    fn i64_store_at(store_at) -> Self::I64StoreAt;
-    fn i64_store_at_imm16(store_at_imm16) -> Self::I64StoreAtImm16;
+    fn i64_store() -> Self::I64Store;
+    fn i64_store_offset16(offset16) -> Self::I64StoreOffset16;
+    fn i64_store_offset16_imm16({offset16_imm<i16>}) -> Self::I64StoreOffset16Imm16;
+    fn i64_store_at(at) -> Self::I64StoreAt;
+    fn i64_store_at_imm16({at_imm<i16>}) -> Self::I64StoreAtImm16;
 
-    fn i64_store8(store) -> Self::I64Store8;
-    fn i64_store8_offset16(store_offset16) -> Self::I64Store8Offset16;
-    fn i64_store8_offset16_imm(store_offset16_imm8) -> Self::I64Store8Offset16Imm;
-    fn i64_store8_at(store_at) -> Self::I64Store8At;
-    fn i64_store8_at_imm(store_at_imm8) -> Self::I64Store8AtImm;
+    fn i64_store8() -> Self::I64Store8;
+    fn i64_store8_offset16(offset16) -> Self::I64Store8Offset16;
+    fn i64_store8_offset16_imm({offset16_imm<i8>}) -> Self::I64Store8Offset16Imm;
+    fn i64_store8_at(at) -> Self::I64Store8At;
+    fn i64_store8_at_imm({at_imm<i8>}) -> Self::I64Store8AtImm;
 
-    fn i64_store16(store) -> Self::I64Store16;
-    fn i64_store16_offset16(store_offset16) -> Self::I64Store16Offset16;
-    fn i64_store16_offset16_imm(store_offset16_imm16) -> Self::I64Store16Offset16Imm;
-    fn i64_store16_at(store_at) -> Self::I64Store16At;
-    fn i64_store16_at_imm(store_at_imm16) -> Self::I64Store16AtImm;
+    fn i64_store16() -> Self::I64Store16;
+    fn i64_store16_offset16(offset16) -> Self::I64Store16Offset16;
+    fn i64_store16_offset16_imm({offset16_imm<i16>}) -> Self::I64Store16Offset16Imm;
+    fn i64_store16_at(at) -> Self::I64Store16At;
+    fn i64_store16_at_imm({at_imm<i16>}) -> Self::I64Store16AtImm;
 
-    fn i64_store32(store) -> Self::I64Store32;
-    fn i64_store32_offset16(store_offset16) -> Self::I64Store32Offset16;
-    fn i64_store32_offset16_imm16(store_offset16_imm16) -> Self::I64Store32Offset16Imm16;
-    fn i64_store32_at(store_at) -> Self::I64Store32At;
-    fn i64_store32_at_imm16(store_at_imm16) -> Self::I64Store32AtImm16;
+    fn i64_store32() -> Self::I64Store32;
+    fn i64_store32_offset16(offset16) -> Self::I64Store32Offset16;
+    fn i64_store32_offset16_imm16({offset16_imm<i16>}) -> Self::I64Store32Offset16Imm16;
+    fn i64_store32_at(at) -> Self::I64Store32At;
+    fn i64_store32_at_imm16({at_imm<i16>}) -> Self::I64Store32AtImm16;
 
-    fn f32_store(store) -> Self::F32Store;
-    fn f32_store_offset16(store_offset16) -> Self::F32StoreOffset16;
-    fn f32_store_at(store_at) -> Self::F32StoreAt;
+    fn f32_store() -> Self::F32Store;
+    fn f32_store_offset16(offset16) -> Self::F32StoreOffset16;
+    fn f32_store_at(at) -> Self::F32StoreAt;
 
-    fn f64_store(store) -> Self::F64Store;
-    fn f64_store_offset16(store_offset16) -> Self::F64StoreOffset16;
-    fn f64_store_at(store_at) -> Self::F64StoreAt;
+    fn f64_store() -> Self::F64Store;
+    fn f64_store_offset16(offset16) -> Self::F64StoreOffset16;
+    fn f64_store_at(at) -> Self::F64StoreAt;
 }

--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -99,24 +99,6 @@ macro_rules! constructor_for {
             Self::$op_code(BinInstrImm16::new(result, rhs, lhs))
         }
     };
-    ( @impl fn $fn_name:ident(load) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(result: Register, ptr: Register) -> Self {
-            Self::$op_code(LoadInstr::new(result, ptr))
-        }
-    };
-    ( @impl fn $fn_name:ident(load_at) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(result: Register, address: Const32<u32>) -> Self {
-            Self::$op_code(LoadAtInstr::new(result, address))
-        }
-    };
-    ( @impl fn $fn_name:ident(load_offset16) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(result: Register, ptr: Register, offset: Const16<u32>) -> Self {
-            Self::$op_code(LoadOffset16Instr::new(result, ptr, offset))
-        }
-    };
     ( @impl fn $fn_name:ident(store) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
         pub fn $fn_name(ptr: Register, offset: Const32<u32>) -> Self {
@@ -1316,64 +1298,6 @@ impl Instruction {
     }
 
     constructor_for! {
-        // Load
-
-        fn i32_load(load) -> Self::I32Load;
-        fn i32_load_at(load_at) -> Self::I32LoadAt;
-        fn i32_load_offset16(load_offset16) -> Self::I32LoadOffset16;
-
-        fn i32_load8_s(load) -> Self::I32Load8s;
-        fn i32_load8_s_at(load_at) -> Self::I32Load8sAt;
-        fn i32_load8_s_offset16(load_offset16) -> Self::I32Load8sOffset16;
-
-        fn i32_load8_u(load) -> Self::I32Load8u;
-        fn i32_load8_u_at(load_at) -> Self::I32Load8uAt;
-        fn i32_load8_u_offset16(load_offset16) -> Self::I32Load8uOffset16;
-
-        fn i32_load16_s(load) -> Self::I32Load16s;
-        fn i32_load16_s_at(load_at) -> Self::I32Load16sAt;
-        fn i32_load16_s_offset16(load_offset16) -> Self::I32Load16sOffset16;
-
-        fn i32_load16_u(load) -> Self::I32Load16u;
-        fn i32_load16_u_at(load_at) -> Self::I32Load16uAt;
-        fn i32_load16_u_offset16(load_offset16) -> Self::I32Load16uOffset16;
-
-        fn i64_load(load) -> Self::I64Load;
-        fn i64_load_at(load_at) -> Self::I64LoadAt;
-        fn i64_load_offset16(load_offset16) -> Self::I64LoadOffset16;
-
-        fn i64_load8_s(load) -> Self::I64Load8s;
-        fn i64_load8_s_at(load_at) -> Self::I64Load8sAt;
-        fn i64_load8_s_offset16(load_offset16) -> Self::I64Load8sOffset16;
-
-        fn i64_load8_u(load) -> Self::I64Load8u;
-        fn i64_load8_u_at(load_at) -> Self::I64Load8uAt;
-        fn i64_load8_u_offset16(load_offset16) -> Self::I64Load8uOffset16;
-
-        fn i64_load16_s(load) -> Self::I64Load16s;
-        fn i64_load16_s_at(load_at) -> Self::I64Load16sAt;
-        fn i64_load16_s_offset16(load_offset16) -> Self::I64Load16sOffset16;
-
-        fn i64_load16_u(load) -> Self::I64Load16u;
-        fn i64_load16_u_at(load_at) -> Self::I64Load16uAt;
-        fn i64_load16_u_offset16(load_offset16) -> Self::I64Load16uOffset16;
-
-        fn i64_load32_s(load) -> Self::I64Load32s;
-        fn i64_load32_s_at(load_at) -> Self::I64Load32sAt;
-        fn i64_load32_s_offset16(load_offset16) -> Self::I64Load32sOffset16;
-
-        fn i64_load32_u(load) -> Self::I64Load32u;
-        fn i64_load32_u_at(load_at) -> Self::I64Load32uAt;
-        fn i64_load32_u_offset16(load_offset16) -> Self::I64Load32uOffset16;
-
-        fn f32_load(load) -> Self::F32Load;
-        fn f32_load_at(load_at) -> Self::F32LoadAt;
-        fn f32_load_offset16(load_offset16) -> Self::F32LoadOffset16;
-
-        fn f64_load(load) -> Self::F64Load;
-        fn f64_load_at(load_at) -> Self::F64LoadAt;
-        fn f64_load_offset16(load_offset16) -> Self::F64LoadOffset16;
-
         // Store
 
         fn i32_store(store) -> Self::I32Store;
@@ -1721,4 +1645,95 @@ constructor_for_unary_instrs! {
     fn f64_convert_i32_u() -> Self::F64ConvertI32U;
     fn f64_convert_i64_s() -> Self::F64ConvertI64S;
     fn f64_convert_i64_u() -> Self::F64ConvertI64U;
+}
+
+macro_rules! constructor_for_load_instrs {
+    (
+        $(
+            fn $fn_name:ident($mode:ident) -> Self::$op_code:ident;
+        )* $(,)?
+    ) => {
+        impl Instruction {
+            $(
+                constructor_for_load_instrs! {
+                    @impl fn $fn_name($mode) -> Self::$op_code
+                }
+            )*
+        }
+    };
+    ( @impl fn $fn_name:ident(load) -> Self::$op_code:ident ) => {
+        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+        pub fn $fn_name(result: Register, ptr: Register) -> Self {
+            Self::$op_code(LoadInstr::new(result, ptr))
+        }
+    };
+    ( @impl fn $fn_name:ident(load_at) -> Self::$op_code:ident ) => {
+        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+        pub fn $fn_name(result: Register, address: Const32<u32>) -> Self {
+            Self::$op_code(LoadAtInstr::new(result, address))
+        }
+    };
+    ( @impl fn $fn_name:ident(load_offset16) -> Self::$op_code:ident ) => {
+        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+        pub fn $fn_name(result: Register, ptr: Register, offset: Const16<u32>) -> Self {
+            Self::$op_code(LoadOffset16Instr::new(result, ptr, offset))
+        }
+    };
+}
+constructor_for_load_instrs! {
+    fn i32_load(load) -> Self::I32Load;
+    fn i32_load_at(load_at) -> Self::I32LoadAt;
+    fn i32_load_offset16(load_offset16) -> Self::I32LoadOffset16;
+
+    fn i32_load8_s(load) -> Self::I32Load8s;
+    fn i32_load8_s_at(load_at) -> Self::I32Load8sAt;
+    fn i32_load8_s_offset16(load_offset16) -> Self::I32Load8sOffset16;
+
+    fn i32_load8_u(load) -> Self::I32Load8u;
+    fn i32_load8_u_at(load_at) -> Self::I32Load8uAt;
+    fn i32_load8_u_offset16(load_offset16) -> Self::I32Load8uOffset16;
+
+    fn i32_load16_s(load) -> Self::I32Load16s;
+    fn i32_load16_s_at(load_at) -> Self::I32Load16sAt;
+    fn i32_load16_s_offset16(load_offset16) -> Self::I32Load16sOffset16;
+
+    fn i32_load16_u(load) -> Self::I32Load16u;
+    fn i32_load16_u_at(load_at) -> Self::I32Load16uAt;
+    fn i32_load16_u_offset16(load_offset16) -> Self::I32Load16uOffset16;
+
+    fn i64_load(load) -> Self::I64Load;
+    fn i64_load_at(load_at) -> Self::I64LoadAt;
+    fn i64_load_offset16(load_offset16) -> Self::I64LoadOffset16;
+
+    fn i64_load8_s(load) -> Self::I64Load8s;
+    fn i64_load8_s_at(load_at) -> Self::I64Load8sAt;
+    fn i64_load8_s_offset16(load_offset16) -> Self::I64Load8sOffset16;
+
+    fn i64_load8_u(load) -> Self::I64Load8u;
+    fn i64_load8_u_at(load_at) -> Self::I64Load8uAt;
+    fn i64_load8_u_offset16(load_offset16) -> Self::I64Load8uOffset16;
+
+    fn i64_load16_s(load) -> Self::I64Load16s;
+    fn i64_load16_s_at(load_at) -> Self::I64Load16sAt;
+    fn i64_load16_s_offset16(load_offset16) -> Self::I64Load16sOffset16;
+
+    fn i64_load16_u(load) -> Self::I64Load16u;
+    fn i64_load16_u_at(load_at) -> Self::I64Load16uAt;
+    fn i64_load16_u_offset16(load_offset16) -> Self::I64Load16uOffset16;
+
+    fn i64_load32_s(load) -> Self::I64Load32s;
+    fn i64_load32_s_at(load_at) -> Self::I64Load32sAt;
+    fn i64_load32_s_offset16(load_offset16) -> Self::I64Load32sOffset16;
+
+    fn i64_load32_u(load) -> Self::I64Load32u;
+    fn i64_load32_u_at(load_at) -> Self::I64Load32uAt;
+    fn i64_load32_u_offset16(load_offset16) -> Self::I64Load32uOffset16;
+
+    fn f32_load(load) -> Self::F32Load;
+    fn f32_load_at(load_at) -> Self::F32LoadAt;
+    fn f32_load_offset16(load_offset16) -> Self::F32LoadOffset16;
+
+    fn f64_load(load) -> Self::F64Load;
+    fn f64_load_at(load_at) -> Self::F64LoadAt;
+    fn f64_load_offset16(load_offset16) -> Self::F64LoadOffset16;
 }

--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -99,48 +99,6 @@ macro_rules! constructor_for {
             Self::$op_code(BinInstrImm16::new(result, rhs, lhs))
         }
     };
-    ( @impl fn $fn_name:ident(store) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(ptr: Register, offset: Const32<u32>) -> Self {
-            Self::$op_code(StoreInstr::new(ptr, offset))
-        }
-    };
-    ( @impl fn $fn_name:ident(store_at) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(address: Const32<u32>, value: Register) -> Self {
-            Self::$op_code(StoreAtInstr::new(address, value))
-        }
-    };
-    ( @impl fn $fn_name:ident(store_offset16) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(ptr: Register, offset: u16, value: Register) -> Self {
-            Self::$op_code(StoreOffset16Instr::new(ptr, offset.into(), value))
-        }
-    };
-    ( @impl fn $fn_name:ident(store_offset16_imm8) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(ptr: Register, offset: u16, value: i8) -> Self {
-            Self::$op_code(StoreOffset16Instr::new(ptr, offset.into(), value.into()))
-        }
-    };
-    ( @impl fn $fn_name:ident(store_offset16_imm16) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(ptr: Register, offset: u16, value: i16) -> Self {
-            Self::$op_code(StoreOffset16Instr::new(ptr, offset.into(), value.into()))
-        }
-    };
-    ( @impl fn $fn_name:ident(store_at_imm8) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(address: Const32<u32>, value: i8) -> Self {
-            Self::$op_code(StoreAtInstr::new(address, value.into()))
-        }
-    };
-    ( @impl fn $fn_name:ident(store_at_imm16) -> Self::$op_code:ident ) => {
-        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(address: Const32<u32>, value: i16) -> Self {
-            Self::$op_code(StoreAtInstr::new(address, value.into()))
-        }
-    };
 }
 
 impl Instruction {
@@ -1298,58 +1256,6 @@ impl Instruction {
     }
 
     constructor_for! {
-        // Store
-
-        fn i32_store(store) -> Self::I32Store;
-        fn i32_store_offset16(store_offset16) -> Self::I32StoreOffset16;
-        fn i32_store_offset16_imm16(store_offset16_imm16) -> Self::I32StoreOffset16Imm16;
-        fn i32_store_at(store_at) -> Self::I32StoreAt;
-        fn i32_store_at_imm16(store_at_imm16) -> Self::I32StoreAtImm16;
-
-        fn i32_store8(store) -> Self::I32Store8;
-        fn i32_store8_offset16(store_offset16) -> Self::I32Store8Offset16;
-        fn i32_store8_offset16_imm(store_offset16_imm8) -> Self::I32Store8Offset16Imm;
-        fn i32_store8_at(store_at) -> Self::I32Store8At;
-        fn i32_store8_at_imm(store_at_imm8) -> Self::I32Store8AtImm;
-
-        fn i32_store16(store) -> Self::I32Store16;
-        fn i32_store16_offset16(store_offset16) -> Self::I32Store16Offset16;
-        fn i32_store16_offset16_imm(store_offset16_imm16) -> Self::I32Store16Offset16Imm;
-        fn i32_store16_at(store_at) -> Self::I32Store16At;
-        fn i32_store16_at_imm(store_at_imm16) -> Self::I32Store16AtImm;
-
-        fn i64_store(store) -> Self::I64Store;
-        fn i64_store_offset16(store_offset16) -> Self::I64StoreOffset16;
-        fn i64_store_offset16_imm16(store_offset16_imm16) -> Self::I64StoreOffset16Imm16;
-        fn i64_store_at(store_at) -> Self::I64StoreAt;
-        fn i64_store_at_imm16(store_at_imm16) -> Self::I64StoreAtImm16;
-
-        fn i64_store8(store) -> Self::I64Store8;
-        fn i64_store8_offset16(store_offset16) -> Self::I64Store8Offset16;
-        fn i64_store8_offset16_imm(store_offset16_imm8) -> Self::I64Store8Offset16Imm;
-        fn i64_store8_at(store_at) -> Self::I64Store8At;
-        fn i64_store8_at_imm(store_at_imm8) -> Self::I64Store8AtImm;
-
-        fn i64_store16(store) -> Self::I64Store16;
-        fn i64_store16_offset16(store_offset16) -> Self::I64Store16Offset16;
-        fn i64_store16_offset16_imm(store_offset16_imm16) -> Self::I64Store16Offset16Imm;
-        fn i64_store16_at(store_at) -> Self::I64Store16At;
-        fn i64_store16_at_imm(store_at_imm16) -> Self::I64Store16AtImm;
-
-        fn i64_store32(store) -> Self::I64Store32;
-        fn i64_store32_offset16(store_offset16) -> Self::I64Store32Offset16;
-        fn i64_store32_offset16_imm16(store_offset16_imm16) -> Self::I64Store32Offset16Imm16;
-        fn i64_store32_at(store_at) -> Self::I64Store32At;
-        fn i64_store32_at_imm16(store_at_imm16) -> Self::I64Store32AtImm16;
-
-        fn f32_store(store) -> Self::F32Store;
-        fn f32_store_offset16(store_offset16) -> Self::F32StoreOffset16;
-        fn f32_store_at(store_at) -> Self::F32StoreAt;
-
-        fn f64_store(store) -> Self::F64Store;
-        fn f64_store_offset16(store_offset16) -> Self::F64StoreOffset16;
-        fn f64_store_at(store_at) -> Self::F64StoreAt;
-
         // Float Arithmetic
 
         fn f32_add(binary) -> Self::F32Add;
@@ -1736,4 +1642,111 @@ constructor_for_load_instrs! {
     fn f64_load(load) -> Self::F64Load;
     fn f64_load_at(load_at) -> Self::F64LoadAt;
     fn f64_load_offset16(load_offset16) -> Self::F64LoadOffset16;
+}
+
+macro_rules! constructor_for_store_instrs {
+    (
+        $( fn $fn_name:ident($mode:ident) -> Self::$op_code:ident; )* $(,)?
+    ) => {
+        impl Instruction {
+            $(
+                constructor_for_store_instrs! {
+                    @impl fn $fn_name($mode) -> Self::$op_code
+                }
+            )*
+        }
+    };
+    ( @impl fn $fn_name:ident(store) -> Self::$op_code:ident ) => {
+        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+        pub fn $fn_name(ptr: Register, offset: Const32<u32>) -> Self {
+            Self::$op_code(StoreInstr::new(ptr, offset))
+        }
+    };
+    ( @impl fn $fn_name:ident(store_at) -> Self::$op_code:ident ) => {
+        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+        pub fn $fn_name(address: Const32<u32>, value: Register) -> Self {
+            Self::$op_code(StoreAtInstr::new(address, value))
+        }
+    };
+    ( @impl fn $fn_name:ident(store_offset16) -> Self::$op_code:ident ) => {
+        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+        pub fn $fn_name(ptr: Register, offset: u16, value: Register) -> Self {
+            Self::$op_code(StoreOffset16Instr::new(ptr, offset.into(), value))
+        }
+    };
+    ( @impl fn $fn_name:ident(store_offset16_imm8) -> Self::$op_code:ident ) => {
+        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+        pub fn $fn_name(ptr: Register, offset: u16, value: i8) -> Self {
+            Self::$op_code(StoreOffset16Instr::new(ptr, offset.into(), value.into()))
+        }
+    };
+    ( @impl fn $fn_name:ident(store_offset16_imm16) -> Self::$op_code:ident ) => {
+        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+        pub fn $fn_name(ptr: Register, offset: u16, value: i16) -> Self {
+            Self::$op_code(StoreOffset16Instr::new(ptr, offset.into(), value.into()))
+        }
+    };
+    ( @impl fn $fn_name:ident(store_at_imm8) -> Self::$op_code:ident ) => {
+        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+        pub fn $fn_name(address: Const32<u32>, value: i8) -> Self {
+            Self::$op_code(StoreAtInstr::new(address, value.into()))
+        }
+    };
+    ( @impl fn $fn_name:ident(store_at_imm16) -> Self::$op_code:ident ) => {
+        #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
+        pub fn $fn_name(address: Const32<u32>, value: i16) -> Self {
+            Self::$op_code(StoreAtInstr::new(address, value.into()))
+        }
+    };
+}
+constructor_for_store_instrs! {
+    fn i32_store(store) -> Self::I32Store;
+    fn i32_store_offset16(store_offset16) -> Self::I32StoreOffset16;
+    fn i32_store_offset16_imm16(store_offset16_imm16) -> Self::I32StoreOffset16Imm16;
+    fn i32_store_at(store_at) -> Self::I32StoreAt;
+    fn i32_store_at_imm16(store_at_imm16) -> Self::I32StoreAtImm16;
+
+    fn i32_store8(store) -> Self::I32Store8;
+    fn i32_store8_offset16(store_offset16) -> Self::I32Store8Offset16;
+    fn i32_store8_offset16_imm(store_offset16_imm8) -> Self::I32Store8Offset16Imm;
+    fn i32_store8_at(store_at) -> Self::I32Store8At;
+    fn i32_store8_at_imm(store_at_imm8) -> Self::I32Store8AtImm;
+
+    fn i32_store16(store) -> Self::I32Store16;
+    fn i32_store16_offset16(store_offset16) -> Self::I32Store16Offset16;
+    fn i32_store16_offset16_imm(store_offset16_imm16) -> Self::I32Store16Offset16Imm;
+    fn i32_store16_at(store_at) -> Self::I32Store16At;
+    fn i32_store16_at_imm(store_at_imm16) -> Self::I32Store16AtImm;
+
+    fn i64_store(store) -> Self::I64Store;
+    fn i64_store_offset16(store_offset16) -> Self::I64StoreOffset16;
+    fn i64_store_offset16_imm16(store_offset16_imm16) -> Self::I64StoreOffset16Imm16;
+    fn i64_store_at(store_at) -> Self::I64StoreAt;
+    fn i64_store_at_imm16(store_at_imm16) -> Self::I64StoreAtImm16;
+
+    fn i64_store8(store) -> Self::I64Store8;
+    fn i64_store8_offset16(store_offset16) -> Self::I64Store8Offset16;
+    fn i64_store8_offset16_imm(store_offset16_imm8) -> Self::I64Store8Offset16Imm;
+    fn i64_store8_at(store_at) -> Self::I64Store8At;
+    fn i64_store8_at_imm(store_at_imm8) -> Self::I64Store8AtImm;
+
+    fn i64_store16(store) -> Self::I64Store16;
+    fn i64_store16_offset16(store_offset16) -> Self::I64Store16Offset16;
+    fn i64_store16_offset16_imm(store_offset16_imm16) -> Self::I64Store16Offset16Imm;
+    fn i64_store16_at(store_at) -> Self::I64Store16At;
+    fn i64_store16_at_imm(store_at_imm16) -> Self::I64Store16AtImm;
+
+    fn i64_store32(store) -> Self::I64Store32;
+    fn i64_store32_offset16(store_offset16) -> Self::I64Store32Offset16;
+    fn i64_store32_offset16_imm16(store_offset16_imm16) -> Self::I64Store32Offset16Imm16;
+    fn i64_store32_at(store_at) -> Self::I64Store32At;
+    fn i64_store32_at_imm16(store_at_imm16) -> Self::I64Store32AtImm16;
+
+    fn f32_store(store) -> Self::F32Store;
+    fn f32_store_offset16(store_offset16) -> Self::F32StoreOffset16;
+    fn f32_store_at(store_at) -> Self::F32StoreAt;
+
+    fn f64_store(store) -> Self::F64Store;
+    fn f64_store_offset16(store_offset16) -> Self::F64StoreOffset16;
+    fn f64_store_at(store_at) -> Self::F64StoreAt;
 }

--- a/crates/wasmi/src/func/into_func.rs
+++ b/crates/wasmi/src/func/into_func.rs
@@ -328,6 +328,7 @@ mod tests {
         marker: core::marker::PhantomData<fn() -> T>,
     }
     /// Utility trait for the fallback case of the `implements_wasm_results` macro.
+    #[allow(dead_code)] // TODO: somehow the tests work without this which is strange.
     pub trait ImplementsWasmRetFallback {
         const VALUE: bool = false;
     }
@@ -356,6 +357,8 @@ mod tests {
 
     #[test]
     fn into_func_trait_impls() {
+        assert!(!implements_wasm_results!(String));
+        assert!(!implements_wasm_results!(Option<i32>));
         assert!(implements_wasm_results!(()));
         assert!(implements_wasm_results!(i32));
         assert!(implements_wasm_results!((i32,)));


### PR DESCRIPTION
This disentangles the macro heavy code and makes it a bit more readable. A superior version would be to use proc. macros and automatically generate constructors for the `Instruction` enum, however, that also introduces a lot of complexity. 