### PR TITLE
Fix `isub` -> `iadd` simplification

### DIFF
--- a/crates/wasmi/src/engine/translator/tests/op/binary/i32_sub.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/binary/i32_sub.rs
@@ -46,8 +46,8 @@ fn reg_imm() {
     test_reg_imm(i32::MAX - 1);
     test_reg_imm(i32::MIN);
     test_reg_imm(i32::MIN + 1);
-    test_reg_imm(i16::MIN as i32);
-    test_reg_imm(i16::MAX as i32 + 2);
+    test_reg_imm(i32::from(i16::MIN));
+    test_reg_imm(i32::from(i16::MAX) + 2);
 }
 
 fn test_reg_imm(value: i32) {

--- a/crates/wasmi/src/engine/translator/tests/op/binary/i32_sub.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/binary/i32_sub.rs
@@ -42,7 +42,28 @@ fn reg_imm16_rev() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn reg_imm() {
-    test_binary_reg_imm32(WASM_OP, i32::MAX, Instruction::i32_sub)
+    test_reg_imm(i32::MAX);
+    test_reg_imm(i32::MAX - 1);
+    test_reg_imm(i32::MIN);
+    test_reg_imm(i32::MIN + 1);
+    test_reg_imm(i16::MIN as i32);
+    test_reg_imm(i16::MAX as i32 + 2);
+}
+
+fn test_reg_imm(value: i32) {
+    let mut testcase = testcase_binary_reg_imm(WASM_OP, value);
+    testcase.expect_func(
+        ExpectedFunc::new([
+            Instruction::i32_add(
+                Register::from_i16(1),
+                Register::from_i16(0),
+                Register::from_i16(-1),
+            ),
+            Instruction::return_reg(Register::from_i16(1)),
+        ])
+        .consts([value.wrapping_neg()]),
+    );
+    testcase.run()
 }
 
 #[test]

--- a/crates/wasmi/src/engine/translator/tests/op/binary/i64_sub.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/binary/i64_sub.rs
@@ -40,7 +40,28 @@ fn reg_imm16_rev() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn reg_imm() {
-    test_binary_reg_imm32(WASM_OP, i64::MAX, Instruction::i64_sub)
+    test_reg_imm(i64::MAX);
+    test_reg_imm(i64::MAX - 1);
+    test_reg_imm(i64::MIN);
+    test_reg_imm(i64::MIN + 1);
+    test_reg_imm(i16::MIN as i64);
+    test_reg_imm(i16::MAX as i64 + 2);
+}
+
+fn test_reg_imm(value: i64) {
+    let mut testcase = testcase_binary_reg_imm(WASM_OP, value);
+    testcase.expect_func(
+        ExpectedFunc::new([
+            Instruction::i64_add(
+                Register::from_i16(1),
+                Register::from_i16(0),
+                Register::from_i16(-1),
+            ),
+            Instruction::return_reg(Register::from_i16(1)),
+        ])
+        .consts([value.wrapping_neg()]),
+    );
+    testcase.run()
 }
 
 #[test]

--- a/crates/wasmi/src/engine/translator/tests/op/binary/i64_sub.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/binary/i64_sub.rs
@@ -44,8 +44,8 @@ fn reg_imm() {
     test_reg_imm(i64::MAX - 1);
     test_reg_imm(i64::MIN);
     test_reg_imm(i64::MIN + 1);
-    test_reg_imm(i16::MIN as i64);
-    test_reg_imm(i16::MAX as i64 + 2);
+    test_reg_imm(i64::from(i16::MIN));
+    test_reg_imm(i64::from(i16::MAX) + 2);
 }
 
 fn test_reg_imm(value: i64) {

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -2532,14 +2532,6 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                     // Simplification: Translate `i64.sub r c` as `i64.add r -c`
                     return Ok(true);
                 }
-                if this.try_push_binary_instr_imm16(
-                    lhs,
-                    rhs.wrapping_neg(),
-                    Instruction::i64_add_imm16,
-                )? {
-                    // Simplification: Translate `i64.sub r c` as `i64.add r -c`
-                    return Ok(true);
-                }
                 this.push_binary_instr_imm(lhs, rhs.wrapping_neg(), Instruction::i64_add)?;
                 Ok(true)
             },

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -2207,11 +2207,16 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                     this.alloc.stack.push_register(lhs)?;
                     return Ok(true);
                 }
-                if this.try_push_binary_instr_imm16(lhs, -rhs, Instruction::i32_add_imm16)? {
+                if this.try_push_binary_instr_imm16(
+                    lhs,
+                    rhs.wrapping_neg(),
+                    Instruction::i32_add_imm16,
+                )? {
                     // Simplification: Translate `i32.sub r c` as `i32.add r -c`
                     return Ok(true);
                 }
-                Ok(false)
+                this.push_binary_instr_imm(lhs, rhs.wrapping_neg(), Instruction::i32_add)?;
+                Ok(true)
             },
             Self::no_custom_opt,
         )
@@ -2519,11 +2524,24 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                     this.alloc.stack.push_register(lhs)?;
                     return Ok(true);
                 }
-                if this.try_push_binary_instr_imm16(lhs, -rhs, Instruction::i64_add_imm16)? {
+                if this.try_push_binary_instr_imm16(
+                    lhs,
+                    rhs.wrapping_neg(),
+                    Instruction::i64_add_imm16,
+                )? {
                     // Simplification: Translate `i64.sub r c` as `i64.add r -c`
                     return Ok(true);
                 }
-                Ok(false)
+                if this.try_push_binary_instr_imm16(
+                    lhs,
+                    rhs.wrapping_neg(),
+                    Instruction::i64_add_imm16,
+                )? {
+                    // Simplification: Translate `i64.sub r c` as `i64.add r -c`
+                    return Ok(true);
+                }
+                this.push_binary_instr_imm(lhs, rhs.wrapping_neg(), Instruction::i64_add)?;
+                Ok(true)
             },
             Self::no_custom_opt,
         )


### PR DESCRIPTION
This fixes a bug with a niche value when `rhs=i16::MIN` since there is no symmetric equivalent for `-i16::MIN` that fits inside an `i16` value. This made the optimization fail for `rhs=i16::MIN`. By always compiling `isub` as `iadd` with negated constant `rhs` value we avoid this situation gracefully.