### PR TITLE
Speed-up `LinkerBuilder::finish`

### DIFF
--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -869,7 +869,7 @@ impl<T> LinkerBuilder<T> {
         }
     }
 
-    /// Returns an exclusive reference to the underlying [`LinkerInner`] if no [`Linker`] has been built, yet.
+    /// Returns an exclusive reference to the underlying [`Linker`] internals if no [`Linker`] has been built, yet.
     ///
     /// # Panics
     ///

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -874,7 +874,7 @@ impl<T> LinkerBuilder<T> {
     /// # Panics
     ///
     /// If the [`LinkerBuilder`] has already created a [`Linker`] using [`LinkerBuilder::finish`].
-    pub fn inner_mut(&mut self) -> &mut LinkerInner<T> {
+    fn inner_mut(&mut self) -> &mut LinkerInner<T> {
         Arc::get_mut(&mut self.inner).unwrap_or_else(|| {
             panic!("tried to define host function in LinkerBuilder after Linker creation")
         })

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -548,6 +548,10 @@ pub struct Linker<T> {
     /// Primarily required to define [`Linker`] owned host functions
     //  using [`Linker::func_wrap`] and [`Linker::func_new`]. TODO: implement methods
     engine: Engine,
+    /// Definitions shared with other [`Linker`] instances created by the same [`LinkerBuilder`].
+    ///
+    /// `None` if no [`LinkerBuilder`] was used for creation of the [`Linker`].
+    shared: Option<Arc<LinkerInner<T>>>,
     /// Inner linker implementation details.
     inner: LinkerInner<T>,
 }
@@ -556,6 +560,7 @@ impl<T> Clone for Linker<T> {
     fn clone(&self) -> Linker<T> {
         Self {
             engine: self.engine.clone(),
+            shared: self.shared.clone(),
             inner: self.inner.clone(),
         }
     }
@@ -572,6 +577,7 @@ impl<T> Linker<T> {
     pub fn new(engine: &Engine) -> Self {
         Self {
             engine: engine.clone(),
+            shared: None,
             inner: LinkerInner::default(),
         }
     }
@@ -579,13 +585,31 @@ impl<T> Linker<T> {
     /// Creates a new [`LinkerBuilder`] to construct a [`Linker`].
     pub fn build() -> LinkerBuilder<T> {
         LinkerBuilder {
-            inner: LinkerInner::default(),
+            inner: Arc::new(LinkerInner::default()),
         }
     }
 
     /// Returns the underlying [`Engine`] of the [`Linker`].
     pub fn engine(&self) -> &Engine {
         &self.engine
+    }
+
+    /// Ensures that the `name` in `module` is undefined in the shared definitions.
+    ///
+    /// Returns `Ok` if no shared definition exists.
+    ///
+    /// # Errors
+    ///
+    /// If there exists a shared definition for `name` in `module`.
+    fn ensure_undefined(&self, module: &str, name: &str) -> Result<(), LinkerError> {
+        if let Some(shared) = &self.shared {
+            if shared.has_definition(module, name) {
+                return Err(LinkerError::DuplicateDefinition {
+                    import_name: ImportName::new(module, name),
+                });
+            }
+        }
+        Ok(())
     }
 
     /// Define a new item in this [`Linker`].
@@ -599,7 +623,8 @@ impl<T> Linker<T> {
         name: &str,
         item: impl Into<Extern>,
     ) -> Result<&mut Self, LinkerError> {
-        let key = self.inner.import_key(module, name);
+        self.ensure_undefined(module, name)?;
+        let key = self.inner.new_import_key(module, name);
         self.inner.insert(key, Definition::Extern(item.into()))?;
         Ok(self)
     }
@@ -621,8 +646,9 @@ impl<T> Linker<T> {
             + Sync
             + 'static,
     ) -> Result<&mut Self, LinkerError> {
+        self.ensure_undefined(module, name)?;
         let func = HostFuncTrampolineEntity::new(ty, func);
-        let key = self.inner.import_key(module, name);
+        let key = self.inner.new_import_key(module, name);
         self.inner.insert(key, Definition::HostFunc(func))?;
         Ok(self)
     }
@@ -654,8 +680,9 @@ impl<T> Linker<T> {
         name: &str,
         func: impl IntoFunc<T, Params, Args>,
     ) -> Result<&mut Self, LinkerError> {
+        self.ensure_undefined(module, name)?;
         let func = HostFuncTrampolineEntity::wrap(func);
-        let key = self.inner.import_key(module, name);
+        let key = self.inner.new_import_key(module, name);
         self.inner.insert(key, Definition::HostFunc(func))?;
         Ok(self)
     }
@@ -697,6 +724,11 @@ impl<T> Linker<T> {
             context.as_context().store.engine(),
             self.engine()
         ));
+        if let Some(shared) = &self.shared {
+            if let Some(item) = shared.get_definition(module, name) {
+                return Some(item);
+            }
+        }
         self.inner.get_definition(module, name)
     }
 
@@ -816,7 +848,7 @@ impl<T> Linker<T> {
 #[derive(Debug)]
 pub struct LinkerBuilder<T> {
     /// Internal linker implementation details.
-    inner: LinkerInner<T>,
+    inner: Arc<LinkerInner<T>>,
 }
 
 impl<T> Clone for LinkerBuilder<T> {
@@ -832,8 +864,20 @@ impl<T> LinkerBuilder<T> {
     pub fn finish(&self, engine: &Engine) -> Linker<T> {
         Linker {
             engine: engine.clone(),
-            inner: self.inner.clone(),
+            shared: self.inner.clone().into(),
+            inner: <LinkerInner<T>>::default(),
         }
+    }
+
+    /// Returns an exclusive reference to the underlying [`LinkerInner`] if no [`Linker`] has been built, yet.
+    ///
+    /// # Panics
+    ///
+    /// If the [`LinkerBuilder`] has already created a [`Linker`] using [`LinkerBuilder::finish`].
+    pub fn inner_mut(&mut self) -> &mut LinkerInner<T> {
+        Arc::get_mut(&mut self.inner).unwrap_or_else(|| {
+            panic!("tried to define host function in LinkerBuilder after Linker creation")
+        })
     }
 
     /// Creates a new named [`Func::new`]-style host [`Func`] for this [`Linker`].
@@ -843,6 +887,10 @@ impl<T> LinkerBuilder<T> {
     /// # Errors
     ///
     /// If there already is a definition under the same name for this [`Linker`].
+    ///
+    /// # Panics
+    ///
+    /// If the [`LinkerBuilder`] has already created a [`Linker`] using [`LinkerBuilder::finish`].
     pub fn func_new(
         &mut self,
         module: &str,
@@ -853,7 +901,7 @@ impl<T> LinkerBuilder<T> {
             + Sync
             + 'static,
     ) -> Result<&mut Self, LinkerError> {
-        self.inner.func_new(module, name, ty, func)?;
+        self.inner_mut().func_new(module, name, ty, func)?;
         Ok(self)
     }
 
@@ -878,13 +926,17 @@ impl<T> LinkerBuilder<T> {
     /// If there already is a definition under the same name for this [`Linker`].
     ///
     /// [`Store`]: crate::Store
+    ///
+    /// # Panics
+    ///
+    /// If the [`LinkerBuilder`] has already created a [`Linker`] using [`LinkerBuilder::finish`].
     pub fn func_wrap<Params, Args>(
         &mut self,
         module: &str,
         name: &str,
         func: impl IntoFunc<T, Params, Args>,
     ) -> Result<&mut Self, LinkerError> {
-        self.inner.func_wrap(module, name, func)?;
+        self.inner_mut().func_wrap(module, name, func)?;
         Ok(self)
     }
 }
@@ -918,11 +970,19 @@ impl<T> Clone for LinkerInner<T> {
 
 impl<T> LinkerInner<T> {
     /// Returns the import key for the module name and item name.
-    fn import_key(&mut self, module: &str, name: &str) -> ImportKey {
+    fn new_import_key(&mut self, module: &str, name: &str) -> ImportKey {
         ImportKey::new(
             self.strings.get_or_intern(module, InternHint::LikelyExists),
             self.strings.get_or_intern(name, InternHint::LikelyNew),
         )
+    }
+
+    /// Returns the import key for the module name and item name.
+    fn get_import_key(&self, module: &str, name: &str) -> Option<ImportKey> {
+        Some(ImportKey::new(
+            self.strings.get(module)?,
+            self.strings.get(name)?,
+        ))
     }
 
     /// Resolves the module and item name of the import key if any.
@@ -971,7 +1031,7 @@ impl<T> LinkerInner<T> {
             + 'static,
     ) -> Result<&mut Self, LinkerError> {
         let func = HostFuncTrampolineEntity::new(ty, func);
-        let key = self.import_key(module, name);
+        let key = self.new_import_key(module, name);
         self.insert(key, Definition::HostFunc(func))?;
         Ok(self)
     }
@@ -1004,7 +1064,7 @@ impl<T> LinkerInner<T> {
         func: impl IntoFunc<T, Params, Args>,
     ) -> Result<&mut Self, LinkerError> {
         let func = HostFuncTrampolineEntity::wrap(func);
-        let key = self.import_key(module, name);
+        let key = self.new_import_key(module, name);
         self.insert(key, Definition::HostFunc(func))?;
         Ok(self)
     }
@@ -1017,8 +1077,16 @@ impl<T> LinkerInner<T> {
     ///
     /// If the [`Engine`] of this [`Linker`] and the [`Engine`] of `context` are not the same.
     fn get_definition(&self, module: &str, name: &str) -> Option<&Definition<T>> {
-        let key = ImportKey::new(self.strings.get(module)?, self.strings.get(name)?);
+        let key = self.get_import_key(module, name)?;
         self.definitions.get(&key)
+    }
+
+    /// Returns `true` if [`LinkerInner`] contains a [`Definition`] for `name` in `module`.
+    fn has_definition(&self, module: &str, name: &str) -> bool {
+        let Some(key) = self.get_import_key(module, name) else {
+            return false;
+        };
+        self.definitions.contains_key(&key)
     }
 }
 


### PR DESCRIPTION
Instead of cloning the `LinkerBuilder` state onto the newly created `Linker` we now simply increment an `Arc` strong counter. I was afraid we were slowing down on all other fronts and thus didn't implement this up front but benchmarks show no significant regressions.

Instead what we can clearly see is yet another 20x speed-up for `Linker` creation via `LinkerBuilder`.
This 20x is on top of the already existing 6x improvement from the `LinkerBuilder` API before this PR.
Therefore the total speed-up is more like 120x.

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/d45fdcaa-5970-4e47-b5f0-db2bfc5f8167)
