### PR TITLE
Fix local preservation when chaining `local.set`

### DIFF
--- a/crates/wasmi/src/engine/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/stack/mod.rs
@@ -130,6 +130,13 @@ impl ValueStack {
         self.providers.preserve_all_locals(&mut self.reg_alloc, f)
     }
 
+    /// Frees all preservation slots that have been flagged for removal.
+    ///
+    /// This is important to allow them for reuse for future preservations.
+    pub fn gc_preservations(&mut self) {
+        self.reg_alloc.gc_preservations()
+    }
+
     /// Returns the number of [`Provider`] on the [`ValueStack`].
     ///
     /// # Note

--- a/crates/wasmi/src/engine/translator/stack/register_alloc.rs
+++ b/crates/wasmi/src/engine/translator/stack/register_alloc.rs
@@ -338,6 +338,22 @@ impl RegisterAlloc {
             None => unreachable!(),
         };
         self.assert_alloc_phase();
+        // Now we can clear the removed preserved registers.
+        self.removed_preserved.clear();
+        let key = self.preservations.put(NZ_TWO, ());
+        let reg = Self::key2reg(key);
+        self.update_min_preserved(reg.prev())?;
+        Ok(reg)
+    }
+
+    /// Frees all preservation slots that are flagged for removal.
+    ///
+    /// This is important to allow them for reuse for future preservations.
+    pub fn gc_preservations(&mut self) {
+        self.assert_alloc_phase();
+        if self.removed_preserved.is_empty() {
+            return;
+        }
         for &key in &self.removed_preserved {
             let entry = self.preservations.get(key);
             debug_assert!(
@@ -352,12 +368,6 @@ impl RegisterAlloc {
                 self.preservations.take_all(key);
             }
         }
-        // Now we can clear the removed preserved registers.
-        self.removed_preserved.clear();
-        let key = self.preservations.put(NZ_TWO, ());
-        let reg = Self::key2reg(key);
-        self.update_min_preserved(reg.prev())?;
-        Ok(reg)
     }
 
     /// Bumps the [`Register`] quantity on the preservation stack by one.

--- a/crates/wasmi/src/engine/translator/tests/op/local_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/local_preserve.rs
@@ -528,8 +528,8 @@ fn invalid_preservation_slot_reuse_1() {
     let wasm = r#"
         (module
             (func (param i32 i32)
-                (local.get 1) ;; preserved after (local.tee 1)
-                (local.get 0) ;; preserved after (local.tee 0)
+                (local.get 1) ;; preserved for (local.tee 1)
+                (local.get 0) ;; preserved for (local.tee 0)
                 (local.tee 0 (i32.popcnt (local.get 0)))
                 (i32.add)
                 (local.set 1)
@@ -586,5 +586,43 @@ fn invalid_preservation_slot_reuse_2() {
             Instruction::copy(1, 2),
             Instruction::Return,
         ]))
+        .run()
+}
+
+#[test]
+fn concat_local_tee_pair() {
+    let wasm = r"
+        (module
+            (func (result i32)
+                (local i32 i32)
+            
+                (local.set 0 (i32.const 10))
+                (local.set 1 (i32.const 20))
+
+                local.get 1
+                local.get 0
+
+                (local.set 0 (i32.const 10))
+
+                local.tee 1
+                i32.add
+            )
+        )
+    ";
+    TranslationTest::from_wat(wasm)
+        .expect_func_instrs([
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy_imm32(Register::from_i16(1), 20_i32),
+            Instruction::copy(Register::from_i16(4), Register::from_i16(0)), // preserved
+            Instruction::copy_imm32(Register::from_i16(0), 10_i32),
+            Instruction::copy(Register::from_i16(3), Register::from_i16(1)), // preserved
+            Instruction::copy(Register::from_i16(1), Register::from_i16(4)),
+            Instruction::i32_add(
+                Register::from_i16(2),
+                Register::from_i16(3),
+                Register::from_i16(1),
+            ),
+            Instruction::return_reg(2),
+        ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -817,6 +817,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     fn visit_local_set(&mut self, local_index: u32) -> Self::Output {
         bail_unreachable!(self);
+        self.alloc.stack.gc_preservations();
         let value = self.alloc.stack.pop();
         let local = Register::try_from(local_index)?;
         if let TypedProvider::Register(value) = value {


### PR DESCRIPTION
Fixes the test case reported in https://github.com/wasmi-labs/wasmi/issues/1051#issuecomment-2146470314.