### PR TITLE
Make `wasmi_collections` compile under `no_std` + `no-hash-maps` feature combination

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,8 @@ jobs:
         run: cargo build --workspace
       - name: Build (all features)
         run: cargo build --workspace --all-features
+      - name: Build (no_std + no-hash-maps)
+        run: cargo build -p wasmi_collections --no-default-features --features no-hash-maps
       - name: Build (no_std)
         run: cargo build --workspace --lib --no-default-features --target thumbv7em-none-eabi --exclude wasmi_cli --exclude wasmi_wasi --exclude wasmi_fuzz
       - name: Build (wasm32)

--- a/crates/collections/src/string_interner/detail.rs
+++ b/crates/collections/src/string_interner/detail.rs
@@ -1,10 +1,8 @@
 use super::{GetOrInternWithHint, InternHint, Sym};
+use core::{cmp::Ordering, mem, ops::Deref};
 use std::{
     borrow::Borrow,
-    cmp::Ordering,
     collections::{btree_map::Entry, BTreeMap},
-    mem,
-    ops::Deref,
     sync::Arc,
     vec::Vec,
 };


### PR DESCRIPTION
Quick fix for `smodot` issues displayed in https://github.com/wasmi-labs/wasmi/issues/1018.

Proper fix still needed after this.