### PR TITLE
Properly mirror Wasmtime fuel API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 - Improve `Debug` and `Display` impls for NaNs of Wasm `f32` and `f64` values.
   - They now show `nan:0x{bytes}` where `{bytes}` is their respective raw bytes.
 - Implement `Sync` for `ResumableInvocation` and `TypedResumableInvocation`. (https://github.com/wasmi-labs/wasmi/pull/870)
+- Properly mirror Wasmtime's fuel API. (https://github.com/wasmi-labs/wasmi/pull/1002)
 
 ### Removed
 

--- a/crates/cli/src/context.rs
+++ b/crates/cli/src/context.rs
@@ -43,7 +43,7 @@ impl Context {
         })?;
         let mut store = wasmi::Store::new(&engine, wasi_ctx);
         if let Some(fuel) = fuel {
-            store.add_fuel(fuel).unwrap_or_else(|error| {
+            store.set_fuel(fuel).unwrap_or_else(|error| {
                 panic!("error: fuel metering is enabled but encountered: {error}")
             });
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -61,11 +61,12 @@ fn main() -> Result<()> {
 
 /// Prints the remaining fuel so far if fuel metering was enabled.
 fn print_remaining_fuel(args: &Args, ctx: &Context) {
-    if let Some(total_fuel) = args.fuel() {
-        let consumed = ctx.store().fuel_consumed().unwrap_or_else(|| {
-            panic!("fuel metering is enabled but could not query consumed fuel")
-        });
-        let remaining = total_fuel - consumed;
+    if let Some(given_fuel) = args.fuel() {
+        let remaining = ctx
+            .store()
+            .get_fuel()
+            .unwrap_or_else(|error| panic!("could not get the remaining fuel: {error}"));
+        let consumed = given_fuel.saturating_sub(remaining);
         println!("fuel consumed: {consumed}, fuel remaining: {remaining}");
     }
 }

--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -328,9 +328,9 @@ impl Config {
     /// a [`TrapCode::OutOfFuel`](crate::core::TrapCode::OutOfFuel) trap is raised.
     /// This way users can deterministically halt or yield the execution of WebAssembly code.
     ///
-    /// - Use [`Store::add_fuel`](crate::Store::add_fuel) to pour some fuel into the [`Store`] before
+    /// - Use [`Store::set_fuel`](crate::Store::set_fuel) to set the remaining fuel of the [`Store`] before
     ///   executing some code as the [`Store`] start with no fuel.
-    /// - Use [`Caller::consume_fuel`](crate::Caller::consume_fuel) to charge costs for executed host functions.
+    /// - Use [`Caller::set_fuel`](crate::Caller::set_fuel) to update the remaining fuel when executing host functions.
     ///
     /// Disabled by default.
     ///

--- a/crates/wasmi/src/func/caller.rs
+++ b/crates/wasmi/src/func/caller.rs
@@ -49,36 +49,26 @@ impl<'a, T> Caller<'a, T> {
         self.ctx.store.engine()
     }
 
-    /// Adds `delta` quantity of fuel to the remaining fuel.
+    /// Returns the remaining fuel of the [`Store`](crate::Store) if fuel metering is enabled.
     ///
-    /// # Panics
-    ///
-    /// If this overflows the remaining fuel counter.
+    /// For more information see [`Store::get_fuel`](crate::Store::get_fuel).
     ///
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn add_fuel(&mut self, delta: u64) -> Result<(), FuelError> {
-        self.ctx.store.add_fuel(delta)
+    pub fn get_fuel(&self) -> Result<u64, FuelError> {
+        self.ctx.store.get_fuel()
     }
 
-    /// Returns the amount of fuel consumed by executions of the [`Store`](crate::Store) so far.
+    /// Sets the remaining fuel of the [`Store`](crate::Store) to `value` if fuel metering is enabled.
     ///
-    /// Returns `None` if fuel metering is disabled.
-    pub fn fuel_consumed(&self) -> Option<u64> {
-        self.ctx.store.fuel_consumed()
-    }
-
-    /// Synthetically consumes an amount of fuel for the [`Store`](crate::Store).
-    ///
-    /// Returns the remaining amount of fuel after this operation.
+    /// For more information see [`Store::get_fuel`](crate::Store::set_fuel).
     ///
     /// # Errors
     ///
-    /// - If fuel metering is disabled.
-    /// - If more fuel is consumed than available.
-    pub fn consume_fuel(&mut self, delta: u64) -> Result<u64, FuelError> {
-        self.ctx.store.consume_fuel(delta)
+    /// If fuel metering is disabled.
+    pub fn set_fuel(&mut self, fuel: u64) -> Result<(), FuelError> {
+        self.ctx.store.set_fuel(fuel)
     }
 }
 

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -5,6 +5,7 @@ use crate::{
     memory::{DataSegment, MemoryError},
     module::InstantiationError,
     table::TableError,
+    Config,
     DataSegmentEntity,
     DataSegmentIdx,
     ElementSegment,
@@ -219,8 +220,7 @@ pub struct Fuel {
 
 impl Fuel {
     /// Creates a new [`Fuel`] for the [`Engine`].
-    pub fn new(engine: &Engine) -> Self {
-        let config = engine.config();
+    pub fn new(config: &Config) -> Self {
         let enabled = config.get_consume_fuel();
         let costs = *config.fuel_costs();
         Self {
@@ -333,7 +333,7 @@ impl Fuel {
 impl StoreInner {
     /// Creates a new [`StoreInner`] for the given [`Engine`].
     pub fn new(engine: &Engine) -> Self {
-        let fuel = Fuel::new(engine);
+        let fuel = Fuel::new(engine.config());
         StoreInner {
             engine: engine.clone(),
             store_idx: StoreIdx::new(),

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -209,8 +209,6 @@ impl FuelError {
 pub struct Fuel {
     /// The remaining fuel.
     remaining: u64,
-    /// The total amount of fuel so far.
-    total: u64,
     /// This is `true` if fuel metering is enabled for the [`Engine`].
     enabled: bool,
     /// The fuel costs provided by the [`Engine`]'s [`Config`].
@@ -227,7 +225,6 @@ impl Fuel {
         let costs = *config.fuel_costs();
         Self {
             remaining: 0,
-            total: 0,
             enabled,
             costs,
         }
@@ -252,33 +249,25 @@ impl Fuel {
         Ok(())
     }
 
-    /// Adds `delta` quantity of fuel to the remaining [`Fuel`].
-    ///
-    /// # Panics
-    ///
-    /// If this overflows the [`Fuel`] counter.
+    /// Sets the remaining fuel to `fuel`.
     ///
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn add_fuel(&mut self, delta: u64) -> Result<(), FuelError> {
+    pub fn set_fuel(&mut self, fuel: u64) -> Result<(), FuelError> {
         self.check_fuel_metering_enabled()?;
-        self.total = self.total.checked_add(delta).unwrap_or_else(|| {
-            panic!(
-                "encountered total fuel overflow: fuel = {}, delta = {delta}",
-                self.total
-            )
-        });
-        // No need to check as well since `self.total >= self.remaining`.
-        self.remaining = self.remaining.wrapping_add(delta);
+        self.remaining = fuel;
         Ok(())
     }
 
-    /// Returns the amount of [`Fuel`] consumed by executions of the [`Store`] so far.
-    pub fn fuel_consumed(&self) -> Option<u64> {
-        self.check_fuel_metering_enabled().ok()?;
-        let consumed = self.total.wrapping_sub(self.remaining);
-        Some(consumed)
+    /// Returns the remaining fuel.
+    ///
+    /// # Errors
+    ///
+    /// If fuel metering is disabled.
+    pub fn get_fuel(&self) -> Result<u64, FuelError> {
+        self.check_fuel_metering_enabled()?;
+        Ok(self.remaining)
     }
 
     /// Synthetically consumes an amount of [`Fuel`] from the [`Store`].
@@ -312,7 +301,10 @@ impl Fuel {
     ///
     /// - If fuel metering is disabled.
     /// - If out of fuel.
-    pub fn consume_fuel(&mut self, f: impl FnOnce(&FuelCosts) -> u64) -> Result<u64, FuelError> {
+    pub(crate) fn consume_fuel(
+        &mut self,
+        f: impl FnOnce(&FuelCosts) -> u64,
+    ) -> Result<u64, FuelError> {
         self.check_fuel_metering_enabled()?;
         self.consume_fuel_unchecked(f(&self.costs))
             .map_err(|_| FuelError::OutOfFuel)
@@ -920,36 +912,30 @@ impl<T> Store<T> {
         (&mut self.inner, resource_limiter)
     }
 
-    /// Adds `delta` quantity of fuel to the remaining fuel.
+    /// Returns the remaining fuel of the [`Store`] if fuel metering is enabled.
     ///
-    /// # Panics
+    /// # Note
     ///
-    /// If this overflows the remaining fuel counter.
+    /// Enable fuel metering via [`Config::consume_fuel`](crate::Config::consume_fuel).
     ///
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn add_fuel(&mut self, delta: u64) -> Result<(), FuelError> {
-        self.inner.fuel.add_fuel(delta)
+    pub fn get_fuel(&self) -> Result<u64, FuelError> {
+        self.inner.fuel.get_fuel()
     }
 
-    /// Returns the amount of fuel consumed by executions of the [`Store`] so far.
+    /// Sets the remaining fuel of the [`Store`] to `value` if fuel metering is enabled.
     ///
-    /// Returns `None` if fuel metering is disabled.
-    pub fn fuel_consumed(&self) -> Option<u64> {
-        self.inner.fuel.fuel_consumed()
-    }
-
-    /// Synthetically consumes an amount of fuel for the [`Store`].
+    /// # Note
     ///
-    /// Returns the remaining amount of fuel after this operation.
+    /// Enable fuel metering via [`Config::consume_fuel`](crate::Config::consume_fuel).
     ///
     /// # Errors
     ///
-    /// - If fuel metering is disabled.
-    /// - If more fuel is consumed than available.
-    pub fn consume_fuel(&mut self, delta: u64) -> Result<u64, FuelError> {
-        self.inner.fuel.consume_fuel(|_| delta)
+    /// If fuel metering is disabled.
+    pub fn set_fuel(&mut self, fuel: u64) -> Result<(), FuelError> {
+        self.inner.fuel.set_fuel(fuel)
     }
 
     /// Allocates a new [`TrampolineEntity`] and returns a [`Trampoline`] reference to it.
@@ -1028,6 +1014,17 @@ impl<'a, T> StoreContext<'a, T> {
     pub fn data(&self) -> &T {
         self.store.data()
     }
+
+    /// Returns the remaining fuel of the [`Store`] if fuel metering is enabled.
+    ///
+    /// For more information see [`Store::get_fuel`](crate::Store::get_fuel).
+    ///
+    /// # Errors
+    ///
+    /// If fuel metering is disabled.
+    pub fn get_fuel(&self) -> Result<u64, FuelError> {
+        self.store.get_fuel()
+    }
 }
 
 impl<'a, T: AsContext> From<&'a T> for StoreContext<'a, T::UserState> {
@@ -1079,6 +1076,28 @@ impl<'a, T> StoreContextMut<'a, T> {
     /// Same as [`Store::data_mut`].
     pub fn data_mut(&mut self) -> &mut T {
         self.store.data_mut()
+    }
+
+    /// Returns the remaining fuel of the [`Store`] if fuel metering is enabled.
+    ///
+    /// For more information see [`Store::get_fuel`](crate::Store::get_fuel).
+    ///
+    /// # Errors
+    ///
+    /// If fuel metering is disabled.
+    pub fn get_fuel(&self) -> Result<u64, FuelError> {
+        self.store.get_fuel()
+    }
+
+    /// Sets the remaining fuel of the [`Store`] to `value` if fuel metering is enabled.
+    ///
+    /// For more information see [`Store::get_fuel`](crate::Store::set_fuel).
+    ///
+    /// # Errors
+    ///
+    /// If fuel metering is disabled.
+    pub fn set_fuel(&mut self, fuel: u64) -> Result<(), FuelError> {
+        self.store.set_fuel(fuel)
     }
 }
 

--- a/crates/wasmi/tests/e2e/v1/fuel_consumption.rs
+++ b/crates/wasmi/tests/e2e/v1/fuel_consumption.rs
@@ -75,9 +75,9 @@ fn check_fuel_consumption(given_fuel: u64, consumed_fuel: u64) {
     let (mut store, func) = default_test_setup(&wasm);
     let func = func.typed::<(), i32>(&store).unwrap();
     // Now add enough fuel, so execution should succeed.
-    store.add_fuel(given_fuel).unwrap(); // this is just enough fuel for a successful `memory.grow`
+    store.set_fuel(given_fuel).unwrap(); // this is just enough fuel for a successful `memory.grow`
     assert_success(func.call(&mut store, ()));
-    assert_eq!(store.fuel_consumed(), Some(consumed_fuel));
+    assert_eq!(given_fuel - store.get_fuel().unwrap(), consumed_fuel);
 }
 
 #[test]

--- a/crates/wasmi/tests/e2e/v1/fuel_metering.rs
+++ b/crates/wasmi/tests/e2e/v1/fuel_metering.rs
@@ -82,13 +82,13 @@ fn metered_i32_add() {
     let func = func.typed::<(i32, i32), i32>(&store).unwrap();
     // No fuel -> no success.
     assert_out_of_fuel(func.call(&mut store, (1, 2)));
-    assert_eq!(store.fuel_consumed(), Some(0));
-    // Now add too little fuel for a start, so still no success.
-    store.add_fuel(1).unwrap();
+    assert_eq!(store.get_fuel().ok(), Some(0));
+    // Now set too little fuel for a start, so still no success.
+    store.set_fuel(1).unwrap();
     assert_out_of_fuel(func.call(&mut store, (1, 2)));
-    assert_eq!(store.fuel_consumed(), Some(0));
+    assert_eq!(store.get_fuel().ok(), Some(1));
     // Now add enough fuel, so execution should succeed.
-    store.add_fuel(10).unwrap();
+    store.set_fuel(10).unwrap();
     assert_success(func.call(&mut store, (1, 2)));
-    assert_eq!(store.fuel_consumed(), Some(3));
+    assert_eq!(store.get_fuel().ok(), Some(7));
 }

--- a/crates/wasmi/tests/spec/context.rs
+++ b/crates/wasmi/tests/spec/context.rs
@@ -52,7 +52,7 @@ impl<'a> TestContext<'a> {
         let engine = Engine::new(&config);
         let mut linker = Linker::new(&engine);
         let mut store = Store::new(&engine, ());
-        _ = store.add_fuel(1_000_000_000);
+        _ = store.set_fuel(1_000_000_000);
         let default_memory = Memory::new(&mut store, MemoryType::new(1, Some(2)).unwrap()).unwrap();
         let default_table = Table::new(
             &mut store,


### PR DESCRIPTION
- Remove `Store::{add_fuel, consume_fuel}`
- Remove `Caller::{add_fuel, consume_fuel}`
- Add `Store::{get_fuel, set_fuel}`
- Add `Caller::{get_fuel, set_fuel}`
- Add `StoreContext::get_fuel`
- Add `StoreContextMut::{get_fuel, set_fuel}`
