### PR TITLE
Preserve locals before entering control flow during compilation

### DIFF
--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -25,7 +25,7 @@ smallvec = { version = "1.13.1", features = ["union"] }
 multi-stash = { version = "0.2.0" }
 num-traits = { version = "0.2", default-features = false }
 num-derive = "0.4"
-slice-group-by = "0.3"
+slice-group-by = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 wat = "1"
@@ -36,7 +36,7 @@ criterion = { version = "0.5", default-features = false }
 
 [features]
 default = ["std"]
-std = ["wasmi_core/std", "wasmi_arena/std", "wasmparser/std", "spin/std", "num-traits/std"]
+std = ["wasmi_core/std", "wasmi_arena/std", "wasmparser/std", "spin/std", "num-traits/std", "slice-group-by/std"]
 
 [[bench]]
 name = "benches"

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -25,6 +25,7 @@ smallvec = { version = "1.13.1", features = ["union"] }
 multi-stash = { version = "0.2.0" }
 num-traits = { version = "0.2", default-features = false }
 num-derive = "0.4"
+slice-group-by = "0.3"
 
 [dev-dependencies]
 wat = "1"

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -26,6 +26,7 @@ multi-stash = { version = "0.2.0" }
 num-traits = { version = "0.2", default-features = false }
 num-derive = "0.4"
 slice-group-by = { version = "0.3", default-features = false }
+arrayvec = { version = "0.7.4", default-features = false }
 
 [dev-dependencies]
 wat = "1"
@@ -36,7 +37,15 @@ criterion = { version = "0.5", default-features = false }
 
 [features]
 default = ["std"]
-std = ["wasmi_core/std", "wasmi_arena/std", "wasmparser/std", "spin/std", "num-traits/std", "slice-group-by/std"]
+std = [
+    "wasmi_core/std",
+    "wasmi_arena/std",
+    "wasmparser/std",
+    "spin/std",
+    "num-traits/std",
+    "slice-group-by/std",
+    "arrayvec/std",
+]
 
 [[bench]]
 name = "benches"

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -803,10 +803,19 @@ impl InstrEncoder {
     ///
     /// This will ignore any preservation notifications after the first one.
     pub fn notify_preserved_register(&mut self, preserve_instr: Instr) {
-        debug_assert!(
-            matches!(self.instrs.get(preserve_instr), Instruction::Copy { .. }),
-            "a preserve instruction is always a register copy instruction"
-        );
+        {
+            let preserved = self.instrs.get(preserve_instr);
+            debug_assert!(
+                matches!(
+                    preserved,
+                    Instruction::Copy { .. }
+                        | Instruction::Copy2 { .. }
+                        | Instruction::CopyManyNonOverlapping { .. }
+                ),
+                "a preserve instruction is always a register copy instruction but found: {:?}",
+                preserved,
+            );
+        }
         if self.notified_preservation.is_none() {
             self.notified_preservation = Some(preserve_instr);
         }

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -810,6 +810,7 @@ impl InstrEncoder {
                     preserved,
                     Instruction::Copy { .. }
                         | Instruction::Copy2 { .. }
+                        | Instruction::CopySpanNonOverlapping { .. }
                         | Instruction::CopyManyNonOverlapping { .. }
                 ),
                 "a preserve instruction is always a register copy instruction but found: {:?}",

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -385,7 +385,7 @@ impl InstrEncoder {
         mut results: RegisterSpanIter,
         values: &[TypedProvider],
         fuel_info: FuelInfo,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<Instr>, Error> {
         assert_eq!(results.len(), values.len());
         if let Some((TypedProvider::Register(value), rest)) = values.split_first() {
             if results.span().head() == *value {
@@ -400,24 +400,20 @@ impl InstrEncoder {
         match values {
             [] => {
                 // The copy sequence is empty, nothing to encode in this case.
-                Ok(())
+                Ok(None)
             }
-            [v0] => {
-                self.encode_copy(stack, result, *v0, fuel_info)?;
-                Ok(())
-            }
+            [v0] => self.encode_copy(stack, result, *v0, fuel_info),
             [v0, v1] => {
                 if TypedProvider::Register(result.next()) == *v1 {
                     // Case: the second of the 2 copies is a no-op which we can avoid
                     // Note: we already asserted that the first copy is not a no-op
-                    self.encode_copy(stack, result, *v0, fuel_info)?;
-                    return Ok(());
+                    return self.encode_copy(stack, result, *v0, fuel_info);
                 }
                 let reg0 = Self::provider2reg(stack, v0)?;
                 let reg1 = Self::provider2reg(stack, v1)?;
                 self.bump_fuel_consumption(fuel_info, FuelCosts::base)?;
-                self.push_instr(Instruction::copy2(results.span(), reg0, reg1))?;
-                Ok(())
+                let instr = self.push_instr(Instruction::copy2(results.span(), reg0, reg1))?;
+                Ok(Some(instr))
             }
             [v0, v1, rest @ ..] => {
                 debug_assert!(!rest.is_empty());
@@ -437,12 +433,12 @@ impl InstrEncoder {
                         true => Instruction::copy_span,
                         false => Instruction::copy_span_non_overlapping,
                     };
-                    self.push_instr(make_instr(
+                    let instr = self.push_instr(make_instr(
                         results.span(),
                         values.span(),
                         values.len_as_u16(),
                     ))?;
-                    return Ok(());
+                    return Ok(Some(instr));
                 }
                 let make_instr = match Self::has_overlapping_copies(results, values) {
                     true => Instruction::copy_many,
@@ -450,9 +446,9 @@ impl InstrEncoder {
                 };
                 let reg0 = Self::provider2reg(stack, v0)?;
                 let reg1 = Self::provider2reg(stack, v1)?;
-                self.push_instr(make_instr(results.span(), reg0, reg1))?;
+                let instr = self.push_instr(make_instr(results.span(), reg0, reg1))?;
                 self.encode_register_list(stack, rest)?;
-                Ok(())
+                Ok(Some(instr))
             }
         }
     }

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -784,6 +784,7 @@ impl FuncTranslator {
     fn preserve_locals(&mut self) -> Result<(), Error> {
         let fuel_info = self.fuel_info();
         let preserved = &mut self.alloc.buffer.preserved;
+        preserved.clear();
         self.alloc.stack.preserve_all_locals(|preserved_local| {
             preserved.push(preserved_local);
             Ok(())

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -755,8 +755,7 @@ impl FuncTranslator {
         let mut preserved = Vec::new();
         self.alloc
             .stack
-            .preserve_all_locals(|local_index, preserved_register| {
-                let local_register = Register::from_i16(local_index as i16);
+            .preserve_all_locals(|local_register, preserved_register| {
                 preserved.push((local_register, preserved_register));
                 Ok(())
             })?;

--- a/crates/wasmi/src/engine/translator/stack/locals.rs
+++ b/crates/wasmi/src/engine/translator/stack/locals.rs
@@ -5,6 +5,9 @@ use std::{
     vec::Vec,
 };
 
+#[cfg(doc)]
+use super::ProviderStack;
+
 /// The index of a `local.get` on the [`ProviderStack`].
 pub type StackIndex = usize;
 
@@ -111,7 +114,7 @@ impl LocalRefsEntries {
 #[derive(Debug, Copy, Clone)]
 enum LocalRefEntry {
     Vacant {
-        /// The next free slot of the [`LocalsRef`] data structure.
+        /// The next free slot of the [`LocalRefs`] data structure.
         next_free: Option<EntryIndex>,
     },
     Occupied {

--- a/crates/wasmi/src/engine/translator/stack/locals.rs
+++ b/crates/wasmi/src/engine/translator/stack/locals.rs
@@ -224,6 +224,7 @@ impl LocalRefs {
             return Ok(());
         };
         self.drain_list_at(last, f)?;
+        self.reset_if_empty();
         Ok(())
     }
 
@@ -243,6 +244,7 @@ impl LocalRefs {
         }
         self.locals_last = local_last;
         self.locals_last.clear();
+        self.entries.reset();
         Ok(())
     }
 
@@ -259,7 +261,6 @@ impl LocalRefs {
             last = prev;
             f(slot)?;
         }
-        self.reset_if_empty();
         Ok(())
     }
 }

--- a/crates/wasmi/src/engine/translator/stack/locals.rs
+++ b/crates/wasmi/src/engine/translator/stack/locals.rs
@@ -1,0 +1,290 @@
+use crate::{engine::bytecode::Register, Error};
+use core::mem;
+use std::{
+    collections::{btree_map, BTreeMap},
+    vec::Vec,
+};
+
+/// The index of a `local.get` on the [`ProviderStack`].
+pub type StackIndex = usize;
+
+/// The index of an entry in the [`LocalRefs`] data structure.
+type EntryIndex = usize;
+
+/// Data structure to store local indices on the compilation stack for large stacks.
+///
+/// # Note
+///
+/// - The main purpose is to provide efficient implementations to preserve locals on
+///   the compilation stack for single local and mass local preservation.
+/// - Also this data structure is critical to not be attackable by malicious actors
+///   when operating on very large stacks or local variable quantities.
+#[derive(Debug, Default)]
+pub struct LocalRefs {
+    /// The last local added to [`LocalRefs`] per local variable if any.
+    locals_last: BTreeMap<Register, EntryIndex>,
+    /// The entries of the [`LocalRefs`] data structure.
+    entries: LocalRefsEntries,
+}
+
+/// The entries of the [`LocalRefs`] data structure.
+///
+/// # Note
+///
+/// This type mostly exists to gracefully resolve some borrow-checking issues
+/// when operating on parts of the fields of the [`LocalRefs`] while `locals_last`
+/// is borrowed.
+#[derive(Debug, Default)]
+pub struct LocalRefsEntries {
+    /// The index of the next free (vacant) entry.
+    next_free: Option<EntryIndex>,
+    /// All entries of the [`LocalRefs`] data structure.
+    entries: Vec<LocalRefEntry>,
+}
+
+impl LocalRefsEntries {
+    /// Resets the [`LocalRefs`].
+    pub fn reset(&mut self) {
+        self.next_free = None;
+        self.entries.clear();
+    }
+
+    /// Returns the next free [`EntryIndex`] for reusing vacant entries.
+    #[inline]
+    pub fn next_free(&self) -> Option<EntryIndex> {
+        self.next_free
+    }
+
+    /// Returns the next [`EntryIndex`] for the next new non-reused entry.
+    #[inline]
+    pub fn next_index(&self) -> EntryIndex {
+        self.entries.len()
+    }
+
+    /// Pushes an occupied entry to the [`LocalRefsEntries`].
+    #[inline]
+    pub fn push_occupied(&mut self, slot: StackIndex, prev: Option<EntryIndex>) -> EntryIndex {
+        let index = self.next_index();
+        self.entries.push(LocalRefEntry::Occupied { slot, prev });
+        index
+    }
+
+    /// Reuses the vacant entry at `index` for a new occupied entry.
+    ///
+    /// # Panics
+    ///
+    /// If the entry at `index` is not vacant.
+    #[inline]
+    pub fn reuse_vacant(&mut self, index: EntryIndex, slot: StackIndex, prev: Option<EntryIndex>) {
+        let old_entry = mem::replace(
+            &mut self.entries[index],
+            LocalRefEntry::Occupied { slot, prev },
+        );
+        self.next_free = match old_entry {
+            LocalRefEntry::Vacant { next_free } => next_free,
+            occupied @ LocalRefEntry::Occupied { .. } => {
+                panic!("tried to reuse occupied entry at index {index}: {occupied:?}")
+            }
+        };
+    }
+
+    /// Removes the entry at the given `index`.
+    ///
+    /// Returns the entry index of the next entry in the list and the
+    /// [`StackIndex`] associated to the removed entry.
+    #[inline]
+    fn remove_entry(&mut self, index: EntryIndex) -> (Option<EntryIndex>, StackIndex) {
+        let next_free = self.next_free();
+        let old_entry = mem::replace(
+            &mut self.entries[index],
+            LocalRefEntry::Vacant { next_free },
+        );
+        let LocalRefEntry::Occupied { prev, slot } = old_entry else {
+            panic!("expected occupied entry but found vacant: {old_entry:?}");
+        };
+        self.next_free = Some(index);
+        (prev, slot)
+    }
+}
+
+/// An entry representing a local variable on the compilation stack or a vacant entry.
+#[derive(Debug, Copy, Clone)]
+enum LocalRefEntry {
+    Vacant {
+        /// The next free slot of the [`LocalsRef`] data structure.
+        next_free: Option<EntryIndex>,
+    },
+    Occupied {
+        /// The slot index of the local variable on the compilation stack.
+        slot: StackIndex,
+        /// The next [`LocalRefEntry`] referencing the same local variable if any.
+        prev: Option<EntryIndex>,
+    },
+}
+
+impl LocalRefs {
+    /// Resets the [`LocalRefs`].
+    pub fn reset(&mut self) {
+        self.locals_last.clear();
+        self.entries.reset();
+    }
+
+    /// Registers an `amount` of function inputs or local variables.
+    ///
+    /// # Errors
+    ///
+    /// If too many registers have been registered.
+    pub fn register_locals(&mut self, _amount: u32) {
+        // Nothing to do here.
+    }
+
+    /// Updates the last index for `local` to `index` and returns the previous last index.
+    fn update_last(&mut self, index: EntryIndex, local: Register) -> Option<EntryIndex> {
+        match self.locals_last.entry(local) {
+            btree_map::Entry::Vacant(entry) => {
+                entry.insert(index);
+                None
+            }
+            btree_map::Entry::Occupied(mut entry) => {
+                let prev = *entry.get();
+                entry.insert(index);
+                Some(prev)
+            }
+        }
+    }
+
+    /// Pushes the stack index of a `local.get` on the [`ProviderStack`].
+    ///
+    /// # Panics
+    ///
+    /// If the `local` index is out of bounds.
+    pub fn push_at(&mut self, local: Register, slot: StackIndex) {
+        match self.entries.next_free() {
+            Some(index) => {
+                let prev = self.update_last(index, local);
+                self.entries.reuse_vacant(index, slot, prev);
+            }
+            None => {
+                let index = self.entries.next_index();
+                let prev = self.update_last(index, local);
+                let pushed = self.entries.push_occupied(slot, prev);
+                debug_assert_eq!(pushed, index);
+            }
+        };
+    }
+
+    /// Returns `true` if `self` is empty.
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.locals_last.is_empty()
+    }
+
+    /// Reset `self` if `self` is empty.
+    #[inline]
+    fn reset_if_empty(&mut self) {
+        if self.is_empty() {
+            self.entries.reset();
+        }
+    }
+
+    /// Pops the stack index of a `local.get` on the [`ProviderStack`].
+    ///
+    /// # Panics
+    ///
+    /// - If the `local` index is out of bounds.
+    /// - If there is no `local.get` stack index on the stack.
+    pub fn pop_at(&mut self, local: Register) -> StackIndex {
+        let btree_map::Entry::Occupied(mut last) = self.locals_last.entry(local) else {
+            panic!("missing stack index for local on the provider stack: {local:?}")
+        };
+        let index = *last.get();
+        let (prev, slot) = self.entries.remove_entry(index);
+        match prev {
+            Some(prev) => last.insert(prev),
+            None => last.remove(),
+        };
+        self.reset_if_empty();
+        slot
+    }
+
+    /// Drains all local indices of the `local` variable on the [`ProviderStack`].
+    ///
+    /// # Note
+    ///
+    /// Calls `f` with the index of each local on the [`ProviderStack`] that matches `local`.
+    pub fn drain_at(
+        &mut self,
+        local: Register,
+        f: impl FnMut(StackIndex) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        let Some(last) = self.locals_last.remove(&local) else {
+            return Ok(());
+        };
+        self.drain_list_at(last, f)?;
+        Ok(())
+    }
+
+    /// Drains all local indices on the [`ProviderStack`].
+    ///
+    /// # Note
+    ///
+    /// Calls `f` with the pair of local and its index of each local on the [`ProviderStack`].
+    pub fn drain_all(
+        &mut self,
+        mut f: impl FnMut(Register, StackIndex) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        let local_last = mem::take(&mut self.locals_last);
+        for (local, last) in &local_last {
+            let local = *local;
+            self.drain_list_at(*last, |index| f(local, index))?;
+        }
+        self.locals_last = local_last;
+        self.locals_last.clear();
+        Ok(())
+    }
+
+    /// Drains the list of locals starting at `index` at the entries array.
+    #[inline]
+    fn drain_list_at(
+        &mut self,
+        index: EntryIndex,
+        mut f: impl FnMut(StackIndex) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        let mut last = Some(index);
+        while let Some(index) = last {
+            let (prev, slot) = self.entries.remove_entry(index);
+            last = prev;
+            f(slot)?;
+        }
+        self.reset_if_empty();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reg(index: i16) -> Register {
+        Register::from_i16(index)
+    }
+
+    #[test]
+    fn push_pop_works() {
+        let mut locals = LocalRefs::default();
+        locals.push_at(reg(0), 2);
+        locals.push_at(reg(0), 4);
+        locals.push_at(reg(1), 6);
+        locals.push_at(reg(2), 8);
+        locals.push_at(reg(5), 10);
+        locals.push_at(reg(1), 12);
+        locals.push_at(reg(0), 14);
+        assert_eq!(locals.pop_at(reg(0)), 14);
+        assert_eq!(locals.pop_at(reg(0)), 4);
+        assert_eq!(locals.pop_at(reg(0)), 2);
+        assert_eq!(locals.pop_at(reg(1)), 12);
+        assert_eq!(locals.pop_at(reg(1)), 6);
+        assert_eq!(locals.pop_at(reg(2)), 8);
+        assert_eq!(locals.pop_at(reg(5)), 10);
+    }
+}

--- a/crates/wasmi/src/engine/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/stack/mod.rs
@@ -7,7 +7,7 @@ pub use self::{
     provider::{ProviderStack, TaggedProvider},
     register_alloc::{RegisterAlloc, RegisterSpace},
 };
-use super::TypedValue;
+use super::{PreservedLocal, TypedValue};
 use crate::{
     engine::{
         bytecode::{Provider, Register, RegisterSpan, UntypedProvider},
@@ -123,7 +123,7 @@ impl ValueStack {
     /// newly allocated `preserved_register` on the presevation register space.
     pub fn preserve_all_locals(
         &mut self,
-        f: impl FnMut(Register, Register) -> Result<(), Error>,
+        f: impl FnMut(PreservedLocal) -> Result<(), Error>,
     ) -> Result<(), Error> {
         self.providers.preserve_all_locals(&mut self.reg_alloc, f)
     }

--- a/crates/wasmi/src/engine/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/stack/mod.rs
@@ -119,11 +119,11 @@ impl ValueStack {
 
     /// Preserves all locals on the [`ProviderStack`] by shifting them to the preservation space.
     ///
-    /// Calls `f(index, register)` for each local preserved this way with its local `index` and the
-    /// newly allocated `register` on the presevation register space.
+    /// Calls `f(local_register, preserved_register)` for each `local_register` preserved this way with its
+    /// newly allocated `preserved_register` on the presevation register space.
     pub fn preserve_all_locals(
         &mut self,
-        f: impl FnMut(u32, Register) -> Result<(), Error>,
+        f: impl FnMut(Register, Register) -> Result<(), Error>,
     ) -> Result<(), Error> {
         self.providers.preserve_all_locals(&mut self.reg_alloc, f)
     }

--- a/crates/wasmi/src/engine/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/stack/mod.rs
@@ -1,9 +1,11 @@
 mod consts;
+mod locals;
 mod provider;
 mod register_alloc;
 
 pub use self::{
     consts::{FuncLocalConsts, FuncLocalConstsIter},
+    locals::LocalRefs,
     provider::{ProviderStack, TaggedProvider},
     register_alloc::{RegisterAlloc, RegisterSpace},
 };

--- a/crates/wasmi/src/engine/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/stack/mod.rs
@@ -107,7 +107,7 @@ impl ValueStack {
         Ok(results)
     }
 
-    /// Preserves `local.get` on the [`ProviderStack`] by shifting to storage space.
+    /// Preserves `local.get` on the [`ProviderStack`] by shifting to the preservation space.
     ///
     /// In case there are `local.get n` with `n == preserve_index` on the [`ProviderStack`]
     /// there is a [`Register`] on the storage space allocated for them. The [`Register`]
@@ -115,6 +115,17 @@ impl ValueStack {
     pub fn preserve_locals(&mut self, preserve_index: u32) -> Result<Option<Register>, Error> {
         self.providers
             .preserve_locals(preserve_index, &mut self.reg_alloc)
+    }
+
+    /// Preserves all locals on the [`ProviderStack`] by shifting them to the preservation space.
+    ///
+    /// Calls `f(index, register)` for each local preserved this way with its local `index` and the
+    /// newly allocated `register` on the presevation register space.
+    pub fn preserve_all_locals(
+        &mut self,
+        f: impl FnMut(u32, Register) -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        self.providers.preserve_all_locals(&mut self.reg_alloc, f)
     }
 
     /// Returns the number of [`Provider`] on the [`ValueStack`].

--- a/crates/wasmi/src/engine/translator/stack/provider.rs
+++ b/crates/wasmi/src/engine/translator/stack/provider.rs
@@ -2,11 +2,11 @@ use ::core::iter;
 
 use super::{RegisterAlloc, TypedValue};
 use crate::{engine::bytecode::Register, Error};
+use smallvec::SmallVec;
 use std::{
     collections::{btree_map, BTreeMap},
     vec::Vec,
 };
-use smallvec::SmallVec;
 
 #[cfg(doc)]
 use wasmi_core::UntypedValue;

--- a/crates/wasmi/src/engine/translator/stack/provider.rs
+++ b/crates/wasmi/src/engine/translator/stack/provider.rs
@@ -202,7 +202,7 @@ impl ProviderStack {
     ) -> Result<(), Error> {
         debug_assert!(!self.use_locals);
         let mut preserved = <ArrayVec<PreservedLocal, { Self::PRESERVE_THRESHOLD }>>::new();
-        for provider in &mut self.providers {
+        for provider in self.providers.iter_mut().rev() {
             let TaggedProvider::Local(local_register) = *provider else {
                 continue;
             };

--- a/crates/wasmi/src/engine/translator/tests/op/block.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/block.rs
@@ -66,8 +66,7 @@ fn identity_block_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(5, 0),
-            Instruction::copy(4, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 0),
             Instruction::return_reg(5),
         ])
         .run()
@@ -110,8 +109,7 @@ fn nested_identity_block_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(5, 0),
-            Instruction::copy(4, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 0),
             Instruction::return_reg(5),
         ])
         .run()
@@ -329,8 +327,7 @@ fn branched_block_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(5, 0),
-            Instruction::copy(4, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 0),
             Instruction::copy2(RegisterSpan::new(Register::from_i16(2)), 5, 4),
             Instruction::branch(BranchOffset::from(1)),
             Instruction::return_reg(Register::from_i16(2)),
@@ -378,8 +375,7 @@ fn branch_if_block_1() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(4, 0),
-            Instruction::copy(3, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 1, 0),
             Instruction::branch_i32_eqz(Register::from_i16(3), BranchOffset16::from(3)),
             Instruction::copy(Register::from_i16(2), Register::from_i16(4)),
             Instruction::branch(BranchOffset::from(2)),

--- a/crates/wasmi/src/engine/translator/tests/op/block.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/block.rs
@@ -46,7 +46,7 @@ fn identity_block_1() {
         )",
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_reg(Register::from_i16(0))])
+        .expect_func_instrs([Instruction::copy(2, 0), Instruction::return_reg(2)])
         .run()
 }
 
@@ -65,7 +65,11 @@ fn identity_block_2() {
         )",
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_reg(Register::from_i16(0))])
+        .expect_func_instrs([
+            Instruction::copy(5, 0),
+            Instruction::copy(4, 1),
+            Instruction::return_reg(5),
+        ])
         .run()
 }
 
@@ -84,7 +88,7 @@ fn nested_identity_block_1() {
         )",
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_reg(Register::from_i16(0))])
+        .expect_func_instrs([Instruction::copy(2, 0), Instruction::return_reg(2)])
         .run()
 }
 
@@ -105,7 +109,11 @@ fn nested_identity_block_2() {
         )",
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_reg(Register::from_i16(0))])
+        .expect_func_instrs([
+            Instruction::copy(5, 0),
+            Instruction::copy(4, 1),
+            Instruction::return_reg(5),
+        ])
         .run()
 }
 
@@ -146,9 +154,10 @@ fn branched_block_1() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(1), Register::from_i16(0)),
+            Instruction::copy(2, 0),
+            Instruction::copy(1, 2),
             Instruction::branch(BranchOffset::from(1)),
-            Instruction::return_reg(Register::from_i16(1)),
+            Instruction::return_reg(1),
         ])
         .run()
 }
@@ -320,7 +329,9 @@ fn branched_block_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(2)), 0, 1),
+            Instruction::copy(5, 0),
+            Instruction::copy(4, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(2)), 5, 4),
             Instruction::branch(BranchOffset::from(1)),
             Instruction::return_reg(Register::from_i16(2)),
         ])
@@ -343,7 +354,8 @@ fn branch_if_block_0() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::branch_i32_nez(Register::from_i16(0), BranchOffset16::from(1)),
+            Instruction::copy(1, 0),
+            Instruction::branch_i32_nez(Register::from_i16(1), BranchOffset16::from(1)),
             Instruction::Return,
         ])
         .run()
@@ -366,10 +378,12 @@ fn branch_if_block_1() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::branch_i32_eqz(Register::from_i16(1), BranchOffset16::from(3)),
-            Instruction::copy(Register::from_i16(2), Register::from_i16(0)),
+            Instruction::copy(4, 0),
+            Instruction::copy(3, 1),
+            Instruction::branch_i32_eqz(Register::from_i16(3), BranchOffset16::from(3)),
+            Instruction::copy(Register::from_i16(2), Register::from_i16(4)),
             Instruction::branch(BranchOffset::from(2)),
-            Instruction::copy(Register::from_i16(2), Register::from_i16(0)),
+            Instruction::copy(Register::from_i16(2), Register::from_i16(4)),
             Instruction::return_reg(Register::from_i16(2)),
         ])
         .run()
@@ -441,6 +455,9 @@ fn branch_to_func_block_nested_1() {
         )",
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_reg(Register::from_i16(0))])
+        .expect_func_instrs([
+            Instruction::copy(2, 0),
+            Instruction::return_reg(Register::from_i16(2)),
+        ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/op/block.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/block.rs
@@ -66,8 +66,8 @@ fn identity_block_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 0),
-            Instruction::return_reg(5),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 0, 1),
+            Instruction::return_reg(4),
         ])
         .run()
 }
@@ -109,8 +109,8 @@ fn nested_identity_block_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 0),
-            Instruction::return_reg(5),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 0, 1),
+            Instruction::return_reg(4),
         ])
         .run()
 }
@@ -327,8 +327,8 @@ fn branched_block_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 0),
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(2)), 5, 4),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 0, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(2)), 4, 5),
             Instruction::branch(BranchOffset::from(1)),
             Instruction::return_reg(Register::from_i16(2)),
         ])
@@ -375,11 +375,11 @@ fn branch_if_block_1() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 1, 0),
-            Instruction::branch_i32_eqz(Register::from_i16(3), BranchOffset16::from(3)),
-            Instruction::copy(Register::from_i16(2), Register::from_i16(4)),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 0, 1),
+            Instruction::branch_i32_eqz(Register::from_i16(4), BranchOffset16::from(3)),
+            Instruction::copy(Register::from_i16(2), Register::from_i16(3)),
             Instruction::branch(BranchOffset::from(2)),
-            Instruction::copy(Register::from_i16(2), Register::from_i16(4)),
+            Instruction::copy(Register::from_i16(2), Register::from_i16(3)),
             Instruction::return_reg(Register::from_i16(2)),
         ])
         .run()

--- a/crates/wasmi/src/engine/translator/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_if.rs
@@ -247,9 +247,10 @@ fn consteval_branch_always() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(Register::from_i16(2), Register::from_i16(0)),
+            Instruction::copy(3, 0),
+            Instruction::copy(2, 3),
             Instruction::branch(BranchOffset::from(1)),
-            Instruction::return_reg(Register::from_i16(2)),
+            Instruction::return_reg(2),
         ])
         .run()
 }
@@ -272,7 +273,10 @@ fn consteval_branch_never() {
         )",
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([Instruction::return_reg(Register::from_i16(1))])
+        .expect_func_instrs([
+            Instruction::copy(3, 0),
+            Instruction::return_reg(Register::from_i16(1)),
+        ])
         .run()
 }
 
@@ -842,7 +846,8 @@ fn branch_if_results_0() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::branch_i32_nez(Register::from_i16(0), BranchOffset16::from(1)),
+            Instruction::copy(1, 0),
+            Instruction::branch_i32_nez(Register::from_i16(1), BranchOffset16::from(1)),
             Instruction::Return,
         ])
         .run()
@@ -865,11 +870,13 @@ fn branch_if_results_1() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::branch_i32_eqz(Register::from_i16(1), BranchOffset16::from(3)),
-            Instruction::copy(Register::from_i16(2), Register::from_i16(0)),
+            Instruction::copy(4, 0),
+            Instruction::copy(3, 1),
+            Instruction::branch_i32_eqz(Register::from_i16(3), BranchOffset16::from(3)),
+            Instruction::copy(2, 4),
             Instruction::branch(BranchOffset::from(2)),
-            Instruction::copy(Register::from_i16(2), Register::from_i16(0)),
-            Instruction::return_reg(Register::from_i16(2)),
+            Instruction::copy(2, 4),
+            Instruction::return_reg(2),
         ])
         .run()
 }
@@ -925,16 +932,19 @@ fn branch_if_results_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::branch_i32_eqz(Register::from_i16(2), BranchOffset16::from(3)),
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 0, 1),
+            Instruction::copy(7, 0),
+            Instruction::copy(6, 1),
+            Instruction::copy(5, 2),
+            Instruction::branch_i32_eqz(Register::from_i16(5), BranchOffset16::from(3)),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 7, 6),
             Instruction::branch(BranchOffset::from(2)),
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 0, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 7, 6),
             Instruction::i32_add(
                 Register::from_i16(3),
                 Register::from_i16(3),
                 Register::from_i16(4),
             ),
-            Instruction::return_reg(Register::from_i16(3)),
+            Instruction::return_reg(3),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_if.rs
@@ -870,11 +870,11 @@ fn branch_if_results_1() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 1, 0),
-            Instruction::branch_i32_eqz(Register::from_i16(3), BranchOffset16::from(3)),
-            Instruction::copy(2, 4),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 0, 1),
+            Instruction::branch_i32_eqz(Register::from_i16(4), BranchOffset16::from(3)),
+            Instruction::copy(2, 3),
             Instruction::branch(BranchOffset::from(2)),
-            Instruction::copy(2, 4),
+            Instruction::copy(2, 3),
             Instruction::return_reg(2),
         ])
         .run()
@@ -931,12 +931,15 @@ fn branch_if_results_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(5)), 2, 1),
-            Instruction::register(0),
-            Instruction::branch_i32_eqz(Register::from_i16(5), BranchOffset16::from(3)),
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 7, 6),
+            Instruction::copy_span_non_overlapping(
+                RegisterSpan::new(Register::from_i16(5)),
+                RegisterSpan::new(Register::from_i16(0)),
+                3,
+            ),
+            Instruction::branch_i32_eqz(Register::from_i16(7), BranchOffset16::from(3)),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 5, 6),
             Instruction::branch(BranchOffset::from(2)),
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 7, 6),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 5, 6),
             Instruction::i32_add(
                 Register::from_i16(3),
                 Register::from_i16(3),

--- a/crates/wasmi/src/engine/translator/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_if.rs
@@ -870,8 +870,7 @@ fn branch_if_results_1() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(4, 0),
-            Instruction::copy(3, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 1, 0),
             Instruction::branch_i32_eqz(Register::from_i16(3), BranchOffset16::from(3)),
             Instruction::copy(2, 4),
             Instruction::branch(BranchOffset::from(2)),
@@ -932,9 +931,8 @@ fn branch_if_results_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(7, 0),
-            Instruction::copy(6, 1),
-            Instruction::copy(5, 2),
+            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(5)), 2, 1),
+            Instruction::register(0),
             Instruction::branch_i32_eqz(Register::from_i16(5), BranchOffset16::from(3)),
             Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 7, 6),
             Instruction::branch(BranchOffset::from(2)),

--- a/crates/wasmi/src/engine/translator/tests/op/if_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/if_.rs
@@ -279,17 +279,19 @@ fn if_then_else_with_params() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
+            Instruction::copy(5, 1),
+            Instruction::copy(4, 2),
             Instruction::branch_i32_eqz(Register::from_i16(0), BranchOffset16::from(3)),
             Instruction::i32_add(
                 Register::from_i16(3),
-                Register::from_i16(1),
-                Register::from_i16(2),
+                Register::from_i16(5),
+                Register::from_i16(4),
             ),
             Instruction::branch(BranchOffset::from(2)),
             Instruction::i32_mul(
                 Register::from_i16(3),
-                Register::from_i16(1),
-                Register::from_i16(2),
+                Register::from_i16(5),
+                Register::from_i16(4),
             ),
             Instruction::return_reg(Register::from_i16(3)),
         ])

--- a/crates/wasmi/src/engine/translator/tests/op/if_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/if_.rs
@@ -279,8 +279,7 @@ fn if_then_else_with_params() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(5, 1),
-            Instruction::copy(4, 2),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 2, 1),
             Instruction::branch_i32_eqz(Register::from_i16(0), BranchOffset16::from(3)),
             Instruction::i32_add(
                 Register::from_i16(3),

--- a/crates/wasmi/src/engine/translator/tests/op/if_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/if_.rs
@@ -279,18 +279,18 @@ fn if_then_else_with_params() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 2, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 2),
             Instruction::branch_i32_eqz(Register::from_i16(0), BranchOffset16::from(3)),
             Instruction::i32_add(
                 Register::from_i16(3),
-                Register::from_i16(5),
                 Register::from_i16(4),
+                Register::from_i16(5),
             ),
             Instruction::branch(BranchOffset::from(2)),
             Instruction::i32_mul(
                 Register::from_i16(3),
-                Register::from_i16(5),
                 Register::from_i16(4),
+                Register::from_i16(5),
             ),
             Instruction::return_reg(Register::from_i16(3)),
         ])

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -3,7 +3,7 @@ use crate::engine::bytecode::BranchOffset16;
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn simple() {
+fn simple_block() {
     let wasm = wat2wasm(
         r#"
         (module
@@ -29,7 +29,7 @@ fn simple() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn nested() {
+fn nested_block() {
     let wasm = wat2wasm(
         r#"
         (module

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -46,44 +46,11 @@ fn simple_block_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 1, 0),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 0, 1),
             Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(3)),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::return_reg2(4, 3),
-        ])
-        .run()
-}
-
-#[test]
-#[cfg_attr(miri, ignore)]
-fn simple_block_3_many() {
-    let wasm = wat2wasm(
-        r#"
-        (module
-            (func (param i32 i32 i32 i32) (result i32 i32 i32)
-                local.get 0
-                local.get 1
-                local.get 2
-                (block
-                    (br_if 0 (local.get 3))
-                    (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
-                    (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
-                    (local.set 2 (i32.const 30)) ;; overwrites (local 2) conditionally
-                )
-            )
-        )
-    "#,
-    );
-    TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(4)), 2, 1),
-            Instruction::register(0),
-            Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(4)),
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
-            Instruction::return_reg3(6, 5, 4),
+            Instruction::return_reg2(3, 4),
         ])
         .run()
 }
@@ -95,9 +62,9 @@ fn simple_block_3_span() {
         r#"
         (module
             (func (param i32 i32 i32 i32) (result i32 i32 i32)
-                local.get 2
-                local.get 1
                 local.get 0
+                local.get 1
+                local.get 2
                 (block
                     (br_if 0 (local.get 3))
                     (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
@@ -119,7 +86,40 @@ fn simple_block_3_span() {
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
             Instruction::copy_imm32(Register::from_i16(2), 30_i32),
-            Instruction::return_reg3(6, 5, 4),
+            Instruction::return_reg3(4, 5, 6),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn simple_block_3_many() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32 i32) (result i32 i32 i32)
+                local.get 2
+                local.get 1
+                local.get 0
+                (block
+                    (br_if 0 (local.get 3))
+                    (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                    (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
+                    (local.set 2 (i32.const 30)) ;; overwrites (local 2) conditionally
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(4)), 2, 1),
+            Instruction::register(0),
+            Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(4)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
+            Instruction::return_reg3(4, 5, 6),
         ])
         .run()
 }
@@ -172,45 +172,11 @@ fn simple_if_2() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 1, 0),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 0, 1),
             Instruction::branch_i32_eq_imm(Register::from_i16(2), 0, BranchOffset16::from(3)),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::return_reg2(4, 3),
-        ])
-        .run()
-}
-
-#[test]
-#[cfg_attr(miri, ignore)]
-fn simple_if_3_many() {
-    let wasm = wat2wasm(
-        r#"
-        (module
-            (func (param i32 i32 i32 i32) (result i32 i32 i32)
-                local.get 0
-                local.get 1
-                local.get 2
-                (if (local.get 3)
-                    (then
-                        (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
-                        (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
-                        (local.set 2 (i32.const 30)) ;; overwrites (local 2) conditionally
-                    )
-                )
-            )
-        )
-    "#,
-    );
-    TranslationTest::new(wasm)
-        .expect_func_instrs([
-            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(4)), 2, 1),
-            Instruction::register(0),
-            Instruction::branch_i32_eq_imm(Register::from_i16(3), 0, BranchOffset16::from(4)),
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
-            Instruction::return_reg3(6, 5, 4),
+            Instruction::return_reg2(3, 4),
         ])
         .run()
 }
@@ -222,9 +188,9 @@ fn simple_if_3_span() {
         r#"
         (module
             (func (param i32 i32 i32 i32) (result i32 i32 i32)
-                local.get 2
-                local.get 1
                 local.get 0
+                local.get 1
+                local.get 2
                 (if (local.get 3)
                     (then
                         (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
@@ -247,7 +213,41 @@ fn simple_if_3_span() {
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
             Instruction::copy_imm32(Register::from_i16(2), 30_i32),
-            Instruction::return_reg3(6, 5, 4),
+            Instruction::return_reg3(4, 5, 6),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn simple_if_3_many() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32 i32) (result i32 i32 i32)
+                local.get 2
+                local.get 1
+                local.get 0
+                (if (local.get 3)
+                    (then
+                        (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                        (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
+                        (local.set 2 (i32.const 30)) ;; overwrites (local 2) conditionally
+                    )
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(4)), 2, 1),
+            Instruction::register(0),
+            Instruction::branch_i32_eq_imm(Register::from_i16(3), 0, BranchOffset16::from(4)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
+            Instruction::return_reg3(4, 5, 6),
         ])
         .run()
 }
@@ -275,12 +275,12 @@ fn nested_block() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 0),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 0, 1),
             Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(4)),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(2)),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::return_reg2(5, 4),
+            Instruction::return_reg2(4, 5),
         ])
         .run()
 }
@@ -310,12 +310,12 @@ fn nested_if() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 0),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 0, 1),
             Instruction::branch_i32_eq_imm(Register::from_i16(2), 0, BranchOffset16::from(4)),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::branch_i32_eq_imm(Register::from_i16(3), 0, BranchOffset16::from(2)),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::return_reg2(5, 4),
+            Instruction::return_reg2(4, 5),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::engine::bytecode::BranchOffset16;
 
 #[test]
 #[cfg_attr(miri, ignore)]

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn simple_block() {
+fn simple_block_1() {
     let wasm = wat2wasm(
         r#"
         (module
@@ -28,13 +28,111 @@ fn simple_block() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn simple_if() {
+fn simple_block_2() {
     let wasm = wat2wasm(
         r#"
         (module
-            (func (param i32 i32 i32) (result i32)
+            (func (param i32 i32 i32) (result i32 i32)
                 local.get 0
-                (if (local.get 2)
+                local.get 1
+                (block
+                    (br_if 0 (local.get 2))
+                    (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                    (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 1, 0),
+            Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(3)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::return_reg2(4, 3),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn simple_block_3_many() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32 i32) (result i32 i32 i32)
+                local.get 0
+                local.get 1
+                local.get 2
+                (block
+                    (br_if 0 (local.get 3))
+                    (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                    (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
+                    (local.set 2 (i32.const 30)) ;; overwrites (local 2) conditionally
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(4)), 2, 1),
+            Instruction::register(0),
+            Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(4)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
+            Instruction::return_reg3(6, 5, 4),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn simple_block_3_span() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32 i32) (result i32 i32 i32)
+                local.get 2
+                local.get 1
+                local.get 0
+                (block
+                    (br_if 0 (local.get 3))
+                    (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                    (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
+                    (local.set 2 (i32.const 30)) ;; overwrites (local 2) conditionally
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy_span_non_overlapping(
+                RegisterSpan::new(Register::from_i16(4)),
+                RegisterSpan::new(Register::from_i16(0)),
+                3,
+            ),
+            Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(4)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
+            Instruction::return_reg3(6, 5, 4),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn simple_if_1() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32) (result i32)
+                local.get 0
+                (if (local.get 1)
                     (then
                         (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
                     )
@@ -45,10 +143,111 @@ fn simple_if() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(3, 0),
-            Instruction::branch_i32_eq_imm(Register::from_i16(2), 0, BranchOffset16::from(2)),
+            Instruction::copy(2, 0),
+            Instruction::branch_i32_eq_imm(Register::from_i16(1), 0, BranchOffset16::from(2)),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::return_reg(3),
+            Instruction::return_reg(2),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn simple_if_2() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32) (result i32 i32)
+                local.get 0
+                local.get 1
+                (if (local.get 2)
+                    (then
+                        (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                        (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
+                    )
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(3)), 1, 0),
+            Instruction::branch_i32_eq_imm(Register::from_i16(2), 0, BranchOffset16::from(3)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::return_reg2(4, 3),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn simple_if_3_many() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32 i32) (result i32 i32 i32)
+                local.get 0
+                local.get 1
+                local.get 2
+                (if (local.get 3)
+                    (then
+                        (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                        (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
+                        (local.set 2 (i32.const 30)) ;; overwrites (local 2) conditionally
+                    )
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy_many_non_overlapping(RegisterSpan::new(Register::from_i16(4)), 2, 1),
+            Instruction::register(0),
+            Instruction::branch_i32_eq_imm(Register::from_i16(3), 0, BranchOffset16::from(4)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
+            Instruction::return_reg3(6, 5, 4),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn simple_if_3_span() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32 i32) (result i32 i32 i32)
+                local.get 2
+                local.get 1
+                local.get 0
+                (if (local.get 3)
+                    (then
+                        (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                        (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
+                        (local.set 2 (i32.const 30)) ;; overwrites (local 2) conditionally
+                    )
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy_span_non_overlapping(
+                RegisterSpan::new(Register::from_i16(4)),
+                RegisterSpan::new(Register::from_i16(0)),
+                3,
+            ),
+            Instruction::branch_i32_eq_imm(Register::from_i16(3), 0, BranchOffset16::from(4)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
+            Instruction::return_reg3(6, 5, 4),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -29,6 +29,33 @@ fn simple_block() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
+fn simple_if() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32) (result i32)
+                local.get 0
+                (if (local.get 2)
+                    (then
+                        (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                    )
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy(3, 0),
+            Instruction::branch_i32_eq_imm(Register::from_i16(2), 0, BranchOffset16::from(2)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::return_reg(3),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
 fn nested_block() {
     let wasm = wat2wasm(
         r#"
@@ -55,6 +82,42 @@ fn nested_block() {
             Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(4)),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(2)),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::return_reg2(5, 4),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn nested_if() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32 i32) (result i32 i32)
+                local.get 0 ;; 1st return value
+                local.get 1 ;; 2nd return value
+                (if (local.get 2)
+                    (then
+                        (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                        (if (local.get 3)
+                            (then
+                                (local.set 1 (i32.const 20)) ;; overwrites (local 1) conditionally
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy(5, 0),
+            Instruction::copy(4, 1),
+            Instruction::branch_i32_eq_imm(Register::from_i16(2), 0, BranchOffset16::from(4)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::branch_i32_eq_imm(Register::from_i16(3), 0, BranchOffset16::from(2)),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
             Instruction::return_reg2(5, 4),
         ])
@@ -97,6 +160,47 @@ fn expr_block() {
                 Register::from_i16(2),
             ),
             Instruction::return_reg(2),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn expr_if() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32) (result i32)
+                (i32.add
+                    (local.get 0)
+                    (if (result i32) (local.get 1)
+                        (then
+                            (local.set 0 (i32.const 10))
+                            (i32.const 20)
+                        )
+                        (else
+                            (i32.const 30)
+                        )
+                    )
+                )
+            )
+        )
+        "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::copy(4, 0),
+            Instruction::branch_i32_eq_imm(Register::from_i16(1), 0, BranchOffset16::from(4)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(3), 20_i32),
+            Instruction::branch(BranchOffset::from(2)),
+            Instruction::copy_imm32(Register::from_i16(3), 30_i32),
+            Instruction::i32_add(
+                Register::from_i16(3),
+                Register::from_i16(4),
+                Register::from_i16(3),
+            ),
+            Instruction::return_reg(3),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -63,39 +63,37 @@ fn nested_block() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn block_with_result() {
+fn expr_block() {
     let wasm = wat2wasm(
         r#"
         (module
-            (func (param i32 i32 i32) (result i32)
-                (select
-                    (local.get 0)       ;; lhs - uses (local 0) that is conditionally overwritten
-                    (block (result i32) ;; rhs - conditionally overwriting (local 0)
+            (func (param i32 i32) (result i32)
+                (i32.add
+                    (local.get 1)
+                    (block (result i32)
                         (drop (br_if 0
-                            (local.get 1) ;; br_if return value
-                            (local.get 2) ;; br_if condition
+                            (i32.const 10) ;; br_if return value
+                            (local.get 0)  ;; br_if condition
                         ))
-                        (local.set 0 (i32.const 0)) ;; overwrites (local 0) after `br_if` conditionally
-                        (i32.const 1)
-                    )
-                    ;; condition - overwriting (local 0)
-                    (local.tee 0
-                        (i32.lt_s (local.get 1) (local.get 2))
+                        (local.set 1 (i32.const 20))
+                        (i32.const 30)
                     )
                 )
             )
         )
-    "#,
+        "#,
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(6)),
-            Instruction::copy(5, 0),
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(3)),
-            Instruction::copy(4, 1),
+            // What Wasmi incorrectly produces:
+            Instruction::branch_i32_eq_imm(Register::from_i16(0), 0, BranchOffset16::from(3)),
+            Instruction::copy_imm32(Register::from_i16(2), 10_i32),
+            Instruction::branch(BranchOffset::from(4)),
+            Instruction::copy(3, 1),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            Instruction::return_reg2(5, 4),
+            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
+            Instruction::i32_add(Register::from_i16(2), Register::from_i16(3), Register::from_i16(2)),
+            Instruction::return_reg(2),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -76,8 +76,7 @@ fn nested_block() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(5, 0),
-            Instruction::copy(4, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 0),
             Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(4)),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(2)),
@@ -112,8 +111,7 @@ fn nested_if() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            Instruction::copy(5, 0),
-            Instruction::copy(4, 1),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(4)), 1, 0),
             Instruction::branch_i32_eq_imm(Register::from_i16(2), 0, BranchOffset16::from(4)),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::branch_i32_eq_imm(Register::from_i16(3), 0, BranchOffset16::from(2)),

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -19,17 +19,10 @@ fn simple_block() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            // What Wasmi incorrectly produces:
-            Instruction::branch_i32_ne_imm(Register::from_i16(1), 0, BranchOffset16::from(3)),
             Instruction::copy(2, 0),
+            Instruction::branch_i32_ne_imm(Register::from_i16(1), 0, BranchOffset16::from(2)),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::return_reg(2),
-
-            // // What Wasmi should ideally produce:
-            // Instruction::copy(2, 0),
-            // Instruction::branch_i32_ne_imm(Register::from_i16(1), 0, BranchOffset16::from(2)),
-            // Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            // Instruction::return_reg(2),
         ])
         .run()
 }
@@ -57,23 +50,13 @@ fn nested_block() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            // What Wasmi incorrectly produces:
-            Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(6)),
             Instruction::copy(5, 0),
-            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(3)),
             Instruction::copy(4, 1),
+            Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(4)),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(2)),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
             Instruction::return_reg2(5, 4),
-
-            // // What Wasmi should ideally produce:
-            // Instruction::copy(5, 0),
-            // Instruction::copy(4, 1),
-            // Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(4)),
-            // Instruction::copy_imm32(Register::from_i16(0), 10_i32),
-            // Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(2)),
-            // Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            // Instruction::return_reg2(5, 4),
         ])
         .run()
 }
@@ -102,25 +85,18 @@ fn expr_block() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
-            // What Wasmi incorrectly produces:
+            Instruction::copy(3, 1),
             Instruction::branch_i32_eq_imm(Register::from_i16(0), 0, BranchOffset16::from(3)),
             Instruction::copy_imm32(Register::from_i16(2), 10_i32),
-            Instruction::branch(BranchOffset::from(4)),
-            Instruction::copy(3, 1),
+            Instruction::branch(BranchOffset::from(3)),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
             Instruction::copy_imm32(Register::from_i16(2), 30_i32),
-            Instruction::i32_add(Register::from_i16(2), Register::from_i16(3), Register::from_i16(2)),
+            Instruction::i32_add(
+                Register::from_i16(2),
+                Register::from_i16(3),
+                Register::from_i16(2),
+            ),
             Instruction::return_reg(2),
-
-            // // What Wasmi should ideally produce:
-            // Instruction::copy(3, 1),
-            // Instruction::branch_i32_eq_imm(Register::from_i16(0), 0, BranchOffset16::from(3)),
-            // Instruction::copy_imm32(Register::from_i16(2), 10_i32),
-            // Instruction::branch(BranchOffset::from(3)),
-            // Instruction::copy_imm32(Register::from_i16(1), 20_i32),
-            // Instruction::copy_imm32(Register::from_i16(2), 30_i32),
-            // Instruction::i32_add(Register::from_i16(2), Register::from_i16(3), Register::from_i16(2)),
-            // Instruction::return_reg(2),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -1,0 +1,101 @@
+use super::*;
+use crate::engine::bytecode::BranchOffset16;
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn simple() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32) (result i32)
+                local.get 0
+                block
+                    (br_if 0 (local.get 1))
+                    (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
+                end
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::branch_i32_ne_imm(Register::from_i16(1), 0, BranchOffset16::from(3)),
+            Instruction::copy(2, 0),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::return_reg(2),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn nested() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32) (param $c0 i32) (param $c1 i32) (result i32 i32)
+                local.get 0 ;; 1st return value
+                local.get 1 ;; 2nd return value
+                block
+                    (br_if 0 (local.get $c0))
+                    (local.set 0 (i32.const 10)) ;; conditionally overwrites (local 0) on stack
+                    block
+                        (br_if 1 (local.get $c1))
+                        (local.set 1 (i32.const 20)) ;; conditionally overwrites (local 1) on stack
+                    end
+                end
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(6)),
+            Instruction::copy(5, 0),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(3)),
+            Instruction::copy(4, 1),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::return_reg2(5, 4),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn block_with_result() {
+    let wasm = wat2wasm(
+        r#"
+        (module
+            (func (param i32 i32 i32) (result i32)
+                (select
+                    (local.get 0)       ;; lhs - uses (local 0) that is conditionally overwritten
+                    (block (result i32) ;; rhs - conditionally overwriting (local 0)
+                        (drop (br_if 0
+                            (local.get 1) ;; br_if return value
+                            (local.get 2) ;; br_if condition
+                        ))
+                        (local.set 0 (i32.const 0)) ;; overwrites (local 0) after `br_if` conditionally
+                        (i32.const 1)
+                    )
+                    ;; condition - overwriting (local 0)
+                    (local.tee 0
+                        (i32.lt_s (local.get 1) (local.get 2))
+                    )
+                )
+            )
+        )
+    "#,
+    );
+    TranslationTest::new(wasm)
+        .expect_func_instrs([
+            Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(6)),
+            Instruction::copy(5, 0),
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(3)),
+            Instruction::copy(4, 1),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::return_reg2(5, 4),
+        ])
+        .run()
+}

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -9,10 +9,10 @@ fn simple_block() {
         (module
             (func (param i32 i32) (result i32)
                 local.get 0
-                block
+                (block
                     (br_if 0 (local.get 1))
                     (local.set 0 (i32.const 10)) ;; overwrites (local 0) conditionally
-                end
+                )
             )
         )
     "#,
@@ -36,14 +36,14 @@ fn nested_block() {
             (func (param i32 i32) (param $c0 i32) (param $c1 i32) (result i32 i32)
                 local.get 0 ;; 1st return value
                 local.get 1 ;; 2nd return value
-                block
+                (block
                     (br_if 0 (local.get $c0))
                     (local.set 0 (i32.const 10)) ;; conditionally overwrites (local 0) on stack
-                    block
+                    (block
                         (br_if 1 (local.get $c1))
                         (local.set 1 (i32.const 20)) ;; conditionally overwrites (local 1) on stack
-                    end
-                end
+                    )
+                )
             )
         )
     "#,

--- a/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/conditional_preserve.rs
@@ -19,10 +19,17 @@ fn simple_block() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
+            // What Wasmi incorrectly produces:
             Instruction::branch_i32_ne_imm(Register::from_i16(1), 0, BranchOffset16::from(3)),
             Instruction::copy(2, 0),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
             Instruction::return_reg(2),
+
+            // // What Wasmi should ideally produce:
+            // Instruction::copy(2, 0),
+            // Instruction::branch_i32_ne_imm(Register::from_i16(1), 0, BranchOffset16::from(2)),
+            // Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            // Instruction::return_reg(2),
         ])
         .run()
 }
@@ -50,6 +57,7 @@ fn nested_block() {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs([
+            // What Wasmi incorrectly produces:
             Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(6)),
             Instruction::copy(5, 0),
             Instruction::copy_imm32(Register::from_i16(0), 10_i32),
@@ -57,6 +65,15 @@ fn nested_block() {
             Instruction::copy(4, 1),
             Instruction::copy_imm32(Register::from_i16(1), 20_i32),
             Instruction::return_reg2(5, 4),
+
+            // // What Wasmi should ideally produce:
+            // Instruction::copy(5, 0),
+            // Instruction::copy(4, 1),
+            // Instruction::branch_i32_ne_imm(Register::from_i16(2), 0, BranchOffset16::from(4)),
+            // Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            // Instruction::branch_i32_ne_imm(Register::from_i16(3), 0, BranchOffset16::from(2)),
+            // Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            // Instruction::return_reg2(5, 4),
         ])
         .run()
 }
@@ -94,6 +111,16 @@ fn expr_block() {
             Instruction::copy_imm32(Register::from_i16(2), 30_i32),
             Instruction::i32_add(Register::from_i16(2), Register::from_i16(3), Register::from_i16(2)),
             Instruction::return_reg(2),
+
+            // // What Wasmi should ideally produce:
+            // Instruction::copy(3, 1),
+            // Instruction::branch_i32_eq_imm(Register::from_i16(0), 0, BranchOffset16::from(3)),
+            // Instruction::copy_imm32(Register::from_i16(2), 10_i32),
+            // Instruction::branch(BranchOffset::from(3)),
+            // Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            // Instruction::copy_imm32(Register::from_i16(2), 30_i32),
+            // Instruction::i32_add(Register::from_i16(2), Register::from_i16(3), Register::from_i16(2)),
+            // Instruction::return_reg(2),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -45,6 +45,7 @@ fn fuzz_regression_2() {
     let wasm = wat2wasm(wat);
     TranslationTest::new(wasm)
         .expect_func_instrs([
+            Instruction::copy(1, 0),
             Instruction::branch_i32_eq_imm(Register::from_i16(0), 0, BranchOffset16::from(2)),
             Instruction::branch(BranchOffset::from(1)),
             Instruction::Return,
@@ -128,11 +129,12 @@ fn fuzz_regression_6() {
     let wasm = wat2wasm(wat);
     TranslationTest::new(wasm)
         .expect_func_instrs([
+            Instruction::copy(2, 0),
             Instruction::branch_i32_eq_imm(Register::from_i16(0), 0, BranchOffset16::from(4)),
             Instruction::branch_i32_eq_imm(Register::from_i16(0), 0, BranchOffset16::from(1)),
-            Instruction::copy(1, 0),
+            Instruction::copy(1, 2),
             Instruction::branch(BranchOffset::from(2)),
-            Instruction::copy(1, 0),
+            Instruction::copy(1, 2),
             Instruction::Trap(TrapCode::UnreachableCodeReached),
         ])
         .run()

--- a/crates/wasmi/src/engine/translator/tests/regression/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/regression/mod.rs
@@ -1,3 +1,5 @@
+mod conditional_preserve;
+
 use super::*;
 use crate::{
     core::TrapCode,

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -156,13 +156,13 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                 ));
             return Ok(());
         }
-        self.preserve_locals()?;
         // Copy `loop` parameters over to where it expects its branch parameters.
         let len_block_params = block_type.len_params(self.engine()) as usize;
         self.alloc
             .stack
             .pop_n(len_block_params, &mut self.alloc.buffer);
         let branch_params = self.alloc.stack.push_dynamic_n(len_block_params)?;
+        self.preserve_locals()?;
         let fuel_info = self.fuel_info();
         self.alloc.instr_encoder.encode_copies(
             &mut self.alloc.stack,

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -162,7 +162,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             .stack
             .pop_n(len_block_params, &mut self.alloc.buffer);
         let branch_params = self.alloc.stack.push_dynamic_n(len_block_params)?;
-        self.preserve_locals()?;
+        // self.preserve_locals()?; // TODO: find a case where local preservation before loops is necessary
         let fuel_info = self.fuel_info();
         self.alloc.instr_encoder.encode_copies(
             &mut self.alloc.stack,

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -121,6 +121,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                 ));
             return Ok(());
         }
+        self.preserve_locals()?;
         // Inherit [`Instruction::ConsumeFuel`] from parent control frame.
         //
         // # Note
@@ -155,6 +156,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                 ));
             return Ok(());
         }
+        self.preserve_locals()?;
         // Copy `loop` parameters over to where it expects its branch parameters.
         let len_block_params = block_type.len_params(self.engine()) as usize;
         self.alloc
@@ -206,6 +208,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         }
         let condition = self.alloc.stack.pop();
         let stack_height = BlockHeight::new(self.engine(), self.alloc.stack.height(), block_type)?;
+        self.preserve_locals()?;
         let end_label = self.alloc.instr_encoder.new_label();
         let len_block_params = block_type.len_params(self.engine()) as usize;
         let len_branch_params = block_type.len_results(self.engine()) as usize;

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -160,14 +160,14 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let len_block_params = block_type.len_params(self.engine()) as usize;
         self.alloc
             .stack
-            .pop_n(len_block_params, &mut self.alloc.buffer);
+            .pop_n(len_block_params, &mut self.alloc.buffer.providers);
         let branch_params = self.alloc.stack.push_dynamic_n(len_block_params)?;
         // self.preserve_locals()?; // TODO: find a case where local preservation before loops is necessary
         let fuel_info = self.fuel_info();
         self.alloc.instr_encoder.encode_copies(
             &mut self.alloc.stack,
             branch_params.iter(len_block_params),
-            &self.alloc.buffer[..],
+            &self.alloc.buffer.providers[..],
             fuel_info,
         )?;
         // Create loop header label and immediately pin it.
@@ -241,10 +241,10 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                 // later use in case we eventually visit the `else` branch.
                 self.alloc
                     .stack
-                    .peek_n(len_block_params, &mut self.alloc.buffer);
+                    .peek_n(len_block_params, &mut self.alloc.buffer.providers);
                 self.alloc
                     .control_stack
-                    .push_else_providers(self.alloc.buffer.iter().copied())?;
+                    .push_else_providers(self.alloc.buffer.providers.iter().copied())?;
                 // Note: We increase preservation register usage of else providers
                 //       so that they cannot be invalidated in the `then` block before
                 //       arriving at the `else` block of an `if`.
@@ -252,6 +252,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                 //       end of the `else`, or `if` in case `else` is missing.
                 self.alloc
                     .buffer
+                    .providers
                     .iter()
                     .copied()
                     .filter_map(TypedProvider::into_register)
@@ -432,10 +433,11 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                         }
                         self.alloc
                             .stack
-                            .peek_n(branch_params.len(), &mut self.alloc.buffer);
+                            .peek_n(branch_params.len(), &mut self.alloc.buffer.providers);
                         if self
                             .alloc
                             .buffer
+                            .providers
                             .iter()
                             .copied()
                             .eq(branch_params.map(TypedProvider::Register))
@@ -470,7 +472,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                         self.alloc.instr_encoder.encode_copies(
                             &mut self.alloc.stack,
                             branch_params,
-                            &self.alloc.buffer[..],
+                            &self.alloc.buffer.providers[..],
                             fuel_info,
                         )?;
                         let branch_offset =
@@ -516,11 +518,11 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         };
         // Add `br_table` targets to `br_table_targets` buffer including default target.
         // This allows us to uniformely treat all `br_table` targets the same and only parse once.
-        self.alloc.br_table_targets.clear();
+        self.alloc.buffer.br_table_targets.clear();
         for target in targets.targets() {
-            self.alloc.br_table_targets.push(target?);
+            self.alloc.buffer.br_table_targets.push(target?);
         }
-        self.alloc.br_table_targets.push(default_target);
+        self.alloc.buffer.br_table_targets.push(default_target);
         // We check if all `br_table` targets expect their results at the same
         // registers which allows us to encode the `br_table` more efficiently
         // by using a single copy instruction before branching instead of having
@@ -531,18 +533,24 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             .acquire_target(default_target)
             .control_frame()
             .branch_params(&engine);
-        let same_branch_params = self.alloc.br_table_targets.iter().copied().all(|target| {
-            match self.alloc.control_stack.acquire_target(target) {
-                AcquiredTarget::Return(_) => {
-                    // Return instructions never need to copy anything and
-                    // thus we can simply ignore them for this conditional.
-                    true
+        let same_branch_params = self
+            .alloc
+            .buffer
+            .br_table_targets
+            .iter()
+            .copied()
+            .all(|target| {
+                match self.alloc.control_stack.acquire_target(target) {
+                    AcquiredTarget::Return(_) => {
+                        // Return instructions never need to copy anything and
+                        // thus we can simply ignore them for this conditional.
+                        true
+                    }
+                    AcquiredTarget::Branch(frame) => {
+                        default_branch_params == frame.branch_params(&engine)
+                    }
                 }
-                AcquiredTarget::Branch(frame) => {
-                    default_branch_params == frame.branch_params(&engine)
-                }
-            }
-        });
+            });
         if default_branch_params.is_empty() || same_branch_params {
             // Case 1: No `br_target` target requires values to be copied around.
             // Case 2: All `br_target` targets use the same branch parameter registers.
@@ -557,7 +565,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                 1 => Instruction::return_reg(default_branch_params.span().head()),
                 _ => Instruction::return_span(default_branch_params),
             };
-            for target in self.alloc.br_table_targets.iter().copied() {
+            for target in self.alloc.buffer.br_table_targets.iter().copied() {
                 match self.alloc.control_stack.acquire_target(target) {
                     AcquiredTarget::Return(_) => {
                         self.alloc.instr_encoder.append_instr(return_instr)?;
@@ -585,7 +593,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         // share codegen for `br_table` arms that have the same branch target.
         self.push_base_instr(Instruction::branch_table(index, targets.len() + 1))?;
         let mut shared_targets = <BTreeMap<u32, LabelRef>>::new();
-        for target in self.alloc.br_table_targets.iter().copied() {
+        for target in self.alloc.buffer.br_table_targets.iter().copied() {
             let shared_label = *shared_targets
                 .entry(target)
                 .or_insert_with(|| self.alloc.instr_encoder.new_label());
@@ -594,7 +602,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                 .instr_encoder
                 .append_instr(Instruction::branch(branch_offset))?;
         }
-        let values = &mut self.alloc.buffer;
+        let values = &mut self.alloc.buffer.providers;
         self.alloc.stack.pop_n(default_branch_params.len(), values);
         for (depth, label) in shared_targets {
             self.alloc.instr_encoder.pin_label(label);
@@ -642,7 +650,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let func_idx = FuncIdx::from(function_index);
         let func_type = self.func_type_of(func_idx);
         let (params, results) = func_type.params_results();
-        let provider_params = &mut self.alloc.buffer;
+        let provider_params = &mut self.alloc.buffer.providers;
         self.alloc.stack.pop_n(params.len(), provider_params);
         let results = self.alloc.stack.push_dynamic_n(results.len())?;
         let instr = match self.module.get_compiled_func(func_idx) {
@@ -682,7 +690,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let func_type = self.func_type_at(type_index);
         let (params, results) = func_type.params_results();
         let index = self.alloc.stack.pop();
-        let provider_params = &mut self.alloc.buffer;
+        let provider_params = &mut self.alloc.buffer.providers;
         self.alloc.stack.pop_n(params.len(), provider_params);
         let table_params = match index {
             TypedProvider::Const(index) => match <Const16<u32>>::try_from(u32::from(index)).ok() {
@@ -719,7 +727,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let func_idx = FuncIdx::from(function_index);
         let func_type = self.func_type_of(func_idx);
         let params = func_type.params();
-        let provider_params = &mut self.alloc.buffer;
+        let provider_params = &mut self.alloc.buffer.providers;
         self.alloc.stack.pop_n(params.len(), provider_params);
         let instr = match self.module.get_compiled_func(func_idx) {
             Some(compiled_func) => {
@@ -754,7 +762,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let func_type = self.func_type_at(type_index);
         let params = func_type.params();
         let index = self.alloc.stack.pop();
-        let provider_params = &mut self.alloc.buffer;
+        let provider_params = &mut self.alloc.buffer.providers;
         self.alloc.stack.pop_n(params.len(), provider_params);
         let table_params = match index {
             TypedProvider::Const(index) => match <Const16<u32>>::try_from(u32::from(index)).ok() {

--- a/crates/wasmi/src/engine/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/translator/visit_register.rs
@@ -147,17 +147,19 @@ impl VisitInputRegisters for Instruction {
             Instruction::BranchF64Ge(instr) => instr.visit_input_registers(f),
 
             Instruction::Copy { result, value } => {
-                // Note: for copy instruction unlike all other instructions
+                // Note: for copy instructions unlike all other instructions
                 //       we need to also visit the result register since
                 //       encoding of `local.set` or `local.tee` might actually
                 //       result in a `copy` instruction with a `result` register
                 //       allocated in the storage-space.
                 visit_registers!(f, result, value)
             }
-            Instruction::Copy2 { results: _, values } => {
-                // Note: no need to visit `result` as in `Instruction::Copy` since
-                //       this is mainly about updating registers in the reserve space
-                //       due to optimizations of `local.set`.
+            Instruction::Copy2 { results, values } => {
+                // Note: we need to visit the results of the `Copy2` instruction
+                //       as well since it might have been generated while preserving locals
+                //       on the compilation stack when entering a control flow `block`
+                //       or `if`.
+                f(results.head_mut());
                 values.visit_input_registers(f);
             }
             Instruction::CopyImm32 { result: _, value: _ } |
@@ -172,7 +174,12 @@ impl VisitInputRegisters for Instruction {
             Instruction::CopyMany { results: _, values } => {
                 values.visit_input_registers(f);
             }
-            Instruction::CopyManyNonOverlapping { results: _, values } => {
+            Instruction::CopyManyNonOverlapping { results, values } => {
+                // Note: we need to visit the results of the `CopyMany` instruction
+                //       as well since it might have been generated while preserving locals
+                //       on the compilation stack when entering a control flow `block`
+                //       or `if`.
+                f(results.head_mut());
                 values.visit_input_registers(f);
             }
             Instruction::CallIndirectParams(params) => f(&mut params.index),

--- a/crates/wasmi/src/engine/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/translator/visit_register.rs
@@ -168,14 +168,19 @@ impl VisitInputRegisters for Instruction {
             Instruction::CopySpan { results: _, values, len: _ } => {
                 values.visit_input_registers(f);
             }
-            Instruction::CopySpanNonOverlapping { results: _, values, len: _ } => {
+            Instruction::CopySpanNonOverlapping { results, values, len: _ } => {
+                // Note: we need to visit the results of the `CopySpanNonOverlapping` instruction
+                //       as well since it might have been generated while preserving locals
+                //       on the compilation stack when entering a control flow `block`
+                //       or `if`.
+                f(results.head_mut());
                 values.visit_input_registers(f);
             }
             Instruction::CopyMany { results: _, values } => {
                 values.visit_input_registers(f);
             }
             Instruction::CopyManyNonOverlapping { results, values } => {
-                // Note: we need to visit the results of the `CopyMany` instruction
+                // Note: we need to visit the results of the `CopyManyNonOverlapping` instruction
                 //       as well since it might have been generated while preserving locals
                 //       on the compilation stack when entering a control flow `block`
                 //       or `if`.


### PR DESCRIPTION
This supposedly fixes https://github.com/wasmi-labs/wasmi/issues/934.

This is still in draft due to the following reasons and ToDos:

- [x] Adjust all translation tests that are failing due to changes in the Wasmi codegen and check if they are still valid.
- [x] Add more translation tests:
    - [x] ~~Test for `loop` control flow.~~
        - I couldn't find a single test case that was invalid before these changes but valid after. My theory is that for `loop` control flow structures local preservation is not needed because it is not possible to conditionally skip local manipulation without using `block` or `if` within the `loop` body somewhere. Someone please proof me wrong.
    - [x] Tests with more inputs encoding `CopySpanNonOverlapping` and `CopyManyNonOverlapping`.
    - [x] Tests with input parameters for `block` and `if`.
    - [x] Add a test that triggers usage of the large stack mode.
- [x] Improve efficiency of the WIP implementation introduced in this PR.
    - The current WIP implementation is very wasteful with memory allocations and the old data structures to manage the locals on the stack are not ideal for their current job. I already know how to fix both problems but the work needs to be done prior to merging to avoid creating new attack surfaces.
    - [x] Avoid unnecessary memory allocations.
    - [x] Introduce new data structure to efficiently handle local variables on the compilation stack.
    - [x] Add `len_locals` to `Providers` stack to act as a fast bail out condition for the common case when no locals need to be preserved.
    - [x] Preserve locals in reserve order of their appearance to avoid a non-critical attack vector in the inline mode of preservation. It is non-critical since the inline mode is used for very limited stack sizes only.
    - [x] Replace the `BTreeMap` in `preserve_all_locals_inplace` with an `ArrayVec` and linear search. This avoids heap allocations and won't introduce an attack vector since `preserve_all_locals_inplace` is guaranteed to operate on very small sets of values.
- [x] Merge `copy` instructions resulting from the new codegen introduced in this PR.
    - This is an optimization that can easily be applied. Although given that it is only an optimization we should first make sure that everything is correct and working.
    - This uses the fact that preservation register slots are usually adjacent to each other and thus we can easily use `copy2` or `copy_many` instructions instead of having multiple `copy` instructions for each preserved local.
- [x] Conduct benchmarks to show that the new Wasmi codegen does not significantly regress performance.
    - Performance benchmarks conducted so far locally show no significant impact.
- [ ] ~~Run the differential fuzzer in order to see if the changes introduced in this PR are actually generally correct.~~
    - Couldn't run the fuzzer due to external problems: https://github.com/wasmi-labs/wasmi/pull/945#issuecomment-1985760066
# Follow-Up PRs
- [ ] The new codegen might result in transitive copies which we can eliminate.
    - Issue: https://github.com/wasmi-labs/wasmi/issues/946
- [ ] Find out what causes the new memory-ouf-of-bounds access problems with execution of the `ffmpeg.wasm` binary.
     - This could either be a correctness issue in this PR or a hint to yet another unrelated bug.
