### PR TITLE
Add `CodeMap::alloc_funcs` API

### DIFF
--- a/crates/collections/src/arena/mod.rs
+++ b/crates/collections/src/arena/mod.rs
@@ -12,7 +12,7 @@ pub use self::{component_vec::ComponentVec, dedup::DedupArena, guarded::GuardedE
 use core::{
     iter::Enumerate,
     marker::PhantomData,
-    ops::{Index, IndexMut},
+    ops::{Index, IndexMut, Range},
     slice,
 };
 use std::vec::Vec;
@@ -118,6 +118,19 @@ where
         let index = self.next_index();
         self.entities.push(entity);
         index
+    }
+
+    /// Allocates a new default initialized entity and returns its index.
+    #[inline]
+    pub fn alloc_many(&mut self, amount: usize) -> Range<Idx>
+    where
+        T: Default,
+    {
+        let start = self.next_index();
+        self.entities
+            .extend(core::iter::repeat_with(T::default).take(amount));
+        let end = self.next_index();
+        Range { start, end }
     }
 
     /// Returns a shared reference to the entity at the given index if any.

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -68,6 +68,124 @@ pub struct CodeMap {
     features: WasmFeatures,
 }
 
+/// A range of [`EngineFunc`]s with contiguous indices.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EngineFuncSpan {
+    start: EngineFunc,
+    end: EngineFunc,
+}
+
+impl Default for EngineFuncSpan {
+    #[inline]
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl EngineFuncSpan {
+    /// Creates an empty [`EngineFuncSpan`].
+    #[inline]
+    pub fn empty() -> Self {
+        Self {
+            start: EngineFunc(0),
+            end: EngineFunc(0),
+        }
+    }
+
+    /// Returns `true` if `self` is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+
+    /// Returns the number of [`EngineFunc`] in `self`.
+    pub fn len(&self) -> u32 {
+        let start = self.start.0;
+        let end = self.end.0;
+        end - start
+    }
+
+    /// Returns the n-th [`EngineFunc`] in `self`, if any.
+    ///
+    /// Returns `None` if `n` is out of bounds.
+    pub fn get(&self, n: u32) -> Option<EngineFunc> {
+        if n >= self.len() {
+            return None;
+        }
+        Some(EngineFunc(self.start.0 + n))
+    }
+
+    /// Returns the `u32` index of the [`EngineFunc`] in `self` if any.
+    ///
+    /// Returns `None` if `func` is not contained in `self`.
+    pub fn position(&self, func: EngineFunc) -> Option<u32> {
+        if func < self.start || func >= self.end {
+            return None;
+        }
+        Some(func.0 - self.start.0)
+    }
+
+    /// Returns the n-th [`EngineFunc`] in `self`, if any.
+    ///
+    /// # Pancis
+    ///
+    /// If `n` is out of bounds.
+    #[track_caller]
+    pub fn get_or_panic(&self, n: u32) -> EngineFunc {
+        self.get(n)
+            .unwrap_or_else(|| panic!("out of bounds `EngineFunc` index: {n}"))
+    }
+
+    /// Returns an iterator over the [`EngineFunc`]s in `self`.
+    #[inline]
+    pub fn iter(&self) -> EngineFuncSpanIter {
+        EngineFuncSpanIter { span: *self }
+    }
+}
+
+#[derive(Debug)]
+pub struct EngineFuncSpanIter {
+    span: EngineFuncSpan,
+}
+
+impl Iterator for EngineFuncSpanIter {
+    type Item = EngineFunc;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.span.is_empty() {
+            return None;
+        }
+        let func = self.span.start;
+        self.span.start = EngineFunc(self.span.start.0 + 1);
+        Some(func)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.span.len() as usize;
+        (remaining, Some(remaining))
+    }
+}
+
+impl DoubleEndedIterator for EngineFuncSpanIter {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.span.is_empty() {
+            return None;
+        }
+        self.span.end = EngineFunc(self.span.end.0 - 1);
+        Some(self.span.end)
+    }
+}
+
+impl ExactSizeIterator for EngineFuncSpanIter {
+    #[inline]
+    fn len(&self) -> usize {
+        self.span.len() as usize
+    }
+}
+
 impl CodeMap {
     /// Creates a new [`CodeMap`].
     pub fn new(config: &Config) -> Self {
@@ -75,18 +193,6 @@ impl CodeMap {
             funcs: Mutex::new(Arena::default()),
             features: config.wasm_features(),
         }
-    }
-
-    /// Allocates a new uninitialized [`EngineFunc`] to the [`CodeMap`].
-    ///
-    /// # Note
-    ///
-    /// Before using the [`CodeMap`] the [`EngineFunc`] must be initialized with either of:
-    ///
-    /// - [`CodeMap::init_func_as_compiled`]
-    /// - [`CodeMap::init_func_as_uncompiled`]
-    pub fn alloc_func(&self) -> EngineFunc {
-        self.funcs.lock().alloc(FuncEntity::Uninit)
     }
 
     /// Allocates `amount` new uninitialized [`EngineFunc`] to the [`CodeMap`].
@@ -97,8 +203,9 @@ impl CodeMap {
     ///
     /// - [`CodeMap::init_func_as_compiled`]
     /// - [`CodeMap::init_func_as_uncompiled`]
-    pub fn alloc_funcs(&self, amount: usize) -> Range<EngineFunc> {
-        self.funcs.lock().alloc_many(amount)
+    pub fn alloc_funcs(&self, amount: usize) -> EngineFuncSpan {
+        let Range { start, end } = self.funcs.lock().alloc_many(amount);
+        EngineFuncSpan { start, end }
     }
 
     /// Initializes the [`EngineFunc`] with its [`CompiledFuncEntity`].

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -24,7 +24,7 @@ use crate::{
 use core::{
     fmt,
     mem::{self, MaybeUninit},
-    ops,
+    ops::{self, Range},
     pin::Pin,
     slice,
 };
@@ -87,6 +87,18 @@ impl CodeMap {
     /// - [`CodeMap::init_func_as_uncompiled`]
     pub fn alloc_func(&self) -> EngineFunc {
         self.funcs.lock().alloc(FuncEntity::Uninit)
+    }
+
+    /// Allocates `amount` new uninitialized [`EngineFunc`] to the [`CodeMap`].
+    ///
+    /// # Note
+    ///
+    /// Before using the [`CodeMap`] all [`EngineFunc`]s must be initialized with either of:
+    ///
+    /// - [`CodeMap::init_func_as_compiled`]
+    /// - [`CodeMap::init_func_as_uncompiled`]
+    pub fn alloc_funcs(&self, amount: usize) -> Range<EngineFunc> {
+        self.funcs.lock().alloc_many(amount)
     }
 
     /// Initializes the [`EngineFunc`] with its [`CompiledFuncEntity`].
@@ -291,6 +303,13 @@ enum FuncEntity {
     FailedToCompile,
     /// An internal function that has already been compiled.
     Compiled(CompiledFuncEntity),
+}
+
+impl Default for FuncEntity {
+    #[inline]
+    fn default() -> Self {
+        Self::Uninit
+    }
 }
 
 impl FuncEntity {

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -36,19 +36,19 @@ pub(crate) use self::{
         WasmTranslator,
     },
 };
+use self::{
+    code_map::{CodeMap, CompiledFuncEntity},
+    func_types::FuncTypeRegistry,
+    resumable::ResumableCallBase,
+};
 pub use self::{
-    code_map::EngineFunc,
+    code_map::{EngineFunc, EngineFuncSpan, EngineFuncSpanIter},
     config::{CompilationMode, Config},
     executor::ResumableHostError,
     limits::{EnforcedLimits, EnforcedLimitsError, StackLimits},
     resumable::{ResumableCall, ResumableInvocation, TypedResumableCall, TypedResumableInvocation},
     traits::{CallParams, CallResults},
     translator::{Instr, TranslationError},
-};
-use self::{
-    code_map::{CodeMap, CompiledFuncEntity},
-    func_types::FuncTypeRegistry,
-    resumable::ResumableCallBase,
 };
 use crate::{
     collections::arena::{ArenaIndex, GuardedEntity},
@@ -58,10 +58,7 @@ use crate::{
     FuncType,
     StoreContextMut,
 };
-use core::{
-    ops::Range,
-    sync::atomic::{AtomicU32, Ordering},
-};
+use core::sync::atomic::{AtomicU32, Ordering};
 use spin::{Mutex, RwLock};
 use std::{
     sync::{Arc, Weak},
@@ -193,17 +190,10 @@ impl Engine {
         self.inner.resolve_func_type(func_type, f)
     }
 
-    /// Allocates a new uninitialized [`EngineFunc`] to the [`Engine`].
-    ///
-    /// Returns a [`EngineFunc`] reference to allow accessing the allocated [`EngineFunc`].
-    pub(super) fn alloc_func(&self) -> EngineFunc {
-        self.inner.alloc_func()
-    }
-
     /// Allocates `amount` new uninitialized [`EngineFunc`] to the [`CodeMap`].
     ///
     /// Returns a range of [`EngineFunc`]s to allow accessing the allocated [`EngineFunc`].
-    fn alloc_funcs(&self, amount: usize) -> Range<EngineFunc> {
+    pub(super) fn alloc_funcs(&self, amount: usize) -> EngineFuncSpan {
         self.inner.alloc_funcs(amount)
     }
 
@@ -639,17 +629,10 @@ impl EngineInner {
         f(self.func_types.read().resolve_func_type(func_type))
     }
 
-    /// Allocates a new uninitialized [`EngineFunc`] to the [`EngineInner`].
-    ///
-    /// Returns a [`EngineFunc`] to allow accessing the allocated [`EngineFunc`].
-    fn alloc_func(&self) -> EngineFunc {
-        self.code_map.alloc_func()
-    }
-
     /// Allocates `amount` new uninitialized [`EngineFunc`] to the [`CodeMap`].
     ///
     /// Returns a range of [`EngineFunc`]s to allow accessing the allocated [`EngineFunc`].
-    fn alloc_funcs(&self, amount: usize) -> Range<EngineFunc> {
+    fn alloc_funcs(&self, amount: usize) -> EngineFuncSpan {
         self.code_map.alloc_funcs(amount)
     }
 

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -58,7 +58,10 @@ use crate::{
     FuncType,
     StoreContextMut,
 };
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::{
+    ops::Range,
+    sync::atomic::{AtomicU32, Ordering},
+};
 use spin::{Mutex, RwLock};
 use std::{
     sync::{Arc, Weak},
@@ -195,6 +198,13 @@ impl Engine {
     /// Returns a [`EngineFunc`] reference to allow accessing the allocated [`EngineFunc`].
     pub(super) fn alloc_func(&self) -> EngineFunc {
         self.inner.alloc_func()
+    }
+
+    /// Allocates `amount` new uninitialized [`EngineFunc`] to the [`CodeMap`].
+    ///
+    /// Returns a range of [`EngineFunc`]s to allow accessing the allocated [`EngineFunc`].
+    fn alloc_funcs(&self, amount: usize) -> Range<EngineFunc> {
+        self.inner.alloc_funcs(amount)
     }
 
     /// Translates the Wasm function using the [`Engine`].
@@ -631,9 +641,16 @@ impl EngineInner {
 
     /// Allocates a new uninitialized [`EngineFunc`] to the [`EngineInner`].
     ///
-    /// Returns a [`EngineFunc`] reference to allow accessing the allocated [`EngineFunc`].
+    /// Returns a [`EngineFunc`] to allow accessing the allocated [`EngineFunc`].
     fn alloc_func(&self) -> EngineFunc {
         self.code_map.alloc_func()
+    }
+
+    /// Allocates `amount` new uninitialized [`EngineFunc`] to the [`CodeMap`].
+    ///
+    /// Returns a range of [`EngineFunc`]s to allow accessing the allocated [`EngineFunc`].
+    fn alloc_funcs(&self, amount: usize) -> Range<EngineFunc> {
+        self.code_map.alloc_funcs(amount)
     }
 
     /// Returns reusable [`FuncTranslatorAllocations`] from the [`Engine`].

--- a/crates/wasmi/src/module/parser.rs
+++ b/crates/wasmi/src/module/parser.rs
@@ -456,7 +456,7 @@ impl ModuleParser {
     /// Returns the next `FuncIdx` for processing of its function body.
     fn next_func(&mut self, header: &ModuleHeader) -> (FuncIdx, EngineFunc) {
         let index = self.engine_funcs;
-        let engine_func = header.inner.engine_funcs[index as usize];
+        let engine_func = header.inner.engine_funcs.get_or_panic(index);
         self.engine_funcs += 1;
         // We have to adjust the initial func reference to the first
         // internal function before we process any of the internal functions.


### PR DESCRIPTION
The new `CodeMap::alloc_funcs` replaces the `CodeMap::alloc_func` API.

The advantage is that fewer `CodeMap` locks are required to allocate multiple `EngineFunc` at the same time which is the only way `CodeMap::alloc_func` was used.

Also this PR introduces the new `EngineFuncSpan` and `EngineFuncSpanIter` abstractions which significantly improve space efficiency of storing newly allocated contiguous `EngineFunc` indices returned by `CodeMap::alloc_funcs`.

This allowed us to optimize the way `ModuleHeader` and `ModuleBuilder` store and manage allocated `EngineFunc`s.

Benchmarks conducted locally confirm that this is a huge performance improvement, especially for lazy Wasm module compilation:

![image](https://github.com/wasmi-labs/wasmi/assets/8193155/16cbe911-f288-486e-84b2-c08de481b50a)
