### PR TITLE
Refactor engine's `ValueStack` API

### DIFF
--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -350,23 +350,6 @@ impl CompiledFuncEntity {
         self.len_registers
     }
 
-    /// Returns the number of mutable registers used by the [`CompiledFunc`].
-    ///
-    /// # Note
-    ///
-    /// This excludes registers required to store function local constant values.
-    pub fn len_cells(&self) -> u16 {
-        debug_assert!(
-            self.consts.len() <= self.len_registers as usize,
-            "len_registers contains function local constant values and therefore must be greater or equals",
-        );
-        debug_assert!(
-            u16::try_from(self.consts.len()).is_ok(),
-            "there can never be more than i16::MAX function local constant values"
-        );
-        self.len_registers - self.consts().len() as u16
-    }
-
     /// Returns the function local constant values of the [`CompiledFunc`].
     pub fn consts(&self) -> &[UntypedVal] {
         &self.consts

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -997,12 +997,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Returns the [`FrameRegisters`] of the [`CallFrame`].
-    #[inline(always)]
-    fn frame_stack_ptr(&mut self, frame: &CallFrame) -> FrameRegisters {
-        Self::frame_stack_ptr_impl(self.value_stack, frame)
-    }
-
-    /// Returns the [`FrameRegisters`] of the [`CallFrame`].
     fn frame_stack_ptr_impl(value_stack: &mut ValueStack, frame: &CallFrame) -> FrameRegisters {
         // Safety: We are using the frame's own base offset as input because it is
         //         guaranteed by the Wasm validation and translation phase to be

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -499,7 +499,6 @@ impl<'engine> Executor<'engine> {
         if <C as CallContext>::HAS_PARAMS {
             let mut uninit_params = FrameParams::new(buffer);
             self.copy_call_params(&mut uninit_params);
-            uninit_params.init_zeroes();
         }
         if matches!(<C as CallContext>::KIND, CallKind::Nested) {
             self.update_instr_ptr_at(1);

--- a/crates/wasmi/src/engine/executor/stack/mod.rs
+++ b/crates/wasmi/src/engine/executor/stack/mod.rs
@@ -3,7 +3,13 @@ mod values;
 
 pub use self::{
     calls::{CallFrame, CallStack},
-    values::{BaseValueStackOffset, FrameRegisters, FrameValueStackOffset, ValueStack},
+    values::{
+        BaseValueStackOffset,
+        FrameParams,
+        FrameRegisters,
+        FrameValueStackOffset,
+        ValueStack,
+    },
 };
 use crate::{core::TrapCode, StackLimits};
 

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -6,6 +6,7 @@ use crate::{
 use core::{
     fmt::{self, Debug},
     mem::{self, MaybeUninit},
+    ops::Range,
     ptr,
     slice,
 };
@@ -151,11 +152,16 @@ impl ValueStack {
     pub fn extend_by(
         &mut self,
         additional: usize,
+        on_resize: impl FnOnce(&mut Self),
     ) -> Result<&mut [MaybeUninit<UntypedVal>], TrapCode> {
         if additional >= self.max_len() - self.len() {
             return Err(err_stack_overflow());
         }
+        let prev_capacity = self.capacity();
         self.values.reserve(additional);
+        if prev_capacity != self.capacity() {
+            on_resize(self);
+        }
         let spare = self.values.spare_capacity_mut().as_mut_ptr();
         unsafe { self.values.set_len(self.values.len() + additional) };
         Ok(unsafe { slice::from_raw_parts_mut(spare, additional) })
@@ -171,43 +177,6 @@ impl ValueStack {
     fn max_len(&self) -> usize {
         debug_assert!(self.values.len() <= self.max_len);
         self.max_len
-    }
-
-    /// Reserves enough space for `additional` cells on the [`ValueStack`].
-    ///
-    /// This may heap allocate in case the [`ValueStack`] ran out of preallocated memory.
-    ///
-    /// # Errors
-    ///
-    /// When trying to grow the [`ValueStack`] over its maximum size limit.
-    #[deprecated(note = "use extend_by instead")]
-    pub fn reserve(&mut self, additional: usize) -> Result<(), TrapCode> {
-        if additional >= self.max_len() - self.len() {
-            return Err(err_stack_overflow());
-        }
-        self.values.reserve(additional);
-        Ok(())
-    }
-
-    /// Extends the [`ValueStack`] by the `amount` of zeros.
-    ///
-    /// Returns the [`ValueStackOffset`] before this operation.
-    /// Use [`ValueStack::truncate`] to undo the [`ValueStack`] state change.
-    ///
-    /// # Safety
-    ///
-    /// The caller is responsible to make sure enough space is reserved for `amount` new values.
-    #[deprecated(note = "use extend_by instead")]
-    pub unsafe fn extend_zeros(&mut self, amount: usize) -> ValueStackOffset {
-        if amount == 0 {
-            return ValueStackOffset(self.len());
-        }
-        let remaining = self.values.spare_capacity_mut();
-        let uninit = unsafe { remaining.get_unchecked_mut(..amount) };
-        uninit.fill(MaybeUninit::new(UntypedVal::default()));
-        let old_len = self.len();
-        unsafe { self.values.set_len(old_len + amount) };
-        ValueStackOffset(old_len)
     }
 
     /// Drop the last `amount` cells of the [`ValueStack`].
@@ -251,44 +220,27 @@ impl ValueStack {
     pub fn alloc_call_frame(
         &mut self,
         func: &CompiledFuncEntity,
-    ) -> Result<(BaseValueStackOffset, FrameValueStackOffset), TrapCode> {
+        on_resize: impl FnMut(&mut Self),
+    ) -> Result<(FrameParams, BaseValueStackOffset, FrameValueStackOffset), TrapCode> {
         let len_registers = func.len_registers();
+        let len_consts = func.consts().len();
         let len = self.len();
-        let mut spare = self.extend_by(len_registers as usize)?.into_iter();
+        let mut spare = self
+            .extend_by(len_registers as usize, on_resize)?
+            .iter_mut();
         (&mut spare)
             .zip(func.consts())
             .for_each(|(uninit, const_value)| {
                 uninit.write(*const_value);
             });
-        spare.for_each(|uninit| {
-            uninit.write(UntypedVal::from(0));
-        });
+        let params = FrameParams::new(spare.into_slice());
         let frame = ValueStackOffset(len);
-        let base = ValueStackOffset(len + func.consts().len());
-        Ok((BaseValueStackOffset(base), FrameValueStackOffset(frame)))
-    }
-
-    /// Fills the [`ValueStack`] cells at `offset` with `values`.
-    ///
-    /// # Safety
-    ///
-    /// The caller has to ensure that `offset` is valid for the range of
-    /// `values` required to be stored on the [`ValueStack`].
-    pub unsafe fn fill_at<IntoIter, Iter>(
-        &mut self,
-        offset: impl Into<ValueStackOffset>,
-        values: IntoIter,
-    ) where
-        IntoIter: IntoIterator<IntoIter = Iter>,
-        Iter: ExactSizeIterator<Item = UntypedVal>,
-    {
-        let offset = offset.into().0;
-        let values = values.into_iter();
-        let len_values = values.len();
-        let cells = &mut self.values[offset..offset + len_values];
-        for (cell, value) in cells.iter_mut().zip(values) {
-            *cell = value;
-        }
+        let base = ValueStackOffset(len + len_consts);
+        Ok((
+            params,
+            BaseValueStackOffset(base),
+            FrameValueStackOffset(frame),
+        ))
     }
 
     /// Returns a shared slice over the values of the [`ValueStack`].
@@ -390,6 +342,40 @@ impl BaseValueStackOffset {
 impl From<BaseValueStackOffset> for usize {
     fn from(offset: BaseValueStackOffset) -> usize {
         offset.0 .0
+    }
+}
+
+/// Uninitialized parameters of a [`CallFrame`].
+pub struct FrameParams {
+    range: Range<*mut MaybeUninit<UntypedVal>>,
+}
+
+impl FrameParams {
+    /// Creates a new [`FrameRegisters`].
+    pub fn new(ptr: &mut [MaybeUninit<UntypedVal>]) -> Self {
+        Self {
+            range: ptr.as_mut_ptr_range(),
+        }
+    }
+
+    /// Sets the value of the `register` to `value`.`
+    ///
+    /// # Safety
+    ///
+    /// It is the callers responsibility to provide a [`Register`] that
+    /// does not access the underlying [`ValueStack`] out of bounds.
+    pub unsafe fn init_next(&mut self, value: UntypedVal) {
+        self.range.start.write(MaybeUninit::new(value));
+        self.range.start = self.range.start.add(1);
+    }
+
+    /// Zero-initialize the remaining locals and parameters.
+    pub fn init_zeroes(mut self) {
+        debug_assert!(self.range.start <= self.range.end);
+        while self.range.start != self.range.end {
+            // Safety: We do not write out-of-buffer due to the above condition.
+            unsafe { self.init_next(UntypedVal::from(0_u64)) }
+        }
     }
 }
 

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -180,6 +180,7 @@ impl ValueStack {
     /// # Errors
     ///
     /// When trying to grow the [`ValueStack`] over its maximum size limit.
+    #[deprecated(note = "use extend_by instead")]
     pub fn reserve(&mut self, additional: usize) -> Result<(), TrapCode> {
         if additional >= self.max_len() - self.len() {
             return Err(err_stack_overflow());
@@ -196,6 +197,7 @@ impl ValueStack {
     /// # Safety
     ///
     /// The caller is responsible to make sure enough space is reserved for `amount` new values.
+    #[deprecated(note = "use extend_by instead")]
     pub unsafe fn extend_zeros(&mut self, amount: usize) -> ValueStackOffset {
         if amount == 0 {
             return ValueStackOffset(self.len());

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -137,6 +137,7 @@ impl ValueStack {
     /// # Errors
     ///
     /// When trying to grow the [`ValueStack`] over its maximum size limit.
+    #[inline(always)]
     pub fn extend_by(
         &mut self,
         additional: usize,
@@ -156,12 +157,14 @@ impl ValueStack {
     }
 
     /// Returns the current length of the [`ValueStack`].
+    #[inline(always)]
     fn len(&self) -> usize {
         debug_assert!(self.values.len() <= self.max_len);
         self.values.len()
     }
 
     /// Returns the maximum length of the [`ValueStack`].
+    #[inline(always)]
     fn max_len(&self) -> usize {
         debug_assert!(self.values.len() <= self.max_len);
         self.max_len


### PR DESCRIPTION
- This somewhat improves the whacky `ValueStack` API of Wasmi's executor engine. It introduces `extend_by` and refactors `alloc_call_frame` and removes plenty of APIs that are no longer needed due to these changes.
- The gist of this PR is that it (hopefully) needs a bit less `unsafe` code or that the `unsafe` code is isolated a bit better.
- Another hope with this PR is that performance stays the same or at best improves, especially for call-intense workloads. However, performance improvements have not been detected locally unfortunately.

## In Summary

- Adds `ValueStack::extend_by` method
- Removes `ValueStack::{reserve, extend_slice, extend_zeros, fill_at, stack_ptr_last_n}` methods
- Adds `FrameParams` type abstraction
- Refactors all code that is touched by the above items