### PR TITLE
Unpack `ResumableHostError` for non-resumeble calls

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -75,8 +75,11 @@ pub enum CallKind {
 /// Error returned from a called host function in a resumable state.
 #[derive(Debug)]
 pub struct ResumableHostError {
+    /// The error returned by the called host function.
     host_error: Error,
+    /// The host function that returned the error.
     host_func: Func,
+    /// The result registers of the caller of the host function.
     caller_results: RegisterSpan,
 }
 

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -51,7 +51,11 @@ impl EngineInner {
         let res = self.res.read();
         let mut stack = self.stacks.lock().reuse_or_new();
         let results = EngineExecutor::new(&res, &mut stack)
-            .execute_root_func(ctx.store, func, params, results);
+            .execute_root_func(ctx.store, func, params, results)
+            .map_err(|error| match error.into_resumable() {
+                Ok(error) => error.into_error(),
+                Err(error) => error,
+            });
         self.stacks.lock().recycle(stack);
         results
     }

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -309,9 +309,9 @@ impl ValueStack {
     /// # Safety
     ///
     /// - This invalidates all [`FrameRegisters`] within the range `from..` and the caller has to
-    /// make sure to properly reinstantiate all those pointers after this operation.
+    ///   make sure to properly reinstantiate all those pointers after this operation.
     /// - This also invalidates all [`FrameValueStackOffset`] and [`BaseValueStackOffset`] indices
-    /// within the range `from..`.
+    ///   within the range `from..`.
     #[inline(always)]
     pub fn drain(&mut self, from: FrameValueStackOffset, to: FrameValueStackOffset) -> usize {
         debug_assert!(from <= to);

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -159,6 +159,12 @@ pub enum ErrorKind {
     /// A trap as defined by the WebAssembly specification.
     Host(Box<dyn HostError>),
     /// An error stemming from a host function call with resumable state information.
+    /// 
+    /// # Note
+    /// 
+    /// This variant is meant for internal uses only in order to store data necessary
+    /// to resume a call after a host function returned an error. This should never
+    /// actually reach user code thus we hide its documentation.
     #[doc(hidden)]
     ResumableHost(ResumableHostError),
     /// A global variable error.

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -159,9 +159,9 @@ pub enum ErrorKind {
     /// A trap as defined by the WebAssembly specification.
     Host(Box<dyn HostError>),
     /// An error stemming from a host function call with resumable state information.
-    /// 
+    ///
     /// # Note
-    /// 
+    ///
     /// This variant is meant for internal uses only in order to store data necessary
     /// to resume a call after a host function returned an error. This should never
     /// actually reach user code thus we hide its documentation.


### PR DESCRIPTION
This was an oversight in #1041.