### PR TITLE
Export ReadError

### DIFF
--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -159,6 +159,7 @@ pub use self::{
         ModuleExportsIter,
         ModuleImportsIter,
         Read,
+        ReadError,
     },
     store::{AsContext, AsContextMut, Store, StoreContext, StoreContextMut},
     table::{Table, TableType},


### PR DESCRIPTION
Currently, `Read` cannot be implemented outside of the crate because the `read` method signature uses `ReadError` which is public but not exported. The PR exports it.