### PR TITLE
Rename `CompiledFunc` to `EngineFunc`

### DIFF
--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -8,11 +8,11 @@ use super::{
     BranchBinOpInstrImm16,
     BranchOffset,
     CallIndirectParams,
-    CompiledFunc,
     Const16,
     Const32,
     DataSegmentIdx,
     ElementSegmentIdx,
+    EngineFunc,
     FuncIdx,
     GlobalIdx,
     Instruction,
@@ -981,12 +981,12 @@ impl Instruction {
     }
 
     /// Creates a new [`Instruction::CallInternal0`] for the given `func`.
-    pub fn return_call_internal_0(func: CompiledFunc) -> Self {
+    pub fn return_call_internal_0(func: EngineFunc) -> Self {
         Self::ReturnCallInternal0 { func }
     }
 
     /// Creates a new [`Instruction::CallInternal`] for the given `func`.
-    pub fn return_call_internal(func: CompiledFunc) -> Self {
+    pub fn return_call_internal(func: EngineFunc) -> Self {
         Self::ReturnCallInternal { func }
     }
 
@@ -1015,12 +1015,12 @@ impl Instruction {
     }
 
     /// Creates a new [`Instruction::CallInternal0`] for the given `func`.
-    pub fn call_internal_0(results: RegisterSpan, func: CompiledFunc) -> Self {
+    pub fn call_internal_0(results: RegisterSpan, func: EngineFunc) -> Self {
         Self::CallInternal0 { results, func }
     }
 
     /// Creates a new [`Instruction::CallInternal`] for the given `func`.
-    pub fn call_internal(results: RegisterSpan, func: CompiledFunc) -> Self {
+    pub fn call_internal(results: RegisterSpan, func: EngineFunc) -> Self {
         Self::CallInternal { results, func }
     }
 

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -43,7 +43,7 @@ pub(crate) use self::{
         UnaryInstr,
     },
 };
-use crate::{core::TrapCode, engine::CompiledFunc, Error};
+use crate::{core::TrapCode, engine::EngineFunc, Error};
 use core::num::{NonZeroI32, NonZeroI64, NonZeroU32, NonZeroU64};
 
 /// A Wasmi instruction.
@@ -698,7 +698,7 @@ pub enum Instruction {
     /// Used for tail calling internally compiled Wasm functions without parameters.
     ReturnCallInternal0 {
         /// The called internal function.
-        func: CompiledFunc,
+        func: EngineFunc,
     },
     /// Wasm `return_call` equivalent Wasmi instruction.
     ///
@@ -717,7 +717,7 @@ pub enum Instruction {
     ///     - [`Instruction::Register3`]
     ReturnCallInternal {
         /// The called internal function.
-        func: CompiledFunc,
+        func: EngineFunc,
     },
 
     /// Wasm `return_call` equivalent Wasmi instruction.
@@ -798,7 +798,7 @@ pub enum Instruction {
         /// The registers storing the results of the call.
         results: RegisterSpan,
         /// The called internal function.
-        func: CompiledFunc,
+        func: EngineFunc,
     },
     /// Wasm `call` equivalent Wasmi instruction.
     ///
@@ -819,7 +819,7 @@ pub enum Instruction {
         /// The registers storing the results of the call.
         results: RegisterSpan,
         /// The called internal function.
-        func: CompiledFunc,
+        func: EngineFunc,
     },
 
     /// Wasm `call` equivalent Wasmi instruction.

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         code_map::CompiledFuncRef,
         executor::stack::{CallFrame, FrameParams, ValueStack},
-        CompiledFunc,
+        EngineFunc,
         FuncParams,
     },
     func::{FuncEntity, HostFuncEntity},
@@ -205,7 +205,7 @@ impl<'engine> Executor<'engine> {
         }
     }
 
-    /// Creates a [`CallFrame`] for calling the [`CompiledFunc`].
+    /// Creates a [`CallFrame`] for calling the [`EngineFunc`].
     #[inline(always)]
     fn dispatch_compiled_func<C: CallContext>(
         &mut self,
@@ -287,13 +287,13 @@ impl<'engine> Executor<'engine> {
         }
     }
 
-    /// Prepares a [`CompiledFunc`] call with optional call parameters.
+    /// Prepares a [`EngineFunc`] call with optional call parameters.
     #[inline(always)]
     fn prepare_compiled_func_call<C: CallContext>(
         &mut self,
         store: &mut StoreInner,
         results: RegisterSpan,
-        func: CompiledFunc,
+        func: EngineFunc,
         mut instance: Option<Instance>,
     ) -> Result<(), Error> {
         let func = self.code_map.get(Some(store.fuel_mut()), func)?;
@@ -330,7 +330,7 @@ impl<'engine> Executor<'engine> {
     pub fn execute_return_call_internal_0(
         &mut self,
         store: &mut StoreInner,
-        func: CompiledFunc,
+        func: EngineFunc,
     ) -> Result<(), Error> {
         self.execute_return_call_internal_impl::<marker::ReturnCall0>(store, func)
     }
@@ -340,7 +340,7 @@ impl<'engine> Executor<'engine> {
     pub fn execute_return_call_internal(
         &mut self,
         store: &mut StoreInner,
-        func: CompiledFunc,
+        func: EngineFunc,
     ) -> Result<(), Error> {
         self.execute_return_call_internal_impl::<marker::ReturnCall>(store, func)
     }
@@ -349,7 +349,7 @@ impl<'engine> Executor<'engine> {
     fn execute_return_call_internal_impl<C: CallContext>(
         &mut self,
         store: &mut StoreInner,
-        func: CompiledFunc,
+        func: EngineFunc,
     ) -> Result<(), Error> {
         let results = self.caller_results();
         self.prepare_compiled_func_call::<C>(store, results, func, None)
@@ -377,7 +377,7 @@ impl<'engine> Executor<'engine> {
         &mut self,
         store: &mut StoreInner,
         results: RegisterSpan,
-        func: CompiledFunc,
+        func: EngineFunc,
     ) -> Result<(), Error> {
         self.prepare_compiled_func_call::<marker::NestedCall0>(store, results, func, None)
     }
@@ -388,7 +388,7 @@ impl<'engine> Executor<'engine> {
         &mut self,
         store: &mut StoreInner,
         results: RegisterSpan,
-        func: CompiledFunc,
+        func: EngineFunc,
     ) -> Result<(), Error> {
         self.prepare_compiled_func_call::<marker::NestedCall>(store, results, func, None)
     }

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -199,10 +199,10 @@ impl<'engine> EngineExecutor<'engine> {
                 let len_results = results.len_results();
                 self.stack.values.extend_by(len_results, do_nothing)?;
                 let instance = *wasm_func.instance();
-                let compiled_func = wasm_func.func_body();
+                let engine_func = wasm_func.func_body();
                 let compiled_func = self
                     .code_map
-                    .get(Some(store.inner.fuel_mut()), compiled_func)?;
+                    .get(Some(store.inner.fuel_mut()), engine_func)?;
                 let (mut uninit_params, offsets) = self
                     .stack
                     .values

--- a/crates/wasmi/src/engine/executor/stack/calls.rs
+++ b/crates/wasmi/src/engine/executor/stack/calls.rs
@@ -12,7 +12,7 @@ use crate::{
     engine::bytecode::Instruction,
     engine::bytecode::Register,
     engine::executor::stack::ValueStack,
-    engine::CompiledFunc,
+    engine::EngineFunc,
     Global,
     Memory,
     Table,
@@ -190,7 +190,7 @@ impl StackOffsets {
     }
 }
 
-/// A single frame of a called [`CompiledFunc`].
+/// A single frame of a called [`EngineFunc`].
 #[derive(Debug, Copy, Clone)]
 pub struct CallFrame {
     /// The pointer to the [`Instruction`] that is executed next.

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -15,7 +15,7 @@ use std::vec::Vec;
 #[cfg(doc)]
 use super::calls::CallFrame;
 #[cfg(doc)]
-use crate::engine::CompiledFunc;
+use crate::engine::EngineFunc;
 
 pub struct ValueStack {
     /// The values on the [`ValueStack`].
@@ -203,14 +203,14 @@ impl ValueStack {
         unsafe { self.values.set_len(new_len) };
     }
 
-    /// Allocates a new [`CompiledFunc`] on the [`ValueStack`].
+    /// Allocates a new [`EngineFunc`] on the [`ValueStack`].
     ///
-    /// Returns the [`BaseValueStackOffset`] and [`FrameValueStackOffset`] of the allocated [`CompiledFunc`].
+    /// Returns the [`BaseValueStackOffset`] and [`FrameValueStackOffset`] of the allocated [`EngineFunc`].
     ///
     /// # Note
     ///
     /// - All live [`FrameRegisters`] might be invalidated and need to be reinstantiated.
-    /// - The parameters of the allocated [`CompiledFunc`] are set to zero
+    /// - The parameters of the allocated [`EngineFunc`] are set to zero
     ///   and require proper initialization after this call.
     ///
     /// # Errors

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -37,7 +37,7 @@ pub(crate) use self::{
     },
 };
 pub use self::{
-    code_map::CompiledFunc,
+    code_map::EngineFunc,
     config::{CompilationMode, Config},
     executor::ResumableHostError,
     limits::{EnforcedLimits, EnforcedLimitsError, StackLimits},
@@ -190,10 +190,10 @@ impl Engine {
         self.inner.resolve_func_type(func_type, f)
     }
 
-    /// Allocates a new uninitialized [`CompiledFunc`] to the [`Engine`].
+    /// Allocates a new uninitialized [`EngineFunc`] to the [`Engine`].
     ///
-    /// Returns a [`CompiledFunc`] reference to allow accessing the allocated [`CompiledFunc`].
-    pub(super) fn alloc_func(&self) -> CompiledFunc {
+    /// Returns a [`EngineFunc`] reference to allow accessing the allocated [`EngineFunc`].
+    pub(super) fn alloc_func(&self) -> EngineFunc {
         self.inner.alloc_func()
     }
 
@@ -205,7 +205,7 @@ impl Engine {
     /// # Parameters
     ///
     /// - `func_index`: The index of the translated function within its Wasm module.
-    /// - `compiled_func`: The index of the translated function in the [`Engine`].
+    /// - `engine_func`: The index of the translated function in the [`Engine`].
     /// - `offset`: The global offset of the Wasm function body within the Wasm binary.
     /// - `bytes`: The bytes that make up the Wasm encoded function body of the translated function.
     /// - `module`: The module header information of the Wasm module of the translated function.
@@ -218,7 +218,7 @@ impl Engine {
     pub(crate) fn translate_func(
         &self,
         func_index: FuncIdx,
-        compiled_func: CompiledFunc,
+        engine_func: EngineFunc,
         offset: usize,
         bytes: &[u8],
         module: ModuleHeader,
@@ -231,7 +231,7 @@ impl Engine {
                 let translator = FuncTranslator::new(func_index, module, translation_allocs)?;
                 let translator = ValidatingFuncTranslator::new(validator, translator)?;
                 let allocs = FuncTranslationDriver::new(offset, bytes, translator)?
-                    .translate(|func_entity| self.inner.init_func(compiled_func, func_entity))?;
+                    .translate(|func_entity| self.inner.init_func(engine_func, func_entity))?;
                 self.inner
                     .recycle_allocs(allocs.translation, allocs.validation);
             }
@@ -239,23 +239,23 @@ impl Engine {
                 let allocs = self.inner.get_translation_allocs();
                 let translator = FuncTranslator::new(func_index, module, allocs)?;
                 let allocs = FuncTranslationDriver::new(offset, bytes, translator)?
-                    .translate(|func_entity| self.inner.init_func(compiled_func, func_entity))?;
+                    .translate(|func_entity| self.inner.init_func(engine_func, func_entity))?;
                 self.inner.recycle_translation_allocs(allocs);
             }
             (CompilationMode::LazyTranslation, Some(func_to_validate)) => {
                 let allocs = self.inner.get_validation_allocs();
-                let translator = LazyFuncTranslator::new(func_index, compiled_func, module, None);
+                let translator = LazyFuncTranslator::new(func_index, engine_func, module, None);
                 let validator = func_to_validate.into_validator(allocs);
                 let translator = ValidatingFuncTranslator::new(validator, translator)?;
                 let allocs = FuncTranslationDriver::new(offset, bytes, translator)?
-                    .translate(|func_entity| self.inner.init_func(compiled_func, func_entity))?;
+                    .translate(|func_entity| self.inner.init_func(engine_func, func_entity))?;
                 self.inner.recycle_validation_allocs(allocs.validation);
             }
             (CompilationMode::Lazy | CompilationMode::LazyTranslation, func_to_validate) => {
                 let translator =
-                    LazyFuncTranslator::new(func_index, compiled_func, module, func_to_validate);
+                    LazyFuncTranslator::new(func_index, engine_func, module, func_to_validate);
                 FuncTranslationDriver::new(offset, bytes, translator)?
-                    .translate(|func_entity| self.inner.init_func(compiled_func, func_entity))?;
+                    .translate(|func_entity| self.inner.init_func(engine_func, func_entity))?;
             }
         }
         Ok(())
@@ -285,7 +285,7 @@ impl Engine {
         self.inner.recycle_allocs(translation, validation)
     }
 
-    /// Initializes the uninitialized [`CompiledFunc`] for the [`Engine`].
+    /// Initializes the uninitialized [`EngineFunc`] for the [`Engine`].
     ///
     /// # Note
     ///
@@ -294,12 +294,12 @@ impl Engine {
     ///
     /// # Panics
     ///
-    /// - If `func` is an invalid [`CompiledFunc`] reference for this [`CodeMap`].
-    /// - If `func` refers to an already initialized [`CompiledFunc`].
+    /// - If `func` is an invalid [`EngineFunc`] reference for this [`CodeMap`].
+    /// - If `func` refers to an already initialized [`EngineFunc`].
     fn init_lazy_func(
         &self,
         func_idx: FuncIdx,
-        func: CompiledFunc,
+        func: EngineFunc,
         bytes: &[u8],
         module: &ModuleHeader,
         func_to_validate: Option<FuncToValidate<ValidatorResources>>,
@@ -308,7 +308,7 @@ impl Engine {
             .init_lazy_func(func_idx, func, bytes, module, func_to_validate)
     }
 
-    /// Resolves the [`CompiledFunc`] to the underlying Wasmi bytecode instructions.
+    /// Resolves the [`EngineFunc`] to the underlying Wasmi bytecode instructions.
     ///
     /// # Note
     ///
@@ -324,18 +324,18 @@ impl Engine {
     ///
     /// # Panics
     ///
-    /// - If the [`CompiledFunc`] is invalid for the [`Engine`].
+    /// - If the [`EngineFunc`] is invalid for the [`Engine`].
     /// - If register machine bytecode translation is disabled.
     #[cfg(test)]
     pub(crate) fn resolve_instr(
         &self,
-        func: CompiledFunc,
+        func: EngineFunc,
         index: usize,
     ) -> Result<Option<Instruction>, Error> {
         self.inner.resolve_instr(func, index)
     }
 
-    /// Resolves the function local constant of [`CompiledFunc`] at `index` if any.
+    /// Resolves the function local constant of [`EngineFunc`] at `index` if any.
     ///
     /// # Note
     ///
@@ -349,14 +349,10 @@ impl Engine {
     ///
     /// # Panics
     ///
-    /// - If the [`CompiledFunc`] is invalid for the [`Engine`].
+    /// - If the [`EngineFunc`] is invalid for the [`Engine`].
     /// - If register machine bytecode translation is disabled.
     #[cfg(test)]
-    fn get_func_const(
-        &self,
-        func: CompiledFunc,
-        index: usize,
-    ) -> Result<Option<UntypedVal>, Error> {
+    fn get_func_const(&self, func: EngineFunc, index: usize) -> Result<Option<UntypedVal>, Error> {
         self.inner.get_func_const(func, index)
     }
 
@@ -633,10 +629,10 @@ impl EngineInner {
         f(self.func_types.read().resolve_func_type(func_type))
     }
 
-    /// Allocates a new uninitialized [`CompiledFunc`] to the [`EngineInner`].
+    /// Allocates a new uninitialized [`EngineFunc`] to the [`EngineInner`].
     ///
-    /// Returns a [`CompiledFunc`] reference to allow accessing the allocated [`CompiledFunc`].
-    fn alloc_func(&self) -> CompiledFunc {
+    /// Returns a [`EngineFunc`] reference to allow accessing the allocated [`EngineFunc`].
+    fn alloc_func(&self) -> EngineFunc {
         self.code_map.alloc_func()
     }
 
@@ -691,7 +687,7 @@ impl EngineInner {
         allocs.recycle_validation_allocs(validation);
     }
 
-    /// Initializes the uninitialized [`CompiledFunc`] for the [`EngineInner`].
+    /// Initializes the uninitialized [`EngineFunc`] for the [`EngineInner`].
     ///
     /// # Note
     ///
@@ -699,14 +695,14 @@ impl EngineInner {
     ///
     /// # Panics
     ///
-    /// - If `func` is an invalid [`CompiledFunc`] reference for this [`CodeMap`].
-    /// - If `func` refers to an already initialized [`CompiledFunc`].
-    fn init_func(&self, compiled_func: CompiledFunc, func_entity: CompiledFuncEntity) {
+    /// - If `func` is an invalid [`EngineFunc`] reference for this [`CodeMap`].
+    /// - If `func` refers to an already initialized [`EngineFunc`].
+    fn init_func(&self, engine_func: EngineFunc, func_entity: CompiledFuncEntity) {
         self.code_map
-            .init_func_as_compiled(compiled_func, func_entity)
+            .init_func_as_compiled(engine_func, func_entity)
     }
 
-    /// Initializes the uninitialized [`CompiledFunc`] for the [`Engine`].
+    /// Initializes the uninitialized [`EngineFunc`] for the [`Engine`].
     ///
     /// # Note
     ///
@@ -715,12 +711,12 @@ impl EngineInner {
     ///
     /// # Panics
     ///
-    /// - If `func` is an invalid [`CompiledFunc`] reference for this [`CodeMap`].
-    /// - If `func` refers to an already initialized [`CompiledFunc`].
+    /// - If `func` is an invalid [`EngineFunc`] reference for this [`CodeMap`].
+    /// - If `func` refers to an already initialized [`EngineFunc`].
     fn init_lazy_func(
         &self,
         func_idx: FuncIdx,
-        func: CompiledFunc,
+        func: EngineFunc,
         bytes: &[u8],
         module: &ModuleHeader,
         func_to_validate: Option<FuncToValidate<ValidatorResources>>,
@@ -729,13 +725,13 @@ impl EngineInner {
             .init_func_as_uncompiled(func, func_idx, bytes, module, func_to_validate)
     }
 
-    /// Resolves the [`InternalFuncEntity`] for [`CompiledFunc`] and applies `f` to it.
+    /// Resolves the [`InternalFuncEntity`] for [`EngineFunc`] and applies `f` to it.
     ///
     /// # Panics
     ///
-    /// If [`CompiledFunc`] is invalid for [`Engine`].
+    /// If [`EngineFunc`] is invalid for [`Engine`].
     #[cfg(test)]
-    pub(super) fn resolve_func<'a, F, R>(&'a self, func: CompiledFunc, f: F) -> Result<R, Error>
+    pub(super) fn resolve_func<'a, F, R>(&'a self, func: EngineFunc, f: F) -> Result<R, Error>
     where
         F: FnOnce(CompiledFuncRef<'a>) -> R,
     {
@@ -757,7 +753,7 @@ impl EngineInner {
     #[cfg(test)]
     pub(crate) fn resolve_instr(
         &self,
-        func: CompiledFunc,
+        func: EngineFunc,
         index: usize,
     ) -> Result<Option<Instruction>, Error> {
         self.resolve_func(func, |func| func.instrs().get(index).copied())
@@ -775,11 +771,7 @@ impl EngineInner {
     ///
     /// If `func` cannot be resolved to a function for the [`EngineInner`].
     #[cfg(test)]
-    fn get_func_const(
-        &self,
-        func: CompiledFunc,
-        index: usize,
-    ) -> Result<Option<UntypedVal>, Error> {
+    fn get_func_const(&self, func: EngineFunc, index: usize) -> Result<Option<UntypedVal>, Error> {
         // Function local constants are stored in reverse order of their indices since
         // they are allocated in reverse order to their absolute indices during function
         // translation. That is why we need to access them in reverse order.

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -55,7 +55,7 @@ use crate::{
         },
         config::FuelCosts,
         BlockType,
-        CompiledFunc,
+        EngineFunc,
     },
     module::{FuncIdx, FuncTypeIdx, ModuleHeader},
     Engine,
@@ -209,7 +209,7 @@ pub trait WasmTranslator<'parser>: VisitOperator<'parser, Output = Result<(), Er
     ///
     /// # Note
     ///
-    /// - Initialized the [`CompiledFunc`] in the [`Engine`].
+    /// - Initialized the [`EngineFunc`] in the [`Engine`].
     /// - Returns the allocations used for translation.
     fn finish(self, finalize: impl FnOnce(CompiledFuncEntity)) -> Result<Self::Allocations, Error>;
 }
@@ -361,7 +361,7 @@ pub struct LazyFuncTranslator {
     /// The index of the lazily compiled function within its module.
     func_idx: FuncIdx,
     /// The identifier of the to be compiled function.
-    compiled_func: CompiledFunc,
+    engine_func: EngineFunc,
     /// The Wasm module header information used for translation.
     module: ModuleHeader,
     /// Optional information about lazy Wasm validation.
@@ -372,7 +372,7 @@ impl fmt::Debug for LazyFuncTranslator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("LazyFuncTranslator")
             .field("func_idx", &self.func_idx)
-            .field("compiled_func", &self.compiled_func)
+            .field("engine_func", &self.engine_func)
             .field("module", &self.module)
             .field("validate", &self.func_to_validate.is_some())
             .finish()
@@ -383,13 +383,13 @@ impl LazyFuncTranslator {
     /// Create a new [`LazyFuncTranslator`].
     pub fn new(
         func_idx: FuncIdx,
-        compiled_func: CompiledFunc,
+        engine_func: EngineFunc,
         module: ModuleHeader,
         func_to_validate: Option<FuncToValidate<ValidatorResources>>,
     ) -> Self {
         Self {
             func_idx,
-            compiled_func,
+            engine_func,
             module,
             func_to_validate,
         }
@@ -411,7 +411,7 @@ impl<'parser> WasmTranslator<'parser> for LazyFuncTranslator {
             })
             .init_lazy_func(
                 self.func_idx,
-                self.compiled_func,
+                self.engine_func,
                 bytes,
                 &self.module,
                 self.func_to_validate.take(),

--- a/crates/wasmi/src/engine/translator/relink_result.rs
+++ b/crates/wasmi/src/engine/translator/relink_result.rs
@@ -13,7 +13,7 @@ use crate::{
             SignatureIdx,
             UnaryInstr,
         },
-        CompiledFunc,
+        EngineFunc,
     },
     module::ModuleHeader,
     Engine,
@@ -563,7 +563,7 @@ fn get_engine(module: &ModuleHeader) -> Engine {
 
 fn relink_call_internal(
     results: &mut RegisterSpan,
-    func: CompiledFunc,
+    func: EngineFunc,
     module: &ModuleHeader,
     new_result: Register,
     old_result: Register,

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     core::{TrapCode, F32},
     engine::{
         bytecode::{BranchOffset, BranchOffset16, GlobalIdx, RegisterSpan},
-        CompiledFunc,
+        EngineFunc,
     },
 };
 
@@ -57,11 +57,11 @@ fn fuzz_regression_3() {
         .expect_func_instrs([
             Instruction::call_internal_0(
                 RegisterSpan::new(Register::from_i16(0)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::call_internal_0(
                 RegisterSpan::new(Register::from_i16(3)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::branch_table(Register::from_i16(5), 2),
             Instruction::copy_span_non_overlapping(
@@ -98,13 +98,13 @@ fn fuzz_regression_5() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(1)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register(Register::from_i16(0)),
             Instruction::branch_i32_eq_imm(Register::from_i16(3), 0, BranchOffset16::from(5)),
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(2)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register(Register::from_i16(2)),
             Instruction::branch_i32_eq_imm(Register::from_i16(4), 0, BranchOffset16::from(1)),

--- a/crates/wasmi/src/engine/translator/tests/op/call/internal.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/call/internal.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::engine::{CompiledFunc, RegisterSpan};
+use crate::engine::{EngineFunc, RegisterSpan};
 
 #[test]
 #[cfg_attr(miri, ignore)]
@@ -17,7 +17,7 @@ fn no_params() {
         .expect_func_instrs([
             Instruction::call_internal_0(
                 RegisterSpan::new(Register::from_i16(0)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::Return,
         ])
@@ -42,7 +42,7 @@ fn one_param_reg() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(1)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register(0),
             Instruction::return_reg(Register::from_i16(1)),
@@ -69,7 +69,7 @@ fn one_param_imm() {
             ExpectedFunc::new([
                 Instruction::call_internal(
                     RegisterSpan::new(Register::from_i16(0)),
-                    CompiledFunc::from_u32(0),
+                    EngineFunc::from_u32(0),
                 ),
                 Instruction::register(-1),
                 Instruction::return_reg(0),
@@ -98,7 +98,7 @@ fn two_params_reg() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(2)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register2(0, 1),
             Instruction::return_reg2(2, 3),
@@ -125,7 +125,7 @@ fn two_params_reg_rev() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(2)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register2(1, 0),
             Instruction::return_reg2(2, 3),
@@ -153,7 +153,7 @@ fn two_params_imm() {
             ExpectedFunc::new([
                 Instruction::call_internal(
                     RegisterSpan::new(Register::from_i16(0)),
-                    CompiledFunc::from_u32(0),
+                    EngineFunc::from_u32(0),
                 ),
                 Instruction::register2(-1, -2),
                 Instruction::return_reg2(0, 1),
@@ -183,7 +183,7 @@ fn three_params_reg() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(3)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register3(0, 1, 2),
             Instruction::return_reg3(3, 4, 5),
@@ -211,7 +211,7 @@ fn three_params_reg_rev() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(3)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register3(2, 1, 0),
             Instruction::return_reg3(3, 4, 5),
@@ -240,7 +240,7 @@ fn three_params_imm() {
             ExpectedFunc::new([
                 Instruction::call_internal(
                     RegisterSpan::new(Register::from_i16(0)),
-                    CompiledFunc::from_u32(0),
+                    EngineFunc::from_u32(0),
                 ),
                 Instruction::register3(-1, -2, -3),
                 Instruction::return_reg3(0, 1, 2),
@@ -284,7 +284,7 @@ fn params7_reg() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(7)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
@@ -328,7 +328,7 @@ fn params7_reg_rev() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(7)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register_list(6, 5, 4),
             Instruction::register_list(3, 2, 1),
@@ -373,7 +373,7 @@ fn params7_imm() {
             ExpectedFunc::new([
                 Instruction::call_internal(
                     RegisterSpan::new(Register::from_i16(0)),
-                    CompiledFunc::from_u32(0),
+                    EngineFunc::from_u32(0),
                 ),
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
@@ -421,7 +421,7 @@ fn params8_reg() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(8)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
@@ -467,7 +467,7 @@ fn params8_reg_rev() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(8)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register_list(7, 6, 5),
             Instruction::register_list(4, 3, 2),
@@ -514,7 +514,7 @@ fn params8_imm() {
             ExpectedFunc::new([
                 Instruction::call_internal(
                     RegisterSpan::new(Register::from_i16(0)),
-                    CompiledFunc::from_u32(0),
+                    EngineFunc::from_u32(0),
                 ),
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
@@ -564,7 +564,7 @@ fn params9_reg() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(9)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
@@ -612,7 +612,7 @@ fn params9_reg_rev() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(9)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register_list(8, 7, 6),
             Instruction::register_list(5, 4, 3),
@@ -661,7 +661,7 @@ fn params9_imm() {
             ExpectedFunc::new([
                 Instruction::call_internal(
                     RegisterSpan::new(Register::from_i16(0)),
-                    CompiledFunc::from_u32(0),
+                    EngineFunc::from_u32(0),
                 ),
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),

--- a/crates/wasmi/src/engine/translator/tests/op/if_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/if_.rs
@@ -3,7 +3,7 @@ use crate::{
     core::{TrapCode, UntypedVal},
     engine::{
         bytecode::{BranchOffset, BranchOffset16, GlobalIdx, RegisterSpan},
-        CompiledFunc,
+        EngineFunc,
     },
 };
 
@@ -551,7 +551,7 @@ fn test_if_without_else_has_result() {
         .expect_func_instrs([
             Instruction::call_internal_0(
                 RegisterSpan::new(Register::from_i16(0)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::branch_i32_eqz(Register::from_i16(1), BranchOffset16::from(3)),
             Instruction::copy_i64imm32(Register::from_i16(0), -1),

--- a/crates/wasmi/src/engine/translator/tests/op/local_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/local_preserve.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::engine::{
     bytecode::{BranchOffset, BranchOffset16, RegisterSpan},
-    CompiledFunc,
+    EngineFunc,
 };
 
 #[test]
@@ -579,7 +579,7 @@ fn invalid_preservation_slot_reuse_2() {
             Instruction::i32_popcnt(Register::from_i16(0), Register::from_i16(0)),
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(2)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register3(1, 3, 0),
             Instruction::copy(3, 1),

--- a/crates/wasmi/src/engine/translator/tests/op/local_set.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/local_set.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::engine::{
     bytecode::{FuncIdx, RegisterSpan, SignatureIdx, TableIdx},
-    CompiledFunc,
+    EngineFunc,
 };
 
 #[test]
@@ -84,7 +84,7 @@ fn overwrite_call_internal_result_1() {
         .expect_func_instrs([
             Instruction::call_internal(
                 RegisterSpan::new(Register::from_i16(0)),
-                CompiledFunc::from_u32(0),
+                EngineFunc::from_u32(0),
             ),
             Instruction::register(0),
             Instruction::return_reg(Register::from_i16(0)),

--- a/crates/wasmi/src/engine/translator/tests/op/return_call/internal.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/return_call/internal.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::engine::{CompiledFunc, RegisterSpan};
+use crate::engine::{EngineFunc, RegisterSpan};
 
 #[test]
 #[cfg_attr(miri, ignore)]
@@ -14,9 +14,7 @@ fn no_params() {
     "#;
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([Instruction::Return])
-        .expect_func_instrs([Instruction::return_call_internal_0(CompiledFunc::from_u32(
-            0,
-        ))])
+        .expect_func_instrs([Instruction::return_call_internal_0(EngineFunc::from_u32(0))])
         .run();
 }
 
@@ -36,7 +34,7 @@ fn one_param_reg() {
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([Instruction::return_reg(Register::from_i16(0))])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register(0),
         ])
         .run();
@@ -59,7 +57,7 @@ fn one_param_imm() {
         .expect_func_instrs([Instruction::return_reg(0)])
         .expect_func(
             ExpectedFunc::new([
-                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::return_call_internal(EngineFunc::from_u32(0)),
                 Instruction::register(-1),
             ])
             .consts([10_i32]),
@@ -84,7 +82,7 @@ fn two_params_reg() {
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([Instruction::return_reg2(0, 1)])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register2(0, 1),
         ])
         .run();
@@ -107,7 +105,7 @@ fn two_params_reg_rev() {
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([Instruction::return_reg2(0, 1)])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register2(1, 0),
         ])
         .run();
@@ -131,7 +129,7 @@ fn two_params_imm() {
         .expect_func_instrs([Instruction::return_reg2(0, 1)])
         .expect_func(
             ExpectedFunc::new([
-                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::return_call_internal(EngineFunc::from_u32(0)),
                 Instruction::register2(-1, -2),
             ])
             .consts([10_i32, 20]),
@@ -157,7 +155,7 @@ fn three_params_reg() {
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([Instruction::return_reg3(0, 1, 2)])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register3(0, 1, 2),
         ])
         .run();
@@ -181,7 +179,7 @@ fn three_params_reg_rev() {
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([Instruction::return_reg3(0, 1, 2)])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register3(2, 1, 0),
         ])
         .run();
@@ -206,7 +204,7 @@ fn three_params_imm() {
         .expect_func_instrs([Instruction::return_reg3(0, 1, 2)])
         .expect_func(
             ExpectedFunc::new([
-                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::return_call_internal(EngineFunc::from_u32(0)),
                 Instruction::register3(-1, -2, -3),
             ])
             .consts([10_i32, 20, 30]),
@@ -246,7 +244,7 @@ fn params7_reg() {
             RegisterSpan::new(Register::from_i16(0)).iter(7),
         )])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
             Instruction::register(6),
@@ -286,7 +284,7 @@ fn params7_reg_rev() {
             RegisterSpan::new(Register::from_i16(0)).iter(7),
         )])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(6, 5, 4),
             Instruction::register_list(3, 2, 1),
             Instruction::register(0),
@@ -327,7 +325,7 @@ fn params7_imm() {
         )])
         .expect_func(
             ExpectedFunc::new([
-                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::return_call_internal(EngineFunc::from_u32(0)),
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register(-7),
@@ -371,7 +369,7 @@ fn params8_reg() {
             RegisterSpan::new(Register::from_i16(0)).iter(8),
         )])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
             Instruction::register2(6, 7),
@@ -413,7 +411,7 @@ fn params8_reg_rev() {
             RegisterSpan::new(Register::from_i16(0)).iter(8),
         )])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(7, 6, 5),
             Instruction::register_list(4, 3, 2),
             Instruction::register2(1, 0),
@@ -456,7 +454,7 @@ fn params8_imm() {
         )])
         .expect_func(
             ExpectedFunc::new([
-                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::return_call_internal(EngineFunc::from_u32(0)),
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register2(-7, -8),
@@ -502,7 +500,7 @@ fn params9_reg() {
             RegisterSpan::new(Register::from_i16(0)).iter(9),
         )])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
             Instruction::register3(6, 7, 8),
@@ -546,7 +544,7 @@ fn params9_reg_rev() {
             RegisterSpan::new(Register::from_i16(0)).iter(9),
         )])
         .expect_func_instrs([
-            Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+            Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(8, 7, 6),
             Instruction::register_list(5, 4, 3),
             Instruction::register3(2, 1, 0),
@@ -591,7 +589,7 @@ fn params9_imm() {
         )])
         .expect_func(
             ExpectedFunc::new([
-                Instruction::return_call_internal(CompiledFunc::from_u32(0)),
+                Instruction::return_call_internal(EngineFunc::from_u32(0)),
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register3(-7, -8, -9),

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -654,13 +654,13 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let provider_params = &mut self.alloc.buffer.providers;
         self.alloc.stack.pop_n(params.len(), provider_params);
         let results = self.alloc.stack.push_dynamic_n(results.len())?;
-        let instr = match self.module.get_compiled_func(func_idx) {
-            Some(compiled_func) => {
+        let instr = match self.module.get_engine_func(func_idx) {
+            Some(engine_func) => {
                 // Case: We are calling an internal function and can optimize
                 //       this case by using the special instruction for it.
                 match params.len() {
-                    0 => Instruction::call_internal_0(results, compiled_func),
-                    _ => Instruction::call_internal(results, compiled_func),
+                    0 => Instruction::call_internal_0(results, engine_func),
+                    _ => Instruction::call_internal(results, engine_func),
                 }
             }
             None => {
@@ -730,13 +730,13 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let params = func_type.params();
         let provider_params = &mut self.alloc.buffer.providers;
         self.alloc.stack.pop_n(params.len(), provider_params);
-        let instr = match self.module.get_compiled_func(func_idx) {
-            Some(compiled_func) => {
+        let instr = match self.module.get_engine_func(func_idx) {
+            Some(engine_func) => {
                 // Case: We are calling an internal function and can optimize
                 //       this case by using the special instruction for it.
                 match params.len() {
-                    0 => Instruction::return_call_internal_0(compiled_func),
-                    _ => Instruction::return_call_internal(compiled_func),
+                    0 => Instruction::return_call_internal_0(engine_func),
+                    _ => Instruction::return_call_internal(engine_func),
                 }
             }
             None => {

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -15,7 +15,7 @@ pub use self::{
     typed_func::{TypedFunc, WasmParams, WasmResults},
 };
 use super::{
-    engine::{CompiledFunc, DedupFuncType, FuncFinished, FuncParams},
+    engine::{DedupFuncType, EngineFunc, FuncFinished, FuncParams},
     AsContext,
     AsContextMut,
     Instance,
@@ -162,14 +162,14 @@ pub struct WasmFuncEntity {
     /// The function type of the Wasm function.
     ty: DedupFuncType,
     /// The compiled function body of the Wasm function.
-    body: CompiledFunc,
+    body: EngineFunc,
     /// The instance associated to the Wasm function.
     instance: Instance,
 }
 
 impl WasmFuncEntity {
     /// Creates a new Wasm function from the given raw parts.
-    pub fn new(signature: DedupFuncType, body: CompiledFunc, instance: Instance) -> Self {
+    pub fn new(signature: DedupFuncType, body: EngineFunc, instance: Instance) -> Self {
         Self {
             ty: signature,
             body,
@@ -188,7 +188,7 @@ impl WasmFuncEntity {
     }
 
     /// Returns the Wasm function body of the [`Func`].
-    pub fn func_body(&self) -> CompiledFunc {
+    pub fn func_body(&self) -> EngineFunc {
         self.body
     }
 }

--- a/crates/wasmi/src/module/builder.rs
+++ b/crates/wasmi/src/module/builder.rs
@@ -19,7 +19,7 @@ use super::{
 };
 use crate::{
     collections::Map,
-    engine::{CompiledFunc, DedupFuncType},
+    engine::{DedupFuncType, EngineFunc},
     Engine,
     Error,
     FuncType,
@@ -50,8 +50,8 @@ pub struct ModuleHeaderBuilder {
     pub globals_init: Vec<ConstExpr>,
     pub exports: Map<Box<str>, ExternIdx>,
     pub start: Option<FuncIdx>,
-    pub compiled_funcs: Vec<CompiledFunc>,
-    pub compiled_funcs_idx: BTreeMap<CompiledFunc, FuncIdx>,
+    pub engine_funcs: Vec<EngineFunc>,
+    pub engine_funcs_idx: BTreeMap<EngineFunc, FuncIdx>,
     pub element_segments: Box<[ElementSegment]>,
 }
 
@@ -69,8 +69,8 @@ impl ModuleHeaderBuilder {
             globals_init: Vec::new(),
             exports: Map::new(),
             start: None,
-            compiled_funcs: Vec::new(),
-            compiled_funcs_idx: BTreeMap::new(),
+            engine_funcs: Vec::new(),
+            engine_funcs_idx: BTreeMap::new(),
             element_segments: Box::from([]),
         }
     }
@@ -89,8 +89,8 @@ impl ModuleHeaderBuilder {
                 globals_init: self.globals_init.into(),
                 exports: self.exports,
                 start: self.start,
-                compiled_funcs: self.compiled_funcs.into(),
-                compiled_funcs_idx: self.compiled_funcs_idx,
+                engine_funcs: self.engine_funcs.into(),
+                engine_funcs_idx: self.engine_funcs_idx,
                 element_segments: self.element_segments,
             }),
         }
@@ -238,7 +238,7 @@ impl ModuleHeaderBuilder {
         //       is the last extension of the vector during the build process
         //       and optimizes conversion to boxed slice.
         self.funcs.reserve_exact(funcs.len());
-        self.compiled_funcs.reserve_exact(funcs.len());
+        self.engine_funcs.reserve_exact(funcs.len());
         for func in funcs {
             let func_type_idx = func?;
             let func_type = self.func_types[func_type_idx.into_u32() as usize];
@@ -246,10 +246,10 @@ impl ModuleHeaderBuilder {
                 panic!("function index out of bounds: {}", self.funcs.len())
             };
             self.funcs.push(func_type);
-            let compiled_func = self.engine.alloc_func();
-            self.compiled_funcs.push(compiled_func);
-            self.compiled_funcs_idx
-                .insert(compiled_func, FuncIdx::from(func_index));
+            let engine_func = self.engine.alloc_func();
+            self.engine_funcs.push(engine_func);
+            self.engine_funcs_idx
+                .insert(engine_func, FuncIdx::from(func_index));
         }
         Ok(())
     }

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -35,7 +35,7 @@ pub(crate) use self::{
 };
 use crate::{
     collections::Map,
-    engine::{CompiledFunc, DedupFuncType, EngineWeak},
+    engine::{DedupFuncType, EngineFunc, EngineWeak},
     Engine,
     Error,
     ExternType,
@@ -75,8 +75,8 @@ struct ModuleHeaderInner {
     globals_init: Box<[ConstExpr]>,
     exports: Map<Box<str>, ExternIdx>,
     start: Option<FuncIdx>,
-    compiled_funcs: Box<[CompiledFunc]>,
-    compiled_funcs_idx: BTreeMap<CompiledFunc, FuncIdx>,
+    engine_funcs: Box<[EngineFunc]>,
+    engine_funcs_idx: BTreeMap<EngineFunc, FuncIdx>,
     element_segments: Box<[ElementSegment]>,
 }
 
@@ -101,21 +101,21 @@ impl ModuleHeader {
         &self.inner.globals[global_idx.into_u32() as usize]
     }
 
-    /// Returns the [`CompiledFunc`] for the given [`FuncIdx`].
+    /// Returns the [`EngineFunc`] for the given [`FuncIdx`].
     ///
     /// Returns `None` if [`FuncIdx`] refers to an imported function.
-    pub fn get_compiled_func(&self, func_idx: FuncIdx) -> Option<CompiledFunc> {
+    pub fn get_engine_func(&self, func_idx: FuncIdx) -> Option<EngineFunc> {
         let index = func_idx.into_u32() as usize;
         let len_imported = self.inner.imports.len_funcs();
         let index = index.checked_sub(len_imported)?;
         // Note: It is a bug if this index access is out of bounds
         //       therefore we panic here instead of using `get`.
-        Some(self.inner.compiled_funcs[index])
+        Some(self.inner.engine_funcs[index])
     }
 
-    /// Returns the [`FuncIdx`] for the given [`CompiledFunc`].
-    pub fn get_func_index(&self, func: CompiledFunc) -> Option<FuncIdx> {
-        self.inner.compiled_funcs_idx.get(&func).copied()
+    /// Returns the [`FuncIdx`] for the given [`EngineFunc`].
+    pub fn get_func_index(&self, func: EngineFunc) -> Option<FuncIdx> {
+        self.inner.engine_funcs_idx.get(&func).copied()
     }
 
     /// Returns the global variable type and optional initial value.
@@ -366,10 +366,10 @@ impl Module {
         // since they refer to imported and not internally defined
         // functions.
         let funcs = &self.header.inner.funcs[len_imported..];
-        let compiled_funcs = &self.header.inner.compiled_funcs[..];
-        assert_eq!(funcs.len(), compiled_funcs.len());
+        let engine_funcs = &self.header.inner.engine_funcs[..];
+        assert_eq!(funcs.len(), engine_funcs.len());
         InternalFuncsIter {
-            iter: funcs.iter().zip(compiled_funcs),
+            iter: funcs.iter().zip(engine_funcs),
         }
     }
 
@@ -574,11 +574,11 @@ impl<'module> ImportType<'module> {
 /// An iterator over the internally defined functions of a [`Module`].
 #[derive(Debug)]
 pub struct InternalFuncsIter<'a> {
-    iter: iter::Zip<SliceIter<'a, DedupFuncType>, SliceIter<'a, CompiledFunc>>,
+    iter: iter::Zip<SliceIter<'a, DedupFuncType>, SliceIter<'a, EngineFunc>>,
 }
 
 impl<'a> Iterator for InternalFuncsIter<'a> {
-    type Item = (DedupFuncType, CompiledFunc);
+    type Item = (DedupFuncType, EngineFunc);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter


### PR DESCRIPTION
This avoid confusion with `EngineFunc`s that have been initialized lazily and are not _yet_ compiled. `EngineFunc` is a better name because it simply states that the function is stored inside the Wasmi `Engine` which is always true for them independent of their current compilation state.