### PR TITLE
Fix `local.set` bug when merging copies with overwriting semantics

### DIFF
--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -328,7 +328,7 @@ impl InstrEncoder {
     /// - Returns `None` if merging of the copy instruction was not possible.
     /// - Returns the `Instr` of the merged `copy2` instruction if merging was successful.
     fn merge_copy_instrs(&mut self, result: Register, value: TypedProvider) -> Option<Instr> {
-        let TypedProvider::Register(value) = value else {
+        let TypedProvider::Register(mut value) = value else {
             // Case: cannot merge copies with immediate values at the moment.
             //
             // Note: we could implement this but it would require us to allocate
@@ -351,11 +351,19 @@ impl InstrEncoder {
             // Case: cannot merge copy instructions as `copy2` since result registers are not contiguous.
             return None;
         }
+
         let (merged_result, value0, value1) = if last_result < result {
+            if last_value == result {
+                value = last_value;
+            }
             (last_result, last_value, value)
         } else {
+            if value == last_result {
+                value = last_value;
+            }
             (result, value, last_value)
         };
+
         let merged_copy = Instruction::copy2(RegisterSpan::new(merged_result), value0, value1);
         *self.instrs.get_mut(last_instr) = merged_copy;
         Some(last_instr)

--- a/crates/wasmi/src/engine/translator/tests/op/local_set.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/local_set.rs
@@ -455,3 +455,61 @@ fn preserve_multiple_6() {
         ])
         .run()
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn merge_overwriting_local_set() {
+    let wasm = r"
+        (module
+            (func (result i32)
+                (local i32 i32)
+
+                i32.const 10
+                local.set 0
+                i32.const 20
+                local.set 1
+            
+                local.get 1
+                local.tee 0
+                local.tee 1
+            )
+        )
+    ";
+    TranslationTest::from_wat(wasm)
+        .expect_func_instrs([
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(0)), 1, 1),
+            Instruction::return_reg(1),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn merge_overwriting_local_set_rev() {
+    let wasm = r"
+        (module
+            (func (result i32)
+                (local i32 i32)
+
+                i32.const 10
+                local.set 0
+                i32.const 20
+                local.set 1
+            
+                local.get 0
+                local.tee 1
+                local.tee 0
+            )
+        )
+    ";
+    TranslationTest::from_wat(wasm)
+        .expect_func_instrs([
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(0)), 0, 0),
+            Instruction::return_reg(0),
+        ])
+        .run()
+}


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1051.