### PR TITLE
Adjust fuel per byte for compiling a function

### DIFF
--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -110,8 +110,8 @@ impl InternalFuncEntity {
             match fuel.consume_fuel(|_costs| {
                 let len_bytes = bytes.as_slice().len() as u64;
                 let compile_factor = match needs_validation {
-                    false => 15,
-                    true => 20,
+                    false => 10,
+                    true => 15,
                 };
                 len_bytes.saturating_mul(compile_factor)
             }) {

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -110,8 +110,8 @@ impl InternalFuncEntity {
             match fuel.consume_fuel(|_costs| {
                 let len_bytes = bytes.as_slice().len() as u64;
                 let compile_factor = match needs_validation {
-                    false => 10,
-                    true => 15,
+                    false => 7,
+                    true => 9,
                 };
                 len_bytes.saturating_mul(compile_factor)
             }) {


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/981.

This only concerns lazy function compilation.
Now it makes a proper distinction between validated and non-validated compilation.

This makes for 56x higher costs for unchecked lazy compilation and 72x higher costs for checked lazy compilation compared to the state before where we charged the same costs as a simple `memset` for function compilation.