### PR TITLE
Allow Wasm module instantiation in host functions called from Wasmi's executor (take 2)

### DIFF
--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -11,7 +11,6 @@ use crate::{
         CallParams,
         CallResults,
         EngineInner,
-        EngineResources,
         ResumableCallBase,
         ResumableInvocation,
     },
@@ -22,6 +21,8 @@ use crate::{
     Store,
     StoreContextMut,
 };
+use spin::RwLock;
+use super::{code_map::CodeMap, func_types::FuncTypeRegistry};
 
 #[cfg(doc)]
 use crate::engine::StackLimits;
@@ -48,9 +49,10 @@ impl EngineInner {
     where
         Results: CallResults,
     {
-        let res = self.res.read();
+        let code_map = self.code_map.read();
+        let func_types = &self.func_types;
         let mut stack = self.stacks.lock().reuse_or_new();
-        let results = EngineExecutor::new(&res, &mut stack)
+        let results = EngineExecutor::new(&code_map, func_types, &mut stack)
             .execute_root_func(ctx.store, func, params, results)
             .map_err(|error| match error.into_resumable() {
                 Ok(error) => error.into_error(),
@@ -78,10 +80,11 @@ impl EngineInner {
         Results: CallResults,
     {
         let store = ctx.store;
-        let res = self.res.read();
+        let code_map = self.code_map.read();
+        let func_types = &self.func_types;
         let mut stack = self.stacks.lock().reuse_or_new();
-        let results =
-            EngineExecutor::new(&res, &mut stack).execute_root_func(store, func, params, results);
+        let results = EngineExecutor::new(&code_map, func_types, &mut stack)
+            .execute_root_func(store, func, params, results);
         match results {
             Ok(results) => {
                 self.stacks.lock().recycle(stack);
@@ -126,16 +129,12 @@ impl EngineInner {
     where
         Results: CallResults,
     {
-        let res = self.res.read();
+        let code_map = self.code_map.read();
+        let func_types = &self.func_types;
         let host_func = invocation.host_func();
         let caller_results = invocation.caller_results();
-        let results = EngineExecutor::new(&res, &mut invocation.stack).resume_func(
-            ctx.store,
-            host_func,
-            params,
-            caller_results,
-            results,
-        );
+        let results = EngineExecutor::new(&code_map, func_types, &mut invocation.stack)
+            .resume_func(ctx.store, host_func, params, caller_results, results);
         match results {
             Ok(results) => {
                 self.stacks.lock().recycle(invocation.take_stack());
@@ -161,7 +160,9 @@ impl EngineInner {
 #[derive(Debug)]
 pub struct EngineExecutor<'engine> {
     /// Shared and reusable generic engine resources.
-    res: &'engine EngineResources,
+    code_map: &'engine CodeMap,
+    /// Stores and resolves deduplicated function types.
+    func_types: &'engine RwLock<FuncTypeRegistry>,
     /// The value and call stacks.
     stack: &'engine mut Stack,
 }
@@ -172,8 +173,16 @@ fn do_nothing<T>(_: &mut T) {}
 
 impl<'engine> EngineExecutor<'engine> {
     /// Creates a new [`EngineExecutor`] with the given [`StackLimits`].
-    fn new(res: &'engine EngineResources, stack: &'engine mut Stack) -> Self {
-        Self { res, stack }
+    fn new(
+        code_map: &'engine CodeMap,
+        func_types: &'engine RwLock<FuncTypeRegistry>,
+        stack: &'engine mut Stack,
+    ) -> Self {
+        Self {
+            code_map,
+            func_types,
+            stack,
+        }
     }
 
     /// Executes the given [`Func`] using the given `params`.
@@ -204,7 +213,6 @@ impl<'engine> EngineExecutor<'engine> {
                 let instance = *wasm_func.instance();
                 let compiled_func = wasm_func.func_body();
                 let compiled_func = self
-                    .res
                     .code_map
                     .get(Some(store.inner.fuel_mut()), compiled_func)?;
                 let (mut uninit_params, offsets) = self
@@ -227,16 +235,13 @@ impl<'engine> EngineExecutor<'engine> {
             }
             FuncEntity::Host(host_func) => {
                 // The host function signature is required for properly
-                // adjusting, inspecting and manipulating the value stack.
-                let (input_types, output_types) = self
-                    .res
-                    .func_types
-                    .resolve_func_type(host_func.ty_dedup())
-                    .params_results();
-                // In case the host function returns more values than it takes
+                // adjusting, inspecting and manipulating the value stack.                // In case the host function returns more values than it takes
                 // we are required to extend the value stack.
-                let len_params = input_types.len();
-                let len_results = output_types.len();
+                let (len_params, len_results) = self
+                    .func_types
+                    .read()
+                    .resolve_func_type(host_func.ty_dedup())
+                    .len_params_results();
                 let max_inout = len_params.max(len_results);
                 let uninit = self.stack.values.extend_by(max_inout, do_nothing)?;
                 for (uninit, param) in uninit.iter_mut().zip(params.call_params()) {
@@ -293,7 +298,7 @@ impl<'engine> EngineExecutor<'engine> {
     /// When encountering a Wasm or host trap during execution.
     #[inline(always)]
     fn execute_func<T>(&mut self, store: &mut Store<T>) -> Result<(), Error> {
-        execute_instrs(store, self.stack, self.res)
+        execute_instrs(store, self.stack, self.code_map, self.func_types)
     }
 
     /// Convenience forwarder to [`dispatch_host_func`].
@@ -305,7 +310,7 @@ impl<'engine> EngineExecutor<'engine> {
     ) -> Result<(), Error> {
         dispatch_host_func(
             store,
-            &self.res.func_types,
+            self.func_types,
             &mut self.stack.values,
             host_func,
             None,

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -4,6 +4,7 @@ use self::{
     instrs::{dispatch_host_func, execute_instrs},
     stack::CallFrame,
 };
+use super::{code_map::CodeMap, func_types::FuncTypeRegistry};
 use crate::{
     engine::{
         bytecode::{Register, RegisterSpan},
@@ -22,7 +23,6 @@ use crate::{
     StoreContextMut,
 };
 use spin::RwLock;
-use super::{code_map::CodeMap, func_types::FuncTypeRegistry};
 
 #[cfg(doc)]
 use crate::engine::StackLimits;

--- a/crates/wasmi/src/func/func_type.rs
+++ b/crates/wasmi/src/func/func_type.rs
@@ -230,6 +230,12 @@ impl FuncType {
         self.inner.len_results()
     }
 
+    /// Returns the number of parameter and result types of the function type.
+    pub(crate) fn len_params_results(&self) -> (usize, usize) {
+        let (params, results) = self.inner.params_results();
+        (params.len(), results.len())
+    }
+
     /// Returns the pair of parameter and result types of the function type.
     pub(crate) fn params_results(&self) -> (&[ValType], &[ValType]) {
         self.inner.params_results()

--- a/crates/wasmi/tests/e2e/v1/host_call_instantiation.rs
+++ b/crates/wasmi/tests/e2e/v1/host_call_instantiation.rs
@@ -1,0 +1,78 @@
+//! This tests that a host function called from Wasm can instantiate Wasm modules and does not deadlock.
+
+use std::{fmt, sync::Arc};
+use wasmi::{AsContextMut, Caller, Engine, Linker, Module, Store};
+
+#[derive(Debug)]
+pub enum Data {
+    Uninit,
+    Init {
+        linker: Arc<Linker<Data>>,
+        module: Arc<Module>,
+    },
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Error {
+    Uninit,
+    InstantiationFailed,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Uninit => write!(f, "error: uninit"),
+            Error::InstantiationFailed => write!(f, "error: instantiation failed"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+impl wasmi::core::HostError for Error {}
+
+/// Converts the given `.wat` into `.wasm`.
+fn wat2wasm(wat: &str) -> Result<Vec<u8>, wat::Error> {
+    wat::parse_str(wat)
+}
+
+#[test]
+fn test_instantiate_in_host_call() {
+    let engine = Engine::default();
+    let mut store = <Store<Data>>::new(&engine, Data::Uninit);
+    let wasm = wat2wasm(include_str!("../wat/host_call_instantiation.wat")).unwrap();
+    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let mut linker = <Linker<Data>>::new(&engine);
+    linker
+        .func_wrap(
+            "env",
+            "instantiate",
+            |mut caller: Caller<Data>| -> Result<(), wasmi::Error> {
+                let mut store = caller.as_context_mut();
+                let Data::Init { linker, module } = store.data() else {
+                    return Err(wasmi::Error::host(Error::Uninit));
+                };
+                let linker = linker.clone();
+                let module = module.clone();
+                let _instance = linker
+                    .instantiate(&mut store, &module)
+                    .unwrap()
+                    .ensure_no_start(&mut store)
+                    .map_err(|_| wasmi::Error::host(Error::InstantiationFailed))?;
+                Ok(())
+            },
+        )
+        .unwrap();
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .unwrap()
+        .ensure_no_start(&mut store)
+        .unwrap();
+    let run = instance
+        .get_typed_func::<(), ()>(&mut store, "run")
+        .unwrap();
+    *store.data_mut() = Data::Init {
+        linker: Arc::new(linker),
+        module: Arc::new(module),
+    };
+    run.call(&mut store, ()).unwrap();
+}

--- a/crates/wasmi/tests/e2e/v1/mod.rs
+++ b/crates/wasmi/tests/e2e/v1/mod.rs
@@ -1,6 +1,7 @@
 mod fuel_consumption;
 mod fuel_metering;
 mod func;
+mod host_call_instantiation;
 mod host_calls_wasm;
 mod resource_limiter;
 mod resumable_call;

--- a/crates/wasmi/tests/e2e/wat/host_call_instantiation.wat
+++ b/crates/wasmi/tests/e2e/wat/host_call_instantiation.wat
@@ -1,0 +1,7 @@
+(module
+    (import "env" "instantiate" (func $instantiate))
+
+    (func (export "run")
+        (call $instantiate)
+    )
+)


### PR DESCRIPTION
This implements 2. outlined in https://github.com/wasmi-labs/wasmi/pull/1116#issue-2394121622.

Unfortunately local benchmarks show that host function calls are severely regressed by these changes:

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/00e384ea-bbfb-4c6f-940f-d6da5dde0761)

The other experimental branch instead seems to improve the performance of host function calls:

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/77bc115e-6ae4-4bfb-b252-a3f18849922b)
