### PR TITLE
Remove unused Cargo profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,3 @@ num-traits = { version = "0.2.8", default-features = false }
 [profile.bench]
 lto = "fat"
 codegen-units = 1
-
-[profile.wasm]
-inherits = "release"
-opt-level = 3
-lto = "fat"
-codegen-units = 1
-panic = "abort"
-strip = "symbols"


### PR DESCRIPTION
This is no longer used since Rust sourced Wasmi benchmarks have been moved into a Git submodule.