### PR TITLE
feat: add static buffer as an alternative to allocating memory

### DIFF
--- a/crates/wasmi/src/memory/buffer.rs
+++ b/crates/wasmi/src/memory/buffer.rs
@@ -1,6 +1,7 @@
+use core::mem::ManuallyDrop;
 use std::{vec, vec::Vec};
 
-/// A `Vec`-based byte buffer implementation.
+/// A byte buffer implementation.
 ///
 /// # Note
 ///
@@ -9,8 +10,15 @@ use std::{vec, vec::Vec};
 /// solution fitting any platform.
 #[derive(Debug)]
 pub struct ByteBuffer {
-    bytes: Vec<u8>,
+    ptr: *mut u8,
+    len: usize,
+    capacity: usize,
+    is_static: bool,
 }
+
+// Safety: `ByteBuffer` is essentially an enum of `Vec<u8>` or `&'static mut [u8]`.
+// They both are `Send` so this is sound.
+unsafe impl Send for ByteBuffer {}
 
 impl ByteBuffer {
     /// Creates a new byte buffer with the given initial length.
@@ -20,8 +28,30 @@ impl ByteBuffer {
     /// - If the initial length is 0.
     /// - If the initial length exceeds the maximum supported limit.
     pub fn new(initial_len: usize) -> Self {
+        let mut vec = ManuallyDrop::new(vec![0x00_u8; initial_len]);
+        let (ptr, len, capacity) = (vec.as_mut_ptr(), vec.len(), vec.capacity());
         Self {
-            bytes: vec![0x00_u8; initial_len],
+            ptr,
+            len,
+            capacity,
+            is_static: false,
+        }
+    }
+
+    /// Creates a new byte buffer with the given initial length.
+    ///
+    /// # Errors
+    ///
+    /// - If the initial length is 0.
+    /// - If the initial length exceeds the maximum supported limit.
+    pub fn new_static(buf: &'static mut [u8], initial_len: usize) -> Self {
+        assert!(initial_len <= buf.len());
+        buf.fill(0);
+        Self {
+            ptr: buf.as_mut_ptr(),
+            len: initial_len,
+            capacity: buf.len(),
+            is_static: true,
         }
     }
 
@@ -29,24 +59,120 @@ impl ByteBuffer {
     ///
     /// # Panics
     ///
-    /// If the current size of the [`ByteBuffer`] is larger than `new_size`.
+    /// - If the current size of the [`ByteBuffer`] is larger than `new_size`.
+    /// - If backed by static buffer and `new_size` is larger than it's capacity.
     pub fn grow(&mut self, new_size: usize) {
         assert!(new_size >= self.len());
-        self.bytes.resize(new_size, 0x00_u8);
+        if self.is_static {
+            if self.capacity < new_size {
+                panic!("Cannot grow static byte buffer more then it's capacity")
+            }
+            self.len = new_size;
+        } else {
+            // Safety: those parts have been obtained from `Vec`.
+            let vec = unsafe { Vec::from_raw_parts(self.ptr, self.len, self.capacity) };
+            let mut vec = ManuallyDrop::new(vec);
+            vec.resize(new_size, 0x00_u8);
+            let (ptr, len, capacity) = (vec.as_mut_ptr(), vec.len(), vec.capacity());
+            self.ptr = ptr;
+            self.len = len;
+            self.capacity = capacity;
+        }
     }
 
     /// Returns the length of the byte buffer in bytes.
     pub fn len(&self) -> usize {
-        self.bytes.len()
+        self.len
     }
 
     /// Returns a shared slice to the bytes underlying to the byte buffer.
     pub fn data(&self) -> &[u8] {
-        &self.bytes[..]
+        // Safety: either is backed by a `Vec` or a static buffer, ptr[0..len] is valid.
+        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
     }
 
     /// Returns an exclusive slice to the bytes underlying to the byte buffer.
     pub fn data_mut(&mut self) -> &mut [u8] {
-        &mut self.bytes[..]
+        // Safety: either is backed by a `Vec` or a static buffer, ptr[0..len] is valid.
+        unsafe { core::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}
+
+impl Drop for ByteBuffer {
+    fn drop(&mut self) {
+        if !self.is_static {
+            // Safety: those parts have been obtained from `Vec`.
+            unsafe { Vec::from_raw_parts(self.ptr, self.len, self.capacity) };
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_basic_allocation_deallocation() {
+        let buffer = ByteBuffer::new(10);
+        assert_eq!(buffer.len(), 10);
+        // Dropping the buffer should not cause UB.
+    }
+
+    #[test]
+    fn test_basic_data_manipulation() {
+        let mut buffer = ByteBuffer::new(10);
+        assert_eq!(buffer.len(), 10);
+        let data = buffer.data(); // test we can read the data
+        assert_eq!(data, &[0; 10]);
+        let data = buffer.data_mut(); // test we can take a mutable reference to the data
+        data[4] = 4; // test we can write to the data and it is not UB
+        let data = buffer.data(); // test we can take a new reference to the data
+        assert_eq!(data, &[0, 0, 0, 0, 4, 0, 0, 0, 0, 0]); // test we can read the data
+                                                           // test drop is okay
+    }
+
+    #[test]
+    fn test_static_buffer_initialization() {
+        static mut BUF: [u8; 10] = [7; 10];
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
+        let mut buffer = ByteBuffer::new_static(buf, 5);
+        assert_eq!(buffer.len(), 5);
+        // Modifying the static buffer through ByteBuffer and checking its content.
+        let data = buffer.data_mut();
+        data[0] = 1;
+        unsafe {
+            assert_eq!(BUF[0], 1);
+        }
+    }
+
+    #[test]
+    fn test_growing_buffer() {
+        let mut buffer = ByteBuffer::new(5);
+        buffer.grow(10);
+        assert_eq!(buffer.len(), 10);
+        assert_eq!(buffer.data(), &[0; 10]);
+    }
+
+    #[test]
+    fn test_growing_static() {
+        static mut BUF: [u8; 10] = [7; 10];
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
+        let mut buffer = ByteBuffer::new_static(buf, 5);
+        assert_eq!(buffer.len(), 5);
+        assert_eq!(buffer.data(), &[0; 5]);
+        buffer.grow(8);
+        assert_eq!(buffer.len(), 8);
+        assert_eq!(buffer.data(), &[0; 8]);
+        buffer.grow(10);
+        assert_eq!(buffer.len(), 10);
+        assert_eq!(buffer.data(), &[0; 10]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_static_buffer_overflow() {
+        static mut BUF: [u8; 5] = [7; 5];
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
+        let mut buffer = ByteBuffer::new_static(buf, 5);
+        buffer.grow(10); // This should panic.
     }
 }

--- a/crates/wasmi/src/memory/buffer.rs
+++ b/crates/wasmi/src/memory/buffer.rs
@@ -46,7 +46,7 @@ impl ByteBuffer {
     /// - If the initial length exceeds the maximum supported limit.
     pub fn new_static(buf: &'static mut [u8], initial_len: usize) -> Self {
         assert!(initial_len <= buf.len());
-        buf.fill(0);
+        buf[..initial_len].fill(0x00_u8);
         Self {
             ptr: buf.as_mut_ptr(),
             len: initial_len,
@@ -67,7 +67,9 @@ impl ByteBuffer {
             if self.capacity < new_size {
                 panic!("Cannot grow static byte buffer more then it's capacity")
             }
+            let len = self.len();
             self.len = new_size;
+            self.data_mut()[len..new_size].fill(0x00_u8);
         } else {
             // Safety: those parts have been obtained from `Vec`.
             let vec = unsafe { Vec::from_raw_parts(self.ptr, self.len, self.capacity) };

--- a/crates/wasmi/src/memory/error.rs
+++ b/crates/wasmi/src/memory/error.rs
@@ -22,6 +22,8 @@ pub enum MemoryError {
     },
     /// Tried to create too many memories
     TooManyMemories,
+    /// Tried to create memory with invalid static buffer size
+    InvalidStaticBufferSize,
 }
 
 impl Display for MemoryError {
@@ -44,6 +46,9 @@ impl Display for MemoryError {
             }
             Self::TooManyMemories => {
                 write!(f, "too many memories")
+            }
+            Self::InvalidStaticBufferSize => {
+                write!(f, "tried to use too small static buffer")
             }
         }
     }


### PR DESCRIPTION
Draft for static buffer as an alternative to allocating memory. Closes #878.

User can give `fn() -> Option<&'static mut [u8]>`, which is a factory for static buffers. I personally only need one, but there are problems if we want user to provide `&'static mut [u8]`. It is not `Copy` or `Clone` for obvious reasons, but `Config` is. It also cannot be wrapped in `RefCell` to be taken from config by shared reference, because there is a `Sync` assert. 

In my code, this feature could used in 100% safe way:
```rust
fn static_buffer_factory() -> Option<&'static mut [u8]> {
    #[repr(align(32))]
    struct Memory([u8; 64 * 1024]);

    // Now the linker will refuse to create the final binary
    // if there is not enough space in the target RAM
    static WASMI_LINEAR_MEMORY: StaticCell<Memory> = StaticCell::new();

    // Will only succeed the first time. Uses atomic CAS operations under the hood
    WASMI_LINEAR_MEMORY
        .try_init_with(|| Memory([0; 64 * 1024]))
        .map(|x| &mut x.0[..])
}

let mut config = Config::default();
let config = config.set_static_buffer_factory(static_buffer_factory);
let engine = Engine::new(config);

```

As can be seen from godbolt, rustc optimizes out enum access in the hot methods `data`, `data_mut` and `len`, so there is no need for unsafe code and enum is sufficient.

![wasmi_godbolt](https://github.com/wasmi-labs/wasmi/assets/63151578/dde12c8c-db47-4e7c-acb2-5813212e15b5)

## Unresolved questions
- Are you okay with that kind of design?
- Should we strengthen/weaken the requirements? For example, add an alignment check?