### PR TITLE
Implement re-designed `call_indirect` instructions

### DIFF
--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -1007,9 +1007,23 @@ impl Instruction {
         }
     }
 
+    /// Creates a new [`Instruction::ReturnCallIndirect0Imm16`] for the given `func`.
+    pub fn return_call_indirect_0_imm16(func_type: impl Into<SignatureIdx>) -> Self {
+        Self::ReturnCallIndirect0Imm16 {
+            func_type: func_type.into(),
+        }
+    }
+
     /// Creates a new [`Instruction::ReturnCallIndirect`] for the given `func`.
     pub fn return_call_indirect(func_type: impl Into<SignatureIdx>) -> Self {
         Self::ReturnCallIndirect {
+            func_type: func_type.into(),
+        }
+    }
+
+    /// Creates a new [`Instruction::ReturnCallIndirectImm16`] for the given `func`.
+    pub fn return_call_indirect_imm16(func_type: impl Into<SignatureIdx>) -> Self {
+        Self::ReturnCallIndirectImm16 {
             func_type: func_type.into(),
         }
     }
@@ -1048,9 +1062,28 @@ impl Instruction {
         }
     }
 
+    /// Creates a new [`Instruction::CallIndirect0Imm16`] for the given `func`.
+    pub fn call_indirect_0_imm16(
+        results: RegisterSpan,
+        func_type: impl Into<SignatureIdx>,
+    ) -> Self {
+        Self::CallIndirect0Imm16 {
+            results,
+            func_type: func_type.into(),
+        }
+    }
+
     /// Creates a new [`Instruction::CallIndirect`] for the given `func`.
     pub fn call_indirect(results: RegisterSpan, func_type: impl Into<SignatureIdx>) -> Self {
         Self::CallIndirect {
+            results,
+            func_type: func_type.into(),
+        }
+    }
+
+    /// Creates a new [`Instruction::CallIndirectImm16`] for the given `func`.
+    pub fn call_indirect_imm16(results: RegisterSpan, func_type: impl Into<SignatureIdx>) -> Self {
+        Self::CallIndirectImm16 {
             results,
             func_type: func_type.into(),
         }

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -757,12 +757,21 @@ pub enum Instruction {
     ///
     /// # Encoding
     ///
-    /// Must be followed by
-    ///
-    /// 1. Either
-    ///     - [`Instruction::CallIndirectParams`]: the `table` and `index`
-    ///     - [`Instruction::CallIndirectParamsImm16`]: the `table` and 16-bit constant `index`
+    /// Must be followed by [`Instruction::CallIndirectParams`] encoding `table` and `index`.
     ReturnCallIndirect0 {
+        /// The called internal function.
+        func_type: SignatureIdx,
+    },
+    /// Wasm `return_call_indirect` equivalent Wasmi instruction.
+    ///
+    /// # Note
+    ///
+    /// Used for indirectly calling Wasm functions without parameters.
+    ///
+    /// # Encoding
+    ///
+    /// Must be followed by [`Instruction::CallIndirectParamsImm16`] encoding `table` and 16-bit immediate `index`.
+    ReturnCallIndirect0Imm16 {
         /// The called internal function.
         func_type: SignatureIdx,
     },
@@ -776,15 +785,33 @@ pub enum Instruction {
     ///
     /// Must be followed by
     ///
-    /// 1. Either
-    ///     - [`Instruction::CallIndirectParams`]: the `table` and `index`
-    ///     - [`Instruction::CallIndirectParamsImm16`]: the `table` and 16-bit constant `index`
+    /// 1. [`Instruction::CallIndirectParams`] encoding `table` and `index`
     /// 2. Zero or more [`Instruction::RegisterList`]
     /// 3. Followed by one of
     ///     - [`Instruction::Register`]
     ///     - [`Instruction::Register2`]
     ///     - [`Instruction::Register3`]
     ReturnCallIndirect {
+        /// The called internal function.
+        func_type: SignatureIdx,
+    },
+    /// Wasm `return_call_indirect` equivalent Wasmi instruction.
+    ///
+    /// # Note
+    ///
+    /// Used for indirectly calling Wasm functions with parameters.
+    ///
+    /// # Encoding
+    ///
+    /// Must be followed by
+    ///
+    /// 1. [`Instruction::CallIndirectParamsImm16`] encoding `table` and 16-bit immediate `index`
+    /// 2. Zero or more [`Instruction::RegisterList`]
+    /// 3. Followed by one of
+    ///     - [`Instruction::Register`]
+    ///     - [`Instruction::Register2`]
+    ///     - [`Instruction::Register3`]
+    ReturnCallIndirectImm16 {
         /// The called internal function.
         func_type: SignatureIdx,
     },
@@ -863,12 +890,43 @@ pub enum Instruction {
     ///
     /// # Encoding
     ///
-    /// Must be followed by
-    ///
-    /// 1. Either
-    ///     - [`Instruction::CallIndirectParams`]: the `table` and `index`
-    ///     - [`Instruction::CallIndirectParamsImm16`]: the `table` and 16-bit constant `index`
+    /// Must be followed by [`Instruction::CallIndirectParams`] encoding `table` and `index`.
     CallIndirect0 {
+        /// The registers storing the results of the call.
+        results: RegisterSpan,
+        /// The called internal function.
+        func_type: SignatureIdx,
+    },
+    /// Wasm `call_indirect` equivalent Wasmi instruction.
+    ///
+    /// # Note
+    ///
+    /// Used for indirectly calling Wasm functions without parameters.
+    ///
+    /// # Encoding
+    ///
+    /// Must be followed by [`Instruction::CallIndirectParamsImm16`] encoding `table` and 16-bit constant `index`.
+    CallIndirect0Imm16 {
+        /// The registers storing the results of the call.
+        results: RegisterSpan,
+        /// The called internal function.
+        func_type: SignatureIdx,
+    },
+    /// Wasm `call_indirect` equivalent Wasmi instruction.
+    ///
+    /// # Note
+    ///
+    /// Used for indirectly calling Wasm functions with parameters.
+    ///
+    /// # Encoding
+    ///
+    /// Must be followed by [`Instruction::CallIndirectParams`] encoding `table` and `index`.
+    /// 2. Zero or more [`Instruction::RegisterList`]
+    /// 3. Followed by one of
+    ///     - [`Instruction::Register`]
+    ///     - [`Instruction::Register2`]
+    ///     - [`Instruction::Register3`]
+    CallIndirect {
         /// The registers storing the results of the call.
         results: RegisterSpan,
         /// The called internal function.
@@ -884,15 +942,13 @@ pub enum Instruction {
     ///
     /// Must be followed by
     ///
-    /// 1. Either
-    ///     - [`Instruction::CallIndirectParams`]: the `table` and `index`
-    ///     - [`Instruction::CallIndirectParamsImm16`]: the `table` and 16-bit constant `index`
+    /// 1. [`Instruction::CallIndirectParamsImm16`] encoding `table` and 16-bit immediate `index`
     /// 2. Zero or more [`Instruction::RegisterList`]
     /// 3. Followed by one of
     ///     - [`Instruction::Register`]
     ///     - [`Instruction::Register2`]
     ///     - [`Instruction::Register3`]
-    CallIndirect {
+    CallIndirectImm16 {
         /// The registers storing the results of the call.
         results: RegisterSpan,
         /// The called internal function.

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -317,8 +317,14 @@ impl<'engine> Executor<'engine> {
                 Instr::ReturnCallIndirect0 { func_type } => {
                     self.execute_return_call_indirect_0::<T>(store, func_type)?
                 }
+                Instr::ReturnCallIndirect0Imm16 { func_type } => {
+                    self.execute_return_call_indirect_0_imm16::<T>(store, func_type)?
+                }
                 Instr::ReturnCallIndirect { func_type } => {
                     self.execute_return_call_indirect::<T>(store, func_type)?
+                }
+                Instr::ReturnCallIndirectImm16 { func_type } => {
+                    self.execute_return_call_indirect_imm16::<T>(store, func_type)?
                 }
                 Instr::CallInternal0 { results, func } => {
                     self.execute_call_internal_0(&mut store.inner, results, func)?
@@ -335,8 +341,14 @@ impl<'engine> Executor<'engine> {
                 Instr::CallIndirect0 { results, func_type } => {
                     self.execute_call_indirect_0::<T>(store, results, func_type)?
                 }
+                Instr::CallIndirect0Imm16 { results, func_type } => {
+                    self.execute_call_indirect_0_imm16::<T>(store, results, func_type)?
+                }
                 Instr::CallIndirect { results, func_type } => {
                     self.execute_call_indirect::<T>(store, results, func_type)?
+                }
+                Instr::CallIndirectImm16 { results, func_type } => {
+                    self.execute_call_indirect_imm16::<T>(store, results, func_type)?
                 }
                 Instr::Select {
                     result,

--- a/crates/wasmi/src/engine/translator/relink_result.rs
+++ b/crates/wasmi/src/engine/translator/relink_result.rs
@@ -143,14 +143,19 @@ impl Instruction {
             | I::ReturnCallImported0 { .. }
             | I::ReturnCallImported { .. }
             | I::ReturnCallIndirect0 { .. }
-            | I::ReturnCallIndirect { .. } => Ok(false),
+            | I::ReturnCallIndirect0Imm16 { .. }
+            | I::ReturnCallIndirect { .. }
+            | I::ReturnCallIndirectImm16 { .. } => Ok(false),
             I::CallInternal0 { results, func } | I::CallInternal { results, func } => {
                 relink_call_internal(results, *func, module, new_result, old_result)
             }
             I::CallImported0 { results, func } | I::CallImported { results, func } => {
                 relink_call_imported(results, *func, module, new_result, old_result)
             }
-            I::CallIndirect0 { results, func_type } | I::CallIndirect { results, func_type } => {
+            I::CallIndirect0 { results, func_type }
+            | I::CallIndirect0Imm16 { results, func_type }
+            | I::CallIndirect { results, func_type }
+            | I::CallIndirectImm16 { results, func_type } => {
                 relink_call_indirect(results, *func_type, module, new_result, old_result)
             }
             I::Select { result, .. }

--- a/crates/wasmi/src/engine/translator/tests/op/call/indirect.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/call/indirect.rs
@@ -47,7 +47,7 @@ fn no_params_imm16() {
         );
         TranslationTest::from_wat(&wasm)
             .expect_func_instrs([
-                Instruction::call_indirect_0(
+                Instruction::call_indirect_0_imm16(
                     RegisterSpan::new(Register::from_i16(1)),
                     SignatureIdx::from(0),
                 ),
@@ -109,7 +109,7 @@ fn one_reg_param_imm16() {
         );
         TranslationTest::from_wat(&wasm)
             .expect_func_instrs([
-                Instruction::call_indirect(
+                Instruction::call_indirect_imm16(
                     RegisterSpan::new(Register::from_i16(2)),
                     SignatureIdx::from(0),
                 ),
@@ -214,7 +214,7 @@ fn one_imm_param_imm16() {
         TranslationTest::from_wat(&wasm)
             .expect_func(
                 ExpectedFunc::new([
-                    Instruction::call_indirect(
+                    Instruction::call_indirect_imm16(
                         RegisterSpan::new(Register::from_i16(1)),
                         SignatureIdx::from(0),
                     ),
@@ -381,7 +381,7 @@ fn two_reg_params_imm16() {
         let elem_index = u32imm16(index);
         TranslationTest::from_wat(&wasm)
             .expect_func_instrs([
-                Instruction::call_indirect(results, SignatureIdx::from(0)),
+                Instruction::call_indirect_imm16(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                 Instruction::register2(0, 1),
                 Instruction::return_reg2(2, 3),
@@ -418,7 +418,7 @@ fn two_reg_params_rev_imm16() {
         let elem_index = u32imm16(index);
         TranslationTest::from_wat(&wasm)
             .expect_func_instrs([
-                Instruction::call_indirect(results, SignatureIdx::from(0)),
+                Instruction::call_indirect_imm16(results, SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                 Instruction::register2(1, 0),
                 Instruction::return_reg2(2, 3),
@@ -456,7 +456,7 @@ fn two_imm_params_imm16() {
         TranslationTest::from_wat(&wasm)
             .expect_func(
                 ExpectedFunc::new([
-                    Instruction::call_indirect(results, SignatureIdx::from(0)),
+                    Instruction::call_indirect_imm16(results, SignatureIdx::from(0)),
                     Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                     Instruction::register2(-1, -2),
                     Instruction::return_reg2(0, 1),
@@ -587,7 +587,7 @@ fn three_imm_params_imm16() {
         TranslationTest::from_wat(&wasm)
             .expect_func(
                 ExpectedFunc::new([
-                    Instruction::call_indirect(results, SignatureIdx::from(0)),
+                    Instruction::call_indirect_imm16(results, SignatureIdx::from(0)),
                     Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                     Instruction::register3(-1, -2, -3),
                     Instruction::return_reg3(0, 1, 2),

--- a/crates/wasmi/src/engine/translator/tests/op/return_call/indirect.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/return_call/indirect.rs
@@ -40,7 +40,7 @@ fn no_params_imm16() {
         );
         TranslationTest::from_wat(&wasm)
             .expect_func_instrs([
-                Instruction::return_call_indirect_0(SignatureIdx::from(0)),
+                Instruction::return_call_indirect_0_imm16(SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(u32imm16(index), TableIdx::from(0)),
             ])
             .run();
@@ -94,7 +94,7 @@ fn one_reg_param_imm16() {
         );
         TranslationTest::from_wat(&wasm)
             .expect_func_instrs([
-                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::return_call_indirect_imm16(SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(u32imm16(index), TableIdx::from(0)),
                 Instruction::register(1),
             ])
@@ -187,7 +187,7 @@ fn one_imm_param_imm16() {
         TranslationTest::from_wat(&wasm)
             .expect_func(
                 ExpectedFunc::new([
-                    Instruction::return_call_indirect(SignatureIdx::from(0)),
+                    Instruction::return_call_indirect_imm16(SignatureIdx::from(0)),
                     Instruction::call_indirect_params_imm16(u32imm16(index), TableIdx::from(0)),
                     Instruction::register(-1),
                 ])
@@ -335,7 +335,7 @@ fn two_reg_params_imm16() {
         let elem_index = u32imm16(index);
         TranslationTest::from_wat(&wasm)
             .expect_func_instrs([
-                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::return_call_indirect_imm16(SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                 Instruction::register2(0, 1),
             ])
@@ -369,7 +369,7 @@ fn two_reg_params_rev_imm16() {
         let elem_index = u32imm16(index);
         TranslationTest::from_wat(&wasm)
             .expect_func_instrs([
-                Instruction::return_call_indirect(SignatureIdx::from(0)),
+                Instruction::return_call_indirect_imm16(SignatureIdx::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                 Instruction::register2(1, 0),
             ])
@@ -404,7 +404,7 @@ fn two_imm_params_imm16() {
         TranslationTest::from_wat(&wasm)
             .expect_func(
                 ExpectedFunc::new([
-                    Instruction::return_call_indirect(SignatureIdx::from(0)),
+                    Instruction::return_call_indirect_imm16(SignatureIdx::from(0)),
                     Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                     Instruction::register2(-1, -2),
                 ])
@@ -523,7 +523,7 @@ fn three_imm_params_imm16() {
         TranslationTest::from_wat(&wasm)
             .expect_func(
                 ExpectedFunc::new([
-                    Instruction::return_call_indirect(SignatureIdx::from(0)),
+                    Instruction::return_call_indirect_imm16(SignatureIdx::from(0)),
                     Instruction::call_indirect_params_imm16(elem_index, TableIdx::from(0)),
                     Instruction::register3(-1, -2, -3),
                 ])

--- a/crates/wasmi/src/engine/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/translator/visit_register.rs
@@ -194,13 +194,17 @@ impl VisitInputRegisters for Instruction {
             Instruction::ReturnCallImported0 { .. } |
             Instruction::ReturnCallImported { .. } |
             Instruction::ReturnCallIndirect0 { .. } |
-            Instruction::ReturnCallIndirect { .. } => {},
+            Instruction::ReturnCallIndirect0Imm16 { .. } |
+            Instruction::ReturnCallIndirect { .. } |
+            Instruction::ReturnCallIndirectImm16 { .. } => {},
             Instruction::CallInternal0 { .. } |
             Instruction::CallInternal { .. } |
             Instruction::CallImported0 { .. } |
             Instruction::CallImported { .. } |
             Instruction::CallIndirect0 { .. } |
-            Instruction::CallIndirect { .. } => {},
+            Instruction::CallIndirect0Imm16 { .. } |
+            Instruction::CallIndirect { .. } |
+            Instruction::CallIndirectImm16 { .. } => {},
             Instruction::Select { condition, lhs, .. } => visit_registers!(f, condition, lhs),
             Instruction::SelectRev { condition, rhs, .. } => visit_registers!(f, condition, rhs),
             Instruction::SelectImm32 { result_or_condition, .. } |


### PR DESCRIPTION
Simplify integration of the new Wasmi bytecode introduced [here](https://github.com/wasmi-labs/wasmi/pull/1152).