### PR TITLE
engine/config: fix wasm_tail_call and wasm_extended_const docs

### DIFF
--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -291,7 +291,7 @@ impl Config {
     ///
     /// # Note
     ///
-    /// Disabled by default.
+    /// Enabled by default.
     ///
     /// [`tail-call`]: https://github.com/WebAssembly/tail-calls
     pub fn wasm_tail_call(&mut self, enable: bool) -> &mut Self {
@@ -303,9 +303,9 @@ impl Config {
     ///
     /// # Note
     ///
-    /// Disabled by default.
+    /// Enabled by default.
     ///
-    /// [`tail-call`]: https://github.com/WebAssembly/extended-const
+    /// [`extended-const`]: https://github.com/WebAssembly/extended-const
     pub fn wasm_extended_const(&mut self, enable: bool) -> &mut Self {
         self.extended_const = enable;
         self


### PR DESCRIPTION
The defaults for `Config::tail_call` and `Config::extended_const` were changed in #1031 but the change wasn't reflected in the documentation.

Also fix the markdown reference for the `extended-const` proposal link.