### PR TITLE
Optimize `Linker`'s string internment

### DIFF
--- a/crates/core/src/hint.rs
+++ b/crates/core/src/hint.rs
@@ -1,7 +1,7 @@
 /// Indicates that the calling scope is unlikely to be executed.
 #[cold]
 #[inline]
-fn cold() {}
+pub fn cold() {}
 
 /// Indicates that the condition is likely `true`.
 #[inline]

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -270,6 +270,7 @@ impl PartialOrd for LenOrder {
 }
 
 impl LenOrder {
+    #[inline]
     pub fn as_str(&self) -> &LenOrderStr {
         (&*self.0).into()
     }

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -401,6 +401,7 @@ impl StringInterner {
     }
 
     /// Returns the symbol for the string if interned.
+    #[inline]
     pub fn get(&self, string: &str) -> Option<Symbol> {
         self.string2symbol
             .get(<&LenOrderStr>::from(string))
@@ -408,6 +409,7 @@ impl StringInterner {
     }
 
     /// Resolves the symbol to the underlying string.
+    #[inline]
     pub fn resolve(&self, symbol: Symbol) -> Option<&str> {
         self.strings.get(symbol.into_usize()).map(Deref::deref)
     }

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -338,21 +338,17 @@ pub struct StringInterner {
 }
 
 impl StringInterner {
-    /// Returns the next symbol.
-    fn next_symbol(&self) -> Symbol {
-        Symbol::from_usize(self.strings.len())
-    }
-
     /// Returns the symbol of the string and interns it if necessary.
     pub fn get_or_intern(&mut self, string: &str) -> Symbol {
-        match self.string2symbol.get(<&LenOrderStr>::from(string)) {
-            Some(symbol) => *symbol,
-            None => {
-                let symbol = self.next_symbol();
-                let rc_string: Arc<str> = Arc::from(string);
-                self.string2symbol.insert(LenOrder(rc_string.clone()), symbol);
-                self.strings.push(rc_string);
+        match self.string2symbol.entry(LenOrder(string.into())) {
+            Entry::Vacant(entry) => {
+                let symbol = Symbol::from_usize(self.strings.len());
+                self.strings.push(entry.key().clone().0);
+                entry.insert(symbol);
                 symbol
+            }
+            Entry::Occupied(entry) => {
+                *entry.get()
             }
         }
     }

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -1,4 +1,5 @@
 use crate::{
+    core::hint,
     func::{FuncEntity, HostFuncEntity, HostFuncTrampolineEntity},
     module::{ImportName, ImportType},
     AsContext,
@@ -371,7 +372,10 @@ impl StringInterner {
                 entry.insert(symbol);
                 symbol
             }
-            Entry::Occupied(entry) => *entry.get(),
+            Entry::Occupied(entry) => {
+                hint::cold();
+                *entry.get()
+            }
         }
     }
 
@@ -385,6 +389,7 @@ impl StringInterner {
         match self.string2symbol.get(<&LenOrderStr>::from(string)) {
             Some(symbol) => *symbol,
             None => {
+                hint::cold();
                 let symbol = Symbol::from_usize(self.strings.len());
                 let rc_string: Arc<str> = Arc::from(string);
                 self.string2symbol

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -333,7 +333,7 @@ impl Ord for LenOrderStr {
 /// Efficiently interns strings and distributes symbols.
 #[derive(Debug, Default, Clone)]
 pub struct StringInterner {
-    string2idx: BTreeMap<LenOrder, Symbol>,
+    string2symbol: BTreeMap<LenOrder, Symbol>,
     strings: Vec<Arc<str>>,
 }
 
@@ -345,12 +345,12 @@ impl StringInterner {
 
     /// Returns the symbol of the string and interns it if necessary.
     pub fn get_or_intern(&mut self, string: &str) -> Symbol {
-        match self.string2idx.get(<&LenOrderStr>::from(string)) {
+        match self.string2symbol.get(<&LenOrderStr>::from(string)) {
             Some(symbol) => *symbol,
             None => {
                 let symbol = self.next_symbol();
                 let rc_string: Arc<str> = Arc::from(string);
-                self.string2idx.insert(LenOrder(rc_string.clone()), symbol);
+                self.string2symbol.insert(LenOrder(rc_string.clone()), symbol);
                 self.strings.push(rc_string);
                 symbol
             }
@@ -359,7 +359,7 @@ impl StringInterner {
 
     /// Returns the symbol for the string if interned.
     pub fn get(&self, string: &str) -> Option<Symbol> {
-        self.string2idx.get(<&LenOrderStr>::from(string)).copied()
+        self.string2symbol.get(<&LenOrderStr>::from(string)).copied()
     }
 
     /// Resolves the symbol to the underlying string.

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -337,9 +337,33 @@ pub struct StringInterner {
     strings: Vec<Arc<str>>,
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum InternHint {
+    /// Hint that the string to be interned likely already exists.
+    LikelyExists,
+    /// Hint that the string to be interned likely does not yet exist.
+    LikelyNew,
+}
+
 impl StringInterner {
     /// Returns the symbol of the string and interns it if necessary.
-    pub fn get_or_intern(&mut self, string: &str) -> Symbol {
+    ///
+    /// Optimized for `string` not to be contained in [`StringInterner`] before this operation.
+    #[inline]
+    pub fn get_or_intern(&mut self, string: &str, hint: InternHint) -> Symbol {
+        match hint {
+            InternHint::LikelyExists => self.get_or_intern_hint_existing(string),
+            InternHint::LikelyNew => self.get_or_intern_hint_new(string),
+        }
+    }
+
+    /// Returns the symbol of the string and interns it if necessary.
+    ///
+    /// # Note
+    ///
+    /// - Optimized for `string` not to be contained in [`StringInterner`] before this operation.
+    /// - Allocates `string` twice on the heap if it already existed prior to this operation.
+    fn get_or_intern_hint_new(&mut self, string: &str) -> Symbol {
         match self.string2symbol.entry(LenOrder(string.into())) {
             Entry::Vacant(entry) => {
                 let symbol = Symbol::from_usize(self.strings.len());
@@ -347,15 +371,35 @@ impl StringInterner {
                 entry.insert(symbol);
                 symbol
             }
-            Entry::Occupied(entry) => {
-                *entry.get()
+            Entry::Occupied(entry) => *entry.get(),
+        }
+    }
+
+    /// Returns the symbol of the string and interns it if necessary.
+    ///
+    /// # Note
+    ///
+    /// - Optimized for `string` to already be contained in [`StringInterner`] before this operation.
+    /// - Queries the position within `strings2symbol` twice in case `string` already existed.
+    fn get_or_intern_hint_existing(&mut self, string: &str) -> Symbol {
+        match self.string2symbol.get(<&LenOrderStr>::from(string)) {
+            Some(symbol) => *symbol,
+            None => {
+                let symbol = Symbol::from_usize(self.strings.len());
+                let rc_string: Arc<str> = Arc::from(string);
+                self.string2symbol
+                    .insert(LenOrder(rc_string.clone()), symbol);
+                self.strings.push(rc_string);
+                symbol
             }
         }
     }
 
     /// Returns the symbol for the string if interned.
     pub fn get(&self, string: &str) -> Option<Symbol> {
-        self.string2symbol.get(<&LenOrderStr>::from(string)).copied()
+        self.string2symbol
+            .get(<&LenOrderStr>::from(string))
+            .copied()
     }
 
     /// Resolves the symbol to the underlying string.
@@ -858,8 +902,8 @@ impl<T> LinkerInner<T> {
     /// Returns the import key for the module name and item name.
     fn import_key(&mut self, module: &str, name: &str) -> ImportKey {
         ImportKey::new(
-            self.strings.get_or_intern(module),
-            self.strings.get_or_intern(name),
+            self.strings.get_or_intern(module, InternHint::LikelyExists),
+            self.strings.get_or_intern(name, InternHint::LikelyNew),
         )
     }
 


### PR DESCRIPTION
I was able to further optimize the `Linker` setup performance by optimizing its internal string internment.

The trick was to provide different strategies for string internment depending on whether it was to be expected that a string is already existing or not. We can easily hint this because usually `module` strings do already exist because many definitions are put under the same `module` namespace whereas definition `name`s within the same `module` usually are unique.

Local benchmarks assessed an improvement by roughly 5-7%.