### PR TITLE
Allow to compile Wasm modules in host functions called from the Wasmi executor (take 2)

### DIFF
--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -93,7 +93,7 @@ impl CodeMap {
     ///
     /// - If `func` is an invalid [`CompiledFunc`] reference for this [`CodeMap`].
     /// - If `func` refers to an already initialized [`CompiledFunc`].
-    pub fn init_func(&self, func: CompiledFunc, entity: CompiledFuncEntity) {
+    pub fn init_func_as_compiled(&self, func: CompiledFunc, entity: CompiledFuncEntity) {
         let mut funcs = self.funcs.lock();
         let Some(func) = funcs.get_mut(func) else {
             panic!("encountered invalid internal function: {func:?}")
@@ -107,7 +107,7 @@ impl CodeMap {
     ///
     /// - If `func` is an invalid [`CompiledFunc`] reference for this [`CodeMap`].
     /// - If `func` refers to an already initialized [`CompiledFunc`].
-    pub fn init_lazy_func(
+    pub fn init_func_as_uncompiled(
         &self,
         func: CompiledFunc,
         func_idx: FuncIdx,

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -414,24 +414,6 @@ impl CompiledFuncEntity {
             len_registers,
         }
     }
-
-    /// Returns the sequence of [`Instruction`] of the [`CompiledFunc`].
-    #[inline]
-    pub fn instrs(&self) -> &[Instruction] {
-        &self.instrs[..]
-    }
-
-    /// Returns the number of registers used by the [`CompiledFunc`].
-    #[inline]
-    pub fn len_registers(&self) -> u16 {
-        self.len_registers
-    }
-
-    /// Returns the function local constant values of the [`CompiledFunc`].
-    #[inline]
-    pub fn consts(&self) -> &[UntypedVal] {
-        &self.consts
-    }
 }
 
 /// A shared reference to the data of a [`CompiledFunc`].

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -402,7 +402,7 @@ impl UncompiledFuncEntity {
     /// Creates a new [`UncompiledFuncEntity`].
     pub fn new(
         func_index: FuncIdx,
-        bytes: impl Into<SmallByteSlice>,
+        bytes: &[u8],
         module: ModuleHeader,
         func_to_validate: impl Into<Option<FuncToValidate<ValidatorResources>>>,
     ) -> Self {
@@ -416,9 +416,10 @@ impl UncompiledFuncEntity {
             );
             (TypeIndex(func_to_validate.ty), func_to_validate.resources)
         });
+        let bytes = bytes.into();
         Self {
             func_index,
-            bytes: bytes.into(),
+            bytes,
             module,
             validation,
         }

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -376,6 +376,11 @@ impl InternalFuncEntity {
     }
 }
 
+/// A function type index into the Wasm module.
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+pub struct TypeIndex(u32);
+
 /// An internal uncompiled function entity.
 pub struct UncompiledFuncEntity {
     /// The index of the function within the Wasm module.
@@ -493,11 +498,6 @@ impl UncompiledFuncEntity {
         Ok(unsafe { result.assume_init() })
     }
 }
-
-/// A function type index into the Wasm module.
-#[derive(Debug, Copy, Clone)]
-#[repr(transparent)]
-pub struct TypeIndex(u32);
 
 impl fmt::Debug for UncompiledFuncEntity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -193,7 +193,7 @@ pub struct UncompiledFuncEntity {
 }
 
 impl UncompiledFuncEntity {
-    /// Compile the uncompiled [`FuncEntity`].
+    /// Compile the [`UncompiledFuncEntity`].
     ///
     /// # Panics
     ///

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -394,6 +394,31 @@ pub struct UncompiledFuncEntity {
 }
 
 impl UncompiledFuncEntity {
+    /// Creates a new [`UncompiledFuncEntity`].
+    pub fn new(
+        func_index: FuncIdx,
+        bytes: impl Into<SmallByteSlice>,
+        module: ModuleHeader,
+        func_to_validate: impl Into<Option<FuncToValidate<ValidatorResources>>>,
+    ) -> Self {
+        let validation = func_to_validate.into().map(|func_to_validate| {
+            assert_eq!(
+                func_to_validate.index,
+                func_index.into_u32(),
+                "Wasmi function index ({}) does not match with Wasm validation function index ({})",
+                func_to_validate.index,
+                func_index.into_u32(),
+            );
+            (TypeIndex(func_to_validate.ty), func_to_validate.resources)
+        });
+        Self {
+            func_index,
+            bytes: bytes.into(),
+            module,
+            validation,
+        }
+    }
+
     /// Compile the [`UncompiledFuncEntity`].
     ///
     /// # Panics
@@ -473,33 +498,6 @@ impl UncompiledFuncEntity {
 #[derive(Debug, Copy, Clone)]
 #[repr(transparent)]
 pub struct TypeIndex(u32);
-
-impl UncompiledFuncEntity {
-    /// Creates a new [`UncompiledFuncEntity`].
-    pub fn new(
-        func_index: FuncIdx,
-        bytes: impl Into<SmallByteSlice>,
-        module: ModuleHeader,
-        func_to_validate: impl Into<Option<FuncToValidate<ValidatorResources>>>,
-    ) -> Self {
-        let validation = func_to_validate.into().map(|func_to_validate| {
-            assert_eq!(
-                func_to_validate.index,
-                func_index.into_u32(),
-                "Wasmi function index ({}) does not match with Wasm validation function index ({})",
-                func_to_validate.index,
-                func_index.into_u32(),
-            );
-            (TypeIndex(func_to_validate.ty), func_to_validate.resources)
-        });
-        Self {
-            func_index,
-            bytes: bytes.into(),
-            module,
-            validation,
-        }
-    }
-}
 
 impl fmt::Debug for UncompiledFuncEntity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -90,6 +90,7 @@ impl InternalFuncEntity {
     /// # Panics
     ///
     /// If `func` has already been initialized.
+    #[inline]
     pub fn init_compiled(&mut self, entity: CompiledFuncEntity) {
         assert!(matches!(self, Self::Uninit | Self::Compiling));
         *self = Self::Compiled(entity);
@@ -100,6 +101,7 @@ impl InternalFuncEntity {
     /// # Panics
     ///
     /// If `func` has already been initialized.
+    #[inline]
     pub fn init_uncompiled(&mut self, entity: UncompiledFuncEntity) {
         assert!(matches!(self, Self::Uninit));
         *self = Self::Uncompiled(entity);
@@ -147,6 +149,7 @@ impl InternalFuncEntity {
     /// # Panics
     ///
     /// If `func` has already been initialized.
+    #[inline]
     pub fn set_compiled(&mut self, entity: CompiledFuncEntity) -> CompiledFuncRef {
         assert!(matches!(self, Self::Compiling));
         *self = Self::Compiled(entity);
@@ -421,16 +424,19 @@ impl CompiledFuncEntity {
     }
 
     /// Returns the sequence of [`Instruction`] of the [`CompiledFunc`].
+    #[inline]
     pub fn instrs(&self) -> &[Instruction] {
         &self.instrs[..]
     }
 
     /// Returns the number of registers used by the [`CompiledFunc`].
+    #[inline]
     pub fn len_registers(&self) -> u16 {
         self.len_registers
     }
 
     /// Returns the function local constant values of the [`CompiledFunc`].
+    #[inline]
     pub fn consts(&self) -> &[UntypedVal] {
         &self.consts
     }
@@ -448,6 +454,7 @@ pub struct CompiledFuncRef<'a> {
 }
 
 impl<'a> From<&'a CompiledFuncEntity> for CompiledFuncRef<'a> {
+    #[inline]
     fn from(func: &'a CompiledFuncEntity) -> Self {
         Self {
             instrs: func.instrs.as_ref(),
@@ -459,16 +466,19 @@ impl<'a> From<&'a CompiledFuncEntity> for CompiledFuncRef<'a> {
 
 impl<'a> CompiledFuncRef<'a> {
     /// Returns the sequence of [`Instruction`] of the [`CompiledFunc`].
+    #[inline]
     pub fn instrs(&self) -> &'a [Instruction] {
         self.instrs.get_ref()
     }
 
     /// Returns the number of registers used by the [`CompiledFunc`].
+    #[inline]
     pub fn len_registers(&self) -> u16 {
         self.len_registers
     }
 
     /// Returns the function local constant values of the [`CompiledFunc`].
+    #[inline]
     pub fn consts(&self) -> &'a [UntypedVal] {
         self.consts.get_ref()
     }
@@ -547,6 +557,7 @@ impl CodeMap {
     /// - If translation or Wasm validation of the [`FuncEntity`] failed.
     /// - If `ctx` ran out of fuel in case fuel consumption is enabled.
     #[track_caller]
+    #[inline]
     pub fn get<'a>(
         &'a self,
         fuel: Option<&mut Fuel>,
@@ -567,11 +578,13 @@ impl CodeMap {
         self.wait_for_compilation(func)
     }
 
+    #[inline]
     fn get_compiled<'a>(&'a self, entity: &InternalFuncEntity) -> Option<CompiledFuncRef<'a>> {
         let cref = entity.get_compiled()?;
         Some(self.adjust_cref_lifetime(cref))
     }
 
+    #[inline]
     fn adjust_cref_lifetime<'a>(&'a self, cref: CompiledFuncRef<'_>) -> CompiledFuncRef<'a> {
         // Safety: we cast the lifetime of `cref` to match `&self` instead of the inner
         //         `MutexGuard` which is safe because `CodeMap` is append-only and the
@@ -579,6 +592,8 @@ impl CodeMap {
         unsafe { mem::transmute::<CompiledFuncRef<'_>, CompiledFuncRef<'a>>(cref) }
     }
 
+    #[cold]
+    #[inline]
     fn compile<'a>(
         &'a self,
         fuel: Option<&mut Fuel>,
@@ -602,6 +617,8 @@ impl CodeMap {
         }
     }
 
+    #[cold]
+    #[inline]
     fn wait_for_compilation(&self, func: CompiledFunc) -> Result<CompiledFuncRef, Error> {
         'wait: loop {
             let funcs = self.funcs.lock();

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -5,13 +5,7 @@
 //! This is the data structure specialized to handle compiled
 //! register machine based bytecode functions.
 
-use super::{
-    FuelCosts,
-    FuncTranslationDriver,
-    FuncTranslator,
-    TranslationError,
-    ValidatingFuncTranslator,
-};
+use super::{FuelCosts, FuncTranslationDriver, FuncTranslator, ValidatingFuncTranslator};
 use crate::{
     collections::arena::{Arena, ArenaIndex},
     core::{TrapCode, UntypedVal},
@@ -22,14 +16,13 @@ use crate::{
     Error,
 };
 use core::{
-    cell::UnsafeCell,
     fmt,
-    hint,
-    mem,
+    mem::{self, MaybeUninit},
     ops,
+    pin::Pin,
     slice,
-    sync::atomic::{AtomicU8, Ordering},
 };
+use spin::Mutex;
 use std::boxed::Box;
 use wasmparser::{FuncToValidate, ValidatorResources, WasmFeatures};
 
@@ -67,10 +60,112 @@ impl ArenaIndex for CompiledFunc {
 /// Either an already compiled or still uncompiled function entity.
 #[derive(Debug)]
 enum InternalFuncEntity {
-    /// An internal function that has already been compiled.
-    Compiled(CompiledFuncEntity),
+    /// The function entity has not yet been initialized.
+    Uninit,
     /// An internal function that has not yet been compiled.
     Uncompiled(UncompiledFuncEntity),
+    /// The function entity is currently compiling.
+    Compiling,
+    /// The function entity failed to compile lazily.
+    FailedToCompile,
+    /// An internal function that has already been compiled.
+    Compiled(CompiledFuncEntity),
+}
+
+#[derive(Debug)]
+pub enum CodeMapError {
+    /// Error when compiling a function that has not yet been initialized.
+    StillUninitialized,
+    /// Error when compiling a function that is already compiling.
+    AlreadyCompiling,
+    /// Error when compiling a function that has already been compiled.
+    AlreadyCompiled,
+    /// Error when compiling a function that already failed to compile.
+    AlreadyFailedToCompile,
+}
+
+impl InternalFuncEntity {
+    /// Initializes the [`InternalFuncEntity`] with a [`CompiledFuncEntity`].
+    ///
+    /// # Panics
+    ///
+    /// If `func` has already been initialized.
+    pub fn init_compiled(&mut self, entity: CompiledFuncEntity) {
+        assert!(matches!(self, Self::Uninit | Self::Compiling));
+        *self = Self::Compiled(entity);
+    }
+
+    /// Initializes the [`InternalFuncEntity`] to an uncompiled state.
+    ///
+    /// # Panics
+    ///
+    /// If `func` has already been initialized.
+    pub fn init_uncompiled(&mut self, entity: UncompiledFuncEntity) {
+        assert!(matches!(self, Self::Uninit));
+        *self = Self::Uncompiled(entity);
+    }
+
+    /// Returns the [`CompiledFuncEntity`] if possible.
+    ///
+    /// Returns `None` if the [`InternalFuncEntity`] has not yet been compiled.
+    #[inline]
+    pub fn get_compiled(&self) -> Option<CompiledFuncRef> {
+        match self {
+            InternalFuncEntity::Compiled(func) => Some(func.into()),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`UncompiledFuncEntity`] if possible.
+    ///
+    /// # Errors
+    ///
+    /// Returns a proper error if the [`InternalFuncEntity`] is not uncompiled.
+    #[inline]
+    pub fn get_uncompiled(&mut self) -> Result<UncompiledFuncEntity, CodeMapError> {
+        match self {
+            InternalFuncEntity::Uninit => return Err(CodeMapError::StillUninitialized),
+            InternalFuncEntity::Compiling => return Err(CodeMapError::AlreadyCompiling),
+            InternalFuncEntity::Compiled(_) => return Err(CodeMapError::AlreadyCompiled),
+            InternalFuncEntity::FailedToCompile => {
+                return Err(CodeMapError::AlreadyFailedToCompile)
+            }
+            _ => {}
+        };
+        let InternalFuncEntity::Uncompiled(func) =
+            mem::replace(self, InternalFuncEntity::Compiling)
+        else {
+            panic!("already asserted that `self` is uncompiled")
+        };
+        Ok(func)
+    }
+
+    /// Sets the [`InternalFuncEntity`] as [`CompiledFuncEntity`].
+    ///
+    /// Returns a [`CompiledFuncRef`] to the [`CompiledFuncEntity`].
+    ///
+    /// # Panics
+    ///
+    /// If `func` has already been initialized.
+    pub fn set_compiled(&mut self, entity: CompiledFuncEntity) -> CompiledFuncRef {
+        assert!(matches!(self, Self::Compiling));
+        *self = Self::Compiled(entity);
+        let Self::Compiled(entity) = self else {
+            panic!("just initialized `self` as compiled")
+        };
+        CompiledFuncRef::from(&*entity)
+    }
+
+    /// Signals a failed compilation for the [`InternalFuncEntity`].
+    ///
+    /// # Panics
+    ///
+    /// If `func` is not in compiling state.
+    #[inline]
+    pub fn set_failed_to_compile(&mut self) {
+        assert!(matches!(self, Self::Compiling));
+        *self = Self::FailedToCompile;
+    }
 }
 
 impl From<CompiledFuncEntity> for InternalFuncEntity {
@@ -82,88 +177,6 @@ impl From<CompiledFuncEntity> for InternalFuncEntity {
 impl From<UncompiledFuncEntity> for InternalFuncEntity {
     fn from(func: UncompiledFuncEntity) -> Self {
         Self::Uncompiled(func)
-    }
-}
-
-impl InternalFuncEntity {
-    /// Create a new uninitialized [`InternalFuncEntity`].
-    fn uninit() -> Self {
-        Self::from(CompiledFuncEntity::uninit())
-    }
-
-    /// Compile the uncompiled [`FuncEntity`].
-    ///
-    /// # Panics
-    ///
-    /// - If the `func` unexpectedly has already been compiled.
-    /// - If the `engine` unexpectedly no longer exists due to weak referencing.
-    ///
-    /// # Errors
-    ///
-    /// - If function translation failed.
-    /// - If `ctx` ran out of fuel in case fuel consumption is enabled.
-    fn compile(&mut self, fuel: Option<&mut Fuel>, features: &WasmFeatures) -> Result<(), Error> {
-        let uncompiled = match self {
-            InternalFuncEntity::Uncompiled(func) => func,
-            InternalFuncEntity::Compiled(func) => {
-                unreachable!("expected func to be uncompiled: {func:?}")
-            }
-        };
-        let func_idx = uncompiled.func_index;
-        let bytes = mem::take(&mut uncompiled.bytes);
-        let needs_validation = uncompiled.validation.is_some();
-        let compilation_fuel = |_costs: &FuelCosts| {
-            let len_bytes = bytes.as_slice().len() as u64;
-            let compile_factor = match needs_validation {
-                false => 7,
-                true => 9,
-            };
-            len_bytes.saturating_mul(compile_factor)
-        };
-        if let Some(fuel) = fuel {
-            match fuel.consume_fuel(compilation_fuel) {
-                Err(FuelError::OutOfFuel) => return Err(Error::from(TrapCode::OutOfFuel)),
-                Ok(_) | Err(FuelError::FuelMeteringDisabled) => {}
-            }
-        }
-        let module = uncompiled.module.clone();
-        let Some(engine) = module.engine().upgrade() else {
-            panic!(
-                "cannot compile function lazily since engine does no longer exist: {:?}",
-                module.engine()
-            )
-        };
-        match uncompiled.validation.take() {
-            Some((type_index, resources)) => {
-                let allocs = engine.get_allocs();
-                let translator = FuncTranslator::new(func_idx, module, allocs.0)?;
-                let func_to_validate = FuncToValidate {
-                    resources,
-                    index: func_idx.into_u32(),
-                    ty: type_index.0,
-                    features: *features,
-                };
-                let validator = func_to_validate.into_validator(allocs.1);
-                let translator = ValidatingFuncTranslator::new(validator, translator)?;
-                let allocs = FuncTranslationDriver::new(0, &bytes[..], translator)?.translate(
-                    |compiled_func| {
-                        *self = InternalFuncEntity::Compiled(compiled_func);
-                    },
-                )?;
-                engine.recycle_allocs(allocs.translation, allocs.validation);
-            }
-            None => {
-                let allocs = engine.get_translation_allocs();
-                let translator = FuncTranslator::new(func_idx, module, allocs)?;
-                let allocs = FuncTranslationDriver::new(0, &bytes[..], translator)?.translate(
-                    |compiled_func| {
-                        *self = InternalFuncEntity::Compiled(compiled_func);
-                    },
-                )?;
-                engine.recycle_translation_allocs(allocs);
-            }
-        };
-        Ok(())
     }
 }
 
@@ -182,6 +195,82 @@ pub struct UncompiledFuncEntity {
     ///
     /// This is `Some` if the [`UncompiledFuncEntity`] is to be validated upon compilation.
     validation: Option<(TypeIndex, ValidatorResources)>,
+}
+
+impl UncompiledFuncEntity {
+    /// Compile the uncompiled [`FuncEntity`].
+    ///
+    /// # Panics
+    ///
+    /// - If the `func` unexpectedly has already been compiled.
+    /// - If the `engine` unexpectedly no longer exists due to weak referencing.
+    ///
+    /// # Errors
+    ///
+    /// - If function translation failed.
+    /// - If `ctx` ran out of fuel in case fuel consumption is enabled.
+    fn compile(
+        &mut self,
+        fuel: Option<&mut Fuel>,
+        features: &WasmFeatures,
+    ) -> Result<CompiledFuncEntity, Error> {
+        let func_idx = self.func_index;
+        let bytes = mem::take(&mut self.bytes);
+        let needs_validation = self.validation.is_some();
+        let compilation_fuel = |_costs: &FuelCosts| {
+            let len_bytes = bytes.as_slice().len() as u64;
+            let compile_factor = match needs_validation {
+                false => 7,
+                true => 9,
+            };
+            len_bytes.saturating_mul(compile_factor)
+        };
+        if let Some(fuel) = fuel {
+            match fuel.consume_fuel(compilation_fuel) {
+                Err(FuelError::OutOfFuel) => return Err(Error::from(TrapCode::OutOfFuel)),
+                Ok(_) | Err(FuelError::FuelMeteringDisabled) => {}
+            }
+        }
+        let module = self.module.clone();
+        let Some(engine) = module.engine().upgrade() else {
+            panic!(
+                "cannot compile function lazily since engine does no longer exist: {:?}",
+                module.engine()
+            )
+        };
+        let mut result = MaybeUninit::uninit();
+        match self.validation.take() {
+            Some((type_index, resources)) => {
+                let allocs = engine.get_allocs();
+                let translator = FuncTranslator::new(func_idx, module, allocs.0)?;
+                let func_to_validate = FuncToValidate {
+                    resources,
+                    index: func_idx.into_u32(),
+                    ty: type_index.0,
+                    features: *features,
+                };
+                let validator = func_to_validate.into_validator(allocs.1);
+                let translator = ValidatingFuncTranslator::new(validator, translator)?;
+                let allocs = FuncTranslationDriver::new(0, &bytes[..], translator)?.translate(
+                    |compiled_func| {
+                        result.write(compiled_func);
+                    },
+                )?;
+                engine.recycle_allocs(allocs.translation, allocs.validation);
+            }
+            None => {
+                let allocs = engine.get_translation_allocs();
+                let translator = FuncTranslator::new(func_idx, module, allocs)?;
+                let allocs = FuncTranslationDriver::new(0, &bytes[..], translator)?.translate(
+                    |compiled_func| {
+                        result.write(compiled_func);
+                    },
+                )?;
+                engine.recycle_translation_allocs(allocs);
+            }
+        };
+        Ok(unsafe { result.assume_init() })
+    }
 }
 
 /// A function type index into the Wasm module.
@@ -294,9 +383,9 @@ impl<'a> From<&'a [u8]> for SmallByteSlice {
 #[derive(Debug)]
 pub struct CompiledFuncEntity {
     /// The sequence of [`Instruction`] of the [`CompiledFuncEntity`].
-    instrs: Box<[Instruction]>,
+    instrs: Pin<Box<[Instruction]>>,
     /// The constant values local to the [`CompiledFunc`].
-    consts: Box<[UntypedVal]>,
+    consts: Pin<Box<[UntypedVal]>>,
     /// The number of registers used by the [`CompiledFunc`] in total.
     ///
     /// # Note
@@ -318,8 +407,8 @@ impl CompiledFuncEntity {
         I: IntoIterator<Item = Instruction>,
         C: IntoIterator<Item = UntypedVal>,
     {
-        let instrs: Box<[Instruction]> = instrs.into_iter().collect();
-        let consts: Box<[UntypedVal]> = consts.into_iter().collect();
+        let instrs: Pin<Box<[Instruction]>> = Pin::new(instrs.into_iter().collect());
+        let consts: Pin<Box<[UntypedVal]>> = Pin::new(consts.into_iter().collect());
         assert!(
             !instrs.is_empty(),
             "compiled functions must have at least one instruction"
@@ -328,15 +417,6 @@ impl CompiledFuncEntity {
             instrs,
             consts,
             len_registers,
-        }
-    }
-
-    /// Create a new uninitialized [`CompiledFuncEntity`].
-    fn uninit() -> Self {
-        Self {
-            instrs: [].into(),
-            len_registers: 0,
-            consts: [].into(),
         }
     }
 
@@ -356,339 +436,56 @@ impl CompiledFuncEntity {
     }
 }
 
+/// A shared reference to the data of a [`CompiledFunc`].
+#[derive(Debug, Copy, Clone)]
+pub struct CompiledFuncRef<'a> {
+    /// The sequence of [`Instruction`] of the [`CompiledFuncEntity`].
+    instrs: Pin<&'a [Instruction]>,
+    /// The constant values local to the [`CompiledFunc`].
+    consts: Pin<&'a [UntypedVal]>,
+    /// The number of registers used by the [`CompiledFunc`] in total.
+    len_registers: u16,
+}
+
+impl<'a> From<&'a CompiledFuncEntity> for CompiledFuncRef<'a> {
+    fn from(func: &'a CompiledFuncEntity) -> Self {
+        Self {
+            instrs: func.instrs.as_ref(),
+            consts: func.consts.as_ref(),
+            len_registers: func.len_registers,
+        }
+    }
+}
+
+impl<'a> CompiledFuncRef<'a> {
+    /// Returns the sequence of [`Instruction`] of the [`CompiledFunc`].
+    pub fn instrs(&self) -> &'a [Instruction] {
+        self.instrs.get_ref()
+    }
+
+    /// Returns the number of registers used by the [`CompiledFunc`].
+    pub fn len_registers(&self) -> u16 {
+        self.len_registers
+    }
+
+    /// Returns the function local constant values of the [`CompiledFunc`].
+    pub fn consts(&self) -> &'a [UntypedVal] {
+        self.consts.get_ref()
+    }
+}
+
 /// Datastructure to efficiently store information about compiled functions.
 #[derive(Debug)]
 pub struct CodeMap {
-    funcs: Arena<CompiledFunc, FuncEntity>,
+    funcs: Mutex<Arena<CompiledFunc, InternalFuncEntity>>,
     features: WasmFeatures,
-}
-
-/// Atomicly accessible [`CompilationPhase`].
-pub struct AtomicCompilationPhase {
-    /// The inner atomic `u8` value to represent the current [`CompilationPhase`].
-    inner: AtomicU8,
-}
-
-impl fmt::Debug for AtomicCompilationPhase {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.get().fmt(f)
-    }
-}
-
-/// Error that may occur when changing [`AtomicCompilationPhase`].
-#[derive(Debug)]
-pub enum CompilationPhaseError {
-    InvalidPhase,
-}
-
-impl AtomicCompilationPhase {
-    /// Convenience `u8` constant to represent [`CompilationPhase::Uninitialized`].
-    const UNINITIALIZED: u8 = CompilationPhase::Uninitialized as u8;
-
-    /// Convenience `u8` constant to represent [`CompilationPhase::Uncompiled`].
-    const UNCOMPILED: u8 = CompilationPhase::Uncompiled as u8;
-
-    /// Convenience `u8` constant to represent [`CompilationPhase::Compiling`].
-    const COMPILING: u8 = CompilationPhase::Compiling as u8;
-
-    /// Convenience `u8` constant to represent [`CompilationPhase::CompilationFailed`].
-    const COMPILATION_FAILED: u8 = CompilationPhase::CompilationFailed as u8;
-
-    /// Convenience `u8` constant to represent [`CompilationPhase::Compiled`].
-    const COMPILED: u8 = CompilationPhase::Compiled as u8;
-
-    /// Creates a new [`AtomicCompilationPhase`] initialized to the given [`CompilationPhase`].
-    const fn new(phase: CompilationPhase) -> Self {
-        Self {
-            inner: AtomicU8::new(phase as u8),
-        }
-    }
-
-    /// Creates a new [`AtomicCompilationPhase`] set to [`CompilationPhase::Uninitialized`].
-    pub const fn uninit() -> Self {
-        Self::new(CompilationPhase::Uninitialized)
-    }
-
-    /// Returns the current [`CompilationPhase`].
-    pub fn get(&self) -> CompilationPhase {
-        match self.inner.load(Ordering::Acquire) {
-            Self::UNINITIALIZED => CompilationPhase::Uninitialized,
-            Self::UNCOMPILED => CompilationPhase::Uncompiled,
-            Self::COMPILING => CompilationPhase::Compiling,
-            Self::COMPILATION_FAILED => CompilationPhase::CompilationFailed,
-            Self::COMPILED => CompilationPhase::Compiled,
-            state => unreachable!("encountered invalid compilation phase state: {state}"),
-        }
-    }
-
-    /// Returns `true` if [`AtomicCompilationPhase`] is [`CompilationPhase::Compiled`].
-    pub fn is_compiled(&self) -> bool {
-        self.inner.load(Ordering::Acquire) == Self::COMPILED
-    }
-
-    /// Returns `true` if [`AtomicCompilationPhase`] is [`CompilationPhase::Uninitialized`].
-    pub fn is_uninit(&mut self) -> bool {
-        *self.inner.get_mut() == CompilationPhase::Uninitialized as u8
-    }
-
-    /// Change [`AtomicCompilationPhase`] from `from` to `to`.
-    ///
-    /// Returns `true` if the phase change was successful.
-    #[inline]
-    fn change_phase(
-        &self,
-        from: CompilationPhase,
-        to: CompilationPhase,
-    ) -> Result<(), CompilationPhaseError> {
-        let from = from as u8;
-        let to = to as u8;
-        match self
-            .inner
-            .compare_exchange(from, to, Ordering::SeqCst, Ordering::Relaxed)
-        {
-            Ok(phase) if phase == from => Ok(()),
-            _ => Err(CompilationPhaseError::InvalidPhase),
-        }
-    }
-
-    /// Change [`AtomicCompilationPhase`] from `from` to `to`.
-    ///
-    /// Returns `true` if the phase change was successful.
-    #[inline]
-    fn change_phase_mut(
-        &mut self,
-        from: CompilationPhase,
-        to: CompilationPhase,
-    ) -> Result<(), CompilationPhaseError> {
-        let phase = self.inner.get_mut();
-        if *phase != from as u8 {
-            return Err(CompilationPhaseError::InvalidPhase);
-        }
-        *phase = to as u8;
-        Ok(())
-    }
-
-    /// Sets [`AtomicCompilationPhase`] to [`CompilationPhase::Compiled`].
-    ///
-    /// # Errors
-    ///
-    /// If the current [`CompilationPhase`] is not [`CompilationPhase::Uninitialized`].
-    pub fn init_compiled(&mut self) -> Result<(), CompilationPhaseError> {
-        self.change_phase_mut(CompilationPhase::Uninitialized, CompilationPhase::Compiled)
-    }
-
-    /// Sets [`AtomicCompilationPhase`] to [`CompilationPhase::Uncompiled`].
-    ///
-    /// # Errors
-    ///
-    /// If the current [`CompilationPhase`] is not [`CompilationPhase::Uninitialized`].
-    pub fn init_uncompiled(&mut self) -> Result<(), CompilationPhaseError> {
-        self.change_phase_mut(
-            CompilationPhase::Uninitialized,
-            CompilationPhase::Uncompiled,
-        )
-    }
-
-    /// Sets [`AtomicCompilationPhase`] to [`CompilationPhase::Compiling`].
-    ///
-    /// # Errors
-    ///
-    /// If the current [`CompilationPhase`] is not [`CompilationPhase::Uncompiled`].
-    pub fn set_compiling(&self) -> Result<(), CompilationPhaseError> {
-        self.change_phase(CompilationPhase::Uncompiled, CompilationPhase::Compiling)
-    }
-
-    /// Sets [`AtomicCompilationPhase`] to [`CompilationPhase::CompilationFailed`].
-    ///
-    /// # Errors
-    ///
-    /// If the current [`CompilationPhase`] is not [`CompilationPhase::Compiling`].
-    pub fn set_compilation_failed(&self) -> Result<(), CompilationPhaseError> {
-        self.change_phase(
-            CompilationPhase::Compiling,
-            CompilationPhase::CompilationFailed,
-        )
-    }
-
-    /// Sets [`AtomicCompilationPhase`] to [`CompilationPhase::CompilationFailed`].
-    ///
-    /// # Errors
-    ///
-    /// If the current [`CompilationPhase`] is not [`CompilationPhase::Compiling`].
-    pub fn set_compiled(&self) -> Result<(), CompilationPhaseError> {
-        self.change_phase(CompilationPhase::Compiling, CompilationPhase::Compiled)
-    }
-}
-
-/// The current [`CompilationPhase`] of an [`InternalFuncEntity`].
-#[derive(Debug, Copy, Clone)]
-#[repr(u8)]
-pub enum CompilationPhase {
-    /// The function has not yet been initialized.
-    ///
-    /// # Note
-    ///
-    /// After allocation of a function entity the function is uninitialized
-    /// until it has been initialized for either eager or lazy compilation purposes.
-    Uninitialized = 0,
-    /// The function is in an uncompiled state and awaits lazy compilation.
-    Uncompiled = 1,
-    /// The function is currently being lazily compiled.
-    Compiling = 2,
-    /// The function has been lazily compiled successfully and is available for execution.
-    Compiled = 3,
-    /// Lazy compilation of the function has failed.
-    CompilationFailed = 4,
-}
-
-/// A function entity of a [`CodeMap`].
-#[derive(Debug)]
-struct FuncEntity {
-    /// Synchronization for the `func` field.
-    phase: AtomicCompilationPhase,
-    /// The underlying function entity.
-    func: UnsafeCell<InternalFuncEntity>,
-}
-
-impl FuncEntity {
-    /// Create a new uninitialized [`FuncEntity`].
-    pub fn uninit() -> Self {
-        Self {
-            phase: AtomicCompilationPhase::uninit(),
-            func: UnsafeCell::new(InternalFuncEntity::uninit()),
-        }
-    }
-
-    /// Initializes the [`CompiledFunc`] with a [`CompiledFuncEntity`].
-    ///
-    /// # Panics
-    ///
-    /// If `func` has already been initialized [`CompiledFunc`].
-    pub fn init_compiled(&mut self, entity: CompiledFuncEntity) {
-        assert!(
-            self.phase.is_uninit(),
-            "function ({:?}) must be uninitialized but found: {:?}",
-            self.func,
-            self.phase
-        );
-        *self.func.get_mut() = entity.into();
-        assert!(
-            self.phase.init_compiled().is_ok(),
-            "function ({:?}) must be initializing but found: {:?}",
-            self.func,
-            self.phase
-        )
-    }
-
-    /// Initializes the [`CompiledFunc`] to an uncompiled state.
-    ///
-    /// # Panics
-    ///
-    /// If `func` has already been initialized [`CompiledFunc`].
-    pub fn init_uncompiled(
-        &mut self,
-        func_idx: FuncIdx,
-        bytes: &[u8],
-        module: &ModuleHeader,
-        func_to_validate: Option<FuncToValidate<ValidatorResources>>,
-    ) {
-        assert!(
-            self.phase.is_uninit(),
-            "function ({:?}) must be uninitialized but found: {:?}",
-            self.func,
-            self.phase
-        );
-        *self.func.get_mut() =
-            UncompiledFuncEntity::new(func_idx, bytes, module.clone(), func_to_validate).into();
-        assert!(
-            self.phase.init_uncompiled().is_ok(),
-            "function ({:?}) must be initializing but found: {:?}",
-            self.func,
-            self.phase
-        )
-    }
-
-    /// Returns the [`CompiledFuncEntity`] if possible.
-    ///
-    /// Returns `None` if the [`FuncEntity`] has not yet been compiled.
-    #[inline]
-    pub fn get_compiled(&self) -> Option<&CompiledFuncEntity> {
-        if self.phase.is_compiled() {
-            // SAFETY: Since `phase.is_compiled()` returned `true` we are guaranteed that
-            //         `self.func` is immutably initialized with a `CompiledFuncEntity`.
-            //         A `CompiledFuncEntity` cannot be mutated after it has been compiled.
-            match unsafe { &*self.func.get() } {
-                InternalFuncEntity::Compiled(func) => return Some(func),
-                InternalFuncEntity::Uncompiled(_func) => {
-                    // SAFETY: Since the function is in compiled state we are guaranteed
-                    //         that it is an `InternalFuncEntity::Compiled` variant.
-                    unsafe { hint::unreachable_unchecked() }
-                }
-            }
-        }
-        None
-    }
-
-    /// Compile the [`FuncEntity`] if necessary and return the resulting [`CompiledFuncEntity`].
-    ///
-    /// # Note
-    ///
-    /// This will either compile the [`FuncEntity`] or busy wait until
-    /// another thread is done compiling the [`FuncEntity`].
-    ///
-    /// # Errors
-    ///
-    /// - If translation or Wasm validation of the [`FuncEntity`] failed.
-    /// - If `ctx` ran out of fuel in case fuel consumption is enabled.
-    #[cold]
-    pub fn compile_and_get(
-        &self,
-        mut fuel: Option<&mut Fuel>,
-        features: &WasmFeatures,
-    ) -> Result<&CompiledFuncEntity, Error> {
-        loop {
-            if let Some(func) = self.get_compiled() {
-                // Case: The function has been compiled and can be returned.
-                return Ok(func);
-            }
-            if matches!(self.phase.get(), CompilationPhase::CompilationFailed) {
-                // Case: Another thread failed to compile the function.
-                return Err(Error::from(TranslationError::LazyCompilationFailed));
-            }
-            let Ok(_) = self.phase.set_compiling() else {
-                // Case: Another thread is currently compiling the function so we have to wait.
-                continue;
-            };
-            // At this point we are now in charge of driving the function translation.
-            //
-            // SAFETY: This method is only called after a lock has been acquired
-            //         to take responsibility for driving the function translation.
-            let func = unsafe { &mut *self.func.get() };
-            // Note: We need to use `take` because Rust doesn't know that this part of
-            //       the loop is only executed once.
-            let fuel = fuel.take();
-            match func.compile(fuel, features) {
-                Ok(()) => {
-                    self.phase
-                        .set_compiled()
-                        .expect("unexpectedly failed to finish function compilation");
-                }
-                Err(error) => {
-                    self.phase
-                        .set_compilation_failed()
-                        .expect("unexpectedly failed to mark function compilation failed");
-                    return Err(error);
-                }
-            }
-        }
-    }
 }
 
 impl CodeMap {
     /// Creates a new [`CodeMap`].
     pub fn new(config: &Config) -> Self {
         Self {
-            funcs: Arena::default(),
+            funcs: Mutex::new(Arena::default()),
             features: config.wasm_features(),
         }
     }
@@ -699,8 +496,8 @@ impl CodeMap {
     ///
     /// The uninitialized [`CompiledFunc`] must be initialized using
     /// [`CodeMap::init_func`] before it is executed.
-    pub fn alloc_func(&mut self) -> CompiledFunc {
-        self.funcs.alloc(FuncEntity::uninit())
+    pub fn alloc_func(&self) -> CompiledFunc {
+        self.funcs.lock().alloc(InternalFuncEntity::Uninit)
     }
 
     /// Initializes the [`CompiledFunc`] with its [`CompiledFuncEntity`].
@@ -709,9 +506,10 @@ impl CodeMap {
     ///
     /// - If `func` is an invalid [`CompiledFunc`] reference for this [`CodeMap`].
     /// - If `func` refers to an already initialized [`CompiledFunc`].
-    pub fn init_func(&mut self, func: CompiledFunc, entity: CompiledFuncEntity) {
-        let Some(func) = self.funcs.get_mut(func) else {
-            panic!("encountered invalid function index for initialization: {func:?}")
+    pub fn init_func(&self, func: CompiledFunc, entity: CompiledFuncEntity) {
+        let mut funcs = self.funcs.lock();
+        let Some(func) = funcs.get_mut(func) else {
+            panic!("encountered invalid internal function: {func:?}")
         };
         func.init_compiled(entity);
     }
@@ -723,17 +521,23 @@ impl CodeMap {
     /// - If `func` is an invalid [`CompiledFunc`] reference for this [`CodeMap`].
     /// - If `func` refers to an already initialized [`CompiledFunc`].
     pub fn init_lazy_func(
-        &mut self,
+        &self,
         func: CompiledFunc,
         func_idx: FuncIdx,
         bytes: &[u8],
         module: &ModuleHeader,
         func_to_validate: Option<FuncToValidate<ValidatorResources>>,
     ) {
-        let Some(func) = self.funcs.get_mut(func) else {
-            panic!("encountered invalid function index for initialization: {func:?}")
+        let mut funcs = self.funcs.lock();
+        let Some(func) = funcs.get_mut(func) else {
+            panic!("encountered invalid internal function: {func:?}")
         };
-        func.init_uncompiled(func_idx, bytes, module, func_to_validate);
+        func.init_uncompiled(UncompiledFuncEntity::new(
+            func_idx,
+            bytes,
+            module.clone(),
+            func_to_validate,
+        ));
     }
 
     /// Returns the [`InternalFuncEntity`] of the [`CompiledFunc`].
@@ -743,17 +547,81 @@ impl CodeMap {
     /// - If translation or Wasm validation of the [`FuncEntity`] failed.
     /// - If `ctx` ran out of fuel in case fuel consumption is enabled.
     #[track_caller]
-    pub fn get(
-        &self,
+    pub fn get<'a>(
+        &'a self,
         fuel: Option<&mut Fuel>,
-        compiled_func: CompiledFunc,
-    ) -> Result<&CompiledFuncEntity, Error> {
-        let Some(func) = self.funcs.get(compiled_func) else {
-            panic!("invalid compiled func: {compiled_func:?}")
+        func: CompiledFunc,
+    ) -> Result<CompiledFuncRef<'a>, Error> {
+        let mut funcs = self.funcs.lock();
+        let Some(entity) = funcs.get_mut(func) else {
+            panic!("encountered invalid internal function: {func:?}")
         };
-        match func.get_compiled() {
-            Some(func) => Ok(func),
-            None => func.compile_and_get(fuel, &self.features),
+        if let Some(cref) = self.get_compiled(entity) {
+            return Ok(cref);
+        }
+        if let Ok(entity) = entity.get_uncompiled() {
+            drop(funcs);
+            return self.compile(fuel, func, entity);
+        }
+        drop(funcs);
+        self.wait_for_compilation(func)
+    }
+
+    fn get_compiled<'a>(&'a self, entity: &InternalFuncEntity) -> Option<CompiledFuncRef<'a>> {
+        let cref = entity.get_compiled()?;
+        Some(self.adjust_cref_lifetime(cref))
+    }
+
+    fn adjust_cref_lifetime<'a>(&'a self, cref: CompiledFuncRef<'_>) -> CompiledFuncRef<'a> {
+        // Safety: we cast the lifetime of `cref` to match `&self` instead of the inner
+        //         `MutexGuard` which is safe because `CodeMap` is append-only and the
+        //         returned `CompiledFuncRef` only references `Pin`ned data.
+        unsafe { mem::transmute::<CompiledFuncRef<'_>, CompiledFuncRef<'a>>(cref) }
+    }
+
+    fn compile<'a>(
+        &'a self,
+        fuel: Option<&mut Fuel>,
+        func: CompiledFunc,
+        mut entity: UncompiledFuncEntity,
+    ) -> Result<CompiledFuncRef<'a>, Error> {
+        let compiled_func = entity.compile(fuel, &self.features);
+        let mut funcs = self.funcs.lock();
+        let Some(entity) = funcs.get_mut(func) else {
+            panic!("encountered invalid internal function: {func:?}")
+        };
+        match compiled_func {
+            Ok(compiled_func) => {
+                let cref = entity.set_compiled(compiled_func);
+                Ok(self.adjust_cref_lifetime(cref))
+            }
+            Err(error) => {
+                entity.set_failed_to_compile();
+                Err(error)
+            }
+        }
+    }
+
+    fn wait_for_compilation(&self, func: CompiledFunc) -> Result<CompiledFuncRef, Error> {
+        'wait: loop {
+            let funcs = self.funcs.lock();
+            let Some(entity) = funcs.get(func) else {
+                panic!("encountered invalid internal function: {func:?}")
+            };
+            match entity {
+                InternalFuncEntity::Compiling => continue 'wait,
+                InternalFuncEntity::Compiled(func) => {
+                    let cref = CompiledFuncRef::from(func);
+                    return Ok(self.adjust_cref_lifetime(cref));
+                }
+                InternalFuncEntity::FailedToCompile => {
+                    // return Err(CodeMapError::FailedToCompile)
+                    todo!()
+                }
+                InternalFuncEntity::Uncompiled(_) | InternalFuncEntity::Uninit => {
+                    panic!("unexpected function state: {entity:?}")
+                }
+            }
         }
     }
 }

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -81,8 +81,10 @@ impl CodeMap {
     ///
     /// # Note
     ///
-    /// The uninitialized [`CompiledFunc`] must be initialized using
-    /// [`CodeMap::init_func`] before it is executed.
+    /// Before using the [`CodeMap`] the [`CompiledFunc`] must be initialized with either of:
+    ///
+    /// - [`CodeMap::init_func_as_compiled`]
+    /// - [`CodeMap::init_func_as_uncompiled`]
     pub fn alloc_func(&self) -> CompiledFunc {
         self.funcs.lock().alloc(FuncEntity::Uninit)
     }
@@ -181,7 +183,7 @@ impl CodeMap {
 
     /// Returns the [`UncompiledFuncEntity`] of `func` if possible, otherwise returns `None`.
     ///
-    /// After this operation `func` will be in [`InternalFuncEntity::Compiling`] state.
+    /// After this operation `func` will be in [`FuncEntity::Compiling`] state.
     #[inline]
     fn get_uncompiled(&self, func: CompiledFunc) -> Option<UncompiledFuncEntity> {
         let mut funcs = self.funcs.lock();

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -126,9 +126,9 @@ impl InternalFuncEntity {
         match mem::replace(self, Self::Compiling) {
             Self::Uncompiled(func) => Some(func),
             _ => {
-                // Safety: this is just called internally with function indices
-                //         that are known to be valid. Since this is a performance
-                //         critical path we need to leave out this check.
+                // Safety: we just asserted that `self` must be an uncompiled function
+                //         since otherwise we would have returned `None` above.
+                //         Since this is a performance critical path we need to leave out this check.
                 unsafe { core::hint::unreachable_unchecked() }
             }
         }

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -628,8 +628,8 @@ impl CodeMap {
         }
     }
 
-    #[inline]
     #[cold]
+    #[inline(never)]
     fn wait_for_compilation(&self, func: CompiledFunc) -> Result<CompiledFuncRef, Error> {
         'wait: loop {
             let funcs = self.funcs.lock();

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -511,7 +511,7 @@ impl fmt::Debug for UncompiledFuncEntity {
     }
 }
 
-/// A boxed byte slice that stores up to 30 bytes inline.
+/// A boxed byte slice that can store some bytes inline.
 #[derive(Debug)]
 pub enum SmallByteSlice {
     /// The byte slice fits in the inline buffer.

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -86,7 +86,7 @@ impl InternalFuncEntity {
     /// If `func` has already been initialized.
     #[inline]
     pub fn init_compiled(&mut self, entity: CompiledFuncEntity) {
-        assert!(matches!(self, Self::Uninit | Self::Compiling));
+        assert!(matches!(self, Self::Uninit));
         *self = Self::Compiled(entity);
     }
 

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -611,6 +611,8 @@ impl CodeMap {
         func: CompiledFunc,
         mut entity: UncompiledFuncEntity,
     ) -> Result<CompiledFuncRef<'a>, Error> {
+        // Note: it is important that compilation happens without locking the `CodeMap`
+        //       since compilation can take a prolonged time.
         let compiled_func = entity.compile(fuel, &self.features);
         let mut funcs = self.funcs.lock();
         let Some(entity) = funcs.get_mut(func) else {

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -126,7 +126,9 @@ impl InternalFuncEntity {
         match mem::replace(self, Self::Compiling) {
             Self::Uncompiled(func) => Some(func),
             _ => {
-                // Safety: TODO
+                // Safety: this is just called internally with function indices
+                //         that are known to be valid. Since this is a performance
+                //         critical path we need to leave out this check.
                 unsafe { core::hint::unreachable_unchecked() }
             }
         }

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -376,18 +376,6 @@ impl InternalFuncEntity {
     }
 }
 
-impl From<CompiledFuncEntity> for InternalFuncEntity {
-    fn from(func: CompiledFuncEntity) -> Self {
-        Self::Compiled(func)
-    }
-}
-
-impl From<UncompiledFuncEntity> for InternalFuncEntity {
-    fn from(func: UncompiledFuncEntity) -> Self {
-        Self::Uncompiled(func)
-    }
-}
-
 /// An internal uncompiled function entity.
 pub struct UncompiledFuncEntity {
     /// The index of the function within the Wasm module.

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -565,7 +565,9 @@ impl CodeMap {
     ) -> Result<CompiledFuncRef<'a>, Error> {
         let funcs = self.funcs.lock();
         let Some(entity) = funcs.get(func) else {
-            // panic!("encountered invalid internal function: {func:?}")
+            // Safety: this is just called internally with function indices
+            //         that are known to be valid. Since this is a performance
+            //         critical path we need to leave out this check.
             unsafe { core::hint::unreachable_unchecked() }
         };
         if let Some(cref) = self.get_compiled(entity) {

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -538,6 +538,9 @@ impl Default for SmallByteSlice {
 
 impl SmallByteSlice {
     /// The maximum amount of bytes that can be stored inline.
+    /// 
+    /// This value was chosen because it allows for the maximum
+    /// amount of bytes stored inline with minimal `size_of`.
     const MAX_INLINE_SIZE: usize = 22;
 
     /// Returns the underlying slice of bytes.

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -3,10 +3,9 @@ use crate::{
     core::TrapCode,
     engine::{
         bytecode::{FuncIdx, Instruction, Register, RegisterSpan, SignatureIdx, TableIdx},
-        code_map::InstructionPtr,
+        code_map::{CompiledFuncRef, InstructionPtr},
         executor::stack::{CallFrame, FrameParams, ValueStack},
         CompiledFunc,
-        CompiledFuncEntity,
         FuncParams,
     },
     func::{FuncEntity, HostFuncEntity},
@@ -203,7 +202,7 @@ impl<'engine> Executor<'engine> {
     fn dispatch_compiled_func<C: CallContext>(
         &mut self,
         results: RegisterSpan,
-        func: &CompiledFuncEntity,
+        func: CompiledFuncRef,
     ) -> Result<CallFrame, Error> {
         // We have to reinstantiate the `self.sp` [`FrameRegisters`] since we just called
         // [`ValueStack::alloc_call_frame`] which might invalidate all live [`FrameRegisters`].

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -49,9 +49,8 @@ impl EngineInner {
     where
         Results: CallResults,
     {
-        let res = self.code_map.read();
         let mut stack = self.stacks.lock().reuse_or_new();
-        let results = EngineExecutor::new(&res, &mut stack)
+        let results = EngineExecutor::new(&self.code_map, &mut stack)
             .execute_root_func(ctx.store, func, params, results)
             .map_err(|error| match error.into_resumable() {
                 Ok(error) => error.into_error(),
@@ -79,9 +78,8 @@ impl EngineInner {
         Results: CallResults,
     {
         let store = ctx.store;
-        let code_map = self.code_map.read();
         let mut stack = self.stacks.lock().reuse_or_new();
-        let results = EngineExecutor::new(&code_map, &mut stack)
+        let results = EngineExecutor::new(&self.code_map, &mut stack)
             .execute_root_func(store, func, params, results);
         match results {
             Ok(results) => {
@@ -127,10 +125,9 @@ impl EngineInner {
     where
         Results: CallResults,
     {
-        let code_map = self.code_map.read();
         let host_func = invocation.host_func();
         let caller_results = invocation.caller_results();
-        let results = EngineExecutor::new(&code_map, &mut invocation.stack).resume_func(
+        let results = EngineExecutor::new(&self.code_map, &mut invocation.stack).resume_func(
             ctx.store,
             host_func,
             params,

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -1,7 +1,7 @@
 use super::{err_stack_overflow, StackOffsets};
 use crate::{
     core::{TrapCode, UntypedVal},
-    engine::{bytecode::Register, CompiledFuncEntity},
+    engine::{bytecode::Register, code_map::CompiledFuncRef},
 };
 use core::{
     fmt::{self, Debug},
@@ -218,7 +218,7 @@ impl ValueStack {
     /// When trying to grow the [`ValueStack`] over its maximum size limit.
     pub fn alloc_call_frame(
         &mut self,
-        func: &CompiledFuncEntity,
+        func: CompiledFuncRef,
         on_resize: impl FnMut(&mut Self),
     ) -> Result<(FrameParams, StackOffsets), TrapCode> {
         let len_registers = func.len_registers();

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -702,7 +702,7 @@ impl EngineInner {
     /// - If `func` is an invalid [`CompiledFunc`] reference for this [`CodeMap`].
     /// - If `func` refers to an already initialized [`CompiledFunc`].
     fn init_func(&self, compiled_func: CompiledFunc, func_entity: CompiledFuncEntity) {
-        self.code_map.init_func(compiled_func, func_entity)
+        self.code_map.init_func_as_compiled(compiled_func, func_entity)
     }
 
     /// Initializes the uninitialized [`CompiledFunc`] for the [`Engine`].
@@ -725,7 +725,7 @@ impl EngineInner {
         func_to_validate: Option<FuncToValidate<ValidatorResources>>,
     ) {
         self.code_map
-            .init_lazy_func(func, func_idx, bytes, module, func_to_validate)
+            .init_func_as_uncompiled(func, func_idx, bytes, module, func_to_validate)
     }
 
     /// Resolves the [`InternalFuncEntity`] for [`CompiledFunc`] and applies `f` to it.

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -702,7 +702,8 @@ impl EngineInner {
     /// - If `func` is an invalid [`CompiledFunc`] reference for this [`CodeMap`].
     /// - If `func` refers to an already initialized [`CompiledFunc`].
     fn init_func(&self, compiled_func: CompiledFunc, func_entity: CompiledFuncEntity) {
-        self.code_map.init_func_as_compiled(compiled_func, func_entity)
+        self.code_map
+            .init_func_as_compiled(compiled_func, func_entity)
     }
 
     /// Initializes the uninitialized [`CompiledFunc`] for the [`Engine`].

--- a/crates/wasmi/tests/e2e/v1/host_call_compilation.rs
+++ b/crates/wasmi/tests/e2e/v1/host_call_compilation.rs
@@ -1,0 +1,43 @@
+//! This tests that a host function called from Wasm can compile Wasm modules and does not deadlock.
+
+use wasmi::{AsContextMut, Caller, Engine, Linker, Module, Store};
+
+/// Converts the given `.wat` into `.wasm`.
+fn wat2wasm(wat: &str) -> Result<Vec<u8>, wat::Error> {
+    wat::parse_str(wat)
+}
+
+fn compile_module(engine: &Engine) -> wasmi::Module {
+    let wasm = wat2wasm(include_str!("../wat/host_call_compilation.wat")).unwrap();
+    Module::new(&engine, &wasm[..]).unwrap()
+}
+
+#[test]
+fn test_compile_in_host_call() {
+    let engine = Engine::default();
+    let mut store = <Store<()>>::new(&engine, ());
+    let module = compile_module(store.engine());
+    let mut linker = <Linker<()>>::new(&engine);
+    linker
+        .func_wrap(
+            "env",
+            "compile",
+            |mut caller: Caller<()>| -> Result<(), wasmi::Error> {
+                let store = caller.as_context_mut();
+                let engine = store.engine();
+                let _module = compile_module(engine);
+                Ok(())
+            },
+        )
+        .unwrap();
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .unwrap()
+        .ensure_no_start(&mut store)
+        .unwrap();
+    instance
+        .get_typed_func::<(), ()>(&mut store, "run")
+        .unwrap()
+        .call(&mut store, ())
+        .unwrap();
+}

--- a/crates/wasmi/tests/e2e/v1/host_call_compilation.rs
+++ b/crates/wasmi/tests/e2e/v1/host_call_compilation.rs
@@ -9,7 +9,7 @@ fn wat2wasm(wat: &str) -> Result<Vec<u8>, wat::Error> {
 
 fn compile_module(engine: &Engine) -> wasmi::Module {
     let wasm = wat2wasm(include_str!("../wat/host_call_compilation.wat")).unwrap();
-    Module::new(&engine, &wasm[..]).unwrap()
+    Module::new(engine, &wasm[..]).unwrap()
 }
 
 #[test]

--- a/crates/wasmi/tests/e2e/v1/mod.rs
+++ b/crates/wasmi/tests/e2e/v1/mod.rs
@@ -1,6 +1,7 @@
 mod fuel_consumption;
 mod fuel_metering;
 mod func;
+mod host_call_compilation;
 mod host_call_instantiation;
 mod host_calls_wasm;
 mod resource_limiter;

--- a/crates/wasmi/tests/e2e/wat/host_call_compilation.wat
+++ b/crates/wasmi/tests/e2e/wat/host_call_compilation.wat
@@ -1,0 +1,7 @@
+(module
+    (import "env" "compile" (func $compile))
+
+    (func (export "run")
+        (call $compile)
+    )
+)


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/631.

This is another relatively naive fix for #631. It heavily refactors the `CodeMap` to no longer use atomics for synchronization but a global `Mutex`. The idea behind this is that this is the lowest we can get with simple synchronization locks. If this technique does not suffice the performance needs, we need to look elsewhere.

Benchmarks comparing this PR with `main`:

Rust-sourced benchmarks do not significantly regress:

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/793e89d1-e40c-4199-bd27-7c530b8347e5)

Call-intense benchmark regress as expected:

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/b589c6e4-ef36-42c8-b74f-65e080146f50)

Other benchmarks are also not signficantly affected:

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/b0fd5014-7cc1-42a6-8345-500b67636f85)
