### PR TITLE
Update wasi-common to 17.0

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -201,20 +201,20 @@ impl Args {
     pub fn wasi_context(&self) -> Result<WasiCtx, Error> {
         let mut wasi_builder = WasiCtxBuilder::new();
         for KeyValue { key, value } in &self.envs {
-            wasi_builder = wasi_builder.env(key, value)?;
+            wasi_builder.env(key, value)?;
         }
-        wasi_builder = wasi_builder.args(&self.argv())?;
+        wasi_builder.args(&self.argv())?;
         // Add pre-opened TCP sockets.
         //
         // Note that `num_fd` starts at 3 because the inherited `stdin`, `stdout` and `stderr`
         // are already mapped to `0, 1, 2` respectively.
-        wasi_builder = wasi_builder.inherit_stdio();
+        wasi_builder.inherit_stdio();
         for (socket, num_fd) in self.preopen_sockets()?.into_iter().zip(3..) {
-            wasi_builder = wasi_builder.preopened_socket(num_fd, socket)?;
+            wasi_builder.preopened_socket(num_fd, socket)?;
         }
         // Add pre-opened directories.
         for (dir_name, dir) in self.preopen_dirs()? {
-            wasi_builder = wasi_builder.preopened_dir(dir, dir_name)?;
+            wasi_builder.preopened_dir(dir, dir_name)?;
         }
         Ok(wasi_builder.build())
     }

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-wasi-common = "2.0"
-wasi-cap-std-sync = "2.0"
-wiggle = { version = "2.0", default-features = false, features = ["wiggle_metadata"] }
+wasi-common = "12.0"
+wasi-cap-std-sync = "12.0"
+wiggle = { version = "12.0", default-features = false, features = ["wiggle_metadata"] }
 wasmi = { version = "0.32.0-beta.6", path = "../wasmi" }
 
 [dev-dependencies]

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-wasi-common = "12.0"
-wasi-cap-std-sync = "12.0"
-wiggle = { version = "12.0", default-features = false, features = ["wiggle_metadata"] }
+wasi-common = "17.0"
+wasi-cap-std-sync = "17.0"
+wiggle = { version = "17.0", default-features = false, features = ["wiggle_metadata"] }
 wasmi = { version = "0.32.0-beta.6", path = "../wasmi" }
 
 [dev-dependencies]

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-wasi-common = "17.0"
-wasi-cap-std-sync = "17.0"
+wasi-common = { version = "17.0", default-features = false, features = ["wiggle_metadata", "trace_log"] }
+wasi-cap-std-sync = {version = "17.0", default-features = false }
 wiggle = { version = "17.0", default-features = false, features = ["wiggle_metadata"] }
 wasmi = { version = "0.32.0-beta.6", path = "../wasmi" }
 

--- a/crates/wasi/src/guest_memory.rs
+++ b/crates/wasi/src/guest_memory.rs
@@ -1,4 +1,6 @@
 use wiggle::{borrow::BorrowChecker, BorrowHandle, GuestError, GuestMemory, Region};
+use std::slice;
+use std::cell::UnsafeCell;
 
 /// Lightweight `wasmi::Memory` wrapper so we can implement the
 /// `wiggle::GuestMemory` trait on it.
@@ -23,8 +25,10 @@ impl<'a> WasmiGuestMemory<'a> {
 }
 
 unsafe impl GuestMemory for WasmiGuestMemory<'_> {
-    fn base(&self) -> (*mut u8, u32) {
-        (self.mem.as_ptr() as *mut u8, self.mem.len() as u32)
+    fn base(&self) -> &[UnsafeCell<u8>] {
+        unsafe {
+            slice::from_raw_parts(self.mem.as_ptr() as *mut u8 as *const UnsafeCell<u8>, self.mem.len())
+        }
     }
     fn has_outstanding_borrows(&self) -> bool {
         self.bc.has_outstanding_borrows()

--- a/crates/wasi/src/sync/snapshots/preview_1.rs
+++ b/crates/wasi/src/sync/snapshots/preview_1.rs
@@ -3,7 +3,7 @@ use std::{
     pin::Pin,
     task::{Context, RawWaker, RawWakerVTable, Waker},
 };
-use wasi_common::Error;
+use wasi_common::{Error, ErrorExt, I32Exit};
 use wasmi::{Caller, Extern, Linker};
 
 // Creates a dummy `RawWaker`. We can only create Wakers from `RawWaker`s
@@ -57,8 +57,7 @@ macro_rules! impl_add_to_linker_for_funcs {
             linker: &mut Linker<T>,
             wasi_ctx: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
         ) -> Result<(), Error>
-        where U: wasi_common::snapshots::preview_1::wasi_snapshot_preview1::WasiSnapshotPreview1 +
-                 wasi_common::snapshots::preview_1::wasi_snapshot_preview1::UserErrorConversion
+        where U: wasi_common::snapshots::preview_1::wasi_snapshot_preview1::WasiSnapshotPreview1 
         {
             $(
                 // $(#[$docs])* // TODO: find place for docs
@@ -76,13 +75,19 @@ macro_rules! impl_add_to_linker_for_funcs {
                             let memory = WasmiGuestMemory::new(memory);
                             match wasi_common::snapshots::preview_1::wasi_snapshot_preview1::$fname(ctx, &memory, $($arg,)*).await {
                                 Ok(r) => Ok(<$ret>::from(r)),
-                                Err(wiggle::Trap::String(err)) => Err(wasmi::Error::new(err)),
-                                Err(wiggle::Trap::I32Exit(i)) => Err(wasmi::Error::i32_exit(i)),
+                                Err(trap) => {
+                                    if let Some(exit) = trap.downcast_ref::<I32Exit>() {
+                                        Err(wasmi::Error::i32_exit(exit.0))
+                                    } else {
+                                        Err(wasmi::Error::new(trap.to_string()))
+                                    }
+
+                                }
                             }
                         };
                         run_in_dummy_executor(result)?
                     }
-                )?;
+                ).map_err(|e| Error::context(Error::not_supported(), e.to_string()))?;
             )*
             Ok(())
         }


### PR DESCRIPTION
We're on 2.0, the latest version is 18.0 though it's not yet available for wasi-cap-std-sync. 2.0 is more than a year old and still uses `syn 1.0` among other older dependencies.

They greatly changed how errors work in https://github.com/bytecodealliance/wasmtime/pull/5149, but hopefully the new error code here is roughly equivalent.


(Would appreciate a release if this gets merged)