### PR TITLE
Add verbose mode to wasmi cli

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -95,6 +95,10 @@ pub struct Args {
     /// Arguments given to the Wasm module or the invoked function.
     #[clap(value_name = "ARGS")]
     func_args: Vec<String>,
+
+    /// Enable informational messages beyond warnings or errors.
+    #[clap(long = "verbose")]
+    verbose: bool,
 }
 
 /// The chosen Wasmi compilation mode.
@@ -140,6 +144,11 @@ impl Args {
     /// Returns `true` if lazy Wasm compilation is enabled.
     pub fn compilation_mode(&self) -> wasmi::CompilationMode {
         self.compilation_mode.into()
+    }
+
+    /// Returns `true` if verbose messaging is enabled.
+    pub fn verbose(&self) -> bool {
+        self.verbose
     }
 
     /// Pre-opens all directories given in `--dir` and returns them for use by the [`WasiCtx`].

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -92,13 +92,13 @@ pub struct Args {
     #[clap(long = "fuel", value_name = "N")]
     fuel: Option<u64>,
 
-    /// Arguments given to the Wasm module or the invoked function.
-    #[clap(value_name = "ARGS")]
-    func_args: Vec<String>,
-
     /// Enable informational messages beyond warnings or errors.
     #[clap(long = "verbose")]
     verbose: bool,
+
+    /// Arguments given to the Wasm module or the invoked function.
+    #[clap(value_name = "ARGS")]
+    func_args: Vec<String>,
 }
 
 /// The chosen Wasmi compilation mode.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -27,7 +27,9 @@ fn main() -> Result<()> {
     let mut func_results = utils::prepare_func_results(&ty);
     typecheck_args(&func_name, &ty, &func_args)?;
 
-    print_execution_start(args.wasm_file(), &func_name, &func_args);
+    if args.verbose() {
+        print_execution_start(args.wasm_file(), &func_name, &func_args);
+    }
     if args.invoked().is_some() && ty.params().len() != args.func_args().len() {
         bail!(
             "invalid amount of arguments given to function {}. expected {} but received {}",

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -27,7 +27,16 @@ where
 fn test_proc_exit() {
     let mut cmd = get_cmd();
     let assert = cmd.arg(get_bin_path("proc_exit")).assert();
+    assert!(assert.get_output().stdout.is_empty());
     assert.failure().code(1);
+}
+
+#[test]
+fn test_verbose() {
+    let mut cmd = get_cmd();
+    let assert = cmd.arg(get_bin_path("proc_exit")).arg("--verbose").assert();
+    let stdout = &assert.get_output().stdout;
+    assert!(contains_slice(stdout, b"proc_exit.wat\")::()"));
 }
 
 /// UTILS


### PR DESCRIPTION
Fix #955.

This prevents the initial "executing File ..." message unless `--verbose` is set.

The only other informational message I found was the remaining fuel message. I didn't require verbose for this, since it already depends on the fuel option. But it's something to consider in the future perhaps.
