### PR TITLE
Fix consume_fuel doc

### DIFF
--- a/crates/wasmi/src/func/caller.rs
+++ b/crates/wasmi/src/func/caller.rs
@@ -73,10 +73,6 @@ impl<'a, T> Caller<'a, T> {
     ///
     /// Returns the remaining amount of fuel after this operation.
     ///
-    /// # Panics
-    ///
-    /// If this overflows the consumed fuel counter.
-    ///
     /// # Errors
     ///
     /// - If fuel metering is disabled.

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -944,10 +944,6 @@ impl<T> Store<T> {
     ///
     /// Returns the remaining amount of fuel after this operation.
     ///
-    /// # Panics
-    ///
-    /// If this overflows the consumed fuel counter.
-    ///
     /// # Errors
     ///
     /// - If fuel metering is disabled.


### PR DESCRIPTION
The doc mentions that `consume_fuel` would panic if it overflows the fuel counter, but we are using [checked_math under the hood ](https://github.com/wasmi-labs/wasmi/blob/e011f7d1070aa90c85fbcf0d6835a7104d1aba17/crates/wasmi/src/store.rs#L299-L305) so not sure if this is accurate.