### PR TITLE
Use `rust-cache` GitHub action in Wasmi's CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,22 +152,13 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dtolnay/rust-toolchain@nightly
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-            ~/target/x86_64-unknown-linux-gnu/
-            ~/target/x86_64-unknown-linux-gnu/release/
+          cache-directories: |
+            ~/fuzz/corpus/
             ~/fuzz/corpus/translate/
-            ~/fuzz/curpus/translate_metered/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+            ~/fuzz/corpus/translate_metered/
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Install cargo-fuzz
@@ -188,23 +179,12 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dtolnay/rust-toolchain@nightly
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-            ~/target/x86_64-unknown-linux-gnu/
-            ~/target/x86_64-unknown-linux-gnu/release/
-            ~/target/release/
-            ~/target/debug/
+          cache-directories: |
+            ~/fuzz/corpus/
             ~/fuzz/corpus/execute/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Install cargo-fuzz
@@ -223,23 +203,12 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dtolnay/rust-toolchain@nightly
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-            ~/target/x86_64-unknown-linux-gnu/
-            ~/target/x86_64-unknown-linux-gnu/release/
-            ~/target/release/
-            ~/target/debug/
-            ~/fuzz/corpus/execute/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+          cache-directories: |
+            ~/fuzz/corpus/
+            ~/fuzz/corpus/differential/
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Install cargo-fuzz

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,18 +85,8 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dtolnay/rust-toolchain@stable
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Build (default features)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,18 +20,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown, x86_64-unknown-none
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Build (default features)
         run: cargo build --workspace --locked
       - name: Build (all features)
@@ -117,18 +107,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-docs, rust-src
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Check Docs
         env:
           RUSTDOCFLAGS: "-D warnings"
@@ -154,18 +134,8 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dtolnay/rust-toolchain@nightly
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Install cargo-udeps
@@ -291,20 +261,8 @@ jobs:
         with:
           components: miri
           targets: x86_64-unknown-linux-gnu
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/bin/cargo-nextest
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-            ~/target/miri/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Install cargo-nextest
@@ -328,20 +286,8 @@ jobs:
         with:
           components: miri
           targets: x86_64-unknown-linux-gnu
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/bin/cargo-nextest
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-            ~/target/miri/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Install cargo-nextest
@@ -365,18 +311,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Clippy (default features)
@@ -401,18 +337,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Run cargo-tarpaulin (default features)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,15 +23,15 @@ jobs:
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Build (default features)
-        run: cargo build --workspace --locked
+        run: cargo build --workspace --locked --verbose
       - name: Build (all features)
-        run: cargo build --workspace --locked --all-features
+        run: cargo build --workspace --locked --all-features --verbose
       - name: Build (no_std + no-hash-maps)
-        run: cargo build --locked -p wasmi_collections --no-default-features --features no-hash-maps
+        run: cargo build --locked -p wasmi_collections --no-default-features --features no-hash-maps --verbose
       - name: Build (no_std)
-        run: cargo build --workspace --locked --lib --no-default-features --target x86_64-unknown-none --exclude wasmi_cli --exclude wasmi_wasi --exclude wasmi_fuzz
+        run: cargo build --workspace --locked --lib --no-default-features --target x86_64-unknown-none --verbose --exclude wasmi_cli --exclude wasmi_wasi --exclude wasmi_fuzz
       - name: Build (wasm32)
-        run: cargo build --workspace --locked --lib --no-default-features --target wasm32-unknown-unknown --exclude wasmi_cli --exclude wasmi_wasi --exclude wasmi_fuzz
+        run: cargo build --workspace --locked --lib --no-default-features --target wasm32-unknown-unknown --verbose --exclude wasmi_cli --exclude wasmi_wasi --exclude wasmi_fuzz
 
   test-asan:
     name: Test (Address Sanitizer)
@@ -50,7 +50,7 @@ jobs:
       - name: Build Tests
         env:
           RUSTFLAGS: "--cfg debug_assertions -Zsanitizer=address"
-        run: cargo build --tests --workspace --locked -Zbuild-std --target x86_64-unknown-linux-gnu
+        run: cargo build --tests --workspace --locked -Zbuild-std --target x86_64-unknown-linux-gnu --verbose
       - name: Test
         env:
           RUSTFLAGS: "--cfg debug_assertions -Zsanitizer=address"
@@ -72,7 +72,7 @@ jobs:
       - name: Build (default features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        run: cargo build --tests --workspace --locked
+        run: cargo build --tests --workspace --locked --verbose
       - name: Test (default features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
@@ -80,7 +80,7 @@ jobs:
       - name: Build (all features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        run: cargo build --tests --workspace --locked --all-features
+        run: cargo build --tests --workspace --locked --all-features --verbose
       - name: Test (all features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,19 +82,19 @@ jobs:
       - name: Build (default features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        run: cargo build --tests --workspace --locked --release
+        run: cargo build --tests --workspace --locked --profile ci
       - name: Test (default features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        run: cargo test --workspace --locked --release
+        run: cargo test --workspace --locked --profile ci
       - name: Build (all features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        run: cargo build --tests --workspace --locked --release --all-features
+        run: cargo build --tests --workspace --locked --profile ci --all-features
       - name: Test (all features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        run: cargo test --workspace --locked --release --all-features
+        run: cargo test --workspace --locked --profile ci --all-features
 
   fmt:
     name: Formatting

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust - Continuous Integration
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 # disable running jobs on earlier commits
 concurrency:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,19 +72,19 @@ jobs:
       - name: Build (default features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        run: cargo build --tests --workspace --locked --profile ci
+        run: cargo build --tests --workspace --locked
       - name: Test (default features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        run: cargo test --workspace --locked --profile ci
+        run: cargo test --workspace --locked
       - name: Build (all features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        run: cargo build --tests --workspace --locked --profile ci --all-features
+        run: cargo build --tests --workspace --locked --all-features
       - name: Test (all features)
         env:
           RUSTFLAGS: "--cfg debug_assertions"
-        run: cargo test --workspace --locked --profile ci --all-features
+        run: cargo test --workspace --locked --all-features
 
   fmt:
     name: Formatting

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,18 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dtolnay/rust-toolchain@nightly
-      - name: Set up Cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/target/
-          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ github.job }}-
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Show Rust Toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ num-traits = { version = "0.2.8", default-features = false }
 lto = "fat"
 codegen-units = 1
 
+# Profile used in GitHub Actions CI for testing Wasmi crates.
+# Geared towards fast compilation while not signficantly slowing down the test driver.
 [profile.ci]
 inherits = "dev"
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,8 @@ num-traits = { version = "0.2.8", default-features = false }
 [profile.bench]
 lto = "fat"
 codegen-units = 1
+
+[profile.ci]
+inherits = "dev"
+opt-level = 1
+incremental = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,3 @@ num-traits = { version = "0.2.8", default-features = false }
 [profile.bench]
 lto = "fat"
 codegen-units = 1
-
-# Profile used in GitHub Actions CI for testing Wasmi crates.
-# Geared towards fast compilation while not signficantly slowing down the test driver.
-[profile.ci]
-inherits = "dev"
-opt-level = 1
-incremental = false


### PR DESCRIPTION
The problem with the current `cargo-cache` setup is that it still re-compiles all crates each run and only avoids re-downloading all the dependencies.
The `rust-cache` GitHub action promises to also avoid re-compiling all dependencies.

Link: https://github.com/Swatinem/rust-cache