### PR TITLE
Add new instance cache: `CachedInstance`

### DIFF
--- a/crates/wasmi/src/engine/executor/cache.rs
+++ b/crates/wasmi/src/engine/executor/cache.rs
@@ -208,6 +208,11 @@ impl CachedMemory {
     }
 
     /// Loads the default [`Memory`] of the currently used [`Instance`].
+    /// 
+    /// # Note
+    /// 
+    /// Must be called whenever the heap allocation of the [`CachedMemory`]
+    /// could have been changed and thus the cached pointer invalidated.
     ///
     /// # Panics
     ///
@@ -220,12 +225,20 @@ impl CachedMemory {
     }
 
     /// Returns a shared slice to the bytes of the cached default linear memory.
+    ///
+    /// # Safety
+    ///
+    /// The user is required to call [`CachedMemory::load_default_memory`] according to its specification.
     #[inline]
     pub unsafe fn data(&self) -> &[u8] {
         unsafe { self.data.as_ref() }
     }
 
     /// Returns an exclusive slice to the bytes of the cached default linear memory.
+    ///
+    /// # Safety
+    ///
+    /// The user is required to call [`CachedMemory::load_default_memory`] according to its specification.
     #[inline]
     pub unsafe fn data_mut(&mut self) -> &mut [u8] {
         unsafe { self.data.as_mut() }
@@ -269,6 +282,11 @@ impl CachedGlobal {
     }
 
     /// Loads the default [`Global`] of the currently used [`Instance`].
+    /// 
+    /// # Note
+    /// 
+    /// Must be called whenever the heap allocation of the [`CachedGlobal`]
+    /// could have been changed and thus the cached pointer invalidated.
     ///
     /// # Panics
     ///
@@ -284,8 +302,7 @@ impl CachedGlobal {
     ///
     /// # Safety
     ///
-    /// The user is required to call [`CachedGlobal::update`] according to its specification.
-    /// For more information read the docs of [`CachedGlobal::update`].
+    /// The user is required to call [`CachedGlobal::load_global`] according to its specification.
     #[inline]
     pub unsafe fn get(&self) -> UntypedVal {
         // SAFETY: This API guarantees to always write to a valid pointer
@@ -297,8 +314,7 @@ impl CachedGlobal {
     ///
     /// # Safety
     ///
-    /// The user is required to call [`CachedGlobal::update`] according to its specification.
-    /// For more information read the docs of [`CachedGlobal::update`].
+    /// The user is required to call [`CachedGlobal::load_global`] according to its specification.
     #[inline]
     pub unsafe fn set(&mut self, new_value: UntypedVal) {
         // SAFETY: This API guarantees to always write to a valid pointer

--- a/crates/wasmi/src/engine/executor/cache.rs
+++ b/crates/wasmi/src/engine/executor/cache.rs
@@ -208,9 +208,9 @@ impl CachedMemory {
     }
 
     /// Loads the default [`Memory`] of the currently used [`Instance`].
-    /// 
+    ///
     /// # Note
-    /// 
+    ///
     /// Must be called whenever the heap allocation of the [`CachedMemory`]
     /// could have been changed and thus the cached pointer invalidated.
     ///
@@ -282,9 +282,9 @@ impl CachedGlobal {
     }
 
     /// Loads the default [`Global`] of the currently used [`Instance`].
-    /// 
+    ///
     /// # Note
-    /// 
+    ///
     /// Must be called whenever the heap allocation of the [`CachedGlobal`]
     /// could have been changed and thus the cached pointer invalidated.
     ///

--- a/crates/wasmi/src/engine/executor/cache.rs
+++ b/crates/wasmi/src/engine/executor/cache.rs
@@ -1,8 +1,93 @@
-use crate::{core::UntypedVal, module::DEFAULT_MEMORY_INDEX, store::StoreInner, Instance};
+use crate::{
+    core::UntypedVal,
+    instance::InstanceEntity,
+    module::DEFAULT_MEMORY_INDEX,
+    store::StoreInner,
+    Global,
+    Instance,
+    Memory,
+};
 use core::ptr::{self, NonNull};
 
+/// Cached WebAssembly instance.
+#[derive(Debug)]
+pub struct CachedInstance {
+    /// The currently used instance.
+    instance: NonNull<InstanceEntity>,
+    /// The cached bytes of the default linear memory.
+    pub memory: CachedMemory,
+    /// The cached value of the global variable at index 0.
+    pub global: CachedGlobal,
+}
+
+impl CachedInstance {
+    /// Creates a new [`CachedInstance`].
+    #[inline]
+    pub fn new(ctx: &mut StoreInner, instance: &Instance) -> Self {
+        let (instance, memory, global) = Self::load_caches(ctx, instance);
+        Self {
+            instance,
+            memory,
+            global,
+        }
+    }
+
+    /// Loads the [`InstanceEntity`] from the [`StoreInner`].
+    #[inline]
+    fn load_instance<'ctx>(ctx: &'ctx mut StoreInner, instance: &Instance) -> &'ctx InstanceEntity {
+        ctx.resolve_instance(instance)
+    }
+
+    /// Loads the cached global and linear memory.
+    #[inline]
+    fn load_caches(
+        ctx: &mut StoreInner,
+        instance: &Instance,
+    ) -> (NonNull<InstanceEntity>, CachedMemory, CachedGlobal) {
+        let entity = Self::load_instance(ctx, instance);
+        let memory = entity.get_memory(DEFAULT_MEMORY_INDEX);
+        let global = entity.get_global(0);
+        let instance = entity.into();
+        let memory = memory
+            .map(|memory| CachedMemory::new(ctx, &memory))
+            .unwrap_or_default();
+        let global = global
+            .map(|global| CachedGlobal::new(ctx, &global))
+            .unwrap_or_default();
+        (instance, memory, global)
+    }
+
+    /// Update the cached instance, linear memory and global variable.
+    #[inline]
+    pub fn update(&mut self, ctx: &mut StoreInner, instance: &Instance) {
+        (self.instance, self.memory, self.global) = Self::load_caches(ctx, instance);
+    }
+
+    /// Updates the [`CachedMemory`]'s linear memory data pointer.
+    ///
+    /// # Note
+    ///
+    /// This needs to be called whenever the cached pointer might have changed.
+    ///
+    /// The linear memory pointer might change when ...
+    ///
+    /// - calling a host function
+    /// - successfully growing the default linear memory
+    /// - calling functions defined in other instances via imported or indirect calls
+    /// - returning from functions that changed the currently used instance
+    #[inline]
+    pub fn update_memory(&mut self, ctx: &mut StoreInner) {
+        // Safety: TODO
+        let instance = unsafe { self.instance.as_ref() };
+        self.memory = instance
+            .get_memory(DEFAULT_MEMORY_INDEX)
+            .map(|memory| CachedMemory::new(ctx, &memory))
+            .unwrap_or_default();
+    }
+}
+
 /// Cached default linear memory bytes.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct CachedMemory {
     data: NonNull<[u8]>,
 }
@@ -17,21 +102,11 @@ impl Default for CachedMemory {
 }
 
 impl CachedMemory {
-    /// Updates the [`CachedMemory`]'s linear memory data pointer.
-    ///
-    /// # Note
-    ///
-    /// This needs to be called whenever the cached pointer might have changed.
-    ///
-    /// The linear memory pointer might change when ...
-    ///
-    /// - calling a host function
-    /// - successfully growing the default linear memory
-    /// - calling functions defined in other instances via imported or indirect calls
-    /// - returning from functions that changed the currently used instance
+    /// Create a new [`CachedMemory`].
     #[inline]
-    pub fn update(&mut self, ctx: &mut StoreInner, instance: &Instance) {
-        self.data = Self::load_default_memory(ctx, instance);
+    fn new(ctx: &mut StoreInner, instance: &Memory) -> Self {
+        let data = Self::load_default_memory(ctx, instance);
+        Self { data }
     }
 
     /// Loads the default [`Memory`] of the currently used [`Instance`].
@@ -42,12 +117,8 @@ impl CachedMemory {
     ///
     /// [`Memory`]: crate::Memory
     #[inline]
-    fn load_default_memory(ctx: &mut StoreInner, instance: &Instance) -> NonNull<[u8]> {
-        ctx.resolve_instance(instance)
-            .get_memory(DEFAULT_MEMORY_INDEX)
-            .map(|memory| ctx.resolve_memory_mut(&memory).data_mut())
-            .unwrap_or_else(|| &mut [])
-            .into()
+    fn load_default_memory(ctx: &mut StoreInner, memory: &Memory) -> NonNull<[u8]> {
+        ctx.resolve_memory_mut(memory).data_mut().into()
     }
 
     /// Returns a shared slice to the bytes of the cached default linear memory.
@@ -64,7 +135,7 @@ impl CachedMemory {
 }
 
 /// Cached default global variable value.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct CachedGlobal {
     data: NonNull<UntypedVal>,
 }
@@ -92,20 +163,11 @@ static mut FALLBACK_GLOBAL_VALUE: NonNull<UntypedVal> = {
 };
 
 impl CachedGlobal {
-    /// Updates the [`CachedGlobal`]'s data pointer.
-    ///
-    /// # Note
-    ///
-    /// This needs to be called whenever the cached pointer might have changed.
-    ///
-    /// The global variable pointer might change when ...
-    ///
-    /// - calling a host function
-    /// - calling functions defined in other instances via imported or indirect calls
-    /// - returning from functions that changed the currently used instance
+    /// Create a new [`CachedGlobal`].
     #[inline]
-    pub fn update(&mut self, ctx: &mut StoreInner, instance: &Instance) {
-        self.data = Self::load_global(ctx, instance);
+    fn new(ctx: &mut StoreInner, global: &Global) -> Self {
+        let data = Self::load_global(ctx, global);
+        Self { data }
     }
 
     /// Loads the default [`Global`] of the currently used [`Instance`].
@@ -116,11 +178,8 @@ impl CachedGlobal {
     ///
     /// [`Global`]: crate::Global
     #[inline]
-    fn load_global(ctx: &mut StoreInner, instance: &Instance) -> NonNull<UntypedVal> {
-        ctx.resolve_instance(instance)
-            .get_global(0)
-            .map(|global| ctx.resolve_global_mut(&global).get_untyped_ptr())
-            .unwrap_or_else(|| unsafe { FALLBACK_GLOBAL_VALUE })
+    fn load_global(ctx: &mut StoreInner, global: &Global) -> NonNull<UntypedVal> {
+        ctx.resolve_global_mut(global).get_untyped_ptr()
     }
 
     /// Returns the value of the cached global variable.

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -38,6 +38,9 @@ use crate::{
     Table,
 };
 
+#[cfg(doc)]
+use crate::Instance;
+
 mod binary;
 mod branch;
 mod call;

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -77,10 +77,7 @@ pub fn execute_instrs<'engine, T>(
     stack: &'engine mut Stack,
     res: &'engine EngineResources,
 ) -> Result<(), Error> {
-    let instance = stack
-        .calls
-        .instance()
-        .expect("must have instance on the call stack");
+    let instance = Executor::instance(&stack.calls);
     let cache = CachedInstance::new(&mut store.inner, instance);
     Executor::new(stack, res, cache).execute(store)
 }

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -21,7 +21,7 @@ use crate::{
             UnaryInstr,
         },
         code_map::InstructionPtr,
-        executor::stack::{CallFrame, CallStack, FrameRegisters, ValueStack},
+        executor::stack::{CallFrame, FrameRegisters, ValueStack},
         DedupFuncType,
         EngineResources,
     },
@@ -33,7 +33,6 @@ use crate::{
     Func,
     FuncRef,
     Global,
-    Instance,
     Memory,
     Store,
     Table,
@@ -77,7 +76,7 @@ pub fn execute_instrs<'engine, T>(
     stack: &'engine mut Stack,
     res: &'engine EngineResources,
 ) -> Result<(), Error> {
-    let instance = Executor::instance(&stack.calls);
+    let instance = stack.calls.instance_expect();
     let cache = CachedInstance::new(&mut store.inner, instance);
     Executor::new(stack, res, cache).execute(store)
 }
@@ -123,14 +122,6 @@ impl<'engine> Executor<'engine> {
             stack,
             res,
         }
-    }
-
-    /// Returns the currently used [`Instance`].
-    #[inline(always)]
-    fn instance(call_stack: &CallStack) -> &Instance {
-        call_stack
-            .instance()
-            .expect("missing instance for non-empty call stack")
     }
 
     /// Executes the function frame until it returns or traps.

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -469,8 +469,7 @@ impl<'engine> Executor<'engine> {
                     func_body,
                     Some(instance),
                 )?;
-                self.memory.update(&mut store.inner, &instance);
-                self.global.update(&mut store.inner, &instance);
+                self.cache.update(&mut store.inner, &instance);
                 Ok(())
             }
             FuncEntity::Host(host_func) => {
@@ -524,8 +523,7 @@ impl<'engine> Executor<'engine> {
                 true => error,
                 false => ResumableHostError::new(error, *func, results).into(),
             })?;
-        self.memory.update(&mut store.inner, &instance);
-        self.global.update(&mut store.inner, &instance);
+        self.cache.update(&mut store.inner, &instance);
         let results = results.iter(len_results);
         let returned = self.stack.values.drop_return(max_inout);
         for (result, value) in results.zip(returned) {

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -499,7 +499,7 @@ impl<'engine> Executor<'engine> {
         let (len_params, len_results) =
             self.res.func_types.len_params_results(host_func.ty_dedup());
         let max_inout = len_params.max(len_results);
-        let instance = *Self::instance(&self.stack.calls);
+        let instance = *self.stack.calls.instance_expect();
         // We have to reinstantiate the `self.sp` [`FrameRegisters`] since we just called
         // [`ValueStack::reserve`] which might invalidate all live [`FrameRegisters`].
         let caller = match <C as CallContext>::KIND {

--- a/crates/wasmi/src/engine/executor/instrs/global.rs
+++ b/crates/wasmi/src/engine/executor/instrs/global.rs
@@ -13,7 +13,7 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     pub fn execute_global_get(&mut self, store: &StoreInner, result: Register, global: GlobalIdx) {
         let value = match u32::from(global) {
-            0 => unsafe { self.global.get() },
+            0 => unsafe { self.cache.global.get() },
             _ => {
                 hint::cold();
                 let global = self.get_global(store, global);
@@ -69,7 +69,7 @@ impl<'engine> Executor<'engine> {
         new_value: UntypedVal,
     ) {
         match u32::from(global) {
-            0 => unsafe { self.global.set(new_value) },
+            0 => unsafe { self.cache.global.set(new_value) },
             _ => {
                 hint::cold();
                 let global = self.get_global(store, global);

--- a/crates/wasmi/src/engine/executor/instrs/global.rs
+++ b/crates/wasmi/src/engine/executor/instrs/global.rs
@@ -16,7 +16,7 @@ impl<'engine> Executor<'engine> {
             0 => unsafe { self.cache.global.get() },
             _ => {
                 hint::cold();
-                let global = self.get_global(store, global);
+                let global = self.get_global(global);
                 store.resolve_global(&global).get_untyped()
             }
         };
@@ -72,7 +72,7 @@ impl<'engine> Executor<'engine> {
             0 => unsafe { self.cache.global.set(new_value) },
             _ => {
                 hint::cold();
-                let global = self.get_global(store, global);
+                let global = self.get_global(global);
                 store.resolve_global_mut(&global).set_untyped(new_value)
             }
         };

--- a/crates/wasmi/src/engine/executor/instrs/load.rs
+++ b/crates/wasmi/src/engine/executor/instrs/load.rs
@@ -36,7 +36,7 @@ impl<'engine> Executor<'engine> {
     ) -> Result<(), Error> {
         // Safety: `self.memory` is always re-loaded conservatively whenever
         //         the heap allocations and thus the pointer might have changed.
-        let memory = unsafe { self.memory.data() };
+        let memory = unsafe { self.cache.memory.data() };
         let loaded_value = load_extend(memory, address, offset)?;
         self.set_register(result, loaded_value);
         Ok(())

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -97,8 +97,7 @@ impl<'engine> Executor<'engine> {
                 // The `memory.grow` operation might have invalidated the cached
                 // linear memory so we need to reset it in order for the cache to
                 // reload in case it is used again.
-                let instance = Self::instance(&self.stack.calls);
-                self.memory.update(store, instance);
+                self.cache.update_memory(store);
                 return_value
             }
             Err(EntityGrowError::InvalidGrow) => EntityGrowError::ERROR_CODE,
@@ -242,7 +241,7 @@ impl<'engine> Executor<'engine> {
         // Safety: The Wasmi executor keep track of the current Wasm instance
         //         being used and properly updates the cached linear memory
         //         whenever needed.
-        let memory = unsafe { self.memory.data_mut() };
+        let memory = unsafe { self.cache.memory.data_mut() };
         // These accesses just perform the bounds checks required by the Wasm spec.
         memory
             .get(src_index..)
@@ -389,7 +388,7 @@ impl<'engine> Executor<'engine> {
         // Safety: The Wasmi executor keep track of the current Wasm instance
         //         being used and properly updates the cached linear memory
         //         whenever needed.
-        let memory = unsafe { self.memory.data_mut() };
+        let memory = unsafe { self.cache.memory.data_mut() };
         let slice = memory
             .get_mut(dst..)
             .and_then(|memory| memory.get_mut(..len))
@@ -539,7 +538,7 @@ impl<'engine> Executor<'engine> {
         // Safety: The Wasmi executor keep track of the current Wasm instance
         //         being used and properly updates the cached linear memory
         //         whenever needed.
-        let memory = unsafe { self.memory.data_mut() };
+        let memory = unsafe { self.cache.memory.data_mut() };
         let memory = memory
             .get_mut(dst_index..)
             .and_then(|memory| memory.get_mut(..len))

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -26,7 +26,7 @@ impl<'engine> Executor<'engine> {
     /// Executes an [`Instruction::DataDrop`].
     #[inline(always)]
     pub fn execute_data_drop(&mut self, store: &mut StoreInner, segment_index: DataSegmentIdx) {
-        let segment = self.get_data_segment(store, segment_index);
+        let segment = self.get_data_segment(segment_index);
         store.resolve_data_segment_mut(&segment).drop_bytes();
         self.next_instr();
     }
@@ -34,7 +34,7 @@ impl<'engine> Executor<'engine> {
     /// Executes an [`Instruction::MemorySize`].
     #[inline(always)]
     pub fn execute_memory_size(&mut self, store: &StoreInner, result: Register) {
-        let memory = self.get_default_memory(store);
+        let memory = self.get_default_memory();
         let size: u32 = store.resolve_memory(&memory).current_pages().into();
         self.set_register(result, size);
         self.next_instr()
@@ -87,7 +87,7 @@ impl<'engine> Executor<'engine> {
                 return self.try_next_instr();
             }
         };
-        let memory = self.get_default_memory(store);
+        let memory = self.get_default_memory();
         let (memory, fuel) = store.resolve_memory_and_fuel_mut(&memory);
         let return_value = memory
             .grow(delta, Some(fuel), resource_limiter)
@@ -97,7 +97,9 @@ impl<'engine> Executor<'engine> {
                 // The `memory.grow` operation might have invalidated the cached
                 // linear memory so we need to reset it in order for the cache to
                 // reload in case it is used again.
-                self.cache.update_memory(store);
+                //
+                // Safety: the instance has not changed thus calling this is valid.
+                unsafe { self.cache.update_memory(store) };
                 return_value
             }
             Err(EntityGrowError::InvalidGrow) => EntityGrowError::ERROR_CODE,
@@ -533,8 +535,7 @@ impl<'engine> Executor<'engine> {
         let src_index = src as usize;
         let len = len as usize;
         let data_index: DataSegmentIdx = self.fetch_data_segment_index(1);
-        let (data, fuel) =
-            store.resolve_data_and_fuel_mut(&self.get_data_segment(store, data_index));
+        let (data, fuel) = store.resolve_data_and_fuel_mut(&self.get_data_segment(data_index));
         // Safety: The Wasmi executor keep track of the current Wasm instance
         //         being used and properly updates the cached linear memory
         //         whenever needed.

--- a/crates/wasmi/src/engine/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/executor/instrs/return_.rs
@@ -33,8 +33,7 @@ impl<'engine> Executor<'engine> {
         self.stack.values.truncate(returned.frame_offset());
         let new_instance = popped_instance.and_then(|_| self.stack.calls.instance());
         if let Some(new_instance) = new_instance {
-            self.global.update(store, new_instance);
-            self.memory.update(store, new_instance);
+            self.cache.update(store, new_instance);
         }
         match self.stack.calls.peek() {
             Some(caller) => {

--- a/crates/wasmi/src/engine/executor/instrs/store.rs
+++ b/crates/wasmi/src/engine/executor/instrs/store.rs
@@ -47,7 +47,7 @@ impl<'engine> Executor<'engine> {
     ) -> Result<(), Error> {
         // Safety: `self.memory` is always re-loaded conservatively whenever
         //         the heap allocations and thus the pointer might have changed.
-        let memory = unsafe { self.memory.data_mut() };
+        let memory = unsafe { self.cache.memory.data_mut() };
         store_wrap(memory, address, offset, value)?;
         Ok(())
     }

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -416,7 +416,7 @@ impl<'engine> Executor<'engine> {
         let table_index = self.fetch_table_index(1);
         let element_index = self.fetch_element_segment_index(2);
         let (instance, table, element, fuel) = store.resolve_table_init_params(
-            Self::instance(&self.stack.calls),
+            self.stack.calls.instance_expect(),
             &self.get_table(table_index),
             &self.get_element_segment(element_index),
         );

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -64,7 +64,7 @@ impl<'engine> Executor<'engine> {
         index: u32,
     ) -> Result<(), Error> {
         let table_index = self.fetch_table_index(1);
-        let table = self.get_table(store, table_index);
+        let table = self.get_table(table_index);
         let value = store
             .resolve_table(&table)
             .get_untyped(index)
@@ -92,7 +92,7 @@ impl<'engine> Executor<'engine> {
         result: Register,
         table_index: TableIdx,
     ) {
-        let table = self.get_table(store, table_index);
+        let table = self.get_table(table_index);
         let size = store.resolve_table(&table).size();
         self.set_register(result, size);
     }
@@ -129,7 +129,7 @@ impl<'engine> Executor<'engine> {
         value: Register,
     ) -> Result<(), Error> {
         let table_index = self.fetch_table_index(1);
-        let table = self.get_table(store, table_index);
+        let table = self.get_table(table_index);
         let value = self.get_register(value);
         store
             .resolve_table_mut(&table)
@@ -270,13 +270,13 @@ impl<'engine> Executor<'engine> {
         let src_table_index = self.fetch_table_index(2);
         if dst_table_index == src_table_index {
             // Case: copy within the same table
-            let table = self.get_table(store, dst_table_index);
+            let table = self.get_table(dst_table_index);
             let (table, fuel) = store.resolve_table_and_fuel_mut(&table);
             table.copy_within(dst_index, src_index, len, Some(fuel))?;
         } else {
             // Case: copy between two different tables
-            let dst_table = self.get_table(store, dst_table_index);
-            let src_table = self.get_table(store, src_table_index);
+            let dst_table = self.get_table(dst_table_index);
+            let src_table = self.get_table(src_table_index);
             // Copy from one table to another table:
             let (dst_table, src_table, fuel) =
                 store.resolve_table_pair_and_fuel(&dst_table, &src_table);
@@ -417,8 +417,8 @@ impl<'engine> Executor<'engine> {
         let element_index = self.fetch_element_segment_index(2);
         let (instance, table, element, fuel) = store.resolve_table_init_params(
             Self::instance(&self.stack.calls),
-            &self.get_table(store, table_index),
-            &self.get_element_segment(store, element_index),
+            &self.get_table(table_index),
+            &self.get_element_segment(element_index),
         );
         table.init(
             dst_index,
@@ -501,7 +501,7 @@ impl<'engine> Executor<'engine> {
     ) -> Result<(), Error> {
         let table_index = self.fetch_table_index(1);
         let value = self.get_register(value);
-        let table = self.get_table(store, table_index);
+        let table = self.get_table(table_index);
         let (table, fuel) = store.resolve_table_and_fuel_mut(&table);
         table.fill_untyped(dst, value, len, Some(fuel))?;
         self.try_next_instr_at(2)
@@ -550,7 +550,7 @@ impl<'engine> Executor<'engine> {
             self.execute_table_size_impl(store, result, table_index);
             return self.try_next_instr_at(2);
         }
-        let table = self.get_table(store, table_index);
+        let table = self.get_table(table_index);
         let value = self.get_register(value);
         let (table, fuel) = store.resolve_table_and_fuel_mut(&table);
         let return_value = table.grow_untyped(delta, value, Some(fuel), resource_limiter);
@@ -570,7 +570,7 @@ impl<'engine> Executor<'engine> {
         store: &mut StoreInner,
         segment_index: ElementSegmentIdx,
     ) {
-        let segment = self.get_element_segment(store, segment_index);
+        let segment = self.get_element_segment(segment_index);
         store.resolve_element_segment_mut(&segment).drop_items();
         self.next_instr();
     }

--- a/crates/wasmi/src/engine/executor/stack/calls.rs
+++ b/crates/wasmi/src/engine/executor/stack/calls.rs
@@ -78,6 +78,19 @@ impl CallStack {
         self.instances.last()
     }
 
+    /// Returns the currently used [`Instance`].
+    ///
+    /// # Panics
+    ///
+    /// If there is no currently used [`Instance`].
+    /// This happens if the [`CallStack`] is empty.
+    #[inline(always)]
+    #[track_caller]
+    pub fn instance_expect(&self) -> &Instance {
+        self.instance()
+            .expect("the currently used instance must be present")
+    }
+
     /// Pushes a [`CallFrame`] onto the [`CallStack`].
     ///
     /// # Errors


### PR DESCRIPTION
This new instance cache works very different from the old one and is supposedly way more efficient.
It relies on the executor updating it whenever the currently used `Instance` has been changed. While the executor is in control over that the `CachedInstance` provides an efficient way to access `Instance` related data.