### PR TITLE
Re-export `EngineWeak` from the `wasmi` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ Dates in this file are formattes as `YYYY-MM-DD`.
       config.engine_limits(wasmi::EnforcedLimits::strict());
       ```
       In future updates we might relax this to make `EnforcedLimits` fully customizable.
+- Added `EngineWeak` constructed via `Engine::weak`. (https://github.com/wasmi-labs/wasmi/pull/1003)
+     - This properly mirrors the Wasmtime API and allows users to store weak references to the `Engine`.
 
 ### Changed
 

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -119,17 +119,15 @@ pub struct Engine {
 }
 
 /// A weak reference to an [`Engine`].
-///
-/// # Note
-///
-/// This was required to break a reference cycle between [`Engine`] and [`ModuleHeader`].
 #[derive(Debug, Clone)]
 pub struct EngineWeak {
     inner: Weak<EngineInner>,
 }
 
 impl EngineWeak {
-    /// Upgrades the [`EngineWeak`] to an [`Engine`] if the [`Engine`] does still exist.
+    /// Upgrades the [`EngineWeak`] to an [`Engine`].
+    ///
+    /// Returns `None` if strong references (the [`Engine`] itself) no longer exist.
     pub fn upgrade(&self) -> Option<Engine> {
         let inner = self.inner.upgrade()?;
         Some(Engine { inner })
@@ -155,7 +153,7 @@ impl Engine {
     }
 
     /// Creates an [`EngineWeak`] from the given [`Engine`].
-    pub(crate) fn downgrade(&self) -> EngineWeak {
+    pub fn weak(&self) -> EngineWeak {
         EngineWeak {
             inner: Arc::downgrade(&self.inner),
         }

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -127,6 +127,7 @@ pub use self::{
         Config,
         EnforcedLimits,
         Engine,
+        EngineWeak,
         ResumableCall,
         ResumableInvocation,
         StackLimits,

--- a/crates/wasmi/src/module/builder.rs
+++ b/crates/wasmi/src/module/builder.rs
@@ -75,7 +75,7 @@ impl ModuleHeaderBuilder {
     pub fn finish(self) -> ModuleHeader {
         ModuleHeader {
             inner: Arc::new(ModuleHeaderInner {
-                engine: self.engine.downgrade(),
+                engine: self.engine.weak(),
                 func_types: self.func_types.into(),
                 imports: self.imports.finish(),
                 funcs: self.funcs.into(),


### PR DESCRIPTION
Also properly mirror Wasmtime API for `Engine::weak` and `EngineWeak` docs.