### PR TITLE
Optimize Wasmi bytecode executor `ValueStack`

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -378,9 +378,10 @@ impl<'ctx, 'engine> Executor<'ctx, 'engine> {
                     .call_stack
                     .peek()
                     .expect("need to have a caller on the call stack");
-                // Safety: We use the base offset of a live call frame on the call stack.
+                // Safety: we use the base offset of a live call frame on the call stack.
                 self.sp = unsafe { self.value_stack.stack_ptr_at(caller.base_offset()) };
-                let offset = self.value_stack.extend_zeros(max_inout);
+                // Safety: we just called reserve to fit the new values.
+                let offset = unsafe { self.value_stack.extend_zeros(max_inout) };
                 let offset_sp = unsafe { self.value_stack.stack_ptr_at(offset) };
                 if <C as CallContext>::HAS_PARAMS {
                     self.copy_call_params(offset_sp);

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -200,7 +200,8 @@ impl<'engine> EngineExecutor<'engine> {
                 // We reserve space on the stack to write the results of the root function execution.
                 let len_results = results.len_results();
                 self.stack.values.reserve(len_results)?;
-                self.stack.values.extend_zeros(len_results);
+                // SAFETY: we just called reserve to fit all new values.
+                unsafe { self.stack.values.extend_zeros(len_results) };
                 let instance = *wasm_func.instance();
                 let compiled_func = wasm_func.func_body();
                 let ctx = ctx.as_context_mut();
@@ -238,7 +239,8 @@ impl<'engine> EngineExecutor<'engine> {
                 let len_results = output_types.len();
                 let max_inout = len_params.max(len_results);
                 self.stack.values.reserve(max_inout)?;
-                self.stack.values.extend_zeros(max_inout);
+                // SAFETY: we just called reserve to fit all new values.
+                unsafe { self.stack.values.extend_zeros(max_inout) };
                 let values = &mut self.stack.values.as_slice_mut()[..len_params];
                 for (value, param) in values.iter_mut().zip(params.call_params()) {
                     *value = param;

--- a/crates/wasmi/src/engine/executor/stack/mod.rs
+++ b/crates/wasmi/src/engine/executor/stack/mod.rs
@@ -73,6 +73,11 @@ impl Stack {
         self.values.is_empty()
     }
 
+    /// Returns the capacity of the [`Stack`].
+    pub fn capacity(&self) -> usize {
+        self.values.capacity()
+    }
+
     /// Merge the two top-most [`CallFrame`] with respect to a tail call.
     ///
     /// # Panics (Debug)

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -217,7 +217,8 @@ impl ValueStack {
     /// If `amount` is greater than the [`ValueStack`] height.
     #[inline]
     pub fn drop(&mut self, amount: usize) {
-        debug_assert!(self.len() >= amount);
+        assert!(self.len() >= amount);
+        // Safety: we just asserted that the current length is large enough to not underflow.
         unsafe { self.values.set_len(self.len() - amount) };
     }
 
@@ -229,7 +230,8 @@ impl ValueStack {
     #[inline]
     pub fn truncate(&mut self, new_len: impl Into<ValueStackOffset>) {
         let new_len = new_len.into().0;
-        debug_assert!(new_len <= self.len());
+        assert!(new_len <= self.len());
+        // Safety: we just asserted that the new length is valid.
         unsafe { self.values.set_len(new_len) };
     }
 

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -131,7 +131,7 @@ impl ValueStack {
     }
 
     /// Returns the capacity of the [`ValueStack`].
-    fn capacity(&self) -> usize {
+    pub fn capacity(&self) -> usize {
         self.values.len()
     }
 

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -3,8 +3,12 @@ use crate::{
     core::{TrapCode, UntypedVal},
     engine::{bytecode::Register, CompiledFuncEntity},
 };
-use core::{fmt, fmt::Debug, iter, mem, ptr};
-use std::{vec, vec::Vec};
+use core::{
+    fmt::{self, Debug},
+    mem::{self, MaybeUninit},
+    ptr,
+};
+use std::vec::Vec;
 
 #[cfg(doc)]
 use super::calls::CallFrame;
@@ -14,10 +18,8 @@ use crate::engine::CompiledFunc;
 pub struct ValueStack {
     /// The values on the [`ValueStack`].
     values: Vec<UntypedVal>,
-    /// Index of the first free value in the `values` buffer.
-    sp: usize,
     /// Maximal possible `sp` value.
-    max_sp: usize,
+    max_len: usize,
 }
 
 impl ValueStack {
@@ -31,9 +33,8 @@ impl ValueStack {
 impl Debug for ValueStack {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ValueStack")
-            .field("sp", &self.sp)
-            .field("max_sp", &self.max_sp)
-            .field("entries", &&self.values[..self.sp])
+            .field("max_len", &self.max_len)
+            .field("entries", &&self.values[..])
             .finish()
     }
 }
@@ -41,7 +42,7 @@ impl Debug for ValueStack {
 #[cfg(test)]
 impl PartialEq for ValueStack {
     fn eq(&self, other: &Self) -> bool {
-        self.sp == other.sp && self.values[..self.sp] == other.values[..other.sp]
+        self.values == other.values
     }
 }
 
@@ -75,9 +76,8 @@ impl ValueStack {
             "initial value stack length is greater than maximum value stack length",
         );
         Self {
-            values: vec![UntypedVal::default(); initial_len],
-            sp: 0,
-            max_sp: maximum_len,
+            values: Vec::with_capacity(initial_len),
+            max_len: maximum_len,
         }
     }
 
@@ -90,8 +90,7 @@ impl ValueStack {
     pub fn empty() -> Self {
         Self {
             values: Vec::new(),
-            sp: 0,
-            max_sp: 0,
+            max_len: 0,
         }
     }
 
@@ -104,7 +103,7 @@ impl ValueStack {
     /// reset the [`ValueStack`] before executing the next function to
     /// provide a clean slate for all executions.
     pub fn reset(&mut self) {
-        self.sp = 0;
+        self.values.clear();
     }
 
     /// Returns the root [`FrameRegisters`] pointing to the first value on the [`ValueStack`].
@@ -132,17 +131,25 @@ impl ValueStack {
 
     /// Returns the capacity of the [`ValueStack`].
     pub fn capacity(&self) -> usize {
-        self.values.len()
+        debug_assert!(self.values.len() <= self.values.capacity());
+        self.values.capacity()
     }
 
     /// Returns `true` if the [`ValueStack`] is empty.
     pub fn is_empty(&self) -> bool {
-        self.values.capacity() == 0
+        self.len() == 0
     }
 
     /// Returns the current length of the [`ValueStack`].
     fn len(&self) -> usize {
-        self.sp
+        debug_assert!(self.values.len() <= self.max_len);
+        self.values.len()
+    }
+
+    /// Returns the maximum length of the [`ValueStack`].
+    fn max_len(&self) -> usize {
+        debug_assert!(self.values.len() <= self.max_len);
+        self.max_len
     }
 
     /// Reserves enough space for `additional` cells on the [`ValueStack`].
@@ -153,18 +160,10 @@ impl ValueStack {
     ///
     /// When trying to grow the [`ValueStack`] over its maximum size limit.
     pub fn reserve(&mut self, additional: usize) -> Result<(), TrapCode> {
-        let new_len = self
-            .len()
-            .checked_add(additional)
-            .filter(|&new_len| new_len <= self.max_sp)
-            .ok_or_else(err_stack_overflow)?;
-        if new_len > self.capacity() {
-            // Note: By extending with the new length we effectively double
-            // the current value stack length and add the additional flat amount
-            // on top. This avoids too many frequent reallocations.
-            self.values
-                .extend(iter::repeat(UntypedVal::default()).take(new_len));
+        if additional >= self.max_len() - self.len() {
+            return Err(err_stack_overflow());
         }
+        self.values.reserve(additional);
         Ok(())
     }
 
@@ -178,17 +177,14 @@ impl ValueStack {
     /// If the value stack cannot fit `additional` stack values.
     pub fn extend_zeros(&mut self, amount: usize) -> ValueStackOffset {
         if amount == 0 {
-            return ValueStackOffset(self.sp);
+            return ValueStackOffset(self.len());
         }
-        let old_sp = self.sp;
-        let cells = self
-            .values
-            .get_mut(self.sp..)
-            .and_then(|slice| slice.get_mut(..amount))
-            .unwrap_or_else(|| panic!("did not reserve enough value stack space"));
-        cells.fill(UntypedVal::default());
-        self.sp += amount;
-        ValueStackOffset(old_sp)
+        let remaining = self.values.spare_capacity_mut();
+        let uninit = unsafe { remaining.get_unchecked_mut(..amount) };
+        uninit.fill(MaybeUninit::new(UntypedVal::default()));
+        let old_len = self.len();
+        unsafe { self.values.set_len(old_len + amount) };
+        ValueStackOffset(old_len)
     }
 
     /// Extends the [`ValueStack`] by the `values` slice.
@@ -201,18 +197,17 @@ impl ValueStack {
     /// If the value stack cannot fit `additional` stack values.
     pub fn extend_slice(&mut self, values: &[UntypedVal]) -> ValueStackOffset {
         if values.is_empty() {
-            return ValueStackOffset(self.sp);
+            return ValueStackOffset(self.len());
         }
-        let old_sp = self.sp;
-        let len_values = values.len();
-        let cells = self
-            .values
-            .get_mut(self.sp..)
-            .and_then(|slice| slice.get_mut(..len_values))
-            .unwrap_or_else(|| panic!("did not reserve enough value stack space"));
-        cells.copy_from_slice(values);
-        self.sp += len_values;
-        ValueStackOffset(old_sp)
+        let amount = values.len();
+        let remaining = self.values.spare_capacity_mut();
+        let uninit = unsafe { remaining.get_unchecked_mut(..amount) };
+        for (uninit, value) in uninit.iter_mut().zip(values) {
+            uninit.write(*value);
+        }
+        let old_len = self.len();
+        unsafe { self.values.set_len(old_len + amount) };
+        ValueStackOffset(old_len)
     }
 
     /// Drop the last `amount` cells of the [`ValueStack`].
@@ -222,8 +217,8 @@ impl ValueStack {
     /// If `amount` is greater than the [`ValueStack`] height.
     #[inline]
     pub fn drop(&mut self, amount: usize) {
-        debug_assert!(self.sp >= amount);
-        self.sp -= amount;
+        debug_assert!(self.len() >= amount);
+        unsafe { self.values.set_len(self.len() - amount) };
     }
 
     /// Shrink the [`ValueStack`] to the [`ValueStackOffset`].
@@ -232,10 +227,10 @@ impl ValueStack {
     ///
     /// If `new_sp` is greater than the current [`ValueStack`] pointer.
     #[inline]
-    pub fn truncate(&mut self, new_sp: impl Into<ValueStackOffset>) {
-        let new_sp = new_sp.into().0;
-        debug_assert!(new_sp <= self.sp);
-        self.sp = new_sp;
+    pub fn truncate(&mut self, new_len: impl Into<ValueStackOffset>) {
+        let new_len = new_len.into().0;
+        debug_assert!(new_len <= self.len());
+        unsafe { self.values.set_len(new_len) };
     }
 
     /// Allocates a new [`CompiledFunc`] on the [`ValueStack`].
@@ -268,18 +263,18 @@ impl ValueStack {
     ///
     /// The caller has to ensure that `offset` is valid for the range of
     /// `values` required to be stored on the [`ValueStack`].
-    pub unsafe fn fill_at<I>(&mut self, offset: impl Into<ValueStackOffset>, values: I)
-    where
-        I: IntoIterator<Item = UntypedVal>,
+    pub unsafe fn fill_at<IntoIter, Iter>(
+        &mut self,
+        offset: impl Into<ValueStackOffset>,
+        values: IntoIter,
+    ) where
+        IntoIter: IntoIterator<IntoIter = Iter>,
+        Iter: ExactSizeIterator<Item = UntypedVal>,
     {
         let offset = offset.into().0;
-        let mut values = values.into_iter();
-        if offset >= self.sp {
-            // In this case we can assert that `values` must be empty since
-            // otherwise there is a buffer overflow on the value stack.
-            debug_assert!(values.next().is_none());
-        }
-        let cells = &mut self.values[offset..];
+        let values = values.into_iter();
+        let len_values = values.len();
+        let cells = &mut self.values[offset..offset + len_values];
         for (cell, value) in cells.iter_mut().zip(values) {
             *cell = value;
         }
@@ -288,13 +283,13 @@ impl ValueStack {
     /// Returns a shared slice over the values of the [`ValueStack`].
     #[inline]
     pub fn as_slice(&self) -> &[UntypedVal] {
-        &self.values[0..self.sp]
+        self.values.as_slice()
     }
 
     /// Returns an exclusive slice over the values of the [`ValueStack`].
     #[inline]
     pub fn as_slice_mut(&mut self) -> &mut [UntypedVal] {
-        &mut self.values[0..self.sp]
+        self.values.as_mut_slice()
     }
 
     /// Removes the slice `from..to` of [`UntypedVal`] cells from the [`ValueStack`].
@@ -312,10 +307,9 @@ impl ValueStack {
         debug_assert!(from <= to);
         let from = from.0 .0;
         let to = to.0 .0;
-        debug_assert!(from <= self.sp);
-        debug_assert!(to <= self.sp);
+        debug_assert!(from <= self.len());
+        debug_assert!(to <= self.len());
         let len_drained = to - from;
-        self.sp -= len_drained;
         self.values.drain(from..to);
         len_drained
     }

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -581,7 +581,7 @@ impl EngineStacks {
 
     /// Disose and recycle the `stack`.
     pub fn recycle(&mut self, stack: Stack) {
-        if !stack.is_empty() && self.stacks.len() < self.keep {
+        if stack.capacity() > 0 && self.stacks.len() < self.keep {
             self.stacks.push(stack);
         }
     }


### PR DESCRIPTION
Locally we see neat performance improvements:
![image](https://github.com/wasmi-labs/wasmi/assets/8193155/57087e01-ff1d-413c-bbc9-8f4d3381aa02)

The downside is that this makes more extensive use of `unsafe` Rust code in the `ValueStack` implementation. But I think that the performance improvements justify this change.