### PR TITLE
Improve `Memory` API

### DIFF
--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -15,7 +15,7 @@ use std::{
     sync::OnceLock,
 };
 use wasmi::{
-    core::{Pages, TrapCode, ValType, F32, F64},
+    core::{TrapCode, ValType, F32, F64},
     CompilationMode,
     Engine,
     Extern,
@@ -1328,7 +1328,7 @@ fn bench_execute_memory_sum(c: &mut Criterion) {
             .get_export(&store, "mem")
             .and_then(Extern::into_memory)
             .unwrap();
-        mem.grow(&mut store, Pages::new(1).unwrap()).unwrap();
+        mem.grow(&mut store, 1).unwrap();
         let len = 100_000;
         let mut expected_sum: i64 = 0;
         for (n, byte) in &mut mem.data_mut(&mut store)[..len].iter_mut().enumerate() {
@@ -1360,7 +1360,7 @@ fn bench_execute_memory_fill(c: &mut Criterion) {
             .get_export(&store, "mem")
             .and_then(Extern::into_memory)
             .unwrap();
-        mem.grow(&mut store, Pages::new(1).unwrap()).unwrap();
+        mem.grow(&mut store, 1).unwrap();
         let ptr = 0x100;
         let len = 100_000;
         let value = 0x42_u8;
@@ -1470,7 +1470,7 @@ fn bench_execute_vec_add(c: &mut Criterion) {
             .get_export(&store, "mem")
             .and_then(Extern::into_memory)
             .unwrap();
-        mem.grow(&mut store, Pages::new(25).unwrap()).unwrap();
+        mem.grow(&mut store, 1).unwrap();
         let len = 100_000;
         test_for(
             b,

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -1,5 +1,3 @@
-use crate::{core::Pages, store::StoreInner, Store};
-
 use super::Executor;
 use crate::{
     core::TrapCode,
@@ -8,8 +6,9 @@ use crate::{
         code_map::InstructionPtr,
     },
     error::EntityGrowError,
-    store::ResourceLimiterRef,
+    store::{ResourceLimiterRef, StoreInner},
     Error,
+    Store,
 };
 
 impl<'engine> Executor<'engine> {
@@ -79,14 +78,6 @@ impl<'engine> Executor<'engine> {
             self.execute_memory_size(store, result);
             return Ok(());
         }
-        let delta = match Pages::new(delta) {
-            Some(pages) => pages,
-            None => {
-                // Cannot grow memory so we push the expected error value.
-                self.set_register(result, EntityGrowError::ERROR_CODE);
-                return self.try_next_instr();
-            }
-        };
         let memory = self.get_default_memory();
         let (memory, fuel) = store.resolve_memory_and_fuel_mut(&memory);
         let return_value = memory

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -35,7 +35,7 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     pub fn execute_memory_size(&mut self, store: &StoreInner, result: Register) {
         let memory = self.get_default_memory();
-        let size: u32 = store.resolve_memory(&memory).current_pages().into();
+        let size = store.resolve_memory(&memory).size();
         self.set_register(result, size);
         self.next_instr()
     }

--- a/crates/wasmi/src/memory/buffer.rs
+++ b/crates/wasmi/src/memory/buffer.rs
@@ -11,14 +11,14 @@ use std::{slice, vec, vec::Vec};
 #[derive(Debug)]
 pub struct ByteBuffer {
     /// The pointer to the underlying byte buffer.
-    ptr: *mut u8,
+    pub(super) ptr: *mut u8,
     /// The current length of the byte buffer.
     ///
     /// # Note
     ///
     /// - **Vec:** `vec.len()`
     /// - **Static:** The accessible subslice of the entire underlying static byte buffer.
-    len: usize,
+    pub(super) len: usize,
     /// The capacity of the current allocation.
     ///
     /// # Note

--- a/crates/wasmi/src/memory/mod.rs
+++ b/crates/wasmi/src/memory/mod.rs
@@ -245,11 +245,11 @@ impl MemoryEntity {
         additional: Pages,
         fuel: Option<&mut Fuel>,
         limiter: &mut ResourceLimiterRef<'_>,
-    ) -> Result<Pages, EntityGrowError> {
+    ) -> Result<u32, EntityGrowError> {
         fn notify_limiter(
             limiter: &mut ResourceLimiterRef<'_>,
             err: EntityGrowError,
-        ) -> Result<Pages, EntityGrowError> {
+        ) -> Result<u32, EntityGrowError> {
             if let Some(limiter) = limiter.as_resource_limiter() {
                 limiter.memory_grow_failed(&MemoryError::OutOfBoundsGrowth)
             }
@@ -259,7 +259,7 @@ impl MemoryEntity {
         let current_pages = self.current_pages();
         if additional == Pages::from(0) {
             // Nothing to do in this case. Bail out early.
-            return Ok(current_pages);
+            return Ok(u32::from(current_pages));
         }
 
         let maximum_pages = self.ty().maximum_pages().unwrap_or_else(Pages::max);
@@ -305,7 +305,7 @@ impl MemoryEntity {
         // 3. There is enough fuel for the operation.
         self.bytes.grow(new_size);
         self.current_pages = new_pages;
-        Ok(current_pages)
+        Ok(u32::from(current_pages))
     }
 
     /// Returns a shared slice to the bytes underlying to the byte buffer.
@@ -465,11 +465,7 @@ impl Memory {
     /// # Panics
     ///
     /// Panics if `ctx` does not own this [`Memory`].
-    pub fn grow(
-        &self,
-        mut ctx: impl AsContextMut,
-        additional: Pages,
-    ) -> Result<Pages, MemoryError> {
+    pub fn grow(&self, mut ctx: impl AsContextMut, additional: Pages) -> Result<u32, MemoryError> {
         let (inner, mut limiter) = ctx
             .as_context_mut()
             .store

--- a/crates/wasmi/src/memory/mod.rs
+++ b/crates/wasmi/src/memory/mod.rs
@@ -223,8 +223,13 @@ impl MemoryEntity {
     }
 
     /// Returns the amount of pages in use by the linear memory.
-    pub fn current_pages(&self) -> Pages {
+    fn current_pages(&self) -> Pages {
         self.current_pages
+    }
+
+    /// Returns the size, in WebAssembly pages, of this Wasm linear memory.
+    pub fn size(&self) -> u32 {
+        self.current_pages.into()
     }
 
     /// Grows the linear memory by the given amount of new pages.
@@ -431,12 +436,21 @@ impl Memory {
     /// # Panics
     ///
     /// Panics if `ctx` does not own this [`Memory`].
-    pub fn current_pages(&self, ctx: impl AsContext) -> Pages {
+    fn current_pages(&self, ctx: impl AsContext) -> Pages {
         ctx.as_context()
             .store
             .inner
             .resolve_memory(self)
             .current_pages()
+    }
+
+    /// Returns the size, in WebAssembly pages, of this Wasm linear memory.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ctx` does not own this [`Memory`].
+    pub fn size(&self, ctx: impl AsContext) -> u32 {
+        self.current_pages(ctx).into()
     }
 
     /// Grows the linear memory by the given amount of new pages.

--- a/crates/wasmi/src/memory/mod.rs
+++ b/crates/wasmi/src/memory/mod.rs
@@ -320,6 +320,18 @@ impl MemoryEntity {
         self.bytes.data_mut()
     }
 
+    /// Returns the base pointer, in the host’s address space, that the [`Memory`] is located at.
+    pub fn data_ptr(&self) -> *mut u8 {
+        self.bytes.ptr
+    }
+
+    /// Returns the byte length of this [`Memory`].
+    ///
+    /// The returned value will be a multiple of the wasm page size, 64k.
+    pub fn data_size(&self) -> usize {
+        self.bytes.len
+    }
+
     /// Reads `n` bytes from `memory[offset..offset+n]` into `buffer`
     /// where `n` is the length of `buffer`.
     ///
@@ -508,6 +520,30 @@ impl Memory {
     ) -> (&'a mut [u8], &'a mut T) {
         let (memory, store) = ctx.into().store.resolve_memory_and_state_mut(self);
         (memory.data_mut(), store)
+    }
+
+    /// Returns the base pointer, in the host’s address space, that the [`Memory`] is located at.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ctx` does not own this [`Memory`].
+    pub fn data_ptr(&self, ctx: impl AsContext) -> *mut u8 {
+        ctx.as_context().store.inner.resolve_memory(self).data_ptr()
+    }
+
+    /// Returns the byte length of this [`Memory`].
+    ///
+    /// The returned value will be a multiple of the wasm page size, 64k.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ctx` does not own this [`Memory`].
+    pub fn data_size(&self, ctx: impl AsContext) -> usize {
+        ctx.as_context()
+            .store
+            .inner
+            .resolve_memory(self)
+            .data_size()
     }
 
     /// Reads `n` bytes from `memory[offset..offset+n]` into `buffer`

--- a/crates/wasmi/src/memory/mod.rs
+++ b/crates/wasmi/src/memory/mod.rs
@@ -445,26 +445,13 @@ impl Memory {
             .dynamic_ty()
     }
 
-    /// Returns the amount of pages in use by the linear memory.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `ctx` does not own this [`Memory`].
-    fn current_pages(&self, ctx: impl AsContext) -> Pages {
-        ctx.as_context()
-            .store
-            .inner
-            .resolve_memory(self)
-            .current_pages()
-    }
-
     /// Returns the size, in WebAssembly pages, of this Wasm linear memory.
     ///
     /// # Panics
     ///
     /// Panics if `ctx` does not own this [`Memory`].
     pub fn size(&self, ctx: impl AsContext) -> u32 {
-        self.current_pages(ctx).into()
+        ctx.as_context().store.inner.resolve_memory(self).size()
     }
 
     /// Grows the linear memory by the given amount of new pages.


### PR DESCRIPTION
- Adds `Memory::{data_ptr, data_size}`
- Changes return type of `Memory::grow` from `Pages` to `u32`
- Changes `additional` parameter type from `Pages` to `u32`
- Remove `Memory::current_pages` method
- Add `Memory::size` method