### PR TITLE
Make `wasmi::Module` implement `Clone`

### DIFF
--- a/crates/wasmi/src/module/builder.rs
+++ b/crates/wasmi/src/module/builder.rs
@@ -16,6 +16,7 @@ use super::{
     ModuleHeader,
     ModuleHeaderInner,
     ModuleImports,
+    ModuleInner,
 };
 use crate::{
     collections::Map,
@@ -409,10 +410,12 @@ impl ModuleBuilder {
     /// Finishes construction of the WebAssembly [`Module`].
     pub fn finish(self, engine: &Engine) -> Module {
         Module {
-            engine: engine.clone(),
-            header: self.header,
-            data_segments: self.data_segments.finish(),
-            custom_sections: self.custom_sections.finish(),
+            inner: Arc::new(ModuleInner {
+                engine: engine.clone(),
+                header: self.header,
+                data_segments: self.data_segments.finish(),
+                custom_sections: self.custom_sections.finish(),
+            }),
         }
     }
 }

--- a/crates/wasmi/src/module/export.rs
+++ b/crates/wasmi/src/module/export.rs
@@ -136,7 +136,7 @@ impl<'module> ModuleExportsIter<'module> {
     /// Creates a new [`ModuleExportsIter`] from the given [`Module`].
     pub(super) fn new(module: &'module Module) -> Self {
         Self {
-            exports: module.header.inner.exports.iter(),
+            exports: module.module_header().exports.iter(),
             module,
         }
     }

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -259,7 +259,7 @@ impl Module {
 
     /// Extracts the Wasm exports from the module and registers them into the [`Instance`].
     fn extract_exports(&self, builder: &mut InstanceEntityBuilder) {
-        for (field, idx) in &self.header.inner.exports {
+        for (field, idx) in &self.module_header().exports {
             let external = match idx {
                 export::ExternIdx::Func(func_index) => {
                     let func_index = func_index.into_u32();
@@ -288,7 +288,7 @@ impl Module {
 
     /// Extracts the optional start function for the build instance.
     fn extract_start_fn(&self, builder: &mut InstanceEntityBuilder) {
-        if let Some(start_fn) = self.header.inner.start {
+        if let Some(start_fn) = self.module_header().start {
             builder.set_start(start_fn)
         }
     }
@@ -299,7 +299,7 @@ impl Module {
         mut context: impl AsContextMut,
         builder: &mut InstanceEntityBuilder,
     ) -> Result<(), Error> {
-        for segment in &self.header.inner.element_segments[..] {
+        for segment in &self.module_header().element_segments[..] {
             let element = ElementSegment::new(context.as_context_mut(), segment);
             if let ElementSegmentKind::Active(active) = segment.kind() {
                 let dst_index = u32::from(Self::eval_init_expr(
@@ -346,7 +346,7 @@ impl Module {
         mut context: impl AsContextMut,
         builder: &mut InstanceEntityBuilder,
     ) -> Result<(), Error> {
-        for segment in &self.data_segments {
+        for segment in &self.inner.data_segments {
             let segment = match segment {
                 InitDataSegment::Active {
                     memory_index,


### PR DESCRIPTION
This mirrors the fact that Wasmtime's `Module` is also `Clone` which is reflected by the standardized Wasm C-API that views Wasm modules as reference types which are generally cheaply clone-able.

Benchmarks conducted locally didn't show any significant performance regressions. There were a few minor 2% perf regressions which could have also been noise.