### PR TITLE
Experiment: allow to compile Wasm modules in host functions called from the Wasmi executor

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -36,6 +36,7 @@ use crate::{
     Store,
     Table,
 };
+use spin::RwLock;
 
 #[cfg(doc)]
 use crate::Instance;
@@ -76,7 +77,7 @@ macro_rules! forward_return {
 pub fn execute_instrs<'engine, T>(
     store: &mut Store<T>,
     stack: &'engine mut Stack,
-    code_map: &'engine CodeMap,
+    code_map: &'engine RwLock<CodeMap>,
 ) -> Result<(), Error> {
     let instance = stack.calls.instance_expect();
     let cache = CachedInstance::new(&mut store.inner, instance);
@@ -97,7 +98,7 @@ struct Executor<'engine> {
     /// The static resources of an [`Engine`].
     ///
     /// [`Engine`]: crate::Engine
-    code_map: &'engine CodeMap,
+    code_map: &'engine RwLock<CodeMap>,
 }
 
 impl<'engine> Executor<'engine> {
@@ -105,7 +106,7 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     pub fn new(
         stack: &'engine mut Stack,
-        code_map: &'engine CodeMap,
+        code_map: &'engine RwLock<CodeMap>,
         cache: CachedInstance,
     ) -> Self {
         let frame = stack

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -289,8 +289,11 @@ impl<'engine> Executor<'engine> {
         func: CompiledFunc,
         mut instance: Option<Instance>,
     ) -> Result<(), Error> {
-        let func = self.code_map.get(Some(store.fuel_mut()), func)?;
-        let mut called = self.dispatch_compiled_func::<C>(results, func)?;
+        let mut called = {
+            let code_map = self.code_map.read();
+            let func = code_map.get(Some(store.fuel_mut()), func)?;
+            self.dispatch_compiled_func::<C>(results, func)?
+        };
         match <C as CallContext>::KIND {
             CallKind::Nested => {
                 // We need to update the instruction pointer of the caller call frame.

--- a/crates/wasmi/tests/e2e/v1/host_call_compilation.rs
+++ b/crates/wasmi/tests/e2e/v1/host_call_compilation.rs
@@ -1,0 +1,43 @@
+//! This tests that a host function called from Wasm can compile Wasm modules and does not deadlock.
+
+use wasmi::{AsContextMut, Caller, Engine, Linker, Module, Store};
+
+/// Converts the given `.wat` into `.wasm`.
+fn wat2wasm(wat: &str) -> Result<Vec<u8>, wat::Error> {
+    wat::parse_str(wat)
+}
+
+fn compile_module(engine: &Engine) -> wasmi::Module {
+    let wasm = wat2wasm(include_str!("../wat/host_call_compilation.wat")).unwrap();
+    Module::new(&engine, &wasm[..]).unwrap()
+}
+
+#[test]
+fn test_compile_in_host_call() {
+    let engine = Engine::default();
+    let mut store = <Store<()>>::new(&engine, ());
+    let module = compile_module(store.engine());
+    let mut linker = <Linker<()>>::new(&engine);
+    linker
+        .func_wrap(
+            "env",
+            "compile",
+            |mut caller: Caller<()>| -> Result<(), wasmi::Error> {
+                let store = caller.as_context_mut();
+                let engine = store.engine();
+                let _module = compile_module(engine);
+                Ok(())
+            },
+        )
+        .unwrap();
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .unwrap()
+        .ensure_no_start(&mut store)
+        .unwrap();
+    instance
+        .get_typed_func::<(), ()>(&mut store, "run")
+        .unwrap()
+        .call(&mut store, ())
+        .unwrap();
+}

--- a/crates/wasmi/tests/e2e/v1/mod.rs
+++ b/crates/wasmi/tests/e2e/v1/mod.rs
@@ -1,6 +1,7 @@
 mod fuel_consumption;
 mod fuel_metering;
 mod func;
+mod host_call_compilation;
 mod host_call_instantiation;
 mod host_calls_wasm;
 mod resource_limiter;

--- a/crates/wasmi/tests/e2e/wat/host_call_compilation.wat
+++ b/crates/wasmi/tests/e2e/wat/host_call_compilation.wat
@@ -1,0 +1,7 @@
+(module
+    (import "env" "compile" (func $compile))
+
+    (func (export "run")
+        (call $compile)
+    )
+)


### PR DESCRIPTION
Maybe closes https://github.com/wasmi-labs/wasmi/issues/631.

Unfortunately with this change the Wasmi executor is roughly 5-15% slower across the board:

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/6e588ac5-4431-4590-b756-48c42e226bc5)

With some exceptionally regressed outliers:

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/4ad76e8c-d826-4efe-a3d7-67935a803b75)

Therefore I declare that these experimental changes are not acceptable for inclusion into Wasmi. However, if Wasm module compilation is an important use case, a user might want to include it until we have a better fix.