### PR TITLE
Implement re-designed Wasmi `select` instructions

### DIFF
--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -344,51 +344,91 @@ impl Instruction {
         Self::F64CopysignImm(BinInstrImm::new(result, lhs, rhs))
     }
 
-    /// Creates a new [`Instruction::Select`].
-    pub fn select(result: Register, condition: Register, lhs: Register) -> Self {
-        Self::Select {
-            result,
-            condition,
-            lhs,
+    /// Creates a new [`Instruction::RegisterAndImm32`].
+    pub fn register_and_imm32(reg: impl Into<Register>, imm: impl Into<AnyConst32>) -> Self {
+        Self::RegisterAndImm32 {
+            reg: reg.into(),
+            imm: imm.into(),
         }
     }
 
-    /// Creates a new [`Instruction::SelectRev`].
-    pub fn select_rev(result: Register, condition: Register, rhs: Register) -> Self {
-        Self::SelectRev {
-            result,
-            condition,
-            rhs,
+    /// Creates a new [`Instruction::Select`].
+    pub fn select(result: impl Into<Register>, lhs: impl Into<Register>) -> Self {
+        Self::Select {
+            result: result.into(),
+            lhs: lhs.into(),
+        }
+    }
+
+    /// Creates a new [`Instruction::SelectImm32Rhs`].
+    pub fn select_imm32_rhs(result: impl Into<Register>, lhs: impl Into<Register>) -> Self {
+        Self::SelectImm32Rhs {
+            result: result.into(),
+            lhs: lhs.into(),
+        }
+    }
+
+    /// Creates a new [`Instruction::SelectImm32Lhs`].
+    pub fn select_imm32_lhs(result: impl Into<Register>, lhs: impl Into<AnyConst32>) -> Self {
+        Self::SelectImm32Lhs {
+            result: result.into(),
+            lhs: lhs.into(),
         }
     }
 
     /// Creates a new [`Instruction::SelectImm32`].
-    pub fn select_imm32(result_or_condition: Register, lhs_or_rhs: impl Into<AnyConst32>) -> Self {
+    pub fn select_imm32(result: impl Into<Register>, lhs: impl Into<AnyConst32>) -> Self {
         Self::SelectImm32 {
-            result_or_condition,
-            lhs_or_rhs: lhs_or_rhs.into(),
+            result: result.into(),
+            lhs: lhs.into(),
+        }
+    }
+
+    /// Creates a new [`Instruction::SelectI64Imm32Rhs`].
+    pub fn select_i64imm32_rhs(result: impl Into<Register>, lhs: impl Into<Register>) -> Self {
+        Self::SelectI64Imm32Rhs {
+            result: result.into(),
+            lhs: lhs.into(),
+        }
+    }
+
+    /// Creates a new [`Instruction::SelectI64Imm32Lhs`].
+    pub fn select_i64imm32_lhs(result: impl Into<Register>, lhs: impl Into<Const32<i64>>) -> Self {
+        Self::SelectI64Imm32Lhs {
+            result: result.into(),
+            lhs: lhs.into(),
         }
     }
 
     /// Creates a new [`Instruction::SelectI64Imm32`].
-    pub fn select_i64imm32(
-        result_or_condition: Register,
-        lhs_or_rhs: impl Into<Const32<i64>>,
-    ) -> Self {
+    pub fn select_i64imm32(result: impl Into<Register>, lhs: impl Into<Const32<i64>>) -> Self {
         Self::SelectI64Imm32 {
-            result_or_condition,
-            lhs_or_rhs: lhs_or_rhs.into(),
+            result: result.into(),
+            lhs: lhs.into(),
+        }
+    }
+
+    /// Creates a new [`Instruction::SelectF64Imm32Rhs`].
+    pub fn select_f64imm32_rhs(result: impl Into<Register>, lhs: impl Into<Register>) -> Self {
+        Self::SelectF64Imm32Rhs {
+            result: result.into(),
+            lhs: lhs.into(),
+        }
+    }
+
+    /// Creates a new [`Instruction::SelectF64Imm32Lhs`].
+    pub fn select_f64imm32_lhs(result: impl Into<Register>, lhs: impl Into<Const32<f64>>) -> Self {
+        Self::SelectF64Imm32Lhs {
+            result: result.into(),
+            lhs: lhs.into(),
         }
     }
 
     /// Creates a new [`Instruction::SelectF64Imm32`].
-    pub fn select_f64imm32(
-        result_or_condition: Register,
-        lhs_or_rhs: impl Into<Const32<f64>>,
-    ) -> Self {
+    pub fn select_f64imm32(result: impl Into<Register>, lhs: impl Into<Const32<f64>>) -> Self {
         Self::SelectF64Imm32 {
-            result_or_condition,
-            lhs_or_rhs: lhs_or_rhs.into(),
+            result: result.into(),
+            lhs: lhs.into(),
         }
     }
 

--- a/crates/wasmi/src/engine/bytecode/immediate.rs
+++ b/crates/wasmi/src/engine/bytecode/immediate.rs
@@ -527,6 +527,12 @@ impl TryFrom<f64> for AnyConst32 {
     }
 }
 
+impl<T> From<Const32<T>> for AnyConst32 {
+    fn from(value: Const32<T>) -> Self {
+        value.inner
+    }
+}
+
 impl From<bool> for AnyConst32 {
     fn from(value: bool) -> Self {
         Self::from(u32::from(value))

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -3179,7 +3179,7 @@ pub enum Instruction {
     F64Const32(Const32<f64>),
     /// An instruction parameter with a [`Register`] and a 32-bit immediate value.
     RegisterAndImm32 {
-        /// The [`Reg`] parameter value.
+        /// The [`Register`] parameter value.
         ///
         /// # Note
         ///

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -955,92 +955,115 @@ pub enum Instruction {
         func_type: SignatureIdx,
     },
 
-    /// A Wasm `select` or `select <ty>` instruction.
-    ///
-    /// Inspect `condition` and if `condition != 0`:
-    ///
-    /// - `true` : store `lhs` into `result`
-    /// - `false`: store `rhs` into `result`
+    /// A Wasm `select` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
-    /// Must be followed by either of
-    ///
-    /// 1. [`Instruction::Register`]
-    /// 1. [`Instruction::Const32`]
-    /// 1. [`Instruction::I64Const32`]
-    /// 1. [`Instruction::F64Const32`]
-    ///
-    /// to encode the `rhs` value.
+    /// Must be followed by [`Instruction::Register2`] to encode `condition` and `rhs`.
     Select {
-        /// The register holding the `result` value.
+        /// The register holding the result of the instruction.
         result: Register,
-        /// The register holding the `condition` value.
-        condition: Register,
-        /// The register holding the `lhs` value.
+        /// The register holding the left-hand side value.
         lhs: Register,
     },
-    /// Variant of [`Instruction::Select`] with swapped `lhs` and `rhs` values.
+    /// A Wasm `select` equivalent Wasmi instruction with 32-bit immediate `rhs` value.
     ///
     /// # Encoding
     ///
-    /// Must be followed by either of
-    ///
-    /// 1. [`Instruction::Register`]
-    /// 1. [`Instruction::Const32`]
-    /// 1. [`Instruction::I64Const32`]
-    /// 1. [`Instruction::F64Const32`]
-    ///
-    /// to encode the `lhs` value.
-    SelectRev {
-        /// The register holding the `result` value.
+    /// Must be followed by [`Instruction::RegisterAndImm32`] to encode `condition` and `rhs`.
+    SelectImm32Rhs {
+        /// The register holding the result of the instruction.
         result: Register,
-        /// The register holding the `condition` value.
-        condition: Register,
-        /// The register holding the `rhs` value.
-        rhs: Register,
+        /// The register holding the left-hand side value.
+        lhs: Register,
     },
-    /// Variant of [`Instruction::Select`] where `lhs` and `rhs` are 32-bit constant values.
+    /// A Wasm `select` equivalent Wasmi instruction with 32-bit immediate `lhs` value.
     ///
     /// # Encoding
     ///
-    /// This [`Instruction`] is always encoded as pair:
+    /// Must be followed by [`Instruction::Register2`] to encode `condition` and `lhs`.
+    SelectImm32Lhs {
+        /// The register holding the result of the instruction.
+        result: Register,
+        /// The register holding the left-hand side value.
+        lhs: AnyConst32,
+    },
+    /// A Wasm `select` equivalent Wasmi instruction with 32-bit immediate `lhs` and `rhs` values.
     ///
-    /// 1. [`Instruction::SelectImm32`] encodes `result` and `lhs`
-    /// 2. [`Instruction::SelectImm32`] encodes `condition` and `rhs`.
+    /// # Encoding
+    ///
+    /// Must be followed by [`Instruction::RegisterAndImm32`] to encode `condition` and `rhs`.
     SelectImm32 {
-        /// Register storing either the `result` or the `condition`.
-        result_or_condition: Register,
-        /// Either the constant 32-bit `lhs` or `rhs` value.
-        lhs_or_rhs: AnyConst32,
+        /// The register holding the result of the instruction.
+        result: Register,
+        /// The register holding the left-hand side value.
+        lhs: AnyConst32,
     },
-    /// Variant of [`Instruction::Select`] where `lhs` and `rhs` are 32-bit encoded `i64` constant values.
+    /// A Wasm `select` equivalent Wasmi instruction with 32-bit encoded `i64` immediate `lhs` value.
     ///
     /// # Encoding
     ///
-    /// This [`Instruction`] is always encoded as pair:
+    /// Must be followed by [`Instruction::RegisterAndImm32`] to encode `condition` and `rhs`.
+    SelectI64Imm32Rhs {
+        /// The register holding the result of the instruction.
+        result: Register,
+        /// The register holding the left-hand side value.
+        lhs: Register,
+    },
+    /// A Wasm `select` equivalent Wasmi instruction with 32-bit encoded `i64` immediate `lhs` value.
     ///
-    /// 1. [`Instruction::SelectI64Imm32`] encodes `result` and `lhs`
-    /// 2. [`Instruction::SelectI64Imm32`] encodes `condition` and `rhs`.
+    /// # Encoding
+    ///
+    /// Must be followed by [`Instruction::Register2`] to encode `condition` and `rhs`.
+    SelectI64Imm32Lhs {
+        /// The register holding the result of the instruction.
+        result: Register,
+        /// The register holding the left-hand side value.
+        lhs: Const32<i64>,
+    },
+    /// A Wasm `select` equivalent Wasmi instruction with 32-bit encoded `i64` immediate `lhs` and `rhs` values.
+    ///
+    /// # Encoding
+    ///
+    /// Must be followed by [`Instruction::RegisterAndImm32`] to encode `condition` and `rhs`.
     SelectI64Imm32 {
-        /// Register storing either the `result` or the `condition`.
-        result_or_condition: Register,
-        /// Either the constant 32-bit `i64` `lhs` or `rhs` value.
-        lhs_or_rhs: Const32<i64>,
+        /// The register holding the result of the instruction.
+        result: Register,
+        /// The register holding the left-hand side value.
+        lhs: Const32<i64>,
     },
-    /// Variant of [`Instruction::Select`] where `lhs` and `rhs` are 32-bit encoded `f64` constant values.
+    /// A Wasm `select` equivalent Wasmi instruction with 32-bit encoded `f64` immediate `rhs` value.
     ///
     /// # Encoding
     ///
-    /// This [`Instruction`] is always encoded as pair:
+    /// Must be followed by [`Instruction::RegisterAndImm32`] to encode `condition` and `rhs`.
+    SelectF64Imm32Rhs {
+        /// The register holding the result of the instruction.
+        result: Register,
+        /// The register holding the left-hand side value.
+        lhs: Register,
+    },
+    /// A Wasm `select` equivalent Wasmi instruction with 32-bit encoded `f64` immediate `lhs` value.
     ///
-    /// 1. [`Instruction::SelectF64Imm32`] encodes `result` and `lhs`
-    /// 2. [`Instruction::SelectF64Imm32`] encodes `condition` and `rhs`.
+    /// # Encoding
+    ///
+    /// Must be followed by [`Instruction::Register2`] to encode `condition` and `rhs`.
+    SelectF64Imm32Lhs {
+        /// The register holding the result of the instruction.
+        result: Register,
+        /// The register holding the left-hand side value.
+        lhs: Const32<f64>,
+    },
+    /// A Wasm `select` equivalent Wasmi instruction with 32-bit encoded `f64` immediate `lhs` and `rhs` value.
+    ///
+    /// # Encoding
+    ///
+    /// Must be followed by [`Instruction::RegisterAndImm32`] to encode `condition` and `rhs`.
     SelectF64Imm32 {
-        /// Register storing either the `result` or the `condition`.
-        result_or_condition: Register,
-        /// Either the constant 32-bit `f64` `lhs` or `rhs` value.
-        lhs_or_rhs: Const32<f64>,
+        /// The register holding the result of the instruction.
+        result: Register,
+        /// The register holding the left-hand side value.
+        lhs: Const32<f64>,
     },
 
     /// A Wasm `ref.func` equivalent Wasmi instruction.
@@ -3154,6 +3177,17 @@ pub enum Instruction {
     /// This [`Instruction`] only acts as a parameter to another
     /// one and will never be executed itself directly.
     F64Const32(Const32<f64>),
+    /// An instruction parameter with a [`Register`] and a 32-bit immediate value.
+    RegisterAndImm32 {
+        /// The [`Reg`] parameter value.
+        ///
+        /// # Note
+        ///
+        /// This also serves as utility to align `imm` to 4-bytes.
+        reg: Register,
+        /// The 32-bit immediate value.
+        imm: AnyConst32,
+    },
     /// A [`Register`] instruction parameter.
     ///
     /// # Note

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -350,28 +350,24 @@ impl<'engine> Executor<'engine> {
                 Instr::CallIndirectImm16 { results, func_type } => {
                     self.execute_call_indirect_imm16::<T>(store, results, func_type)?
                 }
-                Instr::Select {
-                    result,
-                    condition,
-                    lhs,
-                } => self.execute_select(result, condition, lhs),
-                Instr::SelectRev {
-                    result,
-                    condition,
-                    rhs,
-                } => self.execute_select_rev(result, condition, rhs),
-                Instr::SelectImm32 {
-                    result_or_condition,
-                    lhs_or_rhs,
-                } => self.execute_select_imm32(result_or_condition, lhs_or_rhs),
-                Instr::SelectI64Imm32 {
-                    result_or_condition,
-                    lhs_or_rhs,
-                } => self.execute_select_i64imm32(result_or_condition, lhs_or_rhs),
-                Instr::SelectF64Imm32 {
-                    result_or_condition,
-                    lhs_or_rhs,
-                } => self.execute_select_f64imm32(result_or_condition, lhs_or_rhs),
+                Instr::Select { result, lhs } => self.execute_select(result, lhs),
+                Instr::SelectImm32Rhs { result, lhs } => self.execute_select_imm32_rhs(result, lhs),
+                Instr::SelectImm32Lhs { result, lhs } => self.execute_select_imm32_lhs(result, lhs),
+                Instr::SelectImm32 { result, lhs } => self.execute_select_imm32(result, lhs),
+                Instr::SelectI64Imm32Rhs { result, lhs } => {
+                    self.execute_select_i64imm32_rhs(result, lhs)
+                }
+                Instr::SelectI64Imm32Lhs { result, lhs } => {
+                    self.execute_select_i64imm32_lhs(result, lhs)
+                }
+                Instr::SelectI64Imm32 { result, lhs } => self.execute_select_i64imm32(result, lhs),
+                Instr::SelectF64Imm32Rhs { result, lhs } => {
+                    self.execute_select_f64imm32_rhs(result, lhs)
+                }
+                Instr::SelectF64Imm32Lhs { result, lhs } => {
+                    self.execute_select_f64imm32_lhs(result, lhs)
+                }
+                Instr::SelectF64Imm32 { result, lhs } => self.execute_select_f64imm32(result, lhs),
                 Instr::RefFunc { result, func } => self.execute_ref_func(result, func),
                 Instr::GlobalGet { result, global } => {
                     self.execute_global_get(&store.inner, result, global)
@@ -863,6 +859,7 @@ impl<'engine> Executor<'engine> {
                 | Instr::Register(_)
                 | Instr::Register2(_)
                 | Instr::Register3(_)
+                | Instr::RegisterAndImm32 { .. }
                 | Instr::RegisterList(_)
                 | Instr::CallIndirectParams(_)
                 | Instr::CallIndirectParamsImm16(_) => self.invalid_instruction_word()?,

--- a/crates/wasmi/src/engine/translator/relink_result.rs
+++ b/crates/wasmi/src/engine/translator/relink_result.rs
@@ -37,6 +37,7 @@ impl Instruction {
             | I::Const32(_)
             | I::I64Const32(_)
             | I::F64Const32(_)
+            | I::RegisterAndImm32 { .. }
             | I::Register(_)
             | I::Register2(_)
             | I::Register3(_)
@@ -158,25 +159,16 @@ impl Instruction {
             | I::CallIndirectImm16 { results, func_type } => {
                 relink_call_indirect(results, *func_type, module, new_result, old_result)
             }
-            I::Select { result, .. }
-            | I::SelectRev { result, .. }
-            | I::SelectImm32 {
-                result_or_condition: result,
-                ..
-            }
-            | I::SelectI64Imm32 {
-                result_or_condition: result,
-                ..
-            }
-            | I::SelectF64Imm32 {
-                result_or_condition: result,
-                ..
-            } => {
-                // Note: the `result_or_condition` necessarily points to the actual `result`
-                //       register since we make sure elsewhere that only the correct instruction
-                //       word is given to this method.
-                relink_simple(result, new_result, old_result)
-            }
+            I::Select { result, .. } |
+            I::SelectImm32Rhs { result, .. } |
+            I::SelectImm32Lhs { result, .. } |
+            I::SelectImm32 { result, .. } |
+            I::SelectI64Imm32Rhs { result, .. } |
+            I::SelectI64Imm32Lhs { result, .. } |
+            I::SelectI64Imm32 { result, .. } |
+            I::SelectF64Imm32Rhs { result, .. } |
+            I::SelectF64Imm32Lhs { result, .. } |
+            I::SelectF64Imm32 { result, .. } => relink_simple(result, new_result, old_result),
             I::RefFunc { result, .. }
             | I::TableGet { result, .. }
             | I::TableGetImm { result, .. }

--- a/crates/wasmi/src/engine/translator/tests/op/local_set.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/local_set.rs
@@ -154,7 +154,7 @@ fn overwrite_select_result_1() {
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([
             Instruction::select_imm32(Register::from_i16(0), 10_i32),
-            Instruction::select_imm32(Register::from_i16(0), 20_i32),
+            Instruction::register_and_imm32(Register::from_i16(0), 20_i32),
             Instruction::return_reg(Register::from_i16(0)),
         ])
         .run()

--- a/crates/wasmi/src/engine/translator/tests/op/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/mod.rs
@@ -98,26 +98,6 @@ fn f64imm32(value: f64) -> Const32<f64> {
         .unwrap_or_else(|_| panic!("value must be 32-bit encodable: {}", value))
 }
 
-/// Creates an [`Instruction::I64Imm32`] from the given `i64` value.
-///
-/// # Panics
-///
-/// If the `value` cannot be converted into `i32` losslessly.
-#[track_caller]
-fn i64imm32_instr(value: i64) -> Instruction {
-    Instruction::I64Const32(i64imm32(value))
-}
-
-/// Creates an [`Instruction::F64Imm32`] from the given `i64` value.
-///
-/// # Panics
-///
-/// If the `value` cannot be converted into `i32` losslessly.
-#[track_caller]
-fn f64imm32_instr(value: f64) -> Instruction {
-    Instruction::F64Const32(f64imm32(value))
-}
-
 /// Creates an [`Instruction::ReturnI64Imm32`] from the given `i64` value.
 ///
 /// # Panics

--- a/crates/wasmi/src/engine/translator/tests/op/select.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/select.rs
@@ -65,8 +65,8 @@ fn reg() {
         let result = Register::from_i16(3);
         TranslationTest::from_wat(&wasm)
             .expect_func_instrs([
-                Instruction::select(result, condition, lhs),
-                Instruction::Register(rhs),
+                Instruction::select(result, lhs),
+                Instruction::register2(condition, rhs),
                 Instruction::return_reg(result),
             ])
             .run();
@@ -299,8 +299,8 @@ fn reg_imm32() {
         let condition = Register::from_i16(0);
         let lhs = Register::from_i16(1);
         let expected = [
-            Instruction::select(result, condition, lhs),
-            Instruction::const32(value),
+            Instruction::select_imm32_rhs(result, lhs),
+            Instruction::register_and_imm32(condition, value),
             Instruction::return_reg(result),
         ];
         test_reg_imm(kind, value).expect_func_instrs(expected).run();
@@ -349,8 +349,8 @@ fn reg_imm() {
         let condition = Register::from_i16(0);
         let lhs = Register::from_i16(1);
         let instrs = [
-            Instruction::select(result, condition, lhs),
-            Instruction::Register(Register::from_i16(-1)),
+            Instruction::select(result, lhs),
+            Instruction::register2(condition, Register::from_i16(-1)),
             Instruction::return_reg(result),
         ];
         let expected = ExpectedFunc::new(instrs).consts([value]);
@@ -389,8 +389,8 @@ fn reg_i64imm32() {
         let condition = Register::from_i16(0);
         let lhs = Register::from_i16(1);
         let expected = [
-            Instruction::select(result, condition, lhs),
-            i64imm32_instr(value),
+            Instruction::select_i64imm32_rhs(result, lhs),
+            Instruction::register_and_imm32(condition, i32::try_from(value).unwrap()),
             Instruction::return_reg(result),
         ];
         test_reg_imm(kind, value).expect_func_instrs(expected).run();
@@ -418,8 +418,8 @@ fn reg_f64imm32() {
         let condition = Register::from_i16(0);
         let lhs = Register::from_i16(1);
         let expected = [
-            Instruction::select(result, condition, lhs),
-            f64imm32_instr(value),
+            Instruction::select_f64imm32_rhs(result, lhs),
+            Instruction::register_and_imm32(condition, value as f32),
             Instruction::return_reg(result),
         ];
         test_reg_imm(kind, value).expect_func_instrs(expected).run();
@@ -478,8 +478,8 @@ fn imm32_reg() {
         let condition = Register::from_i16(0);
         let lhs = Register::from_i16(1);
         let expected = [
-            Instruction::select_rev(result, condition, lhs),
-            Instruction::const32(value),
+            Instruction::select_imm32_lhs(result, value),
+            Instruction::register2(condition, lhs),
             Instruction::return_reg(result),
         ];
         test_imm_reg(kind, value).expect_func_instrs(expected).run();
@@ -528,8 +528,8 @@ fn imm_reg() {
         let condition = Register::from_i16(0);
         let lhs = Register::from_i16(1);
         let instrs = [
-            Instruction::select_rev(result, condition, lhs),
-            Instruction::Register(Register::from_i16(-1)),
+            Instruction::select(result, Register::from_i16(-1)),
+            Instruction::register2(condition, lhs),
             Instruction::return_reg(result),
         ];
         let expected = ExpectedFunc::new(instrs).consts([value]);
@@ -568,8 +568,8 @@ fn i64imm32_reg() {
         let condition = Register::from_i16(0);
         let lhs = Register::from_i16(1);
         let expected = [
-            Instruction::select_rev(result, condition, lhs),
-            i64imm32_instr(value),
+            Instruction::select_i64imm32_lhs(result, i32::try_from(value).unwrap()),
+            Instruction::register2(condition, lhs),
             Instruction::return_reg(result),
         ];
         test_imm_reg(kind, value).expect_func_instrs(expected).run();
@@ -597,8 +597,8 @@ fn f64imm32_reg() {
         let condition = Register::from_i16(0);
         let lhs = Register::from_i16(1);
         let expected = [
-            Instruction::select_rev(result, condition, lhs),
-            f64imm32_instr(value),
+            Instruction::select_f64imm32_lhs(result, value as f32),
+            Instruction::register2(condition, lhs),
             Instruction::return_reg(result),
         ];
         test_imm_reg(kind, value).expect_func_instrs(expected).run();
@@ -660,7 +660,7 @@ fn both_imm32() {
         let rhs32 = AnyConst32::from(rhs);
         let expected = [
             Instruction::select_imm32(result, lhs32),
-            Instruction::select_imm32(condition, rhs32),
+            Instruction::register_and_imm32(condition, rhs32),
             Instruction::return_reg(result),
         ];
         test_both_imm(kind, lhs, rhs)
@@ -704,8 +704,8 @@ fn both_imm() {
         let lhs_reg = Register::from_i16(-1);
         let rhs_reg = Register::from_i16(-2);
         let instrs = [
-            Instruction::select(result, condition, lhs_reg),
-            Instruction::Register(rhs_reg),
+            Instruction::select(result, lhs_reg),
+            Instruction::register2(condition, rhs_reg),
             Instruction::return_reg(result),
         ];
         test_both_imm(kind, lhs, rhs)
@@ -741,7 +741,7 @@ fn both_i64imm32() {
         let rhs32 = i64imm32(rhs);
         let expected = [
             Instruction::select_i64imm32(result, lhs32),
-            Instruction::select_i64imm32(condition, rhs32),
+            Instruction::register_and_imm32(condition, rhs32),
             Instruction::return_reg(result),
         ];
         test_both_imm(kind, lhs, rhs)
@@ -772,7 +772,7 @@ fn both_f64imm32() {
         let rhs32 = f64imm32(rhs);
         let expected = [
             Instruction::select_f64imm32(result, lhs32),
-            Instruction::select_f64imm32(condition, rhs32),
+            Instruction::register_and_imm32(condition, rhs32),
             Instruction::return_reg(result),
         ];
         test_both_imm(kind, lhs, rhs)

--- a/crates/wasmi/src/engine/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/translator/visit_register.rs
@@ -41,6 +41,7 @@ impl VisitInputRegisters for Instruction {
             Instruction::Const32(_) |
             Instruction::I64Const32(_) |
             Instruction::F64Const32(_) => {},
+            Instruction::RegisterAndImm32 { reg, .. } => f(reg),
             Instruction::Register(register) => f(register),
             Instruction::Register2(registers) => registers.visit_input_registers(f),
             Instruction::Register3(registers) |
@@ -205,11 +206,16 @@ impl VisitInputRegisters for Instruction {
             Instruction::CallIndirect0Imm16 { .. } |
             Instruction::CallIndirect { .. } |
             Instruction::CallIndirectImm16 { .. } => {},
-            Instruction::Select { condition, lhs, .. } => visit_registers!(f, condition, lhs),
-            Instruction::SelectRev { condition, rhs, .. } => visit_registers!(f, condition, rhs),
-            Instruction::SelectImm32 { result_or_condition, .. } |
-            Instruction::SelectI64Imm32 { result_or_condition, .. } |
-            Instruction::SelectF64Imm32 { result_or_condition, .. } => f(result_or_condition),
+            Instruction::Select { lhs, .. } => f(lhs),
+            Instruction::SelectImm32Rhs { lhs, .. } => f(lhs),
+            Instruction::SelectImm32Lhs { .. } |
+            Instruction::SelectImm32 { .. } => {},
+            Instruction::SelectI64Imm32Rhs { lhs, .. } => f(lhs),
+            Instruction::SelectI64Imm32Lhs { .. } |
+            Instruction::SelectI64Imm32 { .. } => {},
+            Instruction::SelectF64Imm32Rhs { lhs, .. } => f(lhs),
+            Instruction::SelectF64Imm32Lhs { .. } |
+            Instruction::SelectF64Imm32 { .. } => {},
             Instruction::RefFunc { .. } |
             Instruction::TableGet { .. } |
             Instruction::TableGetImm { .. } |


### PR DESCRIPTION
This simplifies integration of https://github.com/wasmi-labs/wasmi/pull/1152.