### PR TITLE
Return `Error` instead of `FuelError` from `Store::get/set_fuel` APIs

### DIFF
--- a/crates/wasmi/src/func/caller.rs
+++ b/crates/wasmi/src/func/caller.rs
@@ -1,5 +1,5 @@
 use super::super::{AsContext, AsContextMut, StoreContext, StoreContextMut};
-use crate::{store::FuelError, Engine, Extern, Instance};
+use crate::{Engine, Error, Extern, Instance};
 
 /// Represents the caller’s context when creating a host function via [`Func::wrap`].
 ///
@@ -56,7 +56,7 @@ impl<'a, T> Caller<'a, T> {
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn get_fuel(&self) -> Result<u64, FuelError> {
+    pub fn get_fuel(&self) -> Result<u64, Error> {
         self.ctx.store.get_fuel()
     }
 
@@ -67,7 +67,7 @@ impl<'a, T> Caller<'a, T> {
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn set_fuel(&mut self, fuel: u64) -> Result<(), FuelError> {
+    pub fn set_fuel(&mut self, fuel: u64) -> Result<(), Error> {
         self.ctx.store.set_fuel(fuel)
     }
 }

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -14,6 +14,7 @@ use crate::{
     ElementSegmentEntity,
     ElementSegmentIdx,
     Engine,
+    Error,
     Func,
     FuncEntity,
     FuncIdx,
@@ -923,8 +924,8 @@ impl<T> Store<T> {
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn get_fuel(&self) -> Result<u64, FuelError> {
-        self.inner.fuel.get_fuel()
+    pub fn get_fuel(&self) -> Result<u64, Error> {
+        self.inner.fuel.get_fuel().map_err(Into::into)
     }
 
     /// Sets the remaining fuel of the [`Store`] to `value` if fuel metering is enabled.
@@ -936,8 +937,8 @@ impl<T> Store<T> {
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn set_fuel(&mut self, fuel: u64) -> Result<(), FuelError> {
-        self.inner.fuel.set_fuel(fuel)
+    pub fn set_fuel(&mut self, fuel: u64) -> Result<(), Error> {
+        self.inner.fuel.set_fuel(fuel).map_err(Into::into)
     }
 
     /// Allocates a new [`TrampolineEntity`] and returns a [`Trampoline`] reference to it.
@@ -1024,7 +1025,7 @@ impl<'a, T> StoreContext<'a, T> {
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn get_fuel(&self) -> Result<u64, FuelError> {
+    pub fn get_fuel(&self) -> Result<u64, Error> {
         self.store.get_fuel()
     }
 }
@@ -1087,7 +1088,7 @@ impl<'a, T> StoreContextMut<'a, T> {
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn get_fuel(&self) -> Result<u64, FuelError> {
+    pub fn get_fuel(&self) -> Result<u64, Error> {
         self.store.get_fuel()
     }
 
@@ -1098,7 +1099,7 @@ impl<'a, T> StoreContextMut<'a, T> {
     /// # Errors
     ///
     /// If fuel metering is disabled.
-    pub fn set_fuel(&mut self, fuel: u64) -> Result<(), FuelError> {
+    pub fn set_fuel(&mut self, fuel: u64) -> Result<(), Error> {
         self.store.set_fuel(fuel)
     }
 }


### PR DESCRIPTION
Required for https://github.com/wasmi-labs/wasmi/pull/1009 to simplify API surface.