### PR TITLE
Make `LinkerBuilder` type stateful

### DIFF
--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -269,9 +269,10 @@ fn bench_linker_build_finish_same(c: &mut Criterion) {
         for func_name in &func_names {
             builder.func_wrap("env", func_name, || ()).unwrap();
         }
+        let builder = builder.finish();
         b.iter(|| {
             let engine = Engine::default();
-            _ = builder.finish(&engine);
+            _ = builder.create(&engine);
         })
     });
 }
@@ -371,9 +372,10 @@ fn bench_linker_build_finish_unique(c: &mut Criterion) {
                 )
                 .unwrap();
         }
+        let builder = builder.finish();
         b.iter(|| {
             let engine = Engine::default();
-            _ = builder.finish(&engine);
+            _ = builder.create(&engine);
         })
     });
 }

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -151,7 +151,7 @@ pub use self::{
     global::{Global, GlobalType, Mutability},
     instance::{Export, ExportsIter, Extern, ExternType, Instance},
     limits::{ResourceLimiter, StoreLimits, StoreLimitsBuilder},
-    linker::{Linker, LinkerBuilder},
+    linker::{state, Linker, LinkerBuilder},
     memory::{Memory, MemoryType},
     module::{
         ExportType,

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -28,10 +28,10 @@ use core::{
 };
 use std::{
     collections::{btree_map::Entry, BTreeMap},
-    marker::PhantomData,
     sync::Arc,
     vec::Vec,
 };
+use core::marker::PhantomData;
 
 /// An error that may occur upon operating with [`Linker`] instances.
 #[derive(Debug)]

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -1225,4 +1225,28 @@ mod tests {
         wasm_set_b.call(&mut store, 200).unwrap();
         assert_eq!(wasm_get_b.call(&mut store, ()).unwrap(), 200);
     }
+
+    #[test]
+    fn build_linker() {
+        let mut builder = <Linker<()>>::build();
+        builder
+            .func_wrap("env", "foo", || std::println!("called foo"))
+            .unwrap();
+        builder
+            .func_new(
+                "env",
+                "bar",
+                FuncType::new([], []),
+                |_caller, _params, _results| {
+                    std::println!("called bar");
+                    Ok(())
+                },
+            )
+            .unwrap();
+        let builder = builder.finish();
+        for _ in 0..3 {
+            let engine = Engine::default();
+            let _ = builder.create(&engine);
+        }
+    }
 }

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -23,6 +23,7 @@ use core::{
     borrow::Borrow,
     cmp::Ordering,
     fmt::{self, Debug, Display},
+    marker::PhantomData,
     mem,
     ops::Deref,
 };
@@ -31,7 +32,6 @@ use std::{
     sync::Arc,
     vec::Vec,
 };
-use core::marker::PhantomData;
 
 /// An error that may occur upon operating with [`Linker`] instances.
 #[derive(Debug)]


### PR DESCRIPTION
This makes it impossible to use the `LinkerBuilder` type incorrectly.