### PR TITLE
Rename `EngineLimits` to `EnforcedLimits`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,16 +67,16 @@ Dates in this file are formattes as `YYYY-MM-DD`.
     - Using `LinkerBuilder` to create new `Linker`s with the same set of host functions is a lot more
       efficient than creating those `Linker`s the original way. However, the initial `LinkerBuilder`
       construction will be as inefficient as building up a `Linker` previously.
-- Added `EngineLimits` configuration option to `Config`. (https://github.com/wasmi-labs/wasmi/pull/985)
+- Added `EnforcedLimits` configuration option to `Config`. (https://github.com/wasmi-labs/wasmi/pull/985)
     - Some users want to run Wasm binaries in a specially restricted or limited mode.
       For example this mode limits the amount of functions, globals, tables etc. can be defined
       in a single Wasm module.
       With this change they can enable this new strict mode using
       ```rust
       let mut config = wasmi::Config::default();
-      config.engine_limits(wasmi::EngineLimits::strict());
+      config.engine_limits(wasmi::EnforcedLimits::strict());
       ```
-      In future updates we might relax this to make `EngineLimits` fully customizable.
+      In future updates we might relax this to make `EnforcedLimits` fully customizable.
 
 ### Changed
 

--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -1,4 +1,4 @@
-use super::{EngineLimits, StackLimits};
+use super::{EnforcedLimits, StackLimits};
 use core::{mem::size_of, num::NonZeroU64};
 use wasmi_core::UntypedValue;
 use wasmparser::WasmFeatures;
@@ -40,7 +40,7 @@ pub struct Config {
     /// The mode of Wasm to Wasmi bytecode compilation.
     compilation_mode: CompilationMode,
     /// Enforced limits for Wasm module parsing and compilation.
-    limits: EngineLimits,
+    limits: EnforcedLimits,
 }
 
 /// Type storing all kinds of fuel costs of instructions.
@@ -182,7 +182,7 @@ impl Default for Config {
             consume_fuel: false,
             fuel_costs: FuelCosts::default(),
             compilation_mode: CompilationMode::default(),
-            limits: EngineLimits::default(),
+            limits: EnforcedLimits::default(),
         }
     }
 }
@@ -370,20 +370,20 @@ impl Config {
         self.compilation_mode
     }
 
-    /// Sets the [`EngineLimits`] enforced by the [`Engine`] for Wasm module parsing and compilation.
+    /// Sets the [`EnforcedLimits`] enforced by the [`Engine`] for Wasm module parsing and compilation.
     ///
     /// By default no limits are enforced.
     ///
     /// [`Engine`]: crate::Engine
-    pub fn engine_limits(&mut self, limits: EngineLimits) -> &mut Self {
+    pub fn engine_limits(&mut self, limits: EnforcedLimits) -> &mut Self {
         self.limits = limits;
         self
     }
 
-    /// Returns the [`EngineLimits`] used for the [`Engine`].
+    /// Returns the [`EnforcedLimits`] used for the [`Engine`].
     ///
     /// [`Engine`]: crate::Engine
-    pub(crate) fn get_engine_limits(&self) -> &EngineLimits {
+    pub(crate) fn get_engine_limits(&self) -> &EnforcedLimits {
         &self.limits
     }
 

--- a/crates/wasmi/src/engine/limits/engine.rs
+++ b/crates/wasmi/src/engine/limits/engine.rs
@@ -2,7 +2,7 @@ use core::fmt::{self, Display};
 
 /// An error that can occur upon parsing or compiling a Wasm module when [`EngineLimits`] are set.
 #[derive(Debug, Copy, Clone)]
-pub enum EngineLimitsError {
+pub enum EnforcedLimitsError {
     /// When a Wasm module exceeds the global variable limit.
     TooManyGlobals { limit: u32 },
     /// When a Wasm module exceeds the table limit.
@@ -23,7 +23,7 @@ pub enum EngineLimitsError {
     MinAvgBytesPerFunction { limit: u32, avg: u32 },
 }
 
-impl Display for EngineLimitsError {
+impl Display for EnforcedLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::TooManyGlobals { limit } => write!(
@@ -68,7 +68,7 @@ impl Display for EngineLimitsError {
 ///
 /// [`Engine`]: crate::Engine
 #[derive(Debug, Default, Copy, Clone)]
-pub struct EngineLimits {
+pub struct EnforcedLimits {
     /// Number of global variables a single Wasm module can have at most.
     ///
     /// # Note
@@ -188,7 +188,7 @@ pub struct AvgBytesPerFunctionLimit {
     pub min_avg_bytes_per_function: u32,
 }
 
-impl EngineLimits {
+impl EnforcedLimits {
     /// A strict set of limits that makes use of Wasmi implementation details.
     ///
     /// This set of strict enforced rules can be used by Wasmi users in order

--- a/crates/wasmi/src/engine/limits/mod.rs
+++ b/crates/wasmi/src/engine/limits/mod.rs
@@ -5,6 +5,6 @@ mod stack;
 mod tests;
 
 pub use self::{
-    engine::{EngineLimits, EngineLimitsError},
+    engine::{EnforcedLimits, EnforcedLimitsError},
     stack::StackLimits,
 };

--- a/crates/wasmi/src/engine/limits/tests.rs
+++ b/crates/wasmi/src/engine/limits/tests.rs
@@ -8,8 +8,8 @@ fn wat2wasm(wat: &str) -> Vec<u8> {
     wat::parse_str(wat).unwrap()
 }
 
-/// Parses and returns the Wasm module `wasm` with the given [`EngineLimits`] `limits`.
-fn parse_with(wasm: &str, limits: EngineLimits) -> Result<Module, Error> {
+/// Parses and returns the Wasm module `wasm` with the given [`EnforcedLimits`] `limits`.
+fn parse_with(wasm: &str, limits: EnforcedLimits) -> Result<Module, Error> {
     let wasm = wat2wasm(wasm);
     let mut config = Config::default();
     config.engine_limits(limits);
@@ -27,9 +27,9 @@ fn max_globals_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             max_globals: Some(2),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -44,13 +44,13 @@ fn max_globals_err() {
             (global i32 (i32.const 3))
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         max_globals: Some(2),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::TooManyGlobals { limit: 2 }),
+        ErrorKind::Limits(EnforcedLimitsError::TooManyGlobals { limit: 2 }),
     ))
 }
 
@@ -64,9 +64,9 @@ fn max_functions_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             max_functions: Some(2),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -81,13 +81,13 @@ fn max_functions_err() {
             (func)
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         max_functions: Some(2),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::TooManyFunctions { limit: 2 }),
+        ErrorKind::Limits(EnforcedLimitsError::TooManyFunctions { limit: 2 }),
     ))
 }
 
@@ -101,9 +101,9 @@ fn max_tables_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             max_tables: Some(2),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -118,13 +118,13 @@ fn max_tables_err() {
             (table 0 funcref)
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         max_tables: Some(2),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::TooManyTables { limit: 2 }),
+        ErrorKind::Limits(EnforcedLimitsError::TooManyTables { limit: 2 }),
     ))
 }
 
@@ -139,9 +139,9 @@ fn max_memories_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             max_memories: Some(2),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -157,13 +157,13 @@ fn max_memories_err() {
             (memory 0)
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         max_memories: Some(2),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::TooManyMemories { limit: 2 }),
+        ErrorKind::Limits(EnforcedLimitsError::TooManyMemories { limit: 2 }),
     ))
 }
 
@@ -179,9 +179,9 @@ fn max_element_segments_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             max_element_segments: Some(2),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -198,13 +198,13 @@ fn max_element_segments_err() {
             (elem (table $t) (i32.const 2) funcref (ref.func $f) (ref.null func))
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         max_element_segments: Some(2),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::TooManyElementSegments { limit: 2 }),
+        ErrorKind::Limits(EnforcedLimitsError::TooManyElementSegments { limit: 2 }),
     ))
 }
 
@@ -219,9 +219,9 @@ fn max_data_segments_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             max_data_segments: Some(2),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -237,13 +237,13 @@ fn max_data_segments_err() {
             (data (memory $m) (i32.const 2) \"abc\")
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         max_data_segments: Some(2),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::TooManyDataSegments { limit: 2 }),
+        ErrorKind::Limits(EnforcedLimitsError::TooManyDataSegments { limit: 2 }),
     ))
 }
 
@@ -256,9 +256,9 @@ fn max_params_func_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             max_params: Some(2),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -271,13 +271,13 @@ fn max_params_func_err() {
             (func (param i32 i32 i32))
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         max_params: Some(2),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::TooManyParameters { limit: 2 }),
+        ErrorKind::Limits(EnforcedLimitsError::TooManyParameters { limit: 2 }),
     ))
 }
 
@@ -297,9 +297,9 @@ fn max_params_control_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             max_params: Some(2),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -320,13 +320,13 @@ fn max_params_control_err() {
             )
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         max_params: Some(2),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::TooManyParameters { limit: 2 }),
+        ErrorKind::Limits(EnforcedLimitsError::TooManyParameters { limit: 2 }),
     ))
 }
 
@@ -342,9 +342,9 @@ fn max_results_func_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             max_results: Some(2),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -361,13 +361,13 @@ fn max_results_func_err() {
             )
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         max_results: Some(2),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::TooManyResults { limit: 2 }),
+        ErrorKind::Limits(EnforcedLimitsError::TooManyResults { limit: 2 }),
     ))
 }
 
@@ -387,9 +387,9 @@ fn max_results_control_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             max_results: Some(2),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -411,13 +411,13 @@ fn max_results_control_err() {
             )
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         max_results: Some(2),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::TooManyResults { limit: 2 }),
+        ErrorKind::Limits(EnforcedLimitsError::TooManyResults { limit: 2 }),
     ))
 }
 
@@ -439,12 +439,12 @@ fn min_avg_code_bytes_ok() {
     ";
     parse_with(
         wasm,
-        EngineLimits {
+        EnforcedLimits {
             min_avg_bytes_per_function: Some(AvgBytesPerFunctionLimit {
                 req_funcs_bytes: 0,
                 min_avg_bytes_per_function: 6,
             }),
-            ..EngineLimits::default()
+            ..EnforcedLimits::default()
         },
     )
     .unwrap();
@@ -464,17 +464,17 @@ fn min_avg_code_bytes_err() {
             )
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         min_avg_bytes_per_function: Some(AvgBytesPerFunctionLimit {
             req_funcs_bytes: 0,
             min_avg_bytes_per_function: 6,
         }),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     std::println!("{:?}", parse_with(wasm, limits).unwrap_err());
     assert!(matches!(
         parse_with(wasm, limits).unwrap_err().kind(),
-        ErrorKind::Limits(EngineLimitsError::MinAvgBytesPerFunction { limit: 6, avg: 5 }),
+        ErrorKind::Limits(EnforcedLimitsError::MinAvgBytesPerFunction { limit: 6, avg: 5 }),
     ))
 }
 
@@ -492,12 +492,12 @@ fn min_avg_code_bytes_ok_threshold() {
             )
         )
     ";
-    let limits = EngineLimits {
+    let limits = EnforcedLimits {
         min_avg_bytes_per_function: Some(AvgBytesPerFunctionLimit {
             req_funcs_bytes: 12,
             min_avg_bytes_per_function: 6,
         }),
-        ..EngineLimits::default()
+        ..EnforcedLimits::default()
     };
     parse_with(wasm, limits).unwrap();
 }

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -37,7 +37,7 @@ pub(crate) use self::{
 pub use self::{
     code_map::CompiledFunc,
     config::{CompilationMode, Config},
-    limits::{EngineLimits, EngineLimitsError, StackLimits},
+    limits::{EnforcedLimits, EnforcedLimitsError, StackLimits},
     resumable::{ResumableCall, ResumableInvocation, TypedResumableCall, TypedResumableInvocation},
     traits::{CallParams, CallResults},
     translator::{Instr, TranslationError},

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -1,5 +1,5 @@
 use super::errors::{
-    EngineLimitsError,
+    EnforcedLimitsError,
     FuelError,
     FuncError,
     GlobalError,
@@ -169,7 +169,7 @@ pub enum ErrorKind {
     /// Encountered when there is a Wasm to Wasmi translation error.
     Translation(TranslationError),
     /// Encountered when an enforced limit is exceeded.
-    Limits(EngineLimitsError),
+    Limits(EnforcedLimitsError),
 }
 
 impl ErrorKind {
@@ -264,7 +264,7 @@ impl_from! {
     impl From<ReadError> for Error::Read;
     impl From<FuelError> for Error::Fuel;
     impl From<FuncError> for Error::Func;
-    impl From<EngineLimitsError> for Error::Limits;
+    impl From<EnforcedLimitsError> for Error::Limits;
 }
 
 /// An error that can occur upon `memory.grow` or `table.grow`.

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -109,7 +109,7 @@ pub use wasmi_core as core;
 /// Defines some errors that may occur upon interaction with Wasmi.
 pub mod errors {
     pub use super::{
-        engine::EngineLimitsError,
+        engine::EnforcedLimitsError,
         error::ErrorKind,
         func::FuncError,
         global::GlobalError,
@@ -125,8 +125,8 @@ pub use self::{
     engine::{
         CompilationMode,
         Config,
+        EnforcedLimits,
         Engine,
-        EngineLimits,
         ResumableCall,
         ResumableInvocation,
         StackLimits,

--- a/crates/wasmi/src/module/parser.rs
+++ b/crates/wasmi/src/module/parser.rs
@@ -12,7 +12,7 @@ use super::{
     Read,
 };
 use crate::{
-    engine::{CompiledFunc, EngineLimitsError},
+    engine::{CompiledFunc, EnforcedLimitsError},
     Engine,
     Error,
     FuncType,
@@ -367,12 +367,14 @@ impl ModuleParser {
             let wasmparser::Type::Func(ty) = result?;
             if let Some(limit) = limits.max_params {
                 if ty.params().len() > limit {
-                    return Err(Error::from(EngineLimitsError::TooManyParameters { limit }));
+                    return Err(Error::from(EnforcedLimitsError::TooManyParameters {
+                        limit,
+                    }));
                 }
             }
             if let Some(limit) = limits.max_results {
                 if ty.results().len() > limit {
-                    return Err(Error::from(EngineLimitsError::TooManyResults { limit }));
+                    return Err(Error::from(EnforcedLimitsError::TooManyResults { limit }));
                 }
             }
             Ok(FuncType::from_wasmparser(ty))
@@ -435,7 +437,7 @@ impl ModuleParser {
     ) -> Result<(), Error> {
         if let Some(limit) = self.engine.config().get_engine_limits().max_functions {
             if section.count() > limit {
-                return Err(Error::from(EngineLimitsError::TooManyFunctions { limit }));
+                return Err(Error::from(EnforcedLimitsError::TooManyFunctions { limit }));
             }
         }
         self.validator.function_section(&section)?;
@@ -462,7 +464,7 @@ impl ModuleParser {
     ) -> Result<(), Error> {
         if let Some(limit) = self.engine.config().get_engine_limits().max_tables {
             if section.count() > limit {
-                return Err(Error::from(EngineLimitsError::TooManyTables { limit }));
+                return Err(Error::from(EnforcedLimitsError::TooManyTables { limit }));
             }
         }
         self.validator.table_section(&section)?;
@@ -489,7 +491,7 @@ impl ModuleParser {
     ) -> Result<(), Error> {
         if let Some(limit) = self.engine.config().get_engine_limits().max_memories {
             if section.count() > limit {
-                return Err(Error::from(EngineLimitsError::TooManyMemories { limit }));
+                return Err(Error::from(EnforcedLimitsError::TooManyMemories { limit }));
             }
         }
         self.validator.memory_section(&section)?;
@@ -526,7 +528,7 @@ impl ModuleParser {
     ) -> Result<(), Error> {
         if let Some(limit) = self.engine.config().get_engine_limits().max_globals {
             if section.count() > limit {
-                return Err(Error::from(EngineLimitsError::TooManyGlobals { limit }));
+                return Err(Error::from(EnforcedLimitsError::TooManyGlobals { limit }));
             }
         }
         self.validator.global_section(&section)?;
@@ -603,7 +605,7 @@ impl ModuleParser {
             .max_element_segments
         {
             if section.count() > limit {
-                return Err(Error::from(EngineLimitsError::TooManyElementSegments {
+                return Err(Error::from(EnforcedLimitsError::TooManyElementSegments {
                     limit,
                 }));
             }
@@ -625,7 +627,7 @@ impl ModuleParser {
     fn process_data_count(&mut self, count: u32, range: Range<usize>) -> Result<(), Error> {
         if let Some(limit) = self.engine.config().get_engine_limits().max_data_segments {
             if count > limit {
-                return Err(Error::from(EngineLimitsError::TooManyDataSegments {
+                return Err(Error::from(EnforcedLimitsError::TooManyDataSegments {
                     limit,
                 }));
             }
@@ -651,7 +653,7 @@ impl ModuleParser {
     ) -> Result<(), Error> {
         if let Some(limit) = self.engine.config().get_engine_limits().max_data_segments {
             if section.count() > limit {
-                return Err(Error::from(EngineLimitsError::TooManyDataSegments {
+                return Err(Error::from(EnforcedLimitsError::TooManyDataSegments {
                     limit,
                 }));
             }
@@ -684,7 +686,7 @@ impl ModuleParser {
         let engine_limits = self.engine.config().get_engine_limits();
         if let Some(limit) = engine_limits.max_functions {
             if count > limit {
-                return Err(Error::from(EngineLimitsError::TooManyFunctions { limit }));
+                return Err(Error::from(EnforcedLimitsError::TooManyFunctions { limit }));
             }
         }
         if let Some(limit) = engine_limits.min_avg_bytes_per_function {
@@ -692,7 +694,7 @@ impl ModuleParser {
                 let limit = limit.min_avg_bytes_per_function;
                 let avg = size / count;
                 if avg < limit {
-                    return Err(Error::from(EngineLimitsError::MinAvgBytesPerFunction {
+                    return Err(Error::from(EnforcedLimitsError::MinAvgBytesPerFunction {
                         limit,
                         avg,
                     }));


### PR DESCRIPTION
This is a better name since currently most if not all of these limits are tied to the Wasm module and not the Wasmi engine. This might change over time with the introduction of more limiting parameters.