### PR TITLE
Use `Stack` in `Executor`

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -24,8 +24,7 @@ use crate::{
         },
         code_map::InstructionPtr,
         executor::stack::{CallFrame, CallStack, FrameRegisters, ValueStack},
-        func_types::FuncTypeRegistry,
-        CodeMap,
+        EngineResources,
     },
     memory::DataSegment,
     module::DEFAULT_MEMORY_INDEX,
@@ -77,10 +76,9 @@ macro_rules! forward_return {
 pub fn execute_instrs<'engine, T>(
     store: &mut Store<T>,
     stack: &'engine mut Stack,
-    code_map: &'engine CodeMap,
-    func_types: &'engine FuncTypeRegistry,
+    res: &'engine EngineResources,
 ) -> Result<(), Error> {
-    Executor::new(stack, code_map, func_types).execute(store)
+    Executor::new(stack, res).execute(store)
 }
 
 /// An execution context for executing a Wasmi function frame.
@@ -96,28 +94,14 @@ struct Executor<'engine> {
     global: CachedGlobal,
     /// The value and call stacks.
     stack: &'engine mut Stack,
-    /// The Wasm function code map.
-    ///
-    /// # Note
-    ///
-    /// This is used to lookup Wasm function information.
-    code_map: &'engine CodeMap,
-    /// The Wasm function type registry.
-    ///
-    /// # Note
-    ///
-    /// This is used to lookup Wasm function information.
-    func_types: &'engine FuncTypeRegistry,
+    /// The static resources of an [`Engine`].
+    res: &'engine EngineResources,
 }
 
 impl<'engine> Executor<'engine> {
     /// Creates a new [`Executor`] for executing a Wasmi function frame.
     #[inline(always)]
-    pub fn new(
-        stack: &'engine mut Stack,
-        code_map: &'engine CodeMap,
-        func_types: &'engine FuncTypeRegistry,
-    ) -> Self {
+    pub fn new(stack: &'engine mut Stack, res: &'engine EngineResources) -> Self {
         let frame = stack
             .calls
             .peek()
@@ -133,8 +117,7 @@ impl<'engine> Executor<'engine> {
             memory: CachedMemory::default(),
             global: CachedGlobal::default(),
             stack,
-            code_map,
-            func_types,
+            res,
         }
     }
 

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1,6 +1,9 @@
 pub use self::call::{dispatch_host_func, ResumableHostError};
 use self::return_::ReturnOutcome;
-use super::cache::{CachedGlobal, CachedMemory};
+use super::{
+    cache::{CachedGlobal, CachedMemory},
+    Stack,
+};
 use crate::{
     core::{TrapCode, UntypedVal},
     engine::{
@@ -73,12 +76,11 @@ macro_rules! forward_return {
 #[inline(never)]
 pub fn execute_instrs<'engine, T>(
     store: &mut Store<T>,
-    value_stack: &'engine mut ValueStack,
-    call_stack: &'engine mut CallStack,
+    stack: &'engine mut Stack,
     code_map: &'engine CodeMap,
     func_types: &'engine FuncTypeRegistry,
 ) -> Result<(), Error> {
-    Executor::new(value_stack, call_stack, code_map, func_types).execute(store)
+    Executor::new(stack, code_map, func_types).execute(store)
 }
 
 /// An execution context for executing a Wasmi function frame.
@@ -92,19 +94,8 @@ struct Executor<'engine> {
     memory: CachedMemory,
     /// The cached global variable at index 0.
     global: CachedGlobal,
-    /// The value stack.
-    ///
-    /// # Note
-    ///
-    /// This reference is mainly used to synchronize back state
-    /// after manipulations to the value stack via `sp`.
-    value_stack: &'engine mut ValueStack,
-    /// The call stack.
-    ///
-    /// # Note
-    ///
-    /// This is used to store the stack of nested function calls.
-    call_stack: &'engine mut CallStack,
+    /// The value and call stacks.
+    stack: &'engine mut Stack,
     /// The Wasm function code map.
     ///
     /// # Note
@@ -123,26 +114,25 @@ impl<'engine> Executor<'engine> {
     /// Creates a new [`Executor`] for executing a Wasmi function frame.
     #[inline(always)]
     pub fn new(
-        value_stack: &'engine mut ValueStack,
-        call_stack: &'engine mut CallStack,
+        stack: &'engine mut Stack,
         code_map: &'engine CodeMap,
         func_types: &'engine FuncTypeRegistry,
     ) -> Self {
-        let frame = call_stack
+        let frame = stack
+            .calls
             .peek()
             .expect("must have call frame on the call stack");
         // Safety: We are using the frame's own base offset as input because it is
         //         guaranteed by the Wasm validation and translation phase to be
         //         valid for all register indices used by the associated function body.
-        let sp = unsafe { value_stack.stack_ptr_at(frame.base_offset()) };
+        let sp = unsafe { stack.values.stack_ptr_at(frame.base_offset()) };
         let ip = frame.instr_ptr();
         Self {
             sp,
             ip,
             memory: CachedMemory::default(),
             global: CachedGlobal::default(),
-            value_stack,
-            call_stack,
+            stack,
             code_map,
             func_types,
         }
@@ -160,7 +150,7 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     fn execute<T>(mut self, store: &mut Store<T>) -> Result<(), Error> {
         use Instruction as Instr;
-        let instance = Self::instance(self.call_stack);
+        let instance = Self::instance(&self.stack.calls);
         self.memory.update(&mut store.inner, instance);
         self.global.update(&mut store.inner, instance);
         loop {
@@ -914,7 +904,7 @@ macro_rules! get_entity {
             )]
             #[inline]
             fn $name(&self, store: &StoreInner, index: $index_ty) -> $id_ty {
-                let instance = Self::instance(self.call_stack);
+                let instance = Self::instance(&self.stack.calls);
                 let index = ::core::primitive::u32::from(index);
                 store
                     .resolve_instance(instance)
@@ -1037,7 +1027,7 @@ impl<'engine> Executor<'engine> {
     ///
     /// The initialization of the [`Executor`] allows for efficient execution.
     fn init_call_frame(&mut self, frame: &CallFrame) {
-        Self::init_call_frame_impl(self.value_stack, &mut self.sp, &mut self.ip, frame)
+        Self::init_call_frame_impl(&mut self.stack.values, &mut self.sp, &mut self.ip, frame)
     }
 
     /// Initializes the [`Executor`] state for the [`CallFrame`].

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -95,7 +95,7 @@ struct Executor<'engine> {
     /// The value and call stacks.
     stack: &'engine mut Stack,
     /// The static resources of an [`Engine`].
-    /// 
+    ///
     /// [`Engine`]: crate::Engine
     res: &'engine EngineResources,
 }

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -95,6 +95,8 @@ struct Executor<'engine> {
     /// The value and call stacks.
     stack: &'engine mut Stack,
     /// The static resources of an [`Engine`].
+    /// 
+    /// [`Engine`]: crate::Engine
     res: &'engine EngineResources,
 }
 

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -4,7 +4,7 @@ use crate::{
     engine::{
         bytecode::{FuncIdx, Instruction, Register, RegisterSpan, SignatureIdx, TableIdx},
         code_map::InstructionPtr,
-        executor::stack::{CallFrame, FrameParams, Stack, ValueStack},
+        executor::stack::{CallFrame, FrameParams, ValueStack},
         func_types::FuncTypeRegistry,
         CompiledFunc,
         CompiledFuncEntity,
@@ -318,13 +318,7 @@ impl<'engine> Executor<'engine> {
                 // on the value stack which is what the function expects. After this operation we ensure
                 // that `self.sp` is adjusted via a call to `init_call_frame` since it may have been
                 // invalidated by this method.
-                let caller_instance = unsafe {
-                    Stack::merge_call_frames(
-                        &mut self.stack.calls,
-                        &mut self.stack.values,
-                        &mut called,
-                    )
-                };
+                let caller_instance = unsafe { self.stack.merge_call_frames(&mut called) };
                 if let Some(caller_instance) = caller_instance {
                     instance.get_or_insert(caller_instance);
                 }

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -300,7 +300,7 @@ impl<'engine> Executor<'engine> {
         func: CompiledFunc,
         mut instance: Option<Instance>,
     ) -> Result<(), Error> {
-        let func = self.code_map.get(Some(store.fuel_mut()), func)?;
+        let func = self.res.code_map.get(Some(store.fuel_mut()), func)?;
         let mut called = self.dispatch_compiled_func::<C>(results, func)?;
         match <C as CallContext>::KIND {
             CallKind::Nested => {
@@ -497,7 +497,8 @@ impl<'engine> Executor<'engine> {
         func: &Func,
         host_func: HostFuncEntity,
     ) -> Result<(), Error> {
-        let (len_params, len_results) = self.func_types.len_params_results(host_func.ty_dedup());
+        let (len_params, len_results) =
+            self.res.func_types.len_params_results(host_func.ty_dedup());
         let max_inout = len_params.max(len_results);
         let instance = *Self::instance(&self.stack.calls);
         // We have to reinstantiate the `self.sp` [`FrameRegisters`] since we just called
@@ -551,7 +552,7 @@ impl<'engine> Executor<'engine> {
     ) -> Result<(usize, usize), Error> {
         dispatch_host_func(
             store,
-            self.func_types,
+            &self.res.func_types,
             &mut self.stack.values,
             host_func,
             Some(instance),

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -97,7 +97,7 @@ impl<'engine> Executor<'engine> {
                 // The `memory.grow` operation might have invalidated the cached
                 // linear memory so we need to reset it in order for the cache to
                 // reload in case it is used again.
-                let instance = Self::instance(self.call_stack);
+                let instance = Self::instance(&self.stack.calls);
                 self.memory.update(store, instance);
                 return_value
             }

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -416,7 +416,7 @@ impl<'engine> Executor<'engine> {
         let table_index = self.fetch_table_index(1);
         let element_index = self.fetch_element_segment_index(2);
         let (instance, table, element, fuel) = store.resolve_table_init_params(
-            Self::instance(self.call_stack),
+            Self::instance(&self.stack.calls),
             &self.get_table(store, table_index),
             &self.get_element_segment(store, element_index),
         );

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -293,11 +293,9 @@ impl<'engine> EngineExecutor<'engine> {
     /// When encountering a Wasm or host trap during execution.
     #[inline(always)]
     fn execute_func<T>(&mut self, store: &mut Store<T>) -> Result<(), Error> {
-        let value_stack = &mut self.stack.values;
-        let call_stack = &mut self.stack.calls;
         let code_map = &self.res.code_map;
         let func_types = &self.res.func_types;
-        execute_instrs(store, value_stack, call_stack, code_map, func_types)
+        execute_instrs(store, self.stack, code_map, func_types)
     }
 
     /// Convenience forwarder to [`dispatch_host_func`].

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -293,9 +293,7 @@ impl<'engine> EngineExecutor<'engine> {
     /// When encountering a Wasm or host trap during execution.
     #[inline(always)]
     fn execute_func<T>(&mut self, store: &mut Store<T>) -> Result<(), Error> {
-        let code_map = &self.res.code_map;
-        let func_types = &self.res.func_types;
-        execute_instrs(store, self.stack, code_map, func_types)
+        execute_instrs(store, self.stack, self.res)
     }
 
     /// Convenience forwarder to [`dispatch_host_func`].

--- a/crates/wasmi/src/engine/executor/stack/mod.rs
+++ b/crates/wasmi/src/engine/executor/stack/mod.rs
@@ -54,8 +54,8 @@ impl Stack {
 
     /// Resets the [`Stack`] for clean reuse.
     pub fn reset(&mut self) {
-        self.values.reset();
         self.calls.reset();
+        self.values.reset();
     }
 
     /// Create an empty [`Stack`].

--- a/crates/wasmi/src/engine/executor/stack/mod.rs
+++ b/crates/wasmi/src/engine/executor/stack/mod.rs
@@ -22,10 +22,10 @@ fn err_stack_overflow() -> TrapCode {
 /// Data structure that combines both value stack and call stack.
 #[derive(Debug, Default)]
 pub struct Stack {
-    /// The value stack.
-    pub values: ValueStack,
     /// The call stack.
     pub calls: CallStack,
+    /// The value stack.
+    pub values: ValueStack,
 }
 
 impl Stack {

--- a/crates/wasmi/src/engine/executor/stack/mod.rs
+++ b/crates/wasmi/src/engine/executor/stack/mod.rs
@@ -49,7 +49,7 @@ impl Stack {
             limits.initial_value_stack_height,
             limits.maximum_value_stack_height,
         );
-        Self { values, calls }
+        Self { calls, values }
     }
 
     /// Resets the [`Stack`] for clean reuse.

--- a/crates/wasmi/src/engine/executor/stack/mod.rs
+++ b/crates/wasmi/src/engine/executor/stack/mod.rs
@@ -98,12 +98,8 @@ impl Stack {
     /// all [`FrameRegisters`] affected by this.
     #[inline(always)]
     #[must_use]
-    pub unsafe fn merge_call_frames(
-        call_stack: &mut CallStack,
-        value_stack: &mut ValueStack,
-        callee: &mut CallFrame,
-    ) -> Option<Instance> {
-        let (caller, instance) = call_stack.pop().expect("caller call frame must exist");
+    pub unsafe fn merge_call_frames(&mut self, callee: &mut CallFrame) -> Option<Instance> {
+        let (caller, instance) = self.calls.pop().expect("caller call frame must exist");
         debug_assert_eq!(callee.results(), caller.results());
         debug_assert!(caller.base_offset() <= callee.base_offset());
         // Safety:
@@ -112,7 +108,9 @@ impl Stack {
         // Therefore only value stack offsets of the top-most call frame on the
         // value stack are going to be invalidated which we ensure to adjust and
         // reinstantiate after this operation.
-        let len_drained = value_stack.drain(caller.frame_offset(), callee.frame_offset());
+        let len_drained = self
+            .values
+            .drain(caller.frame_offset(), callee.frame_offset());
         callee.move_down(len_drained);
         instance
     }


### PR DESCRIPTION
This replaces the `ValueStack` and `CallStack` references with a single `Stack` reference in the `Executor`.