### PR TITLE
Optimize memory access in the Wasmi executor

### DIFF
--- a/crates/wasmi/src/engine/cache.rs
+++ b/crates/wasmi/src/engine/cache.rs
@@ -146,19 +146,17 @@ impl InstanceCache {
         ctx.resolve_table_init_params(inst, &tab, &seg)
     }
 
-    /// Clears the cached default memory instance and global variable.
+    /// Clears the cached global variable.
     ///
     /// # Note
     ///
-    /// - This is required for host function calls for reasons explained
-    ///   in [`InstanceCache::reset_default_memory_bytes`].
-    /// - Furthermore a called host function could introduce new global
-    ///   variables to the [`Store`] and thus might invalidate cached
-    ///   global variables. So we need to reset them as well.
+    /// A called host function could introduce new global
+    /// variables to the [`Store`] and thus might invalidate cached
+    /// global variable. So we need to reset them.
     ///
     /// [`Store`]: crate::Store
     #[inline]
-    pub fn reset(&mut self) {
+    pub fn reset_last_global(&mut self) {
         self.last_global = None;
     }
 

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -512,7 +512,7 @@ impl<'engine> Executor<'engine> {
                 true => error,
                 false => ResumableHostError::new(error, *func, results).into(),
             })?;
-        self.cache.reset();
+        self.cache.reset_last_global();
         self.memory = Self::load_default_memory(&mut store.inner, caller.instance());
         let results = results.iter(len_results);
         let returned = self.value_stack.drop_return(max_inout);

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -460,6 +460,7 @@ impl<'engine> Executor<'engine> {
                 let func_body = func.func_body();
                 self.prepare_compiled_func_call::<C>(&mut store.inner, results, func_body)?;
                 self.cache.update_instance(&instance);
+                self.memory = Self::load_default_memory(&mut store.inner, &instance);
                 Ok(())
             }
             FuncEntity::Host(host_func) => {
@@ -506,12 +507,13 @@ impl<'engine> Executor<'engine> {
         if matches!(<C as CallContext>::KIND, CallKind::Nested) {
             self.update_instr_ptr_at(1);
         }
-        self.cache.reset();
         self.dispatch_host_func::<T>(store, host_func, caller)
             .map_err(|error| match self.call_stack.is_empty() {
                 true => error,
                 false => ResumableHostError::new(error, *func, results).into(),
             })?;
+        self.cache.reset();
+        self.memory = Self::load_default_memory(&mut store.inner, caller.instance());
         let results = results.iter(len_results);
         let returned = self.value_stack.drop_return(max_inout);
         for (result, value) in results.zip(returned) {

--- a/crates/wasmi/src/engine/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/executor/instrs/return_.rs
@@ -5,6 +5,7 @@ use crate::{
         bytecode::{AnyConst32, Const32, Instruction, Register, RegisterSpan, RegisterSpanIter},
         executor::stack::FrameRegisters,
     },
+    store::StoreInner,
 };
 use core::slice;
 
@@ -23,7 +24,7 @@ impl<'engine> Executor<'engine> {
     /// Any return values are expected to already have been transferred
     /// from the returning callee to the caller.
     #[inline(always)]
-    fn return_impl(&mut self) -> ReturnOutcome {
+    fn return_impl(&mut self, store: &mut StoreInner) -> ReturnOutcome {
         let returned = self
             .call_stack
             .pop()
@@ -32,7 +33,9 @@ impl<'engine> Executor<'engine> {
         match self.call_stack.peek() {
             Some(caller) => {
                 Self::init_call_frame_impl(self.value_stack, &mut self.sp, &mut self.ip, caller);
-                self.cache.update_instance(caller.instance());
+                let instance = caller.instance();
+                self.cache.update_instance(instance);
+                self.memory = Self::load_default_memory(store, instance);
                 ReturnOutcome::Wasm
             }
             None => ReturnOutcome::Host,
@@ -41,8 +44,8 @@ impl<'engine> Executor<'engine> {
 
     /// Execute an [`Instruction::Return`].
     #[inline(always)]
-    pub fn execute_return(&mut self) -> ReturnOutcome {
-        self.return_impl()
+    pub fn execute_return(&mut self, store: &mut StoreInner) -> ReturnOutcome {
+        self.return_impl(store)
     }
 
     /// Returns the [`FrameRegisters`] of the caller and the [`RegisterSpan`] of the results.
@@ -83,6 +86,7 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     fn execute_return_value<T>(
         &mut self,
+        store: &mut StoreInner,
         value: T,
         f: fn(&Self, T) -> UntypedVal,
     ) -> ReturnOutcome {
@@ -93,31 +97,40 @@ impl<'engine> Executor<'engine> {
         //         registers of the callee since they reside in different
         //         call frames. Therefore this access is safe.
         unsafe { caller_sp.set(results.head(), value) }
-        self.return_impl()
+        self.return_impl(store)
     }
 
     /// Execute an [`Instruction::ReturnReg`] returning a single [`Register`] value.
     #[inline(always)]
-    pub fn execute_return_reg(&mut self, value: Register) -> ReturnOutcome {
-        self.execute_return_value(value, Self::get_register)
+    pub fn execute_return_reg(&mut self, store: &mut StoreInner, value: Register) -> ReturnOutcome {
+        self.execute_return_value(store, value, Self::get_register)
     }
 
     /// Execute an [`Instruction::ReturnReg2`] returning two [`Register`] values.
     #[inline(always)]
-    pub fn execute_return_reg2(&mut self, values: [Register; 2]) -> ReturnOutcome {
-        self.execute_return_reg_n_impl::<2>(values)
+    pub fn execute_return_reg2(
+        &mut self,
+        store: &mut StoreInner,
+        values: [Register; 2],
+    ) -> ReturnOutcome {
+        self.execute_return_reg_n_impl::<2>(store, values)
     }
 
     /// Execute an [`Instruction::ReturnReg3`] returning three [`Register`] values.
     #[inline(always)]
-    pub fn execute_return_reg3(&mut self, values: [Register; 3]) -> ReturnOutcome {
-        self.execute_return_reg_n_impl::<3>(values)
+    pub fn execute_return_reg3(
+        &mut self,
+        store: &mut StoreInner,
+        values: [Register; 3],
+    ) -> ReturnOutcome {
+        self.execute_return_reg_n_impl::<3>(store, values)
     }
 
     /// Executes an [`Instruction::ReturnReg2`] or [`Instruction::ReturnReg3`] generically.
     #[inline(always)]
     fn execute_return_reg_n_impl<const N: usize>(
         &mut self,
+        store: &mut StoreInner,
         values: [Register; N],
     ) -> ReturnOutcome {
         let (mut caller_sp, results) = self.return_caller_results();
@@ -130,30 +143,46 @@ impl<'engine> Executor<'engine> {
             //         call frames. Therefore this access is safe.
             unsafe { caller_sp.set(result, value) }
         }
-        self.return_impl()
+        self.return_impl(store)
     }
 
     /// Execute an [`Instruction::ReturnImm32`] returning a single 32-bit value.
     #[inline(always)]
-    pub fn execute_return_imm32(&mut self, value: AnyConst32) -> ReturnOutcome {
-        self.execute_return_value(value, |_, value| u32::from(value).into())
+    pub fn execute_return_imm32(
+        &mut self,
+        store: &mut StoreInner,
+        value: AnyConst32,
+    ) -> ReturnOutcome {
+        self.execute_return_value(store, value, |_, value| u32::from(value).into())
     }
 
     /// Execute an [`Instruction::ReturnI64Imm32`] returning a single 32-bit encoded `i64` value.
     #[inline(always)]
-    pub fn execute_return_i64imm32(&mut self, value: Const32<i64>) -> ReturnOutcome {
-        self.execute_return_value(value, |_, value| i64::from(value).into())
+    pub fn execute_return_i64imm32(
+        &mut self,
+        store: &mut StoreInner,
+        value: Const32<i64>,
+    ) -> ReturnOutcome {
+        self.execute_return_value(store, value, |_, value| i64::from(value).into())
     }
 
     /// Execute an [`Instruction::ReturnF64Imm32`] returning a single 32-bit encoded `f64` value.
     #[inline(always)]
-    pub fn execute_return_f64imm32(&mut self, value: Const32<f64>) -> ReturnOutcome {
-        self.execute_return_value(value, |_, value| f64::from(value).into())
+    pub fn execute_return_f64imm32(
+        &mut self,
+        store: &mut StoreInner,
+        value: Const32<f64>,
+    ) -> ReturnOutcome {
+        self.execute_return_value(store, value, |_, value| f64::from(value).into())
     }
 
     /// Execute an [`Instruction::ReturnSpan`] returning many values.
     #[inline(always)]
-    pub fn execute_return_span(&mut self, values: RegisterSpanIter) -> ReturnOutcome {
+    pub fn execute_return_span(
+        &mut self,
+        store: &mut StoreInner,
+        values: RegisterSpanIter,
+    ) -> ReturnOutcome {
         let (mut caller_sp, results) = self.return_caller_results();
         let results = results.iter(values.len());
         for (result, value) in results.zip(values) {
@@ -164,17 +193,25 @@ impl<'engine> Executor<'engine> {
             let value = self.get_register(value);
             unsafe { caller_sp.set(result, value) }
         }
-        self.return_impl()
+        self.return_impl(store)
     }
 
     /// Execute an [`Instruction::ReturnMany`] returning many values.
     #[inline(always)]
-    pub fn execute_return_many(&mut self, values: [Register; 3]) -> ReturnOutcome {
-        self.execute_return_many_impl(&values)
+    pub fn execute_return_many(
+        &mut self,
+        store: &mut StoreInner,
+        values: [Register; 3],
+    ) -> ReturnOutcome {
+        self.execute_return_many_impl(store, &values)
     }
 
     /// Executes [`Instruction::ReturnMany`] or parts of [`Instruction::ReturnNezMany`] generically.
-    fn execute_return_many_impl(&mut self, values: &[Register]) -> ReturnOutcome {
+    fn execute_return_many_impl(
+        &mut self,
+        store: &mut StoreInner,
+        values: &[Register],
+    ) -> ReturnOutcome {
         let (mut caller_sp, results) = self.return_caller_results();
         let mut result = results.head();
         let mut copy_results = |values: &[Register]| {
@@ -202,20 +239,21 @@ impl<'engine> Executor<'engine> {
             unexpected => unreachable!("unexpected Instruction found while executing Instruction::ReturnMany: {unexpected:?}"),
         };
         copy_results(values);
-        self.return_impl()
+        self.return_impl(store)
     }
 
     /// Execute a generic conditional return [`Instruction`].
     #[inline(always)]
     fn execute_return_nez_impl<T>(
         &mut self,
+        store: &mut StoreInner,
         condition: Register,
         value: T,
-        f: fn(&mut Self, T) -> ReturnOutcome,
+        f: fn(&mut Self, &mut StoreInner, T) -> ReturnOutcome,
     ) -> ReturnOutcome {
         let condition = self.get_register(condition);
         match bool::from(condition) {
-            true => f(self, value),
+            true => f(self, store, value),
             false => {
                 self.next_instr();
                 ReturnOutcome::Wasm
@@ -225,80 +263,93 @@ impl<'engine> Executor<'engine> {
 
     /// Execute an [`Instruction::Return`].
     #[inline(always)]
-    pub fn execute_return_nez(&mut self, condition: Register) -> ReturnOutcome {
-        self.execute_return_nez_impl(condition, (), |this, _| this.execute_return())
+    pub fn execute_return_nez(
+        &mut self,
+        store: &mut StoreInner,
+        condition: Register,
+    ) -> ReturnOutcome {
+        self.execute_return_nez_impl(store, condition, (), |this, store, _| {
+            this.execute_return(store)
+        })
     }
 
     /// Execute an [`Instruction::ReturnNezReg`] returning a single [`Register`] value.
     #[inline(always)]
     pub fn execute_return_nez_reg(
         &mut self,
+        store: &mut StoreInner,
         condition: Register,
         value: Register,
     ) -> ReturnOutcome {
-        self.execute_return_nez_impl(condition, value, Self::execute_return_reg)
+        self.execute_return_nez_impl(store, condition, value, Self::execute_return_reg)
     }
 
     /// Execute an [`Instruction::ReturnNezReg`] returning a single [`Register`] value.
     #[inline(always)]
     pub fn execute_return_nez_reg2(
         &mut self,
+        store: &mut StoreInner,
         condition: Register,
         value: [Register; 2],
     ) -> ReturnOutcome {
-        self.execute_return_nez_impl(condition, value, Self::execute_return_reg2)
+        self.execute_return_nez_impl(store, condition, value, Self::execute_return_reg2)
     }
 
     /// Execute an [`Instruction::ReturnNezImm32`] returning a single 32-bit constant value.
     #[inline(always)]
     pub fn execute_return_nez_imm32(
         &mut self,
+        store: &mut StoreInner,
         condition: Register,
         value: AnyConst32,
     ) -> ReturnOutcome {
-        self.execute_return_nez_impl(condition, value, Self::execute_return_imm32)
+        self.execute_return_nez_impl(store, condition, value, Self::execute_return_imm32)
     }
 
     /// Execute an [`Instruction::ReturnNezI64Imm32`] returning a single 32-bit encoded constant `i64` value.
     #[inline(always)]
     pub fn execute_return_nez_i64imm32(
         &mut self,
+        store: &mut StoreInner,
         condition: Register,
         value: Const32<i64>,
     ) -> ReturnOutcome {
-        self.execute_return_nez_impl(condition, value, Self::execute_return_i64imm32)
+        self.execute_return_nez_impl(store, condition, value, Self::execute_return_i64imm32)
     }
 
     /// Execute an [`Instruction::ReturnNezF64Imm32`] returning a single 32-bit encoded constant `f64` value.
     #[inline(always)]
     pub fn execute_return_nez_f64imm32(
         &mut self,
+        store: &mut StoreInner,
         condition: Register,
         value: Const32<f64>,
     ) -> ReturnOutcome {
-        self.execute_return_nez_impl(condition, value, Self::execute_return_f64imm32)
+        self.execute_return_nez_impl(store, condition, value, Self::execute_return_f64imm32)
     }
 
     /// Execute an [`Instruction::ReturnNezSpan`] returning many values.
     #[inline(always)]
     pub fn execute_return_nez_span(
         &mut self,
+        store: &mut StoreInner,
         condition: Register,
         values: RegisterSpanIter,
     ) -> ReturnOutcome {
-        self.execute_return_nez_impl(condition, values, Self::execute_return_span)
+        self.execute_return_nez_impl(store, condition, values, Self::execute_return_span)
     }
 
     /// Execute an [`Instruction::ReturnNezMany`] returning many values.
     #[inline(always)]
     pub fn execute_return_nez_many(
         &mut self,
+        store: &mut StoreInner,
         condition: Register,
         values: [Register; 2],
     ) -> ReturnOutcome {
         let condition = self.get_register(condition);
         match bool::from(condition) {
-            true => self.execute_return_many_impl(&values),
+            true => self.execute_return_many_impl(store, &values),
             false => {
                 self.ip.add(1);
                 while let Instruction::RegisterList(_values) = self.ip.get() {

--- a/crates/wasmi/src/engine/executor/instrs/store.rs
+++ b/crates/wasmi/src/engine/executor/instrs/store.rs
@@ -5,7 +5,6 @@ use crate::{
         bytecode::{Const16, Instruction, Register, StoreAtInstr, StoreInstr, StoreOffset16Instr},
         code_map::InstructionPtr,
     },
-    store::StoreInner,
     Error,
 };
 
@@ -41,27 +40,22 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     fn execute_store_wrap(
         &mut self,
-        store: &mut StoreInner,
         address: UntypedVal,
         offset: u32,
         value: UntypedVal,
         store_wrap: WasmStoreOp,
     ) -> Result<(), Error> {
-        let memory = self.cache.default_memory_bytes(store);
+        // Safety: `self.memory` is always re-loaded conservatively whenever
+        //         the heap allocations and thus the pointer might have changed.
+        let memory = unsafe { self.memory.as_mut() };
         store_wrap(memory, address, offset, value)?;
         Ok(())
     }
 
     #[inline(always)]
-    fn execute_store(
-        &mut self,
-        store: &mut StoreInner,
-        instr: StoreInstr,
-        store_op: WasmStoreOp,
-    ) -> Result<(), Error> {
+    fn execute_store(&mut self, instr: StoreInstr, store_op: WasmStoreOp) -> Result<(), Error> {
         let value = self.fetch_store_value(1);
         self.execute_store_wrap(
-            store,
             self.get_register(instr.ptr),
             u32::from(instr.offset),
             self.get_register(value),
@@ -73,12 +67,10 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     fn execute_store_offset16(
         &mut self,
-        store: &mut StoreInner,
         instr: StoreOffset16Instr<Register>,
         store_op: WasmStoreOp,
     ) -> Result<(), Error> {
         self.execute_store_wrap(
-            store,
             self.get_register(instr.ptr),
             u32::from(instr.offset),
             self.get_register(instr.value),
@@ -90,7 +82,6 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     fn execute_store_offset16_imm16<T, V>(
         &mut self,
-        store: &mut StoreInner,
         instr: StoreOffset16Instr<V>,
         store_op: WasmStoreOp,
     ) -> Result<(), Error>
@@ -98,7 +89,6 @@ impl<'engine> Executor<'engine> {
         T: From<V> + Into<UntypedVal>,
     {
         self.execute_store_wrap(
-            store,
             self.get_register(instr.ptr),
             u32::from(instr.offset),
             T::from(instr.value).into(),
@@ -110,12 +100,10 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     fn execute_store_at(
         &mut self,
-        store: &mut StoreInner,
         instr: StoreAtInstr<Register>,
         store_op: WasmStoreOp,
     ) -> Result<(), Error> {
         self.execute_store_wrap(
-            store,
             UntypedVal::from(0u32),
             u32::from(instr.address),
             self.get_register(instr.value),
@@ -127,7 +115,6 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     fn execute_store_at_imm16<T, V>(
         &mut self,
-        store: &mut StoreInner,
         instr: StoreAtInstr<V>,
         store_op: WasmStoreOp,
     ) -> Result<(), Error>
@@ -135,7 +122,6 @@ impl<'engine> Executor<'engine> {
         T: From<V> + Into<UntypedVal>,
     {
         self.execute_store_wrap(
-            store,
             UntypedVal::from(0u32),
             u32::from(instr.address),
             T::from(instr.value).into(),
@@ -160,44 +146,41 @@ macro_rules! impl_execute_istore {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store), "`].")]
             #[inline(always)]
-            pub fn $fn_store(&mut self, store: &mut StoreInner, instr: StoreInstr) -> Result<(), Error> {
-                self.execute_store(store, instr, $impl_fn)
+            pub fn $fn_store(&mut self,  instr: StoreInstr) -> Result<(), Error> {
+                self.execute_store(instr, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_off16), "`].")]
             #[inline(always)]
             pub fn $fn_store_off16(
                 &mut self,
-                store: &mut StoreInner,
                 instr: StoreOffset16Instr<Register>,
             ) -> Result<(), Error> {
-                self.execute_store_offset16(store, instr, $impl_fn)
+                self.execute_store_offset16(instr, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_off16_imm16), "`].")]
             #[inline(always)]
             pub fn $fn_store_off16_imm16(
                 &mut self,
-                store: &mut StoreInner,
                 instr: StoreOffset16Instr<$from_ty>,
             ) -> Result<(), Error> {
-                self.execute_store_offset16_imm16::<$to_ty, _>(store, instr, $impl_fn)
+                self.execute_store_offset16_imm16::<$to_ty, _>(instr, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_at), "`].")]
             #[inline(always)]
-            pub fn $fn_store_at(&mut self, store: &mut StoreInner,instr: StoreAtInstr<Register>) -> Result<(), Error> {
-                self.execute_store_at(store, instr, $impl_fn)
+            pub fn $fn_store_at(&mut self,instr: StoreAtInstr<Register>) -> Result<(), Error> {
+                self.execute_store_at(instr, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_at_imm16), "`].")]
             #[inline(always)]
             pub fn $fn_store_at_imm16(
                 &mut self,
-                store: &mut StoreInner,
                 instr: StoreAtInstr<$from_ty>,
             ) -> Result<(), Error> {
-                self.execute_store_at_imm16::<$to_ty, _>(store, instr, $impl_fn)
+                self.execute_store_at_imm16::<$to_ty, _>(instr, $impl_fn)
             }
         )*
     };
@@ -282,23 +265,23 @@ macro_rules! impl_execute_fstore {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store), "`].")]
             #[inline(always)]
-            pub fn $fn_store(&mut self, store: &mut StoreInner, instr: StoreInstr) -> Result<(), Error> {
-                self.execute_store(store, instr, $impl_fn)
+            pub fn $fn_store(&mut self, instr: StoreInstr) -> Result<(), Error> {
+                self.execute_store(instr, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_off16), "`].")]
             #[inline(always)]
             pub fn $fn_store_off16(
-                &mut self, store: &mut StoreInner,
+                &mut self,
                 instr: StoreOffset16Instr<Register>,
             ) -> Result<(), Error> {
-                self.execute_store_offset16(store, instr, $impl_fn)
+                self.execute_store_offset16(instr, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_at), "`].")]
             #[inline(always)]
-            pub fn $fn_store_at(&mut self, store: &mut StoreInner, instr: StoreAtInstr<Register>) -> Result<(), Error> {
-                self.execute_store_at(store, instr, $impl_fn)
+            pub fn $fn_store_at(&mut self, instr: StoreAtInstr<Register>) -> Result<(), Error> {
+                self.execute_store_at(instr, $impl_fn)
             }
         )*
     }


### PR DESCRIPTION
This has fewer indirections when using the default linear memory. Local perf measurements indicated up to 20% improvements for memory-intense workloads. Unfortunately it seems that call-intense workloads regress.