### PR TITLE
Reduce codemap memory usage

### DIFF
--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [dependencies]
-wasmparser = { version = "0.100.1", package = "wasmparser-nostd", default-features = false }
+wasmparser = { version = "0.100.2", package = "wasmparser-nostd", default-features = false }
 wasmi_core = { workspace = true }
 wasmi_arena = { workspace = true }
 spin = { version = "0.9", default-features = false, features = [

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -255,7 +255,7 @@ impl Default for SmallByteSlice {
 
 impl SmallByteSlice {
     /// The maximum amount of bytes that can be stored inline.
-    const MAX_INLINE_SIZE: usize = 30;
+    const MAX_INLINE_SIZE: usize = 22;
 
     /// Returns the underlying slice of bytes.
     #[inline]

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -17,6 +17,7 @@ use crate::{
     engine::bytecode::Instruction,
     module::{FuncIdx, ModuleHeader},
     store::{Fuel, FuelError},
+    Config,
     Error,
 };
 use core::{
@@ -31,7 +32,7 @@ use core::{
 use std::boxed::Box;
 use wasmi_arena::{Arena, ArenaIndex};
 use wasmi_core::TrapCode;
-use wasmparser::{FuncToValidate, ValidatorResources};
+use wasmparser::{FuncToValidate, ValidatorResources, WasmFeatures};
 
 /// A reference to a compiled function stored in the [`CodeMap`] of an [`Engine`](crate::Engine).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -353,9 +354,10 @@ impl CompiledFuncEntity {
 }
 
 /// Datastructure to efficiently store information about compiled functions.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct CodeMap {
     funcs: Arena<CompiledFunc, FuncEntity>,
+    features: WasmFeatures,
 }
 
 /// Atomicly accessible [`CompilationPhase`].
@@ -679,6 +681,14 @@ impl FuncEntity {
 }
 
 impl CodeMap {
+    /// Creates a new [`CodeMap`].
+    pub fn new(config: &Config) -> Self {
+        Self {
+            funcs: Arena::default(),
+            features: config.wasm_features(),
+        }
+    }
+
     /// Allocates a new uninitialized [`CompiledFunc`] to the [`CodeMap`].
     ///
     /// # Note

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -109,7 +109,7 @@ impl InternalFuncEntity {
                 unreachable!("expected func to be uncompiled: {func:?}")
             }
         };
-        let func_idx = uncompiled.func_idx;
+        let func_idx = uncompiled.func_index;
         let bytes = mem::take(&mut uncompiled.bytes);
         let needs_validation = uncompiled.func_to_validate.is_some();
         let compilation_fuel = |_costs: &FuelCosts| {
@@ -163,8 +163,8 @@ impl InternalFuncEntity {
 
 /// An internal uncompiled function entity.
 pub struct UncompiledFuncEntity {
-    /// The index of the function within the `module`.
-    func_idx: FuncIdx,
+    /// The index of the function within the Wasm module.
+    func_index: FuncIdx,
     /// The Wasm binary bytes.
     bytes: SmallByteSlice,
     /// The Wasm module of the Wasm function.
@@ -187,7 +187,7 @@ impl UncompiledFuncEntity {
         func_to_validate: impl Into<Option<FuncToValidate<ValidatorResources>>>,
     ) -> Self {
         Self {
-            func_idx,
+            func_index: func_idx,
             bytes: bytes.into(),
             module,
             func_to_validate: func_to_validate.into(),
@@ -198,7 +198,7 @@ impl UncompiledFuncEntity {
 impl fmt::Debug for UncompiledFuncEntity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("UncompiledFuncEntity")
-            .field("func_idx", &self.func_idx)
+            .field("func_idx", &self.func_index)
             .field("bytes", &self.bytes)
             .field("module", &self.module)
             .field("validate", &self.func_to_validate.is_some())

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -111,7 +111,7 @@ impl InternalFuncEntity {
         };
         let func_idx = uncompiled.func_index;
         let bytes = mem::take(&mut uncompiled.bytes);
-        let needs_validation = uncompiled.func_to_validate.is_some();
+        let needs_validation = uncompiled.validation.is_some();
         let compilation_fuel = |_costs: &FuelCosts| {
             let len_bytes = bytes.as_slice().len() as u64;
             let compile_factor = match needs_validation {
@@ -133,7 +133,7 @@ impl InternalFuncEntity {
                 module.engine()
             )
         };
-        match uncompiled.func_to_validate.take() {
+        match uncompiled.validation.take() {
             Some(func_to_validate) => {
                 let allocs = engine.get_allocs();
                 let translator = FuncTranslator::new(func_idx, module, allocs.0)?;
@@ -175,7 +175,7 @@ pub struct UncompiledFuncEntity {
     /// Optional Wasm validation information.
     ///
     /// This is `Some` if the [`UncompiledFuncEntity`] is to be validated upon compilation.
-    func_to_validate: Option<FuncToValidate<ValidatorResources>>,
+    validation: Option<FuncToValidate<ValidatorResources>>,
 }
 
 impl UncompiledFuncEntity {
@@ -190,7 +190,7 @@ impl UncompiledFuncEntity {
             func_index: func_idx,
             bytes: bytes.into(),
             module,
-            func_to_validate: func_to_validate.into(),
+            validation: func_to_validate.into(),
         }
     }
 }
@@ -201,7 +201,7 @@ impl fmt::Debug for UncompiledFuncEntity {
             .field("func_idx", &self.func_index)
             .field("bytes", &self.bytes)
             .field("module", &self.module)
-            .field("validate", &self.func_to_validate.is_some())
+            .field("validate", &self.validation.is_some())
             .finish()
     }
 }

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -594,7 +594,7 @@ impl EngineInner {
     fn new(config: &Config) -> Self {
         Self {
             config: *config,
-            res: RwLock::new(EngineResources::new()),
+            res: RwLock::new(EngineResources::new(config)),
             allocs: Mutex::new(ReusableAllocationStack::default()),
             stacks: Mutex::new(EngineStacks::new(config)),
         }
@@ -804,10 +804,10 @@ pub struct EngineResources {
 
 impl EngineResources {
     /// Creates a new [`EngineResources`].
-    fn new() -> Self {
+    fn new(config: &Config) -> Self {
         let engine_idx = EngineIdx::new();
         Self {
-            code_map: CodeMap::default(),
+            code_map: CodeMap::new(config),
             func_types: FuncTypeRegistry::new(engine_idx),
         }
     }


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/982.

This reduces the `size_of<UncompiledFuncEntity>()` from 88 bytes down to 56 bytes.
Technically we could shave off yet another 8 bytes but this would require more massive refactorings so this PR is a decent compromise.

Benchmarks conducted locally did not show significant performance regressions or improvements.