### PR TITLE
Fix `local.set` miscompilation with propagating values more generally

### DIFF
--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -352,15 +352,14 @@ impl InstrEncoder {
             return None;
         }
 
+        // Propagate values according to the order of the merged copies.
+        if value == last_result {
+            value = last_value;
+        }
+
         let (merged_result, value0, value1) = if last_result < result {
-            if last_value == result {
-                value = last_value;
-            }
             (last_result, last_value, value)
         } else {
-            if value == last_result {
-                value = last_value;
-            }
             (result, value, last_value)
         };
 

--- a/crates/wasmi/src/engine/translator/tests/op/local_set.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/local_set.rs
@@ -513,3 +513,61 @@ fn merge_overwriting_local_set_rev() {
         ])
         .run()
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn merge_overwriting_local_set_3() {
+    let wasm = r"
+        (module
+            (func (result i32)
+                (local i32 i32 i32) 
+
+                (local.set 0 (i32.const 10))
+                (local.set 1 (i32.const 20))
+                (local.set 2 (i32.const 30))
+
+                local.get 2
+                local.tee 0
+                local.tee 1
+            )
+        )
+    ";
+    TranslationTest::from_wat(wasm)
+        .expect_func_instrs([
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(0)), 2, 2),
+            Instruction::return_reg(1),
+        ])
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn merge_overwriting_local_set_3_rev() {
+    let wasm = r"
+        (module
+            (func (result i32)
+                (local i32 i32 i32) 
+
+                (local.set 0 (i32.const 10))
+                (local.set 1 (i32.const 20))
+                (local.set 2 (i32.const 30))
+
+                local.get 2
+                local.tee 1
+                local.tee 0
+            )
+        )
+    ";
+    TranslationTest::from_wat(wasm)
+        .expect_func_instrs([
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy_imm32(Register::from_i16(2), 30_i32),
+            Instruction::copy2(RegisterSpan::new(Register::from_i16(0)), 2, 2),
+            Instruction::return_reg(0),
+        ])
+        .run()
+}


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1051.