### PR TITLE
Optimize `wasmi::Linker` host function setup

### DIFF
--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -16,6 +16,7 @@ use wasmi::{
     Engine,
     Extern,
     Func,
+    FuncType,
     Linker,
     Memory,
     Module,
@@ -63,6 +64,16 @@ criterion_group!(
         bench_overhead_call_untyped_0,
         bench_overhead_call_untyped_16,
 );
+criterion_group!(
+    name = bench_linker;
+    config = Criterion::default()
+        .sample_size(10)
+        .measurement_time(Duration::from_millis(1000))
+        .warm_up_time(Duration::from_millis(1000));
+    targets =
+        bench_linker_setup_same,
+        bench_linker_setup_unique,
+);
 criterion_group! {
     name = bench_execute;
     config = Criterion::default()
@@ -96,7 +107,8 @@ criterion_main!(
     bench_translate,
     bench_instantiate,
     bench_execute,
-    bench_overhead
+    bench_overhead,
+    bench_linker,
 );
 
 const WASM_KERNEL: &str =
@@ -240,6 +252,67 @@ fn bench_instantiate_wasm_kernel(c: &mut Criterion) {
         b.iter(|| {
             let mut store = Store::new(module.engine(), ());
             let _instance = linker.instantiate(&mut store, &module).unwrap();
+        })
+    });
+}
+
+fn bench_linker_setup_same(c: &mut Criterion) {
+    let len_funcs = 50;
+    let bench_id = format!("linker/setup/same/{len_funcs}");
+    let func_names: Vec<String> = (0..len_funcs).into_iter().map(|i| i.to_string()).collect();
+    c.bench_function(&bench_id, |b| {
+        b.iter(|| {
+            let engine = Engine::default();
+            let mut linker = <Linker<()>>::new(&engine);
+            for func_name in &func_names {
+                linker.func_wrap("env", func_name, || ()).unwrap();
+            }
+        })
+    });
+}
+
+fn bench_linker_setup_unique(c: &mut Criterion) {
+    let len_funcs = 50;
+    let bench_id = format!("linker/setup/unique/{len_funcs}");
+    let types = [
+        ValueType::I32,
+        ValueType::I64,
+        ValueType::F32,
+        ValueType::F64,
+        ValueType::FuncRef,
+        ValueType::ExternRef,
+    ];
+    let funcs: Vec<(String, FuncType)> = (0..len_funcs)
+        .into_iter()
+        .map(|i| {
+            let func_name = i.to_string();
+            let (len_params, len_results) = if i % 2 == 0 {
+                ((i / (types.len() * 2)) + 1, 0)
+            } else {
+                (0, (i / (types.len() * 2)) + 1)
+            };
+            let chosen_type = types[i % 4];
+            let func_type = FuncType::new(
+                vec![chosen_type; len_params],
+                vec![chosen_type; len_results],
+            );
+            (func_name, func_type)
+        })
+        .collect();
+    c.bench_function(&bench_id, |b| {
+        b.iter(|| {
+            let engine = Engine::default();
+            let mut linker = <Linker<()>>::new(&engine);
+            for (func_name, func_type) in &funcs {
+                linker
+                    .func_new(
+                        "env",
+                        func_name,
+                        func_type.clone(),
+                        move |_caller, _params, _results| Ok(()),
+                    )
+                    .unwrap();
+            }
         })
     });
 }

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -259,8 +259,8 @@ fn bench_instantiate_wasm_kernel(c: &mut Criterion) {
 fn bench_linker_setup_same(c: &mut Criterion) {
     let len_funcs = 50;
     let bench_id = format!("linker/setup/same/{len_funcs}");
-    let func_names: Vec<String> = (0..len_funcs).into_iter().map(|i| i.to_string()).collect();
     c.bench_function(&bench_id, |b| {
+        let func_names: Vec<String> = (0..len_funcs).into_iter().map(|i| i.to_string()).collect();
         b.iter(|| {
             let engine = Engine::default();
             let mut linker = <Linker<()>>::new(&engine);
@@ -274,32 +274,32 @@ fn bench_linker_setup_same(c: &mut Criterion) {
 fn bench_linker_setup_unique(c: &mut Criterion) {
     let len_funcs = 50;
     let bench_id = format!("linker/setup/unique/{len_funcs}");
-    let types = [
-        ValueType::I32,
-        ValueType::I64,
-        ValueType::F32,
-        ValueType::F64,
-        ValueType::FuncRef,
-        ValueType::ExternRef,
-    ];
-    let funcs: Vec<(String, FuncType)> = (0..len_funcs)
-        .into_iter()
-        .map(|i| {
-            let func_name = i.to_string();
-            let (len_params, len_results) = if i % 2 == 0 {
-                ((i / (types.len() * 2)) + 1, 0)
-            } else {
-                (0, (i / (types.len() * 2)) + 1)
-            };
-            let chosen_type = types[i % 4];
-            let func_type = FuncType::new(
-                vec![chosen_type; len_params],
-                vec![chosen_type; len_results],
-            );
-            (func_name, func_type)
-        })
-        .collect();
     c.bench_function(&bench_id, |b| {
+        let types = [
+            ValueType::I32,
+            ValueType::I64,
+            ValueType::F32,
+            ValueType::F64,
+            ValueType::FuncRef,
+            ValueType::ExternRef,
+        ];
+        let funcs: Vec<(String, FuncType)> = (0..len_funcs)
+            .into_iter()
+            .map(|i| {
+                let func_name = i.to_string();
+                let (len_params, len_results) = if i % 2 == 0 {
+                    ((i / (types.len() * 2)) + 1, 0)
+                } else {
+                    (0, (i / (types.len() * 2)) + 1)
+                };
+                let chosen_type = types[i % 4];
+                let func_type = FuncType::new(
+                    vec![chosen_type; len_params],
+                    vec![chosen_type; len_results],
+                );
+                (func_name, func_type)
+            })
+            .collect();
         b.iter(|| {
             let engine = Engine::default();
             let mut linker = <Linker<()>>::new(&engine);

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -305,34 +305,39 @@ fn bench_linker_setup_same(c: &mut Criterion) {
     });
 }
 
+/// Generates `count` host functions with different signatures.
+fn generate_unique_host_functions(count: usize) -> Vec<(String, FuncType)> {
+    let types = [
+        ValueType::I32,
+        ValueType::I64,
+        ValueType::F32,
+        ValueType::F64,
+        ValueType::FuncRef,
+        ValueType::ExternRef,
+    ];
+    (0..count)
+        .map(|i| {
+            let func_name = format!("{i}");
+            let (len_params, len_results) = if i % 2 == 0 {
+                ((i / (types.len() * 2)) + 1, 0)
+            } else {
+                (0, (i / (types.len() * 2)) + 1)
+            };
+            let chosen_type = types[i % 4];
+            let func_type = FuncType::new(
+                vec![chosen_type; len_params],
+                vec![chosen_type; len_results],
+            );
+            (func_name, func_type)
+        })
+        .collect()
+}
+
 fn bench_linker_setup_unique(c: &mut Criterion) {
     let len_funcs = 50;
     let bench_id = format!("linker/setup/unique/{len_funcs}");
     c.bench_function(&bench_id, |b| {
-        let types = [
-            ValueType::I32,
-            ValueType::I64,
-            ValueType::F32,
-            ValueType::F64,
-            ValueType::FuncRef,
-            ValueType::ExternRef,
-        ];
-        let funcs: Vec<(String, FuncType)> = (0..len_funcs)
-            .map(|i| {
-                let func_name = format!("{i}");
-                let (len_params, len_results) = if i % 2 == 0 {
-                    ((i / (types.len() * 2)) + 1, 0)
-                } else {
-                    (0, (i / (types.len() * 2)) + 1)
-                };
-                let chosen_type = types[i % 4];
-                let func_type = FuncType::new(
-                    vec![chosen_type; len_params],
-                    vec![chosen_type; len_results],
-                );
-                (func_name, func_type)
-            })
-            .collect();
+        let funcs = generate_unique_host_functions(len_funcs);
         b.iter(|| {
             let engine = Engine::default();
             let mut linker = <Linker<()>>::new(&engine);
@@ -354,30 +359,7 @@ fn bench_linker_build_finish_unique(c: &mut Criterion) {
     let len_funcs = 50;
     let bench_id = format!("linker/build/finish/unique/{len_funcs}");
     c.bench_function(&bench_id, |b| {
-        let types = [
-            ValueType::I32,
-            ValueType::I64,
-            ValueType::F32,
-            ValueType::F64,
-            ValueType::FuncRef,
-            ValueType::ExternRef,
-        ];
-        let funcs: Vec<(String, FuncType)> = (0..len_funcs)
-            .map(|i| {
-                let func_name = format!("{i}");
-                let (len_params, len_results) = if i % 2 == 0 {
-                    ((i / (types.len() * 2)) + 1, 0)
-                } else {
-                    (0, (i / (types.len() * 2)) + 1)
-                };
-                let chosen_type = types[i % 4];
-                let func_type = FuncType::new(
-                    vec![chosen_type; len_params],
-                    vec![chosen_type; len_results],
-                );
-                (func_name, func_type)
-            })
-            .collect();
+        let funcs = generate_unique_host_functions(len_funcs);
         let mut builder = <Linker<()>>::build();
         for (func_name, func_type) in &funcs {
             builder
@@ -400,30 +382,7 @@ fn bench_linker_build_construct_unique(c: &mut Criterion) {
     let len_funcs = 50;
     let bench_id = format!("linker/build/construct/unique/{len_funcs}");
     c.bench_function(&bench_id, |b| {
-        let types = [
-            ValueType::I32,
-            ValueType::I64,
-            ValueType::F32,
-            ValueType::F64,
-            ValueType::FuncRef,
-            ValueType::ExternRef,
-        ];
-        let funcs: Vec<(String, FuncType)> = (0..len_funcs)
-            .map(|i| {
-                let func_name = format!("{i}");
-                let (len_params, len_results) = if i % 2 == 0 {
-                    ((i / (types.len() * 2)) + 1, 0)
-                } else {
-                    (0, (i / (types.len() * 2)) + 1)
-                };
-                let chosen_type = types[i % 4];
-                let func_type = FuncType::new(
-                    vec![chosen_type; len_params],
-                    vec![chosen_type; len_results],
-                );
-                (func_name, func_type)
-            })
-            .collect();
+        let funcs = generate_unique_host_functions(len_funcs);
         b.iter(|| {
             let mut builder = <Linker<()>>::build();
             for (func_name, func_type) in &funcs {

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -260,7 +260,7 @@ fn bench_linker_setup_same(c: &mut Criterion) {
     let len_funcs = 50;
     let bench_id = format!("linker/setup/same/{len_funcs}");
     c.bench_function(&bench_id, |b| {
-        let func_names: Vec<String> = (0..len_funcs).into_iter().map(|i| i.to_string()).collect();
+        let func_names: Vec<String> = (0..len_funcs).map(|i| format!("{i}")).collect();
         b.iter(|| {
             let engine = Engine::default();
             let mut linker = <Linker<()>>::new(&engine);
@@ -284,9 +284,8 @@ fn bench_linker_setup_unique(c: &mut Criterion) {
             ValueType::ExternRef,
         ];
         let funcs: Vec<(String, FuncType)> = (0..len_funcs)
-            .into_iter()
             .map(|i| {
-                let func_name = i.to_string();
+                let func_name = format!("{i}");
                 let (len_params, len_results) = if i % 2 == 0 {
                     ((i / (types.len() * 2)) + 1, 0)
                 } else {

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -151,7 +151,7 @@ pub use self::{
     global::{Global, GlobalType, Mutability},
     instance::{Export, ExportsIter, Extern, ExternType, Instance},
     limits::{ResourceLimiter, StoreLimits, StoreLimitsBuilder},
-    linker::Linker,
+    linker::{Linker, LinkerBuilder},
     memory::{Memory, MemoryType},
     module::{
         ExportType,

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -23,7 +23,7 @@ use core::{
     cmp::Ordering,
     fmt::{self, Debug, Display},
     mem,
-    num::NonZeroUsize,
+    num::NonZeroU32,
     ops::Deref,
 };
 use std::{
@@ -222,12 +222,12 @@ impl Display for LinkerError {
 ///
 /// # Dev. Note
 ///
-/// Internally we use [`NonZeroUsize`] so that `Option<Symbol>` can
+/// Internally we use [`NonZeroU32`] so that `Option<Symbol>` can
 /// be space optimized easily by the compiler. This is important since
 /// in [`ImportKey`] we are making extensive use of `Option<Symbol>`.
 #[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct Symbol(NonZeroUsize);
+pub struct Symbol(NonZeroU32);
 
 impl Symbol {
     /// Creates a new symbol.
@@ -236,14 +236,17 @@ impl Symbol {
     ///
     /// If the `value` is equal to `usize::MAX`.
     pub fn from_usize(value: usize) -> Self {
-        NonZeroUsize::new(value.wrapping_add(1))
+        let Ok(value) = u32::try_from(value) else {
+            panic!("encountered invalid symvol value: {value}");
+        };
+        NonZeroU32::new(value.wrapping_add(1))
             .map(Symbol)
             .expect("encountered invalid symbol value")
     }
 
     /// Returns the underlying `usize` value of the [`Symbol`].
     pub fn into_usize(self) -> usize {
-        self.0.get().wrapping_sub(1)
+        self.0.get().wrapping_sub(1) as usize
     }
 }
 

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -309,13 +309,17 @@ impl Ord for LenOrderStr {
         let rhs = other.0.as_bytes();
         match lhs.len().cmp(&rhs.len()) {
             Ordering::Equal => {
-                for (l, r) in lhs.iter().zip(rhs) {
-                    match l.cmp(r) {
-                        Ordering::Equal => (),
-                        ordering => return ordering,
+                if lhs.len() < 8 {
+                    for (l, r) in lhs.iter().zip(rhs) {
+                        match l.cmp(r) {
+                            Ordering::Equal => (),
+                            ordering => return ordering,
+                        }
                     }
+                    Ordering::Equal
+                } else {
+                    lhs.cmp(rhs)
                 }
-                Ordering::Equal
             }
             ordering => ordering,
         }


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/979.

cc @athei 

Most inefficiencies are in `StringInterner::get_or_insert` and in `memcmp` calls to compare definition names.

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/b7a93b7c-a185-4868-9b82-78ba9a7acef2)

## Findings

- By using an empty `""` name for the `module` name for all host functions we can improve performance by ~15%.
    - This is likely due to a fast check for empty-string to avoid having to use `memcmp`.
- Introduction of `struct LenOrder(Arc<str>)` and `struct LenOrderStr(str)` wrapper types with new `Ord` implementation to avoid `memcmp` are very effective, improving performance by roughly 50%. Unfortunately this requires a single line of `unsafe` Rust code since Rust's `BTreeMap` does not support custom comparators.

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/14e22aee-00c5-4390-acc5-932d5f420325)
