### PR TITLE
Fix crates.io Wasmi package size

### DIFF
--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -11,7 +11,12 @@ readme.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
-exclude.workspace = true
+exclude = [
+    "benches/wat",
+    "benches/wasm",
+    "tests/spec/testsuite",
+    "**.wast",
+]
 
 [dependencies]
 wasmparser = { version = "0.100.1", package = "wasmparser-nostd", default-features = false }


### PR DESCRIPTION
I just noticed that the last Wasmi `v0.32.0-beta.8` release exploded the Wasmi package size on crates.io.
The cause is probably this PR (https://github.com/wasmi-labs/wasmi/pull/954) where I unified a lot of workspace package fields and probably forgot to exclude enough.

I checked with `cargo publish --list -p wasmi` and with this PR it seesm to be cleaned up again.

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/cf5f0626-f860-4b35-b28e-b3bb413d2ca1)
