### PR TITLE
Remove usage of the `compile-time-rng` crate feature from the `ahash` dependency

### DIFF
--- a/crates/collections/Cargo.toml
+++ b/crates/collections/Cargo.toml
@@ -16,7 +16,7 @@ exclude.workspace = true
 [dependencies]
 hashbrown = { version = "0.14", default-features = false, features = ["ahash", "inline-more"] }
 string-interner = { version = "0.17", default-features = false, features = ["inline-more", "backends"] }
-ahash = { version = "0.8.11", default-features = false, features = ["compile-time-rng"] }
+ahash = { version = "0.8.11", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/collections/src/hash.rs
+++ b/crates/collections/src/hash.rs
@@ -96,10 +96,17 @@ use std::collections::hash_map::RandomState as RandomStateImpl;
 
 // When the `std` feature is NOT active then rely on `ahash::RandomState`
 // which relies on ASLR by default for randomness.
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg(not(feature = "std"))]
 struct RandomStateImpl {
     state: ahash::RandomState,
+}
+
+#[cfg(not(feature = "std"))]
+impl Default for RandomStateImpl {
+    fn default() -> Self {
+        Self { state: ahash::RandomState::new() }
+    }
 }
 
 #[cfg(not(feature = "std"))]

--- a/crates/collections/src/hash.rs
+++ b/crates/collections/src/hash.rs
@@ -105,7 +105,9 @@ struct RandomStateImpl {
 #[cfg(not(feature = "std"))]
 impl Default for RandomStateImpl {
     fn default() -> Self {
-        Self { state: ahash::RandomState::new() }
+        Self {
+            state: ahash::RandomState::new(),
+        }
     }
 }
 


### PR DESCRIPTION
Reason: https://github.com/bytecodealliance/wasm-tools/pull/1536#issuecomment-2098562789