### PR TITLE
Allow Wasm module instantiation in host functions called from Wasmi's executor

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -20,10 +20,9 @@ use crate::{
             TableIdx,
             UnaryInstr,
         },
-        code_map::InstructionPtr,
+        code_map::{CodeMap, InstructionPtr},
         executor::stack::{CallFrame, FrameRegisters, ValueStack},
         DedupFuncType,
-        EngineResources,
     },
     memory::DataSegment,
     module::DEFAULT_MEMORY_INDEX,
@@ -77,11 +76,11 @@ macro_rules! forward_return {
 pub fn execute_instrs<'engine, T>(
     store: &mut Store<T>,
     stack: &'engine mut Stack,
-    res: &'engine EngineResources,
+    code_map: &'engine CodeMap,
 ) -> Result<(), Error> {
     let instance = stack.calls.instance_expect();
     let cache = CachedInstance::new(&mut store.inner, instance);
-    Executor::new(stack, res, cache).execute(store)
+    Executor::new(stack, code_map, cache).execute(store)
 }
 
 /// An execution context for executing a Wasmi function frame.
@@ -98,7 +97,7 @@ struct Executor<'engine> {
     /// The static resources of an [`Engine`].
     ///
     /// [`Engine`]: crate::Engine
-    res: &'engine EngineResources,
+    code_map: &'engine CodeMap,
 }
 
 impl<'engine> Executor<'engine> {
@@ -106,7 +105,7 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     pub fn new(
         stack: &'engine mut Stack,
-        res: &'engine EngineResources,
+        code_map: &'engine CodeMap,
         cache: CachedInstance,
     ) -> Self {
         let frame = stack
@@ -123,7 +122,7 @@ impl<'engine> Executor<'engine> {
             ip,
             cache,
             stack,
-            res,
+            code_map,
         }
     }
 

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -289,7 +289,7 @@ impl<'engine> Executor<'engine> {
         func: CompiledFunc,
         mut instance: Option<Instance>,
     ) -> Result<(), Error> {
-        let func = self.res.code_map.get(Some(store.fuel_mut()), func)?;
+        let func = self.code_map.get(Some(store.fuel_mut()), func)?;
         let mut called = self.dispatch_compiled_func::<C>(results, func)?;
         match <C as CallContext>::KIND {
             CallKind::Nested => {

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -33,15 +33,15 @@ pub fn dispatch_host_func<T>(
     value_stack: &mut ValueStack,
     host_func: HostFuncEntity,
     instance: Option<&Instance>,
-) -> Result<(usize, usize), Error> {
+) -> Result<(u16, u16), Error> {
     let len_params = host_func.len_params();
     let len_results = host_func.len_results();
     let max_inout = len_params.max(len_results);
     let values = value_stack.as_slice_mut();
     let params_results = FuncParams::new(
-        values.split_at_mut(values.len() - max_inout).1,
-        len_params,
-        len_results,
+        values.split_at_mut(values.len() - usize::from(max_inout)).1,
+        usize::from(len_params),
+        usize::from(len_results),
     );
     let trampoline = store.resolve_trampoline(host_func.trampoline()).clone();
     trampoline
@@ -52,7 +52,7 @@ pub fn dispatch_host_func<T>(
             //       called host function. Since the host function failed we
             //       need to clean up the temporary buffer values here.
             //       This is required for resumable calls to work properly.
-            value_stack.drop(max_inout);
+            value_stack.drop(usize::from(max_inout));
         })?;
     Ok((len_params, len_results))
 }
@@ -485,8 +485,8 @@ impl<'engine> Executor<'engine> {
         func: &Func,
         host_func: HostFuncEntity,
     ) -> Result<(), Error> {
-        let len_params = host_func.len_params();
-        let len_results = host_func.len_results();
+        let len_params = usize::from(host_func.len_params());
+        let len_results = usize::from(host_func.len_results());
         let max_inout = len_params.max(len_results);
         let instance = *self.stack.calls.instance_expect();
         // We have to reinstantiate the `self.sp` [`FrameRegisters`] since we just called
@@ -536,7 +536,7 @@ impl<'engine> Executor<'engine> {
         store: &mut Store<T>,
         host_func: HostFuncEntity,
         instance: &Instance,
-    ) -> Result<(usize, usize), Error> {
+    ) -> Result<(u16, u16), Error> {
         dispatch_host_func(store, &mut self.stack.values, host_func, Some(instance))
     }
 

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -11,7 +11,6 @@ use crate::{
         CallParams,
         CallResults,
         EngineInner,
-        EngineResources,
         ResumableCallBase,
         ResumableInvocation,
     },
@@ -25,6 +24,8 @@ use crate::{
 
 #[cfg(doc)]
 use crate::engine::StackLimits;
+
+use super::code_map::CodeMap;
 
 mod cache;
 mod instrs;
@@ -48,7 +49,7 @@ impl EngineInner {
     where
         Results: CallResults,
     {
-        let res = self.res.read();
+        let res = self.code_map.read();
         let mut stack = self.stacks.lock().reuse_or_new();
         let results = EngineExecutor::new(&res, &mut stack)
             .execute_root_func(ctx.store, func, params, results)
@@ -78,10 +79,10 @@ impl EngineInner {
         Results: CallResults,
     {
         let store = ctx.store;
-        let res = self.res.read();
+        let code_map = self.code_map.read();
         let mut stack = self.stacks.lock().reuse_or_new();
-        let results =
-            EngineExecutor::new(&res, &mut stack).execute_root_func(store, func, params, results);
+        let results = EngineExecutor::new(&code_map, &mut stack)
+            .execute_root_func(store, func, params, results);
         match results {
             Ok(results) => {
                 self.stacks.lock().recycle(stack);
@@ -126,10 +127,10 @@ impl EngineInner {
     where
         Results: CallResults,
     {
-        let res = self.res.read();
+        let code_map = self.code_map.read();
         let host_func = invocation.host_func();
         let caller_results = invocation.caller_results();
-        let results = EngineExecutor::new(&res, &mut invocation.stack).resume_func(
+        let results = EngineExecutor::new(&code_map, &mut invocation.stack).resume_func(
             ctx.store,
             host_func,
             params,
@@ -161,7 +162,7 @@ impl EngineInner {
 #[derive(Debug)]
 pub struct EngineExecutor<'engine> {
     /// Shared and reusable generic engine resources.
-    res: &'engine EngineResources,
+    code_map: &'engine CodeMap,
     /// The value and call stacks.
     stack: &'engine mut Stack,
 }
@@ -172,8 +173,8 @@ fn do_nothing<T>(_: &mut T) {}
 
 impl<'engine> EngineExecutor<'engine> {
     /// Creates a new [`EngineExecutor`] with the given [`StackLimits`].
-    fn new(res: &'engine EngineResources, stack: &'engine mut Stack) -> Self {
-        Self { res, stack }
+    fn new(code_map: &'engine CodeMap, stack: &'engine mut Stack) -> Self {
+        Self { code_map, stack }
     }
 
     /// Executes the given [`Func`] using the given `params`.
@@ -204,7 +205,6 @@ impl<'engine> EngineExecutor<'engine> {
                 let instance = *wasm_func.instance();
                 let compiled_func = wasm_func.func_body();
                 let compiled_func = self
-                    .res
                     .code_map
                     .get(Some(store.inner.fuel_mut()), compiled_func)?;
                 let (mut uninit_params, offsets) = self
@@ -288,7 +288,7 @@ impl<'engine> EngineExecutor<'engine> {
     /// When encountering a Wasm or host trap during execution.
     #[inline(always)]
     fn execute_func<T>(&mut self, store: &mut Store<T>) -> Result<(), Error> {
-        execute_instrs(store, self.stack, self.res)
+        execute_instrs(store, self.stack, self.code_map)
     }
 
     /// Convenience forwarder to [`dispatch_host_func`].

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -233,7 +233,10 @@ impl<'engine> EngineExecutor<'engine> {
                 let len_params = host_func.len_params();
                 let len_results = host_func.len_results();
                 let max_inout = len_params.max(len_results);
-                let uninit = self.stack.values.extend_by(max_inout, do_nothing)?;
+                let uninit = self
+                    .stack
+                    .values
+                    .extend_by(usize::from(max_inout), do_nothing)?;
                 for (uninit, param) in uninit.iter_mut().zip(params.call_params()) {
                     uninit.write(param);
                 }

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -228,15 +228,10 @@ impl<'engine> EngineExecutor<'engine> {
             FuncEntity::Host(host_func) => {
                 // The host function signature is required for properly
                 // adjusting, inspecting and manipulating the value stack.
-                let (input_types, output_types) = self
-                    .res
-                    .func_types
-                    .resolve_func_type(host_func.ty_dedup())
-                    .params_results();
                 // In case the host function returns more values than it takes
                 // we are required to extend the value stack.
-                let len_params = input_types.len();
-                let len_results = output_types.len();
+                let len_params = host_func.len_params();
+                let len_results = host_func.len_results();
                 let max_inout = len_params.max(len_results);
                 let uninit = self.stack.values.extend_by(max_inout, do_nothing)?;
                 for (uninit, param) in uninit.iter_mut().zip(params.call_params()) {
@@ -303,13 +298,7 @@ impl<'engine> EngineExecutor<'engine> {
         store: &mut Store<T>,
         host_func: HostFuncEntity,
     ) -> Result<(), Error> {
-        dispatch_host_func(
-            store,
-            &self.res.func_types,
-            &mut self.stack.values,
-            host_func,
-            None,
-        )?;
+        dispatch_host_func(store, &mut self.stack.values, host_func, None)?;
         Ok(())
     }
 

--- a/crates/wasmi/src/func/func_type.rs
+++ b/crates/wasmi/src/func/func_type.rs
@@ -149,6 +149,14 @@ impl FuncTypeInner {
         }
     }
 
+    /// Returns the number of parameter types of the function type.
+    pub fn len_params(&self) -> usize {
+        match self {
+            FuncTypeInner::Inline { len_params, .. } => usize::from(*len_params),
+            FuncTypeInner::Big { len_params, .. } => *len_params as usize,
+        }
+    }
+
     /// Returns the number of result types of the function type.
     pub fn len_results(&self) -> usize {
         match self {
@@ -223,6 +231,11 @@ impl FuncType {
     /// Returns the result types of the function type.
     pub fn results(&self) -> &[ValType] {
         self.inner.results()
+    }
+
+    /// Returns the number of parameter types of the function type.
+    pub fn len_params(&self) -> usize {
+        self.inner.len_params()
     }
 
     /// Returns the number of result types of the function type.

--- a/crates/wasmi/src/func/func_type.rs
+++ b/crates/wasmi/src/func/func_type.rs
@@ -28,7 +28,7 @@ pub enum FuncTypeInner {
     /// Stores the value types of the parameters and results on the heap.
     Big {
         /// The number of parameters.
-        len_params: u32,
+        len_params: u16,
         /// Combined parameter and result types allocated on the heap.
         params_results: Arc<[ValType]>,
     },
@@ -51,6 +51,12 @@ impl FuncTypeInner {
     #[cfg(target_pointer_width = "64")]
     const INLINE_SIZE: usize = 21;
 
+    /// The maximum number of parameter types allowed of a [`FuncType`].
+    const MAX_LEN_PARAMS: usize = 1_000;
+
+    /// The maximum number of result types allowed of a [`FuncType`].
+    const MAX_LEN_RESULTS: usize = 1_000;
+
     /// Creates a new [`FuncTypeInner`].
     ///
     /// # Panics
@@ -65,15 +71,16 @@ impl FuncTypeInner {
     {
         let mut params = params.into_iter();
         let mut results = results.into_iter();
-        let len_params = params.len();
-        let len_results = results.len();
         if let Some(small) = Self::try_new_small(&mut params, &mut results) {
             return small;
         }
-        let mut params_results = params.collect::<Vec<_>>();
-        let len_params = u32::try_from(params_results.len()).unwrap_or_else(|_| {
+        let len_params = params.len();
+        let len_results = results.len();
+        if !(len_params <= Self::MAX_LEN_PARAMS && len_results <= Self::MAX_LEN_RESULTS) {
             panic!("out of bounds parameters (={len_params}) and results (={len_results}) for FuncType")
-        });
+        }
+        let len_params = len_params as u16;
+        let mut params_results = params.collect::<Vec<_>>();
         params_results.extend(results);
         Self::Big {
             params_results: params_results.into(),
@@ -94,12 +101,12 @@ impl FuncTypeInner {
     {
         let params = params.into_iter();
         let results = results.into_iter();
-        let len_params = u8::try_from(params.len()).ok()?;
-        let len_results = u8::try_from(results.len()).ok()?;
-        let len = len_params.checked_add(len_results)?;
-        if usize::from(len) > Self::INLINE_SIZE {
+        if params.len().saturating_add(results.len()) > Self::INLINE_SIZE {
             return None;
         }
+        // Inline size requirements are met so both values must be valid `u8`.
+        let len_params = params.len() as u8;
+        let len_results = results.len() as u8;
         let mut params_results = [ValType::I32; Self::INLINE_SIZE];
         params_results
             .iter_mut()

--- a/crates/wasmi/src/func/func_type.rs
+++ b/crates/wasmi/src/func/func_type.rs
@@ -157,23 +157,26 @@ impl FuncTypeInner {
     }
 
     /// Returns the number of parameter types of the function type.
-    pub fn len_params(&self) -> usize {
+    pub fn len_params(&self) -> u16 {
         match self {
-            FuncTypeInner::Inline { len_params, .. } => usize::from(*len_params),
-            FuncTypeInner::Big { len_params, .. } => *len_params as usize,
+            FuncTypeInner::Inline { len_params, .. } => u16::from(*len_params),
+            FuncTypeInner::Big { len_params, .. } => *len_params,
         }
     }
 
     /// Returns the number of result types of the function type.
-    pub fn len_results(&self) -> usize {
+    pub fn len_results(&self) -> u16 {
         match self {
-            FuncTypeInner::Inline { len_results, .. } => usize::from(*len_results),
+            FuncTypeInner::Inline { len_results, .. } => u16::from(*len_results),
             FuncTypeInner::Big {
                 len_params,
                 params_results,
             } => {
-                let len_buffer = params_results.len();
-                let len_params = *len_params as usize;
+                // Note: this cast is safe since the number of parameters and results
+                //       are both bounded to 1000 maximum and `params_results`
+                //       thus contains 2000 items at most.
+                let len_buffer = params_results.len() as u16;
+                let len_params = *len_params;
                 len_buffer - len_params
             }
         }
@@ -241,12 +244,12 @@ impl FuncType {
     }
 
     /// Returns the number of parameter types of the function type.
-    pub fn len_params(&self) -> usize {
+    pub fn len_params(&self) -> u16 {
         self.inner.len_params()
     }
 
     /// Returns the number of result types of the function type.
-    pub fn len_results(&self) -> usize {
+    pub fn len_results(&self) -> u16 {
         self.inner.len_results()
     }
 

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -22,7 +22,7 @@ use super::{
     StoreContext,
     Stored,
 };
-use crate::{collections::arena::ArenaIndex, engine::ResumableCall, Error, Val};
+use crate::{collections::arena::ArenaIndex, engine::ResumableCall, Engine, Error, Val};
 use core::{fmt, fmt::Debug, num::NonZeroU32};
 use std::{boxed::Box, sync::Arc};
 
@@ -114,6 +114,19 @@ pub struct HostFuncEntity {
 impl HostFuncEntity {
     /// Creates a new [`HostFuncEntity`].
     pub fn new(len_params: usize, len_results: usize, ty: DedupFuncType, func: Trampoline) -> Self {
+        Self {
+            len_params,
+            len_results,
+            ty,
+            func,
+        }
+    }
+
+    /// Creates a new [`HostFuncEntity`].
+    pub fn new2(engine: &Engine, ty: &FuncType, func: Trampoline) -> Self {
+        let len_params = ty.len_params();
+        let len_results = ty.len_results();
+        let ty = engine.alloc_func_type(ty.clone());
         Self {
             len_params,
             len_results,

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -113,7 +113,7 @@ pub struct HostFuncEntity {
 
 impl HostFuncEntity {
     /// Creates a new [`HostFuncEntity`].
-    pub fn new2(engine: &Engine, ty: &FuncType, func: Trampoline) -> Self {
+    pub fn new(engine: &Engine, ty: &FuncType, func: Trampoline) -> Self {
         let len_params = ty.len_params();
         let len_results = ty.len_results();
         let ty = engine.alloc_func_type(ty.clone());
@@ -357,7 +357,7 @@ impl Func {
         let host_func = HostFuncTrampolineEntity::new(ty.clone(), func);
         let trampoline = host_func.trampoline().clone();
         let func = ctx.as_context_mut().store.alloc_trampoline(trampoline);
-        let host_func = HostFuncEntity::new2(ctx.as_context().engine(), &ty, func);
+        let host_func = HostFuncEntity::new(ctx.as_context().engine(), &ty, func);
         ctx.as_context_mut()
             .store
             .inner
@@ -373,7 +373,7 @@ impl Func {
         let ty = host_func.func_type();
         let trampoline = host_func.trampoline().clone();
         let func = ctx.as_context_mut().store.alloc_trampoline(trampoline);
-        let host_func = HostFuncEntity::new2(ctx.as_context().engine(), ty, func);
+        let host_func = HostFuncEntity::new(ctx.as_context().engine(), ty, func);
         ctx.as_context_mut()
             .store
             .inner

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -102,9 +102,9 @@ impl From<HostFuncEntity> for FuncEntity {
 #[derive(Debug, Copy, Clone)]
 pub struct HostFuncEntity {
     /// The number of parameters of the [`HostFuncEntity`].
-    len_params: usize,
+    len_params: u16,
     /// The number of results of the [`HostFuncEntity`].
-    len_results: usize,
+    len_results: u16,
     /// The function type of the host function.
     ty: DedupFuncType,
     /// A reference to the trampoline of the host function.
@@ -126,12 +126,12 @@ impl HostFuncEntity {
     }
 
     /// Returns the number of parameters of the [`HostFuncEntity`].
-    pub fn len_params(&self) -> usize {
+    pub fn len_params(&self) -> u16 {
         self.len_params
     }
 
     /// Returns the number of results of the [`HostFuncEntity`].
-    pub fn len_results(&self) -> usize {
+    pub fn len_results(&self) -> u16 {
         self.len_results
     }
 

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -113,16 +113,6 @@ pub struct HostFuncEntity {
 
 impl HostFuncEntity {
     /// Creates a new [`HostFuncEntity`].
-    pub fn new(len_params: usize, len_results: usize, ty: DedupFuncType, func: Trampoline) -> Self {
-        Self {
-            len_params,
-            len_results,
-            ty,
-            func,
-        }
-    }
-
-    /// Creates a new [`HostFuncEntity`].
     pub fn new2(engine: &Engine, ty: &FuncType, func: Trampoline) -> Self {
         let len_params = ty.len_params();
         let len_results = ty.len_results();

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -242,7 +242,6 @@ impl<T> HostFuncTrampolineEntity<T> {
             func(caller, params, results)?;
             Ok(func_results.encode_results_from_slice(results).unwrap())
         });
-        // let ty = engine.alloc_func_type(ty.clone());
         Self { ty, trampoline }
     }
 

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -307,11 +307,11 @@ impl<T> Definition<T> {
                     .as_context_mut()
                     .store
                     .alloc_trampoline(host_func.trampoline().clone());
-                let ty_dedup = ctx
-                    .as_context()
-                    .engine()
-                    .alloc_func_type(host_func.func_type().clone());
-                let entity = HostFuncEntity::new(ty_dedup, trampoline);
+                let ty = host_func.func_type();
+                let len_params = ty.len_params();
+                let len_results = ty.len_results();
+                let ty_dedup = ctx.as_context().engine().alloc_func_type(ty.clone());
+                let entity = HostFuncEntity::new(len_params, len_results, ty_dedup, trampoline);
                 let func = ctx
                     .as_context_mut()
                     .store

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -308,10 +308,7 @@ impl<T> Definition<T> {
                     .store
                     .alloc_trampoline(host_func.trampoline().clone());
                 let ty = host_func.func_type();
-                let len_params = ty.len_params();
-                let len_results = ty.len_results();
-                let ty_dedup = ctx.as_context().engine().alloc_func_type(ty.clone());
-                let entity = HostFuncEntity::new(len_params, len_results, ty_dedup, trampoline);
+                let entity = HostFuncEntity::new2(ctx.as_context().engine(), ty, trampoline);
                 let func = ctx
                     .as_context_mut()
                     .store

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -308,7 +308,7 @@ impl<T> Definition<T> {
                     .store
                     .alloc_trampoline(host_func.trampoline().clone());
                 let ty = host_func.func_type();
-                let entity = HostFuncEntity::new2(ctx.as_context().engine(), ty, trampoline);
+                let entity = HostFuncEntity::new(ctx.as_context().engine(), ty, trampoline);
                 let func = ctx
                     .as_context_mut()
                     .store

--- a/crates/wasmi/tests/e2e/v1/host_call_instantiation.rs
+++ b/crates/wasmi/tests/e2e/v1/host_call_instantiation.rs
@@ -1,0 +1,78 @@
+//! This tests that a host function called from Wasm can instantiate Wasm modules and does not deadlock.
+
+use std::{fmt, sync::Arc};
+use wasmi::{AsContextMut, Caller, Engine, Linker, Module, Store};
+
+#[derive(Debug)]
+pub enum Data {
+    Uninit,
+    Init {
+        linker: Arc<Linker<Data>>,
+        module: Arc<Module>,
+    },
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Error {
+    Uninit,
+    InstantiationFailed,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Uninit => write!(f, "error: uninit"),
+            Error::InstantiationFailed => write!(f, "error: instantiation failed"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+impl wasmi::core::HostError for Error {}
+
+/// Converts the given `.wat` into `.wasm`.
+fn wat2wasm(wat: &str) -> Result<Vec<u8>, wat::Error> {
+    wat::parse_str(wat)
+}
+
+#[test]
+fn test_instantiate_in_host_call() {
+    let engine = Engine::default();
+    let mut store = <Store<Data>>::new(&engine, Data::Uninit);
+    let wasm = wat2wasm(include_str!("../wat/host_call_instantiation.wat")).unwrap();
+    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let mut linker = <Linker<Data>>::new(&engine);
+    linker
+        .func_wrap(
+            "env",
+            "instantiate",
+            |mut caller: Caller<Data>| -> Result<(), wasmi::Error> {
+                let mut store = caller.as_context_mut();
+                let Data::Init { linker, module } = store.data() else {
+                    return Err(wasmi::Error::host(Error::Uninit));
+                };
+                let linker = linker.clone();
+                let module = module.clone();
+                let _instance = linker
+                    .instantiate(&mut store, &module)
+                    .unwrap()
+                    .ensure_no_start(&mut store)
+                    .map_err(|_| wasmi::Error::host(Error::InstantiationFailed))?;
+                Ok(())
+            },
+        )
+        .unwrap();
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .unwrap()
+        .ensure_no_start(&mut store)
+        .unwrap();
+    let run = instance
+        .get_typed_func::<(), ()>(&mut store, "run")
+        .unwrap();
+    *store.data_mut() = Data::Init {
+        linker: Arc::new(linker),
+        module: Arc::new(module),
+    };
+    run.call(&mut store, ()).unwrap();
+}

--- a/crates/wasmi/tests/e2e/v1/mod.rs
+++ b/crates/wasmi/tests/e2e/v1/mod.rs
@@ -1,6 +1,7 @@
 mod fuel_consumption;
 mod fuel_metering;
 mod func;
+mod host_call_instantiation;
 mod host_calls_wasm;
 mod resource_limiter;
 mod resumable_call;

--- a/crates/wasmi/tests/e2e/wat/host_call_instantiation.wat
+++ b/crates/wasmi/tests/e2e/wat/host_call_instantiation.wat
@@ -1,0 +1,7 @@
+(module
+    (import "env" "instantiate" (func $instantiate))
+
+    (func (export "run")
+        (call $instantiate)
+    )
+)


### PR DESCRIPTION
So far it was not possible to instantiate a Wasm module in a host function that has been called from Wasmi's executor.
This was because of a dead lock that occurred due to a `RwLock<EngineResources>` which contained the `FuncTypeRegistry` which was (in the end) mainly used for resolving the number of parameter and result types of a called host function in the Wasmi executor.

There are two ways of solving this with the following change:

Remove `EngineResources` and instead `RwLock` both `CodeMap` and `FuncTypeRegistry` themselves.

1. Continue to use `&CodeMap` in the Wasmi executor but now also a `RwLock<FuncTypeRegistry>`. Unlock the registry very shortly to resolve the number of parameters and results whenever a host function is called which should occur kind of rarely. The downside is that this probably regresses performance of host function calls due to the additional locking per call.
2. Populate `HostFuncEntity` with inline information about the number of its parameter types and result types. This acts as chace. Since `HostFuncEntity` has to be resolved anyway for a host function call no performance regressions are expected with this solution. The downside is increased space requirements for the `FuncEntity` buffer.

This PR chose 2. for its implementation. Before merging we might want to experiment with another PR that tried out 1. Local benchmarks confirmed that there were no significant changes.

## ToDo

- [ ] Try to reduce space regression by using `u16` instead of `usize` to store the inline number of parameters and results in `HostFuncEntity`. This is safely possible since we limit the number of both values between `0..=1000` similar to Wasmtime.