### PR TITLE
Implement `std::error::Error` for all error types that implement `Display`

### DIFF
--- a/crates/core/src/untyped.rs
+++ b/crates/core/src/untyped.rs
@@ -1358,6 +1358,9 @@ impl UntypedError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for UntypedError {}
+
 impl Display for UntypedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -91,6 +91,9 @@ pub struct ResumableHostError {
     caller_results: RegisterSpan,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for ResumableHostError {}
+
 impl fmt::Display for ResumableHostError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.host_error.fmt(f)

--- a/crates/wasmi/src/engine/limits/engine.rs
+++ b/crates/wasmi/src/engine/limits/engine.rs
@@ -23,6 +23,9 @@ pub enum EnforcedLimitsError {
     MinAvgBytesPerFunction { limit: u32, avg: u32 },
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for EnforcedLimitsError {}
+
 impl Display for EnforcedLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/wasmi/src/engine/limits/stack.rs
+++ b/crates/wasmi/src/engine/limits/stack.rs
@@ -31,6 +31,9 @@ pub enum LimitsError {
     InitialValueStackExceedsMaximum,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for LimitsError {}
+
 impl Display for LimitsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/wasmi/src/engine/translator/error.rs
+++ b/crates/wasmi/src/engine/translator/error.rs
@@ -43,6 +43,9 @@ impl TranslationError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for TranslationError {}
+
 impl Display for TranslationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/wasmi/src/engine/translator/labels.rs
+++ b/crates/wasmi/src/engine/translator/labels.rs
@@ -61,6 +61,9 @@ pub enum LabelError {
     Unpinned { label: LabelRef },
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for LabelError {}
+
 impl Display for LabelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/wasmi/src/func/error.rs
+++ b/crates/wasmi/src/func/error.rs
@@ -15,6 +15,9 @@ pub enum FuncError {
     MismatchingResultLen,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for FuncError {}
+
 impl Display for FuncError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/wasmi/src/global.rs
+++ b/crates/wasmi/src/global.rs
@@ -46,6 +46,9 @@ pub enum GlobalError {
     },
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for GlobalError {}
+
 impl Display for GlobalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/crates/wasmi/src/memory/error.rs
+++ b/crates/wasmi/src/memory/error.rs
@@ -26,6 +26,9 @@ pub enum MemoryError {
     InvalidStaticBufferSize,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for MemoryError {}
+
 impl Display for MemoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/crates/wasmi/src/module/read.rs
+++ b/crates/wasmi/src/module/read.rs
@@ -12,6 +12,9 @@ pub enum ReadError {
     UnknownError,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for ReadError {}
+
 impl Display for ReadError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -174,6 +174,9 @@ pub enum FuelError {
     OutOfFuel,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for FuelError {}
+
 impl fmt::Display for FuelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/wasmi/src/table/error.rs
+++ b/crates/wasmi/src/table/error.rs
@@ -41,6 +41,9 @@ pub enum TableError {
     TooManyTables,
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for TableError {}
+
 impl Display for TableError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
I added an Error impl for all errors that implement Display. I am planning on making another pull request that implements Display and Error for the remaining errors later.