### PR TITLE
Use `CachedMemory` in bulk-ops executors

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -251,7 +251,9 @@ impl<'engine> Executor<'engine> {
             .get(dst_index..)
             .and_then(|memory| memory.get(..len as usize))
             .ok_or(TrapCode::MemoryOutOfBounds)?;
-        store.fuel_mut().consume_fuel_if(|costs| costs.fuel_for_bytes(u64::from(len)))?;
+        store
+            .fuel_mut()
+            .consume_fuel_if(|costs| costs.fuel_for_bytes(u64::from(len)))?;
         memory.copy_within(src_index..src_index.wrapping_add(len as usize), dst_index);
         self.try_next_instr()
     }
@@ -390,7 +392,9 @@ impl<'engine> Executor<'engine> {
             .get_mut(dst..)
             .and_then(|memory| memory.get_mut(..len))
             .ok_or(TrapCode::MemoryOutOfBounds)?;
-        store.fuel_mut().consume_fuel_if(|costs| costs.fuel_for_bytes(len as u64))?;
+        store
+            .fuel_mut()
+            .consume_fuel_if(|costs| costs.fuel_for_bytes(len as u64))?;
         slice.fill(value);
         self.try_next_instr()
     }

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -229,6 +229,7 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `memory.copy` instruction.
+    #[inline(never)]
     fn execute_memory_copy_impl(
         &mut self,
         store: &mut StoreInner,
@@ -375,6 +376,7 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `memory.fill` instruction.
+    #[inline(never)]
     fn execute_memory_fill_impl(
         &mut self,
         store: &mut StoreInner,
@@ -520,6 +522,7 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `memory.init` instruction.
+    #[inline(never)]
     fn execute_memory_init_impl(
         &mut self,
         store: &mut StoreInner,

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -238,7 +238,6 @@ impl<'engine> Executor<'engine> {
     ) -> Result<(), Error> {
         let src_index = src_index as usize;
         let dst_index = dst_index as usize;
-        let fuel = store.fuel_mut();
         // Safety: The Wasmi executor keep track of the current Wasm instance
         //         being used and properly updates the cached linear memory
         //         whenever needed.
@@ -252,7 +251,7 @@ impl<'engine> Executor<'engine> {
             .get(dst_index..)
             .and_then(|memory| memory.get(..len as usize))
             .ok_or(TrapCode::MemoryOutOfBounds)?;
-        fuel.consume_fuel_if(|costs| costs.fuel_for_bytes(u64::from(len)))?;
+        store.fuel_mut().consume_fuel_if(|costs| costs.fuel_for_bytes(u64::from(len)))?;
         memory.copy_within(src_index..src_index.wrapping_add(len as usize), dst_index);
         self.try_next_instr()
     }
@@ -383,7 +382,6 @@ impl<'engine> Executor<'engine> {
     ) -> Result<(), Error> {
         let dst = dst as usize;
         let len = len as usize;
-        let fuel = store.fuel_mut();
         // Safety: The Wasmi executor keep track of the current Wasm instance
         //         being used and properly updates the cached linear memory
         //         whenever needed.
@@ -392,7 +390,7 @@ impl<'engine> Executor<'engine> {
             .get_mut(dst..)
             .and_then(|memory| memory.get_mut(..len))
             .ok_or(TrapCode::MemoryOutOfBounds)?;
-        fuel.consume_fuel_if(|costs| costs.fuel_for_bytes(len as u64))?;
+        store.fuel_mut().consume_fuel_if(|costs| costs.fuel_for_bytes(len as u64))?;
         slice.fill(value);
         self.try_next_instr()
     }

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -238,18 +238,22 @@ impl<'engine> Executor<'engine> {
     ) -> Result<(), Error> {
         let src_index = src_index as usize;
         let dst_index = dst_index as usize;
-        let default_memory = self.get_default_memory(store);
-        let (memory, fuel) = store.resolve_memory_and_fuel_mut(&default_memory);
-        let data = memory.data_mut();
+        let fuel = store.fuel_mut();
+        // Safety: The Wasmi executor keep track of the current Wasm instance
+        //         being used and properly updates the cached linear memory
+        //         whenever needed.
+        let memory = unsafe { self.memory.data_mut() };
         // These accesses just perform the bounds checks required by the Wasm spec.
-        data.get(src_index..)
+        memory
+            .get(src_index..)
             .and_then(|memory| memory.get(..len as usize))
             .ok_or(TrapCode::MemoryOutOfBounds)?;
-        data.get(dst_index..)
+        memory
+            .get(dst_index..)
             .and_then(|memory| memory.get(..len as usize))
             .ok_or(TrapCode::MemoryOutOfBounds)?;
         fuel.consume_fuel_if(|costs| costs.fuel_for_bytes(u64::from(len)))?;
-        data.copy_within(src_index..src_index.wrapping_add(len as usize), dst_index);
+        memory.copy_within(src_index..src_index.wrapping_add(len as usize), dst_index);
         self.try_next_instr()
     }
 
@@ -379,15 +383,17 @@ impl<'engine> Executor<'engine> {
     ) -> Result<(), Error> {
         let dst = dst as usize;
         let len = len as usize;
-        let default_memory = self.get_default_memory(store);
-        let (memory, fuel) = store.resolve_memory_and_fuel_mut(&default_memory);
-        let memory = memory
-            .data_mut()
+        let fuel = store.fuel_mut();
+        // Safety: The Wasmi executor keep track of the current Wasm instance
+        //         being used and properly updates the cached linear memory
+        //         whenever needed.
+        let memory = unsafe { self.memory.data_mut() };
+        let slice = memory
             .get_mut(dst..)
             .and_then(|memory| memory.get_mut(..len))
             .ok_or(TrapCode::MemoryOutOfBounds)?;
         fuel.consume_fuel_if(|costs| costs.fuel_for_bytes(len as u64))?;
-        memory.fill(value);
+        slice.fill(value);
         self.try_next_instr()
     }
 
@@ -523,14 +529,13 @@ impl<'engine> Executor<'engine> {
         let src_index = src as usize;
         let len = len as usize;
         let data_index: DataSegmentIdx = self.fetch_data_segment_index(1);
-        // TODO: We could re-use the `CachedMemory` here instead of resolving it.
-        //       Once Wasmi supports `multi-memory` this is required to be reverted again though.
-        let (memory, data, fuel) = store.resolve_memory_init_triplet(
-            &self.get_default_memory(store),
-            &self.get_data_segment(store, data_index),
-        );
+        let (data, fuel) =
+            store.resolve_data_and_fuel_mut(&self.get_data_segment(store, data_index));
+        // Safety: The Wasmi executor keep track of the current Wasm instance
+        //         being used and properly updates the cached linear memory
+        //         whenever needed.
+        let memory = unsafe { self.memory.data_mut() };
         let memory = memory
-            .data_mut()
             .get_mut(dst_index..)
             .and_then(|memory| memory.get_mut(..len))
             .ok_or(TrapCode::MemoryOutOfBounds)?;

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -740,12 +740,12 @@ impl StoreInner {
         (memory, fuel)
     }
 
-    /// Returns an exclusive reference to the [`MemoryEntity`] associated to the given [`Memory`].
+    /// Returns an exclusive reference to the [`DataEntity`] associated to the given [`Memory`].
     ///
     /// # Panics
     ///
-    /// - If the [`Memory`] does not originate from this [`Store`].
-    /// - If the [`Memory`] cannot be resolved to its entity.
+    /// - If the [`DataSegment`] does not originate from this [`Store`].
+    /// - If the [`DataSegment`] cannot be resolved to its entity.
     pub fn resolve_data_and_fuel_mut(
         &mut self,
         data: &DataSegment,

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -740,6 +740,22 @@ impl StoreInner {
         (memory, fuel)
     }
 
+    /// Returns an exclusive reference to the [`MemoryEntity`] associated to the given [`Memory`].
+    ///
+    /// # Panics
+    ///
+    /// - If the [`Memory`] does not originate from this [`Store`].
+    /// - If the [`Memory`] cannot be resolved to its entity.
+    pub fn resolve_data_and_fuel_mut(
+        &mut self,
+        data: &DataSegment,
+    ) -> (&mut DataSegmentEntity, &mut Fuel) {
+        let idx = self.unwrap_stored(data.as_inner());
+        let data_segment = Self::resolve_mut(idx, &mut self.datas);
+        let fuel = &mut self.fuel;
+        (data_segment, fuel)
+    }
+
     /// Returns the triple of:
     ///
     /// - An exclusive reference to the [`MemoryEntity`] associated to the given [`Memory`].

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -756,37 +756,6 @@ impl StoreInner {
         (data_segment, fuel)
     }
 
-    /// Returns the triple of:
-    ///
-    /// - An exclusive reference to the [`MemoryEntity`] associated to the given [`Memory`].
-    /// - A shared reference to the [`DataSegmentEntity`] associated to the given [`DataSegment`].
-    /// - An exclusive reference to the [`Fuel`] for fuel metering.
-    ///
-    ///
-    /// # Note
-    ///
-    /// This method exists to properly handle use cases where
-    /// otherwise the Rust borrow-checker would not accept.
-    ///
-    /// # Panics
-    ///
-    /// - If the [`Memory`] does not originate from this [`Store`].
-    /// - If the [`Memory`] cannot be resolved to its entity.
-    /// - If the [`DataSegment`] does not originate from this [`Store`].
-    /// - If the [`DataSegment`] cannot be resolved to its entity.
-    pub(super) fn resolve_memory_init_triplet(
-        &mut self,
-        memory: &Memory,
-        segment: &DataSegment,
-    ) -> (&mut MemoryEntity, &DataSegmentEntity, &mut Fuel) {
-        let mem_idx = self.unwrap_stored(memory.as_inner());
-        let data_idx = segment.as_inner();
-        let data = self.resolve(data_idx, &self.datas);
-        let mem = Self::resolve_mut(mem_idx, &mut self.memories);
-        let fuel = &mut self.fuel;
-        (mem, data, fuel)
-    }
-
     /// Returns an exclusive reference to the [`DataSegmentEntity`] associated to the given [`DataSegment`].
     ///
     /// # Panics

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -740,7 +740,7 @@ impl StoreInner {
         (memory, fuel)
     }
 
-    /// Returns an exclusive reference to the [`DataEntity`] associated to the given [`Memory`].
+    /// Returns an exclusive reference to the [`DataSegmentEntity`] associated to the given [`Memory`].
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Locally this yielded a performance improvement for our bulk-ops benchmark test case by roughly 3.5%.
The local test uses `memory.copy` and `memory.fill` with 5000 bytes per operation.
Note that performance wins for bulk-ops with smaller lengths are going to be way more significant.