### PR TITLE
Optimize data section parsing and storage

### DIFF
--- a/crates/wasmi/src/memory/data.rs
+++ b/crates/wasmi/src/memory/data.rs
@@ -1,10 +1,10 @@
-use core::convert::AsRef;
 use crate::{
     collections::arena::ArenaIndex,
     module::{self, PassiveDataSegmentBytes},
     store::Stored,
     AsContextMut,
 };
+use core::convert::AsRef;
 
 /// A raw index to a data segment entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/wasmi/src/memory/data.rs
+++ b/crates/wasmi/src/memory/data.rs
@@ -71,7 +71,7 @@ pub struct DataSegmentEntity {
 impl From<&'_ module::DataSegment> for DataSegmentEntity {
     fn from(segment: &'_ module::DataSegment) -> Self {
         Self {
-            bytes: segment.clone_bytes(),
+            bytes: segment.passive_data_segment_bytes(),
         }
     }
 }

--- a/crates/wasmi/src/memory/data.rs
+++ b/crates/wasmi/src/memory/data.rs
@@ -84,10 +84,12 @@ pub struct DataSegmentEntity {
 }
 
 impl DataSegmentEntity {
+    /// Creates a new active [`DataSegmentEntity`].
     pub fn active() -> Self {
         Self { bytes: None }
     }
 
+    /// Creates a new passive [`DataSegmentEntity`] with its `bytes`.
     pub fn passive(bytes: PassiveDataSegmentBytes) -> Self {
         Self { bytes: Some(bytes) }
     }

--- a/crates/wasmi/src/module/builder.rs
+++ b/crates/wasmi/src/module/builder.rs
@@ -371,10 +371,12 @@ impl ModuleHeaderBuilder {
 }
 
 impl ModuleBuilder {
-    pub fn reserve_data_segments(&mut self, count: usize) {
-        self.data_segments.reserve(count);
+    /// Reserve space for at least `additional` new data segments.
+    pub fn reserve_data_segments(&mut self, additional: usize) {
+        self.data_segments.reserve(additional);
     }
 
+    /// Push another parsed data segment to the [`ModuleBuilder`].
     pub fn push_data_segment(&mut self, data: wasmparser::Data) -> Result<(), Error> {
         self.data_segments.push_data_segment(data)
     }

--- a/crates/wasmi/src/module/data.rs
+++ b/crates/wasmi/src/module/data.rs
@@ -85,9 +85,9 @@ pub struct DataSegments {
     /// All data segments.
     segments: Box<[DataSegment]>,
     /// All bytes from all active data segments.
-    /// 
+    ///
     /// # Note
-    /// 
+    ///
     /// We deliberately do not use `Box<[u8]>` here because it is not possible
     /// to properly pre-reserve space for the bytes and thus finishing construction
     /// of the [`DataSegments`] would highly likely reallocate and mass-copy

--- a/crates/wasmi/src/module/data.rs
+++ b/crates/wasmi/src/module/data.rs
@@ -49,19 +49,52 @@ impl ActiveDataSegment {
 /// The bytes of the passive data segment.
 #[derive(Debug, Clone)]
 pub struct PassiveDataSegmentBytes {
-    bytes: Arc<[u8]>,
+    inner: PassiveDataSegmentBytesInner,
+}
+
+#[derive(Debug, Clone)]
+enum PassiveDataSegmentBytesInner {
+    Small {
+        len: u8,
+        bytes: [u8; Self::INLINE_SIZE],
+    },
+    Large {
+        bytes: Arc<[u8]>,
+    },
+}
+
+impl PassiveDataSegmentBytesInner {
+    const INLINE_SIZE: usize = if cfg!(target_pointer_width = "64") { 30 } else { 18 };
+}
+
+impl<'a> From<&'a [u8]> for PassiveDataSegmentBytes {
+    fn from(bytes: &'a [u8]) -> Self {
+        let inner = if bytes.len() <= PassiveDataSegmentBytesInner::INLINE_SIZE {
+            let len = bytes.len();
+            let mut buffer = [0x0; PassiveDataSegmentBytesInner::INLINE_SIZE];
+            buffer[..len].copy_from_slice(bytes);
+            PassiveDataSegmentBytesInner::Small { len: len as u8, bytes: buffer }
+        } else {
+            PassiveDataSegmentBytesInner::Large { bytes: bytes.into() }
+        };
+        Self { inner }
+    }
 }
 
 impl AsRef<[u8]> for PassiveDataSegmentBytes {
     fn as_ref(&self) -> &[u8] {
-        &self.bytes[..]
+        match &self.inner {
+            PassiveDataSegmentBytesInner::Small { len, bytes } => &bytes[..*len as usize],
+            PassiveDataSegmentBytesInner::Large { bytes } => &bytes[..],
+        }
     }
 }
 
 #[test]
 fn size_of_data_segment() {
-    assert_eq!(core::mem::size_of::<DataSegment>(), 40);
-    assert_eq!(core::mem::size_of::<DataSegmentInner>(), 40);
+    assert!(core::mem::size_of::<DataSegment>() <= 40);
+    assert!(core::mem::size_of::<DataSegmentInner>() <= 40);
+    assert!(core::mem::size_of::<PassiveDataSegmentBytes>() <= 40);
 }
 
 impl DataSegment {
@@ -112,9 +145,7 @@ impl DataSegmentsBuilder {
             wasmparser::DataKind::Passive => {
                 self.segments.push(DataSegment {
                     inner: DataSegmentInner::Passive {
-                        bytes: PassiveDataSegmentBytes {
-                            bytes: segment.data.into(),
-                        },
+                        bytes: PassiveDataSegmentBytes::from(segment.data)
                     },
                 });
             }

--- a/crates/wasmi/src/module/data.rs
+++ b/crates/wasmi/src/module/data.rs
@@ -112,8 +112,8 @@ impl DataSegment {
         }
     }
 
-    /// Clone the underlying bytes of the [`DataSegment`].
-    pub fn clone_bytes(&self) -> Option<PassiveDataSegmentBytes> {
+    /// Returns the bytes of the [`DataSegment`] if passive, otherwise returns `None`.
+    pub fn passive_data_segment_bytes(&self) -> Option<PassiveDataSegmentBytes> {
         match &self.inner {
             DataSegmentInner::Active { .. } => None,
             DataSegmentInner::Passive { bytes } => Some(bytes.clone()),

--- a/crates/wasmi/src/module/data.rs
+++ b/crates/wasmi/src/module/data.rs
@@ -65,8 +65,8 @@ impl AsRef<[u8]> for PassiveDataSegmentBytes {
 
 #[test]
 fn size_of_data_segment() {
-    assert_eq!(core::mem::size_of::<DataSegment>(), 40);
-    assert_eq!(core::mem::size_of::<DataSegmentInner>(), 40);
+    assert!(core::mem::size_of::<DataSegment>() <= 32);
+    assert!(core::mem::size_of::<DataSegmentInner>() <= 32);
 }
 
 impl DataSegment {

--- a/crates/wasmi/src/module/data.rs
+++ b/crates/wasmi/src/module/data.rs
@@ -205,6 +205,8 @@ impl<'a> Iterator for InitDataSegmentIter<'a> {
 }
 
 /// Iterated-over [`DataSegment`] when instantiating a [`Module`].
+/// 
+/// [`Module`]: crate::Module
 pub enum InitDataSegment<'a> {
     Active {
         /// The linear memory that is to be initialized with this active segment.

--- a/crates/wasmi/src/module/data.rs
+++ b/crates/wasmi/src/module/data.rs
@@ -85,7 +85,14 @@ pub struct DataSegments {
     /// All data segments.
     segments: Box<[DataSegment]>,
     /// All bytes from all active data segments.
-    bytes: Box<[u8]>,
+    /// 
+    /// # Note
+    /// 
+    /// We deliberately do not use `Box<[u8]>` here because it is not possible
+    /// to properly pre-reserve space for the bytes and thus finishing construction
+    /// of the [`DataSegments`] would highly likely reallocate and mass-copy
+    /// which we prevent by simply using a `Vec<u8>` instead.
+    bytes: Vec<u8>,
 }
 
 impl DataSegments {
@@ -158,7 +165,7 @@ impl DataSegmentsBuilder {
     pub fn finish(self) -> DataSegments {
         DataSegments {
             segments: self.segments.into(),
-            bytes: self.bytes.into(),
+            bytes: self.bytes,
         }
     }
 }

--- a/crates/wasmi/src/module/data.rs
+++ b/crates/wasmi/src/module/data.rs
@@ -1,5 +1,7 @@
+use crate::Error;
 use super::{ConstExpr, MemoryIdx};
-use std::{boxed::Box, sync::Arc};
+use core::slice;
+use std::{boxed::Box, sync::Arc, vec::Vec};
 
 /// A Wasm [`Module`] data segment.
 ///
@@ -28,8 +30,20 @@ pub struct ActiveDataSegment {
     memory_index: MemoryIdx,
     /// The offset at which the data segment is initialized.
     offset: ConstExpr,
-    /// The bytes of the active data segment.
-    bytes: Box<[u8]>,
+    /// End-index of the data segments bytes buffer.
+    end: usize,
+}
+
+impl ActiveDataSegment {
+    /// Returns the Wasm module memory index that is to be initialized.
+    pub fn memory_index(&self) -> MemoryIdx {
+        self.memory_index
+    }
+
+    /// Returns the offset expression of the [`ActiveDataSegment`].
+    pub fn offset(&self) -> &ConstExpr {
+        &self.offset
+    }
 }
 
 /// The bytes of the passive data segment.
@@ -46,72 +60,11 @@ impl AsRef<[u8]> for PassiveDataSegmentBytes {
 
 #[test]
 fn size_of_data_segment() {
-    assert_eq!(core::mem::size_of::<DataSegment>(), 48);
-    assert_eq!(core::mem::size_of::<DataSegmentInner>(), 48);
-}
-
-impl ActiveDataSegment {
-    /// Returns the Wasm module memory index that is to be initialized.
-    pub fn memory_index(&self) -> MemoryIdx {
-        self.memory_index
-    }
-
-    /// Returns the offset expression of the [`ActiveDataSegment`].
-    pub fn offset(&self) -> &ConstExpr {
-        &self.offset
-    }
-
-    /// Returns the bytes of the active data segment.
-    pub fn bytes(&self) -> &[u8] {
-        &self.bytes[..]
-    }
-}
-
-impl From<wasmparser::Data<'_>> for DataSegment {
-    fn from(data: wasmparser::Data<'_>) -> Self {
-        match data.kind {
-            wasmparser::DataKind::Passive => Self {
-                inner: DataSegmentInner::Passive {
-                    bytes: PassiveDataSegmentBytes {
-                        bytes: data.data.into(),
-                    },
-                },
-            },
-            wasmparser::DataKind::Active {
-                memory_index,
-                offset_expr,
-            } => {
-                let memory_index = MemoryIdx::from(memory_index);
-                let offset = ConstExpr::new(offset_expr);
-                Self {
-                    inner: DataSegmentInner::Active(ActiveDataSegment {
-                        memory_index,
-                        offset,
-                        bytes: data.data.into(),
-                    }),
-                }
-            }
-        }
-    }
+    assert_eq!(core::mem::size_of::<DataSegment>(), 40);
+    assert_eq!(core::mem::size_of::<DataSegmentInner>(), 40);
 }
 
 impl DataSegment {
-    /// Returns the [`ActiveDataSegment`] if this [`DataSegment`] is active.
-    pub fn get_active(&self) -> Option<&ActiveDataSegment> {
-        match &self.inner {
-            DataSegmentInner::Active(segment) => Some(segment),
-            DataSegmentInner::Passive { .. } => None,
-        }
-    }
-
-    /// Returns the bytes of the [`DataSegment`].
-    pub fn bytes(&self) -> &[u8] {
-        match &self.inner {
-            DataSegmentInner::Active(segment) => segment.bytes(),
-            DataSegmentInner::Passive { bytes } => bytes.as_ref(),
-        }
-    }
-
     /// Returns the bytes of the [`DataSegment`] if passive, otherwise returns `None`.
     pub fn passive_data_segment_bytes(&self) -> Option<PassiveDataSegmentBytes> {
         match &self.inner {
@@ -119,4 +72,134 @@ impl DataSegment {
             DataSegmentInner::Passive { bytes } => Some(bytes.clone()),
         }
     }
+}
+
+/// Stores all data segments and their associated data.
+#[derive(Debug)]
+pub struct DataSegments {
+    /// All data segments.
+    segments: Box<[DataSegment]>,
+    /// All bytes from all active data segments.
+    bytes: Box<[u8]>,
+}
+
+impl DataSegments {
+    pub fn build() -> DataSegmentsBuilder {
+        DataSegmentsBuilder {
+            segments: Vec::new(),
+            bytes: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DataSegmentsBuilder {
+    segments: Vec<DataSegment>,
+    bytes: Vec<u8>,
+}
+
+impl DataSegmentsBuilder {
+    pub fn reserve(&mut self, count: usize) {
+        assert!(
+            self.segments.capacity() == 0,
+            "must not reserve multiple times"
+        );
+        self.segments.reserve(count);
+    }
+
+    pub fn push_data_segment(&mut self, segment: wasmparser::Data) -> Result<(), Error> {
+        match segment.kind {
+            wasmparser::DataKind::Passive => {
+                self.segments.push(DataSegment {
+                    inner: DataSegmentInner::Passive {
+                        bytes: PassiveDataSegmentBytes {
+                            bytes: segment.data.into(),
+                        },
+                    },
+                });
+            }
+            wasmparser::DataKind::Active {
+                memory_index,
+                offset_expr,
+            } => {
+                let memory_index = MemoryIdx::from(memory_index);
+                let offset = ConstExpr::new(offset_expr);
+                self.bytes.extend_from_slice(segment.data);
+                let end = self.bytes.len();
+                self.segments.push(DataSegment {
+                    inner: DataSegmentInner::Active(ActiveDataSegment {
+                        memory_index,
+                        offset,
+                        end,
+                    }),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub fn finish(self) -> DataSegments {
+        DataSegments {
+            segments: self.segments.into(),
+            bytes: self.bytes.into(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a DataSegments {
+    type Item = InitDataSegment<'a>;
+    type IntoIter = InitDataSegmentIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        InitDataSegmentIter {
+            segments: self.segments.iter(),
+            bytes: &self.bytes[..],
+            start: 0,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InitDataSegmentIter<'a> {
+    segments: slice::Iter<'a, DataSegment>,
+    bytes: &'a [u8],
+    start: usize,
+}
+
+impl<'a> Iterator for InitDataSegmentIter<'a> {
+    type Item = InitDataSegment<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let segment = self.segments.next()?;
+        match &segment.inner {
+            DataSegmentInner::Active(segment) => {
+                let end = segment.end;
+                let bytes = &self.bytes[self.start..end];
+                self.start = end;
+                Some(InitDataSegment::Active {
+                    memory_index: segment.memory_index(),
+                    offset: segment.offset(),
+                    bytes,
+                })
+            }
+            DataSegmentInner::Passive { bytes } => Some(InitDataSegment::Passive {
+                bytes: bytes.clone(),
+            }),
+        }
+    }
+}
+
+/// Iterated-over [`DataSegment`] when instantiating a [`Module`].
+pub enum InitDataSegment<'a> {
+    Active {
+        /// The linear memory that is to be initialized with this active segment.
+        memory_index: MemoryIdx,
+        /// The offset at which the data segment is initialized.
+        offset: &'a ConstExpr,
+        /// The bytes of the active data segment.
+        bytes: &'a [u8],
+    },
+    Passive {
+        bytes: PassiveDataSegmentBytes,
+    },
 }

--- a/crates/wasmi/src/module/data.rs
+++ b/crates/wasmi/src/module/data.rs
@@ -205,7 +205,7 @@ impl<'a> Iterator for InitDataSegmentIter<'a> {
 }
 
 /// Iterated-over [`DataSegment`] when instantiating a [`Module`].
-/// 
+///
 /// [`Module`]: crate::Module
 pub enum InitDataSegment<'a> {
     Active {

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -5,7 +5,7 @@ mod pre;
 mod tests;
 
 pub use self::{error::InstantiationError, pre::InstancePre};
-use super::{element::ElementSegmentKind, export, ConstExpr, Module};
+use super::{element::ElementSegmentKind, export, ConstExpr, InitDataSegment, Module};
 use crate::{
     core::UntypedVal,
     func::WasmFuncEntity,
@@ -350,16 +350,24 @@ impl Module {
         context: &mut impl AsContextMut,
         builder: &mut InstanceEntityBuilder,
     ) -> Result<(), Error> {
-        for segment in &self.data_segments[..] {
-            let bytes = segment.bytes();
-            if let Some(segment) = segment.get_active() {
-                let offset_expr = segment.offset();
-                let offset =
-                    u32::from(Self::eval_init_expr(&mut *context, builder, offset_expr)) as usize;
-                let memory = builder.get_memory(segment.memory_index().into_u32());
-                memory.write(&mut *context, offset, bytes)?;
-            }
-            builder.push_data_segment(DataSegment::new(context.as_context_mut(), segment));
+        for segment in &self.data_segments {
+            let segment = match segment {
+                InitDataSegment::Active {
+                    memory_index,
+                    offset,
+                    bytes,
+                } => {
+                    let offset =
+                        u32::from(Self::eval_init_expr(&mut *context, builder, offset)) as usize;
+                    let memory = builder.get_memory(memory_index.into_u32());
+                    memory.write(&mut *context, offset, bytes)?;
+                    DataSegment::new_active(context.as_context_mut())
+                }
+                InitDataSegment::Passive { bytes } => {
+                    DataSegment::new_passive(context.as_context_mut(), bytes)
+                }
+            };
+            builder.push_data_segment(segment);
         }
         Ok(())
     }

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -5,7 +5,7 @@ mod pre;
 mod tests;
 
 pub use self::{error::InstantiationError, pre::InstancePre};
-use super::{element::ElementSegmentKind, export, ConstExpr, DataSegmentKind, Module};
+use super::{element::ElementSegmentKind, export, ConstExpr, Module};
 use crate::{
     core::UntypedVal,
     func::WasmFuncEntity,
@@ -352,7 +352,7 @@ impl Module {
     ) -> Result<(), Error> {
         for segment in &self.data_segments[..] {
             let bytes = segment.bytes();
-            if let DataSegmentKind::Active(segment) = segment.kind() {
+            if let Some(segment) = segment.get_active() {
                 let offset_expr = segment.offset();
                 let offset =
                     u32::from(Self::eval_init_expr(&mut *context, builder, offset_expr)) as usize;

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -18,7 +18,7 @@ use self::{
     parser::{parse, parse_unchecked},
 };
 pub(crate) use self::{
-    data::{DataSegment, PassiveDataSegmentBytes},
+    data::{DataSegment, DataSegments, InitDataSegment, PassiveDataSegmentBytes},
     element::{ElementSegment, ElementSegmentItems, ElementSegmentKind},
     init_expr::ConstExpr,
     utils::WasmiValueType,
@@ -50,7 +50,7 @@ use wasmparser::{FuncValidatorAllocations, Parser, ValidPayload, Validator};
 pub struct Module {
     engine: Engine,
     header: ModuleHeader,
-    data_segments: Box<[DataSegment]>,
+    data_segments: DataSegments,
 }
 
 /// A parsed and validated WebAssembly module header.

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -18,7 +18,7 @@ use self::{
     parser::{parse, parse_unchecked},
 };
 pub(crate) use self::{
-    data::{DataSegment, DataSegmentKind},
+    data::{DataSegment, PassiveDataSegmentBytes},
     element::{ElementSegment, ElementSegmentItems, ElementSegmentKind},
     init_expr::ConstExpr,
     utils::WasmiValueType,

--- a/crates/wasmi/src/module/parser.rs
+++ b/crates/wasmi/src/module/parser.rs
@@ -3,7 +3,6 @@ use super::{
     export::ExternIdx,
     global::Global,
     import::{FuncTypeIdx, Import},
-    DataSegment,
     ElementSegment,
     FuncIdx,
     Module,
@@ -659,10 +658,10 @@ impl ModuleParser {
             }
         }
         self.validator.data_section(&section)?;
-        let segments = section
-            .into_iter()
-            .map(|segment| segment.map(DataSegment::from).map_err(Error::from));
-        builder.push_data_segments(segments)?;
+        builder.reserve_data_segments(section.count() as usize);
+        for segment in section {
+            builder.push_data_segment(segment?)?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Benchmarks revealed that parsing and handling of data sections were a big contributor to the overall spent time for some benchmarks, such as `ffmpeg.wasm`. This is probably due to heap memory allocator pressure since all of its many data segments each allocated a bit of heap memory for their bytes.
This PR bundles bytes of all active data segments into a single buffer reducing the overall memory consumption and pressure on the heap memory allocator.
Benchmarks show roughly 15% improvement for compiling `ffmpeg.wasm` in lazy compilation mode.