### PR TITLE
Improve `no_std` imports for the entire workspace

### DIFF
--- a/crates/arena/src/component_vec.rs
+++ b/crates/arena/src/component_vec.rs
@@ -153,6 +153,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{format, string::String};
 
     /// Add `n` components and perform checks along the way.
     fn add_components(vec: &mut ComponentVec<usize, String>, n: usize) {

--- a/crates/arena/src/component_vec.rs
+++ b/crates/arena/src/component_vec.rs
@@ -1,10 +1,10 @@
 use crate::ArenaIndex;
-use alloc::vec::Vec;
 use core::{
     fmt::{self, Debug},
     marker::PhantomData,
     ops::{Index, IndexMut},
 };
+use std::vec::Vec;
 
 /// Stores components for entities backed by a [`Vec`].
 pub struct ComponentVec<Idx, T> {

--- a/crates/arena/src/dedup.rs
+++ b/crates/arena/src/dedup.rs
@@ -1,6 +1,6 @@
 use super::{Arena, ArenaIndex, Iter, IterMut};
-use alloc::collections::BTreeMap;
 use core::ops::{Index, IndexMut};
+use std::collections::BTreeMap;
 
 /// A deduplicating arena allocator with a given index and entity type.
 ///

--- a/crates/arena/src/lib.rs
+++ b/crates/arena/src/lib.rs
@@ -17,7 +17,8 @@
     clippy::items_after_statements
 )]
 
-extern crate alloc;
+#[cfg(not(feature = "std"))]
+extern crate alloc as std;
 
 #[cfg(feature = "std")]
 extern crate std;
@@ -30,13 +31,13 @@ mod guarded;
 mod tests;
 
 pub use self::{component_vec::ComponentVec, dedup::DedupArena, guarded::GuardedEntity};
-use alloc::vec::Vec;
 use core::{
     iter::Enumerate,
     marker::PhantomData,
     ops::{Index, IndexMut},
     slice,
 };
+use std::vec::Vec;
 
 /// Types that can be used as indices for arenas.
 pub trait ArenaIndex: Copy {

--- a/crates/arena/src/lib.rs
+++ b/crates/arena/src/lib.rs
@@ -4,7 +4,7 @@
 //! These allocators mainly serve as the backbone for an efficient Wasm store
 //! implementation.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(
     clippy::cast_lossless,
     clippy::missing_errors_doc,
@@ -16,10 +16,11 @@
     clippy::map_unwrap_or,
     clippy::items_after_statements
 )]
-#[cfg(not(feature = "std"))]
+
 extern crate alloc;
+
 #[cfg(feature = "std")]
-extern crate std as alloc;
+extern crate std;
 
 mod component_vec;
 mod dedup;
@@ -31,7 +32,7 @@ mod tests;
 pub use self::{component_vec::ComponentVec, dedup::DedupArena, guarded::GuardedEntity};
 use alloc::vec::Vec;
 use core::{
-    iter::{DoubleEndedIterator, Enumerate, ExactSizeIterator},
+    iter::Enumerate,
     marker::PhantomData,
     ops::{Index, IndexMut},
     slice,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(
     clippy::cast_lossless,
     clippy::missing_errors_doc,
@@ -18,11 +18,10 @@ mod units;
 mod untyped;
 mod value;
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 #[cfg(feature = "std")]
-extern crate std as alloc;
+extern crate std;
 
 use self::value::{
     ArithmeticOps,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,7 +18,8 @@ mod units;
 mod untyped;
 mod value;
 
-extern crate alloc;
+#[cfg(not(feature = "std"))]
+extern crate alloc as std;
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/crates/core/src/trap.rs
+++ b/crates/core/src/trap.rs
@@ -1,6 +1,6 @@
 use crate::HostError;
-use alloc::{boxed::Box, string::String};
 use core::fmt::{self, Display};
+use std::{boxed::Box, string::String};
 
 #[cfg(feature = "std")]
 use std::error::Error as StdError;

--- a/crates/wasmi/src/engine/bytecode/provider.rs
+++ b/crates/wasmi/src/engine/bytecode/provider.rs
@@ -1,6 +1,6 @@
 use super::{AnyConst32, Register};
 use crate::{engine::translator::TranslationError, Error};
-use alloc::vec::{Drain, Vec};
+use std::vec::{Drain, Vec};
 use wasmi_core::UntypedValue;
 
 #[cfg(doc)]

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -13,7 +13,6 @@ use crate::{
     store::{Fuel, FuelError},
     Error,
 };
-use alloc::boxed::Box;
 use core::{
     cell::UnsafeCell,
     fmt,
@@ -23,6 +22,7 @@ use core::{
     slice,
     sync::atomic::{AtomicU8, Ordering},
 };
+use std::boxed::Box;
 use wasmi_arena::{Arena, ArenaIndex};
 use wasmi_core::TrapCode;
 use wasmparser::{FuncToValidate, ValidatorResources};

--- a/crates/wasmi/src/engine/executor/stack/calls.rs
+++ b/crates/wasmi/src/engine/executor/stack/calls.rs
@@ -3,7 +3,7 @@ use crate::{
     engine::{bytecode::RegisterSpan, code_map::InstructionPtr},
     Instance,
 };
-use alloc::vec::Vec;
+use std::vec::Vec;
 use wasmi_core::TrapCode;
 
 #[cfg(doc)]

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -3,8 +3,8 @@ use crate::{
     core::UntypedValue,
     engine::{bytecode::Register, CompiledFuncEntity},
 };
-use alloc::{vec, vec::Vec};
 use core::{fmt, fmt::Debug, iter, mem, ptr};
+use std::{vec, vec::Vec};
 use wasmi_core::TrapCode;
 
 #[cfg(doc)]

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -3,7 +3,7 @@ use crate::{
     core::UntypedValue,
     engine::{bytecode::Register, CompiledFuncEntity},
 };
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use core::{fmt, fmt::Debug, iter, mem, ptr};
 use wasmi_core::TrapCode;
 

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -54,12 +54,12 @@ use crate::{
     FuncType,
     StoreContextMut,
 };
-use alloc::{
+use core::sync::atomic::{AtomicU32, Ordering};
+use spin::{Mutex, RwLock};
+use std::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use core::sync::atomic::{AtomicU32, Ordering};
-use spin::{Mutex, RwLock};
 use wasmi_arena::{ArenaIndex, GuardedEntity};
 use wasmparser::{FuncToValidate, FuncValidatorAllocations, ValidatorResources};
 

--- a/crates/wasmi/src/engine/translator/control_stack.rs
+++ b/crates/wasmi/src/engine/translator/control_stack.rs
@@ -3,7 +3,7 @@ use crate::{
     engine::bytecode::{Provider, ProviderSliceStack},
     Error,
 };
-use alloc::vec::{Drain, Vec};
+use std::vec::{Drain, Vec};
 
 /// An acquired branch target.
 #[derive(Debug)]

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -28,8 +28,8 @@ use crate::{
     module::ModuleHeader,
     Error,
 };
-use alloc::vec::{Drain, Vec};
 use core::mem;
+use std::vec::{Drain, Vec};
 use wasmi_core::{UntypedValue, ValueType, F32};
 
 /// A reference to an instruction of the partially

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -1404,7 +1404,7 @@ impl Instruction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::{bytecode::RegisterSpan, translator::typed_value::TypedValue};
+    use crate::engine::translator::typed_value::TypedValue;
 
     #[test]
     fn has_overlapping_copies_works() {

--- a/crates/wasmi/src/engine/translator/labels.rs
+++ b/crates/wasmi/src/engine/translator/labels.rs
@@ -1,10 +1,10 @@
 use super::Instr;
 use crate::{engine::bytecode::BranchOffset, Error};
-use alloc::vec::Vec;
 use core::{
     fmt::{self, Display},
     slice::Iter as SliceIter,
 };
+use std::vec::Vec;
 
 /// A label during the Wasmi compilation process.
 #[derive(Debug, Copy, Clone)]

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -61,8 +61,8 @@ use crate::{
     Error,
     FuncType,
 };
-use alloc::vec::Vec;
 use core::fmt;
+use std::vec::Vec;
 use wasmi_core::{TrapCode, UntypedValue, ValueType};
 use wasmparser::{
     BinaryReaderError,

--- a/crates/wasmi/src/engine/translator/stack/consts.rs
+++ b/crates/wasmi/src/engine/translator/stack/consts.rs
@@ -1,10 +1,10 @@
 use super::Register;
 use crate::{core::UntypedValue, engine::TranslationError, Error};
-use alloc::{
+use core::{iter::Rev, slice::Iter as SliceIter};
+use std::{
     collections::{btree_map, BTreeMap},
     vec::Vec,
 };
-use core::{iter::Rev, slice::Iter as SliceIter};
 
 /// A pool of deduplicated function local constant values.
 ///

--- a/crates/wasmi/src/engine/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/stack/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     Error,
     FuncType,
 };
-use alloc::vec::Vec;
+use std::vec::Vec;
 use wasmi_core::UntypedValue;
 
 /// Typed inputs to Wasmi bytecode instructions.

--- a/crates/wasmi/src/engine/translator/stack/provider.rs
+++ b/crates/wasmi/src/engine/translator/stack/provider.rs
@@ -2,8 +2,8 @@ use ::core::iter;
 
 use super::{RegisterAlloc, TypedValue};
 use crate::{engine::bytecode::Register, Error};
-use alloc::vec::Vec;
 use smallvec::SmallVec;
+use std::vec::Vec;
 
 #[cfg(doc)]
 use wasmi_core::UntypedValue;

--- a/crates/wasmi/src/engine/translator/stack/register_alloc.rs
+++ b/crates/wasmi/src/engine/translator/stack/register_alloc.rs
@@ -6,12 +6,12 @@ use crate::{
     },
     Error,
 };
-use alloc::collections::BTreeSet;
 use core::{
     cmp::{max, min},
     num::NonZeroUsize,
 };
 use multi_stash::{Key, Key as StashKey, MultiStash};
+use std::collections::BTreeSet;
 
 #[cfg(doc)]
 use crate::engine::translator::InstrEncoder;

--- a/crates/wasmi/src/engine/translator/tests/driver.rs
+++ b/crates/wasmi/src/engine/translator/tests/driver.rs
@@ -6,7 +6,7 @@ use crate::{
     Module,
 };
 use core::sync::atomic::Ordering;
-use std::sync::atomic::AtomicBool;
+use std::{boxed::Box, sync::atomic::AtomicBool, vec::Vec};
 use wasmi_core::UntypedValue;
 
 /// A test driver for translation tests.

--- a/crates/wasmi/src/engine/translator/tests/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     Engine,
     Module,
 };
-use std::fmt::Display;
+use std::{fmt::Display, format, vec::Vec};
 
 /// Converts the `wat` string source into `wasm` encoded byte.
 fn wat2wasm(wat: &str) -> Vec<u8> {

--- a/crates/wasmi/src/engine/translator/tests/op/binary/i64_rem_u.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/binary/i64_rem_u.rs
@@ -1,5 +1,4 @@
 use super::*;
-use core::num::NonZeroU64;
 use wasmi_core::TrapCode;
 
 const WASM_OP: WasmOp = WasmOp::binary(WasmType::I64, "rem_u");

--- a/crates/wasmi/src/engine/translator/tests/op/block.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/block.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::engine::{
     bytecode::{BranchOffset, BranchOffset16, RegisterSpan},
-    translator::tests::{display_wasm::DisplayValueType, wasm_type::WasmType},
+    translator::tests::wasm_type::WasmType,
 };
 use std::fmt::Display;
 

--- a/crates/wasmi/src/engine/translator/tests/op/br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br.rs
@@ -1,14 +1,7 @@
 use super::*;
 use crate::{
     core::UntypedValue,
-    engine::{
-        bytecode::BranchOffset,
-        translator::tests::{
-            display_wasm::DisplayValueType,
-            driver::ExpectedFunc,
-            wasm_type::WasmType,
-        },
-    },
+    engine::{bytecode::BranchOffset, translator::tests::wasm_type::WasmType},
 };
 use core::fmt::Display;
 

--- a/crates/wasmi/src/engine/translator/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_if.rs
@@ -1,11 +1,7 @@
 use super::*;
 use crate::engine::{
     bytecode::{BranchOffset, BranchOffset16, RegisterSpan},
-    translator::tests::{
-        display_wasm::DisplayValueType,
-        driver::ExpectedFunc,
-        wasm_type::WasmType,
-    },
+    translator::tests::wasm_type::WasmType,
 };
 use core::fmt::Display;
 use std::vec::Vec;

--- a/crates/wasmi/src/engine/translator/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_if.rs
@@ -8,6 +8,7 @@ use crate::engine::{
     },
 };
 use core::fmt::Display;
+use std::vec::Vec;
 use wasmi_core::UntypedValue;
 
 #[test]

--- a/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
@@ -1,10 +1,7 @@
 use super::{wasm_type::WasmType, *};
 use crate::{
     core::ValueType,
-    engine::{
-        bytecode::{BranchOffset, BranchOffset16, GlobalIdx},
-        translator::tests::display_wasm::DisplayValueType,
-    },
+    engine::bytecode::{BranchOffset, BranchOffset16, GlobalIdx},
 };
 use std::fmt::{Debug, Display};
 

--- a/crates/wasmi/src/engine/translator/tests/op/global_set.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/global_set.rs
@@ -1,9 +1,6 @@
 use super::*;
 
-use crate::engine::{
-    bytecode::GlobalIdx,
-    translator::tests::{display_wasm::DisplayValueType, driver::ExpectedFunc},
-};
+use crate::engine::bytecode::GlobalIdx;
 use core::fmt::Display;
 use wasm_type::WasmType;
 use wasmi_core::ValueType;

--- a/crates/wasmi/src/engine/translator/tests/op/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/mod.rs
@@ -50,6 +50,7 @@ use super::{
     WasmOp,
     WasmType,
 };
+use std::format;
 
 /// Creates an [`Const32<i32>`] from the given `i32` value.
 ///

--- a/crates/wasmi/src/engine/translator/tests/op/return_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/return_.rs
@@ -1,12 +1,5 @@
 use super::*;
-use crate::engine::{
-    bytecode::RegisterSpan,
-    translator::tests::{
-        display_wasm::DisplayValueType,
-        driver::ExpectedFunc,
-        wasm_type::WasmType,
-    },
-};
+use crate::engine::{bytecode::RegisterSpan, translator::tests::wasm_type::WasmType};
 use core::fmt::Display;
 
 #[test]

--- a/crates/wasmi/src/engine/translator/tests/op/select.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/select.rs
@@ -1,12 +1,5 @@
 use super::*;
-use crate::{
-    core::ValueType,
-    engine::translator::tests::{
-        display_wasm::DisplayValueType,
-        driver::ExpectedFunc,
-        wasm_type::WasmType,
-    },
-};
+use crate::{core::ValueType, engine::translator::tests::wasm_type::WasmType};
 use core::{fmt, fmt::Display};
 
 /// Tells which kind of `select` instruction to test.

--- a/crates/wasmi/src/engine/translator/tests/op/unary/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/unary/mod.rs
@@ -4,7 +4,6 @@ mod conversion;
 mod op;
 
 use super::*;
-use crate::engine::translator::tests::driver::{ExpectedFunc, TranslationTest};
 use std::{fmt::Display, vec::Vec};
 use wasm_type::WasmType;
 use wasmi_core::{TrapCode, UntypedValue};

--- a/crates/wasmi/src/engine/translator/tests/op/unary/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/unary/mod.rs
@@ -5,7 +5,7 @@ mod op;
 
 use super::*;
 use crate::engine::translator::tests::driver::{ExpectedFunc, TranslationTest};
-use std::fmt::Display;
+use std::{fmt::Display, vec::Vec};
 use wasm_type::WasmType;
 use wasmi_core::{TrapCode, UntypedValue};
 

--- a/crates/wasmi/src/engine/translator/tests/op/unary/op.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/unary/op.rs
@@ -194,7 +194,6 @@ mod f32_trunc {
 
 mod f32_nearest {
     use super::*;
-    use wasmi_core::UntypedValue;
 
     const OP_NAME: &str = "nearest";
 
@@ -343,7 +342,6 @@ mod f64_trunc {
 
 mod f64_nearest {
     use super::*;
-    use wasmi_core::UntypedValue;
 
     const OP_NAME: &str = "nearest";
 

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -29,8 +29,8 @@ use crate::{
     FuncRef,
     Mutability,
 };
-use alloc::collections::BTreeMap;
 use core::num::{NonZeroU32, NonZeroU64};
+use std::collections::BTreeMap;
 use wasmi_core::{TrapCode, ValueType, F32, F64};
 use wasmparser::VisitOperator;
 

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -12,8 +12,8 @@ use crate::{
     engine::TranslationError,
     module::ReadError,
 };
-use alloc::{boxed::Box, string::String};
 use core::{fmt, fmt::Display};
+use std::{boxed::Box, string::String};
 use wasmparser::BinaryReaderError as WasmError;
 
 /// The generic Wasmi root error type.

--- a/crates/wasmi/src/externref.rs
+++ b/crates/wasmi/src/externref.rs
@@ -1,6 +1,6 @@
 use crate::{reftype::Transposer, store::Stored, AsContextMut, StoreContext};
-use alloc::boxed::Box;
 use core::{any::Any, num::NonZeroU32};
+use std::boxed::Box;
 use wasmi_arena::ArenaIndex;
 use wasmi_core::UntypedValue;
 

--- a/crates/wasmi/src/foreach_tuple.rs
+++ b/crates/wasmi/src/foreach_tuple.rs
@@ -20,6 +20,3 @@ macro_rules! for_each_tuple {
         $mac!(16 T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16);
     }
 }
-
-#[doc(inline)]
-pub(crate) use for_each_tuple;

--- a/crates/wasmi/src/func/func_type.rs
+++ b/crates/wasmi/src/func/func_type.rs
@@ -1,6 +1,6 @@
 use crate::{core::ValueType, func::FuncError, Value};
-use alloc::{sync::Arc, vec::Vec};
 use core::fmt;
+use std::{sync::Arc, vec::Vec};
 
 /// A function type representing a function's parameter and result types.
 ///

--- a/crates/wasmi/src/func/into_func.rs
+++ b/crates/wasmi/src/func/into_func.rs
@@ -320,7 +320,6 @@ for_each_tuple!(impl_wasm_type_list);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{F32, F64};
     use std::string::String;
 
     /// Utility struct helper for the `implements_wasm_results` macro.

--- a/crates/wasmi/src/func/into_func.rs
+++ b/crates/wasmi/src/func/into_func.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use crate::{
     core::{ValueType, F32, F64},
-    foreach_tuple::for_each_tuple,
     Caller,
     Error,
     ExternRef,
@@ -322,6 +321,7 @@ for_each_tuple!(impl_wasm_type_list);
 mod tests {
     use super::*;
     use crate::core::{F32, F64};
+    use std::string::String;
 
     /// Utility struct helper for the `implements_wasm_results` macro.
     pub struct ImplementsWasmRet<T> {

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -23,8 +23,8 @@ use super::{
     Stored,
 };
 use crate::{engine::ResumableCall, Engine, Error, Value};
-use alloc::{boxed::Box, sync::Arc};
 use core::{fmt, fmt::Debug, num::NonZeroU32};
+use std::{boxed::Box, sync::Arc};
 use wasmi_arena::ArenaIndex;
 
 /// A raw index to a function entity.

--- a/crates/wasmi/src/instance/builder.rs
+++ b/crates/wasmi/src/instance/builder.rs
@@ -12,7 +12,7 @@ use crate::{
     Module,
     Table,
 };
-use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
+use std::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
 
 /// A module instance entity builder.
 #[derive(Debug)]

--- a/crates/wasmi/src/instance/exports.rs
+++ b/crates/wasmi/src/instance/exports.rs
@@ -1,6 +1,6 @@
 use crate::{AsContext, Func, FuncType, Global, GlobalType, Memory, MemoryType, Table, TableType};
-use alloc::{boxed::Box, collections::btree_map};
 use core::iter::FusedIterator;
+use std::{boxed::Box, collections::btree_map};
 
 /// An external item to a WebAssembly module.
 ///

--- a/crates/wasmi/src/instance/mod.rs
+++ b/crates/wasmi/src/instance/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     WasmParams,
     WasmResults,
 };
-use alloc::{boxed::Box, collections::BTreeMap, sync::Arc};
+use std::{boxed::Box, collections::BTreeMap, sync::Arc};
 use wasmi_arena::ArenaIndex;
 
 mod builder;

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -78,7 +78,8 @@
 )]
 #![recursion_limit = "750"]
 
-extern crate alloc;
+#[cfg(not(feature = "std"))]
+extern crate alloc as std;
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -65,7 +65,7 @@
 //! }
 //! ```
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(
     clippy::cast_lossless,
     clippy::missing_errors_doc,
@@ -78,11 +78,10 @@
 )]
 #![recursion_limit = "750"]
 
-#[cfg(not(feature = "std"))]
-#[macro_use]
 extern crate alloc;
+
 #[cfg(feature = "std")]
-extern crate std as alloc;
+extern crate std;
 
 #[macro_use]
 mod foreach_tuple;

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -18,16 +18,16 @@ use crate::{
     TableType,
     Value,
 };
-use alloc::{
-    collections::{btree_map::Entry, BTreeMap},
-    sync::Arc,
-    vec::Vec,
-};
 use core::{
     fmt,
     fmt::{Debug, Display},
     num::NonZeroUsize,
     ops::Deref,
+};
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    sync::Arc,
+    vec::Vec,
 };
 
 /// An error that may occur upon operating with [`Linker`] instances.

--- a/crates/wasmi/src/memory/buffer.rs
+++ b/crates/wasmi/src/memory/buffer.rs
@@ -1,4 +1,4 @@
-use alloc::{vec, vec::Vec};
+use std::{vec, vec::Vec};
 
 /// A `Vec`-based byte buffer implementation.
 ///

--- a/crates/wasmi/src/memory/data.rs
+++ b/crates/wasmi/src/memory/data.rs
@@ -1,5 +1,5 @@
 use crate::{module, store::Stored, AsContextMut};
-use alloc::sync::Arc;
+use std::sync::Arc;
 use wasmi_arena::ArenaIndex;
 
 /// A raw index to a data segment entity.

--- a/crates/wasmi/src/module/builder.rs
+++ b/crates/wasmi/src/module/builder.rs
@@ -24,7 +24,7 @@ use crate::{
     MemoryType,
     TableType,
 };
-use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
+use std::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
 
 /// A builder for a WebAssembly [`Module`].
 #[derive(Debug)]

--- a/crates/wasmi/src/module/data.rs
+++ b/crates/wasmi/src/module/data.rs
@@ -1,5 +1,5 @@
 use super::{ConstExpr, MemoryIdx};
-use alloc::sync::Arc;
+use std::sync::Arc;
 
 /// A Wasm [`Module`] data segment.
 ///

--- a/crates/wasmi/src/module/element.rs
+++ b/crates/wasmi/src/module/element.rs
@@ -1,6 +1,6 @@
 use super::{ConstExpr, TableIdx};
 use crate::module::utils::WasmiValueType;
-use alloc::sync::Arc;
+use std::sync::Arc;
 use wasmi_core::ValueType;
 
 /// A table element segment within a [`Module`].

--- a/crates/wasmi/src/module/export.rs
+++ b/crates/wasmi/src/module/export.rs
@@ -1,6 +1,6 @@
 use super::GlobalIdx;
 use crate::{Error, ExternType, Module};
-use alloc::{boxed::Box, collections::btree_map::Iter as BTreeIter};
+use std::{boxed::Box, collections::btree_map::Iter as BTreeIter};
 
 /// The index of a function declaration within a [`Module`].
 ///

--- a/crates/wasmi/src/module/import.rs
+++ b/crates/wasmi/src/module/import.rs
@@ -1,6 +1,6 @@
 use crate::{GlobalType, MemoryType, TableType};
-use alloc::boxed::Box;
 use core::fmt::{self, Display};
+use std::boxed::Box;
 use wasmparser::TypeRef;
 
 /// A [`Module`] import item.

--- a/crates/wasmi/src/module/init_expr.rs
+++ b/crates/wasmi/src/module/init_expr.rs
@@ -8,9 +8,9 @@
 
 use super::FuncIdx;
 use crate::{ExternRef, FuncRef, Value};
-use alloc::boxed::Box;
 use core::fmt;
 use smallvec::SmallVec;
+use std::boxed::Box;
 use wasmi_core::{UntypedValue, F32, F64};
 
 /// Types that allow evluation given an evaluation context.

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -40,8 +40,8 @@ use crate::{
     MemoryType,
     TableType,
 };
-use alloc::{boxed::Box, collections::BTreeMap, sync::Arc};
 use core::{iter, slice::Iter as SliceIter};
+use std::{boxed::Box, collections::BTreeMap, sync::Arc};
 use wasmparser::{FuncValidatorAllocations, Parser, ValidPayload, Validator};
 
 /// A parsed and validated WebAssembly module.

--- a/crates/wasmi/src/module/parser.rs
+++ b/crates/wasmi/src/module/parser.rs
@@ -12,8 +12,8 @@ use super::{
     Read,
 };
 use crate::{engine::CompiledFunc, Engine, Error, FuncType, MemoryType, TableType};
-use alloc::{boxed::Box, vec::Vec};
 use core::ops::Range;
+use std::{boxed::Box, vec::Vec};
 use wasmparser::{
     Chunk,
     DataSectionReader,

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -29,11 +29,11 @@ use crate::{
     TableEntity,
     TableIdx,
 };
-use alloc::boxed::Box;
 use core::{
     fmt::{self, Debug},
     sync::atomic::{AtomicU32, Ordering},
 };
+use std::boxed::Box;
 use wasmi_arena::{Arena, ArenaIndex, GuardedEntity};
 use wasmi_core::TrapCode;
 

--- a/crates/wasmi/src/table/mod.rs
+++ b/crates/wasmi/src/table/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     FuncRef,
     Value,
 };
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use core::cmp::max;
 use wasmi_arena::ArenaIndex;
 use wasmi_core::{TrapCode, UntypedValue, ValueType};

--- a/crates/wasmi/src/table/mod.rs
+++ b/crates/wasmi/src/table/mod.rs
@@ -12,8 +12,8 @@ use crate::{
     FuncRef,
     Value,
 };
-use alloc::{vec, vec::Vec};
 use core::cmp::max;
+use std::{vec, vec::Vec};
 use wasmi_arena::ArenaIndex;
 use wasmi_core::{TrapCode, UntypedValue, ValueType};
 

--- a/crates/wasmi/tests/spec/context.rs
+++ b/crates/wasmi/tests/spec/context.rs
@@ -205,7 +205,7 @@ impl TestContext<'_> {
 
     /// Registers the given [`Instance`] with the given `name` and sets it as the last instance.
     pub fn register_instance(&mut self, name: &str, instance: Instance) {
-        if self.instances.get(name).is_some() {
+        if self.instances.contains_key(name) {
             // Already registered the instance.
             return;
         }


### PR DESCRIPTION
Fixes the warnings introduced by https://github.com/rust-lang/rust/issues/121708 for this workspace.