### PR TITLE
Implement re-designed Wasmi `br_table` instructions

### DIFF
--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -236,7 +236,7 @@ impl Instruction {
 
     /// Creates a new [`Instruction::BranchTableSpan`] for the given `index` and `len_targets`.
     pub fn branch_table_span(index: impl Into<Register>, len_targets: u32) -> Self {
-        Self::BranchTable1 {
+        Self::BranchTableSpan {
             index: index.into(),
             len_targets,
         }
@@ -244,7 +244,7 @@ impl Instruction {
 
     /// Creates a new [`Instruction::BranchTableMany`] for the given `index` and `len_targets`.
     pub fn branch_table_many(index: impl Into<Register>, len_targets: u32) -> Self {
-        Self::BranchTable1 {
+        Self::BranchTableMany {
             index: index.into(),
             len_targets,
         }

--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -202,11 +202,49 @@ impl Instruction {
         Self::branch_i64_ne_imm(condition, 0_i16, offset)
     }
 
-    /// Creates a new [`Instruction::BranchTable`] for the given `index` and `len_targets`.
-    pub fn branch_table(index: Register, len_targets: impl Into<Const32<u32>>) -> Self {
-        Self::BranchTable {
-            index,
-            len_targets: len_targets.into(),
+    // TODO: remove this method
+    /// Creates a new [`Instruction::BranchTable0`] for the given `index` and `len_targets`.
+    pub fn branch_table(index: Register, len_targets: u32) -> Self {
+        Self::branch_table_0(index, len_targets)
+    }
+
+    /// Creates a new [`Instruction::BranchTable0`] for the given `index` and `len_targets`.
+    pub fn branch_table_0(index: impl Into<Register>, len_targets: u32) -> Self {
+        Self::BranchTable0 {
+            index: index.into(),
+            len_targets,
+        }
+    }
+
+    /// Creates a new [`Instruction::BranchTable1`] for the given `index` and `len_targets`.
+    pub fn branch_table_1(index: impl Into<Register>, len_targets: u32) -> Self {
+        Self::BranchTable1 {
+            index: index.into(),
+            len_targets,
+        }
+    }
+
+    /// Creates a new [`Instruction::BranchTable2`] for the given `index` and `len_targets`.
+    pub fn branch_table_2(index: impl Into<Register>, len_targets: u32) -> Self {
+        Self::BranchTable2 {
+            index: index.into(),
+            len_targets,
+        }
+    }
+
+    /// Creates a new [`Instruction::BranchTableSpan`] for the given `index` and `len_targets`.
+    pub fn branch_table_span(index: impl Into<Register>, len_targets: u32) -> Self {
+        Self::BranchTable1 {
+            index: index.into(),
+            len_targets,
+        }
+    }
+
+    /// Creates a new [`Instruction::BranchTableMany`] for the given `index` and `len_targets`.
+    pub fn branch_table_many(index: impl Into<Register>, len_targets: u32) -> Self {
+        Self::BranchTable1 {
+            index: index.into(),
+            len_targets,
         }
     }
 

--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -232,6 +232,14 @@ impl Instruction {
         }
     }
 
+    /// Creates a new [`Instruction::BranchTable3`] for the given `index` and `len_targets`.
+    pub fn branch_table_3(index: impl Into<Register>, len_targets: u32) -> Self {
+        Self::BranchTable3 {
+            index: index.into(),
+            len_targets,
+        }
+    }
+
     /// Creates a new [`Instruction::BranchTableSpan`] for the given `index` and `len_targets`.
     pub fn branch_table_span(index: impl Into<Register>, len_targets: u32) -> Self {
         Self::BranchTable1 {
@@ -246,6 +254,19 @@ impl Instruction {
             index: index.into(),
             len_targets,
         }
+    }
+
+    /// Creates a new [`Instruction::BranchTableTarget`] for the given `index` and `len_targets`.
+    pub fn branch_table_target(results: RegisterSpan, offset: BranchOffset) -> Self {
+        Self::BranchTableTarget { results, offset }
+    }
+
+    /// Creates a new [`Instruction::BranchTableTargetNonOverlapping`] for the given `index` and `len_targets`.
+    pub fn branch_table_target_non_overlapping(
+        results: RegisterSpan,
+        offset: BranchOffset,
+    ) -> Self {
+        Self::BranchTableTargetNonOverlapping { results, offset }
     }
 
     /// Creates a new [`Instruction::Copy`].
@@ -1037,6 +1058,11 @@ impl Instruction {
         reg2: impl Into<Register>,
     ) -> Self {
         Self::RegisterList([reg0.into(), reg1.into(), reg2.into()])
+    }
+
+    /// Creates a new [`Instruction::RegisterSpan`].
+    pub fn register_span(span: RegisterSpanIter) -> Self {
+        Self::RegisterSpan(span)
     }
 
     /// Creates a new [`Instruction::CallIndirectParams`] for the given `index` and `table`.

--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -202,12 +202,6 @@ impl Instruction {
         Self::branch_i64_ne_imm(condition, 0_i16, offset)
     }
 
-    // TODO: remove this method
-    /// Creates a new [`Instruction::BranchTable0`] for the given `index` and `len_targets`.
-    pub fn branch_table(index: Register, len_targets: u32) -> Self {
-        Self::branch_table_0(index, len_targets)
-    }
-
     /// Creates a new [`Instruction::BranchTable0`] for the given `index` and `len_targets`.
     pub fn branch_table_0(index: impl Into<Register>, len_targets: u32) -> Self {
         Self::BranchTable0 {

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -552,25 +552,110 @@ pub enum Instruction {
     /// A fused [`Instruction::F64Ge`] and Wasm branch instruction.
     BranchF64Ge(BranchBinOpInstr),
 
-    /// A Wasm `br_table` instruction.
+    /// A Wasm `br_table` equivalent Wasmi instruction.
     ///
     /// # Encoding
     ///
-    /// 1. May be followed by one of the copy instructions.
-    /// 1. Must be followed `len_targets` times by any of:
+    /// Followed `len_target` times by
     ///
     /// - [`Instruction::Branch`]
     /// - [`Instruction::Return`]
     /// - [`Instruction::ReturnReg`]
+    /// - [`Instruction::ReturnReg2`]
+    /// - [`Instruction::ReturnReg3`]
     /// - [`Instruction::ReturnImm32`]
     /// - [`Instruction::ReturnI64Imm32`]
     /// - [`Instruction::ReturnF64Imm32`]
     /// - [`Instruction::ReturnSpan`]
-    BranchTable {
+    BranchTable0 {
         /// The register holding the index of the instruction.
         index: Register,
         /// The number of branch table targets including the default target.
-        len_targets: Const32<u32>,
+        len_targets: u32,
+    },
+    /// A Wasm `br_table` equivalent Wasmi instruction.
+    ///
+    /// # Encoding
+    ///
+    /// 1. Followed by one of
+    ///
+    /// - [`Instruction::Copy`]
+    /// - [`Instruction::CopyImm32`]
+    /// - [`Instruction::CopyI64Imm32`]
+    /// - [`Instruction::CopyF64Imm32`]
+    ///
+    /// 2. Followed `len_target` times by
+    ///
+    /// - [`Instruction::Branch`]
+    /// - [`Instruction::ReturnReg`]
+    /// - [`Instruction::ReturnReg2`]
+    /// - [`Instruction::ReturnReg3`]
+    /// - [`Instruction::ReturnImm32`]
+    /// - [`Instruction::ReturnI64Imm32`]
+    /// - [`Instruction::ReturnF64Imm32`]
+    /// - [`Instruction::ReturnSpan`]
+    BranchTable1 {
+        /// The register holding the index of the instruction.
+        index: Register,
+        /// The number of branch table targets including the default target.
+        len_targets: u32,
+    },
+    /// A Wasm `br_table` equivalent Wasmi instruction.
+    ///
+    /// # Encoding
+    ///
+    /// 1. Followed by [`Instruction::Copy2`].
+    /// 2. Followed `len_target` times by
+    ///
+    /// - [`Instruction::Branch`]
+    /// - [`Instruction::ReturnReg2`]
+    /// - [`Instruction::ReturnReg3`]
+    /// - [`Instruction::ReturnSpan`]
+    BranchTable2 {
+        /// The register holding the index of the instruction.
+        index: Register,
+        /// The number of branch table targets including the default target.
+        len_targets: u32,
+    },
+    /// A Wasm `br_table` equivalent Wasmi instruction.
+    ///
+    /// # Encoding
+    ///
+    /// 1. Followed by one of
+    ///
+    /// - [`Instruction::CopySpan`]
+    /// - [`Instruction::CopySpanNonOverlapping`]
+    ///
+    /// 2. Followed `len_target` times by
+    ///
+    /// - [`Instruction::Branch`]
+    /// - [`Instruction::ReturnSpan`]
+    /// - [`Instruction::ReturnReg3`]
+    BranchTableSpan {
+        /// The register holding the index of the instruction.
+        index: Register,
+        /// The number of branch table targets including the default target.
+        len_targets: u32,
+    },
+    /// A Wasm `br_table` equivalent Wasmi instruction.
+    ///
+    /// # Encoding
+    ///
+    /// 1. Followed by one of
+    ///
+    /// - [`Instruction::CopyMany`]
+    /// - [`Instruction::CopyManyNonOverlapping`]
+    ///
+    /// 2. Followed `len_target` times by
+    ///
+    /// - [`Instruction::Branch`]
+    /// - [`Instruction::ReturnSpan`]
+    /// - [`Instruction::ReturnReg3`]
+    BranchTableMany {
+        /// The register holding the index of the instruction.
+        index: Register,
+        /// The number of branch table targets including the default target.
+        len_targets: u32,
     },
 
     /// Copies `value` to `result`.

--- a/crates/wasmi/src/engine/bytecode/utils.rs
+++ b/crates/wasmi/src/engine/bytecode/utils.rs
@@ -229,6 +229,11 @@ impl Iterator for RegisterSpanIter {
         self.next = self.next.next();
         Some(reg)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len_as_u16() as usize;
+        (remaining, Some(remaining))
+    }
 }
 
 impl DoubleEndedIterator for RegisterSpanIter {

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -213,8 +213,20 @@ impl<'engine> Executor<'engine> {
                     ))
                 }
                 Instr::Branch { offset } => self.execute_branch(offset),
-                Instr::BranchTable { index, len_targets } => {
-                    self.execute_branch_table(index, len_targets)
+                Instr::BranchTable0 { index, len_targets } => {
+                    self.execute_branch_table_0(index, len_targets)
+                }
+                Instr::BranchTable1 { index, len_targets } => {
+                    self.execute_branch_table_1(index, len_targets)
+                }
+                Instr::BranchTable2 { index, len_targets } => {
+                    self.execute_branch_table_2(index, len_targets)
+                }
+                Instr::BranchTableSpan { index, len_targets } => {
+                    self.execute_branch_table_span(index, len_targets)
+                }
+                Instr::BranchTableMany { index, len_targets } => {
+                    self.execute_branch_table_many(index, len_targets)
                 }
                 Instr::BranchCmpFallback { lhs, rhs, params } => {
                     self.execute_branch_cmp_fallback(lhs, rhs, params)

--- a/crates/wasmi/src/engine/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/executor/instrs/copy.rs
@@ -29,13 +29,19 @@ impl<'engine> Executor<'engine> {
     /// Executes an [`Instruction::Copy2`].
     #[inline(always)]
     pub fn execute_copy_2(&mut self, results: RegisterSpan, values: [Register; 2]) {
+        self.execute_copy_2_impl(results, values);
+        self.next_instr()
+    }
+
+    /// Internal implementation of [`Instruction::Copy2`] execution.
+    #[inline(always)]
+    pub fn execute_copy_2_impl(&mut self, results: RegisterSpan, values: [Register; 2]) {
         let result0 = results.head();
         let result1 = result0.next();
         // We need `tmp` in case `results[0] == values[1]` to avoid overwriting `values[1]` before reading it.
         let tmp = self.get_register(values[1]);
         self.set_register(result0, self.get_register(values[0]));
         self.set_register(result1, tmp);
-        self.next_instr()
     }
 
     /// Executes an [`Instruction::CopyImm32`].
@@ -66,6 +72,18 @@ impl<'engine> Executor<'engine> {
     /// - If `results` and `values` do _not_ overlap [`Instruction::CopySpanNonOverlapping`] is used.
     #[inline(always)]
     pub fn execute_copy_span(&mut self, results: RegisterSpan, values: RegisterSpan, len: u16) {
+        self.execute_copy_span_impl(results, values, len);
+        self.next_instr();
+    }
+
+    /// Internal implementation of [`Instruction::CopySpan`] execution.
+    #[inline(always)]
+    pub fn execute_copy_span_impl(
+        &mut self,
+        results: RegisterSpan,
+        values: RegisterSpan,
+        len: u16,
+    ) {
         let results = results.iter_u16(len);
         let values = values.iter_u16(len);
         let mut tmp = <SmallVec<[UntypedVal; 8]>>::default();
@@ -73,7 +91,6 @@ impl<'engine> Executor<'engine> {
         for (result, value) in results.into_iter().zip(tmp) {
             self.set_register(result, value);
         }
-        self.next_instr();
     }
 
     /// Executes an [`Instruction::CopySpanNonOverlapping`].
@@ -85,6 +102,18 @@ impl<'engine> Executor<'engine> {
     /// - If `results` and `values` _do_ overlap [`Instruction::CopySpan`] is used.
     #[inline(always)]
     pub fn execute_copy_span_non_overlapping(
+        &mut self,
+        results: RegisterSpan,
+        values: RegisterSpan,
+        len: u16,
+    ) {
+        self.execute_copy_span_non_overlapping_impl(results, values, len);
+        self.next_instr();
+    }
+
+    /// Internal implementation of [`Instruction::CopySpanNonOverlapping`] execution.
+    #[inline(always)]
+    pub fn execute_copy_span_non_overlapping_impl(
         &mut self,
         results: RegisterSpan,
         values: RegisterSpan,

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -527,7 +527,11 @@ impl InstrEncoder {
     /// - `[ 1 <- 0 ]`: single element never overlaps
     /// - `[ 0 <- 1, 1 <- 2, 2 <- 3 ]``: no overlap
     /// - `[ 1 <- 0, 2 <- 1 ]`: overlaps!
-    fn has_overlapping_copy_spans(results: RegisterSpan, values: RegisterSpan, len: usize) -> bool {
+    pub fn has_overlapping_copy_spans(
+        results: RegisterSpan,
+        values: RegisterSpan,
+        len: usize,
+    ) -> bool {
         RegisterSpanIter::has_overlapping_copies(results.iter(len), values.iter(len))
     }
 
@@ -540,7 +544,7 @@ impl InstrEncoder {
     ///   is written to in the first copy but read from in the next.
     /// - The sequence `[ 3 <- 1, 4 <- 2, 5 <- 3 ]` has overlapping copies since register `3`
     ///   is written to in the first copy but read from in the third.
-    fn has_overlapping_copies(results: RegisterSpanIter, values: &[TypedProvider]) -> bool {
+    pub fn has_overlapping_copies(results: RegisterSpanIter, values: &[TypedProvider]) -> bool {
         debug_assert_eq!(results.len(), values.len());
         if results.is_empty() {
             // Note: An empty set of copies can never have overlapping copies.

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -475,8 +475,8 @@ impl InstrEncoder {
                     // Note: we already asserted that the first copy is not a no-op
                     return self.encode_copy(stack, result, *v0, fuel_info);
                 }
-                let reg0 = Self::provider2reg(stack, v0)?;
-                let reg1 = Self::provider2reg(stack, v1)?;
+                let reg0 = stack.provider2reg(v0)?;
+                let reg1 = stack.provider2reg(v1)?;
                 self.bump_fuel_consumption(fuel_info, FuelCosts::base)?;
                 let instr = self.push_instr(Instruction::copy2(results.span(), reg0, reg1))?;
                 Ok(Some(instr))
@@ -510,8 +510,8 @@ impl InstrEncoder {
                     true => Instruction::copy_many,
                     false => Instruction::copy_many_non_overlapping,
                 };
-                let reg0 = Self::provider2reg(stack, v0)?;
-                let reg1 = Self::provider2reg(stack, v1)?;
+                let reg0 = stack.provider2reg(v0)?;
+                let reg1 = stack.provider2reg(v1)?;
                 let instr = self.push_instr(make_instr(results.span(), reg0, reg1))?;
                 self.encode_register_list(stack, rest)?;
                 Ok(Some(instr))
@@ -607,14 +607,14 @@ impl InstrEncoder {
                 }
             },
             [v0, v1] => {
-                let reg0 = Self::provider2reg(stack, v0)?;
-                let reg1 = Self::provider2reg(stack, v1)?;
+                let reg0 = stack.provider2reg(v0)?;
+                let reg1 = stack.provider2reg(v1)?;
                 Instruction::return_reg2(reg0, reg1)
             }
             [v0, v1, v2] => {
-                let reg0 = Self::provider2reg(stack, v0)?;
-                let reg1 = Self::provider2reg(stack, v1)?;
-                let reg2 = Self::provider2reg(stack, v2)?;
+                let reg0 = stack.provider2reg(v0)?;
+                let reg1 = stack.provider2reg(v1)?;
+                let reg2 = stack.provider2reg(v2)?;
                 Instruction::return_reg3(reg0, reg1, reg2)
             }
             [v0, v1, v2, rest @ ..] => {
@@ -630,9 +630,9 @@ impl InstrEncoder {
                     self.push_instr(Instruction::return_span(span))?;
                     return Ok(());
                 }
-                let reg0 = Self::provider2reg(stack, v0)?;
-                let reg1 = Self::provider2reg(stack, v1)?;
-                let reg2 = Self::provider2reg(stack, v2)?;
+                let reg0 = stack.provider2reg(v0)?;
+                let reg1 = stack.provider2reg(v1)?;
+                let reg2 = stack.provider2reg(v2)?;
                 self.push_instr(Instruction::return_many(reg0, reg1, reg2))?;
                 self.encode_register_list(stack, rest)?;
                 return Ok(());
@@ -675,8 +675,8 @@ impl InstrEncoder {
                 }
             },
             [v0, v1] => {
-                let reg0 = Self::provider2reg(stack, v0)?;
-                let reg1 = Self::provider2reg(stack, v1)?;
+                let reg0 = stack.provider2reg(v0)?;
+                let reg1 = stack.provider2reg(v1)?;
                 Instruction::return_nez_reg2(condition, reg0, reg1)
             }
             [v0, v1, rest @ ..] => {
@@ -692,8 +692,8 @@ impl InstrEncoder {
                     self.push_instr(Instruction::return_nez_span(condition, span))?;
                     return Ok(());
                 }
-                let reg0 = Self::provider2reg(stack, v0)?;
-                let reg1 = Self::provider2reg(stack, v1)?;
+                let reg0 = stack.provider2reg(v0)?;
+                let reg1 = stack.provider2reg(v1)?;
                 self.push_instr(Instruction::return_nez_many(condition, reg0, reg1))?;
                 self.encode_register_list(stack, rest)?;
                 return Ok(());
@@ -702,16 +702,6 @@ impl InstrEncoder {
         self.bump_fuel_consumption(fuel_info, FuelCosts::base)?;
         self.push_instr(instr)?;
         Ok(())
-    }
-
-    /// Converts a [`TypedProvider`] into a [`Register`].
-    ///
-    /// This allocates constant values for [`TypedProvider::Const`].
-    pub fn provider2reg(
-        stack: &mut ValueStack,
-        provider: &TypedProvider,
-    ) -> Result<Register, Error> {
-        stack.provider2reg(provider)
     }
 
     /// Encode the given slice of [`TypedProvider`] as a list of [`Register`].

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -2478,6 +2478,7 @@ impl FuncTranslator {
         Ok(buffer)
     }
 
+    /// Convenience method to allow inspecting the provider buffer while manipulating `self` circumventing the borrow checker.
     fn apply_providers_buffer<R>(&mut self, f: impl FnOnce(&mut Self, &[TypedProvider]) -> R) -> R {
         let values = core::mem::take(&mut self.alloc.buffer.providers);
         let result = f(self, &values[..]);
@@ -2531,10 +2532,15 @@ impl FuncTranslator {
         }
     }
 
+    /// Translates the branching targets of a Wasm `br_table` instruction for simple cases without value copying.
     fn translate_br_table_targets_simple(&mut self, values: &[TypedProvider]) -> Result<(), Error> {
         self.translate_br_table_targets(values, |_, _| unreachable!())
     }
 
+    /// Translates the branching targets of a Wasm `br_table` instruction.
+    ///
+    /// The `make_target` closure allows to define the branch table target instruction being used
+    /// for each branch that copies 4 or more values to the destination.
     fn translate_br_table_targets(
         &mut self,
         values: &[TypedProvider],
@@ -2571,6 +2577,7 @@ impl FuncTranslator {
         Ok(())
     }
 
+    /// Translates a Wasm `br_table` instruction without inputs.
     fn translate_br_table_0(&mut self, index: Register) -> Result<(), Error> {
         let targets = &self.alloc.buffer.br_table_targets;
         let len_targets = targets.len() as u32;
@@ -2584,6 +2591,7 @@ impl FuncTranslator {
         Ok(())
     }
 
+    /// Translates a Wasm `br_table` instruction with a single input.
     fn translate_br_table_1(&mut self, index: Register) -> Result<(), Error> {
         let targets = &self.alloc.buffer.br_table_targets;
         let len_targets = targets.len() as u32;
@@ -2625,6 +2633,7 @@ impl FuncTranslator {
         Ok(())
     }
 
+    /// Translates a Wasm `br_table` instruction with exactly two inputs.
     fn translate_br_table_2(&mut self, index: Register) -> Result<(), Error> {
         let targets = &self.alloc.buffer.br_table_targets;
         let len_targets = targets.len() as u32;
@@ -2647,6 +2656,7 @@ impl FuncTranslator {
         Ok(())
     }
 
+    /// Translates a Wasm `br_table` instruction with exactly three inputs.
     fn translate_br_table_3(&mut self, index: Register) -> Result<(), Error> {
         let targets = &self.alloc.buffer.br_table_targets;
         let len_targets = targets.len() as u32;
@@ -2670,6 +2680,7 @@ impl FuncTranslator {
         Ok(())
     }
 
+    /// Translates a Wasm `br_table` instruction with 4 or more inputs.
     fn translate_br_table_n(&mut self, index: Register, len_values: usize) -> Result<(), Error> {
         debug_assert!(len_values > 3);
         let values = &mut self.alloc.buffer.providers;
@@ -2680,6 +2691,7 @@ impl FuncTranslator {
         }
     }
 
+    /// Translates a Wasm `br_table` instruction with 4 or more inputs that form a [`RegisterSpan`].
     fn translate_br_table_span(
         &mut self,
         index: Register,
@@ -2715,6 +2727,7 @@ impl FuncTranslator {
         Ok(())
     }
 
+    /// Translates a Wasm `br_table` instruction with 4 or more inputs that cannot form a [`RegisterSpan`].
     fn translate_br_table_many(&mut self, index: Register) -> Result<(), Error> {
         let targets = &mut self.alloc.buffer.br_table_targets;
         let len_targets = targets.len() as u32;

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -858,21 +858,21 @@ impl FuncTranslator {
     fn translate_copy_branch_params(
         &mut self,
         branch_params: RegisterSpanIter,
-    ) -> Result<Option<Instr>, Error> {
+    ) -> Result<(), Error> {
         if branch_params.is_empty() {
             // If the block does not have branch parameters there is no need to copy anything.
-            return Ok(None);
+            return Ok(());
         }
         let fuel_info = self.fuel_info();
         let params = &mut self.alloc.buffer.providers;
         self.alloc.stack.pop_n(branch_params.len(), params);
-        let copy_instr = self.alloc.instr_encoder.encode_copies(
+        self.alloc.instr_encoder.encode_copies(
             &mut self.alloc.stack,
             branch_params,
             &self.alloc.buffer.providers[..],
             fuel_info,
         )?;
-        Ok(copy_instr)
+        Ok(())
     }
 
     /// Translates the `end` of a Wasm `block` control frame.

--- a/crates/wasmi/src/engine/translator/relink_result.rs
+++ b/crates/wasmi/src/engine/translator/relink_result.rs
@@ -41,7 +41,10 @@ impl Instruction {
             | I::Register(_)
             | I::Register2(_)
             | I::Register3(_)
+            | I::RegisterSpan(_)
             | I::RegisterList(_)
+            | I::BranchTableTarget { .. } // can't relink since `br_table` diverts control flow
+            | I::BranchTableTargetNonOverlapping { .. } // can't relink since `br_table` diverts control flow
             | I::CallIndirectParams(_)
             | I::CallIndirectParamsImm16(_)
             | I::Trap(_)
@@ -80,6 +83,7 @@ impl Instruction {
             | I::BranchTable0 { .. }
             | I::BranchTable1 { .. }
             | I::BranchTable2 { .. }
+            | I::BranchTable3 { .. }
             | I::BranchTableSpan { .. }
             | I::BranchTableMany { .. }
             | I::BranchI32Eq(_)

--- a/crates/wasmi/src/engine/translator/relink_result.rs
+++ b/crates/wasmi/src/engine/translator/relink_result.rs
@@ -77,7 +77,11 @@ impl Instruction {
             | I::BranchI32OrEqzImm(_)
             | I::BranchI32XorEqz(_)
             | I::BranchI32XorEqzImm(_)
-            | I::BranchTable { .. }
+            | I::BranchTable0 { .. }
+            | I::BranchTable1 { .. }
+            | I::BranchTable2 { .. }
+            | I::BranchTableSpan { .. }
+            | I::BranchTableMany { .. }
             | I::BranchI32Eq(_)
             | I::BranchI32EqImm(_)
             | I::BranchI32Ne(_)

--- a/crates/wasmi/src/engine/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/stack/mod.rs
@@ -189,6 +189,16 @@ impl ValueStack {
         self.consts.alloc(value.into())
     }
 
+    /// Converts a [`TypedProvider`] into a [`Register`].
+    ///
+    /// This allocates constant values for [`TypedProvider::Const`].
+    pub fn provider2reg(&mut self, provider: &TypedProvider) -> Result<Register, Error> {
+        match provider {
+            Provider::Register(register) => Ok(*register),
+            Provider::Const(value) => self.alloc_const(*value),
+        }
+    }
+
     /// Returns the allocated function local constant values in reversed allocation order.
     ///
     /// # Note

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -349,10 +349,16 @@ fn fuzz_regression_15_01_codegen() {
             ExpectedFunc::new([
                 Instruction::i32_wrap_i64(Register::from_i16(1), Register::from_i16(0)),
                 Instruction::branch_table_1(Register::from_i16(1), 3),
-                Instruction::copy_imm32(Register::from_i16(1), 10.0_f32),
-                Instruction::branch(BranchOffset::from(3)),
+                Instruction::const32(10.0_f32),
+                Instruction::branch_table_target(
+                    RegisterSpan::new(Register::from(1)),
+                    BranchOffset::from(3),
+                ),
                 Instruction::return_imm32(10.0_f32),
-                Instruction::branch(BranchOffset::from(1)),
+                Instruction::branch_table_target(
+                    RegisterSpan::new(Register::from(1)),
+                    BranchOffset::from(1),
+                ),
                 Instruction::Trap(TrapCode::UnreachableCodeReached),
             ]),
         )
@@ -395,14 +401,16 @@ fn fuzz_regression_15_02() {
             ExpectedFunc::new([
                 Instruction::i32_wrap_i64(Register::from_i16(1), Register::from_i16(0)),
                 Instruction::branch_table_2(Register::from_i16(1), 3),
-                Instruction::copy2(
-                    RegisterSpan::new(Register::from_i16(1)),
-                    Register::from_i16(-1),
-                    Register::from_i16(-2),
+                Instruction::register2(Register::from_i16(-1), Register::from_i16(-2)),
+                Instruction::branch_table_target(
+                    RegisterSpan::new(Register::from(1)),
+                    BranchOffset::from(3),
                 ),
-                Instruction::branch(BranchOffset::from(3)),
                 Instruction::return_reg2(Register::from_i16(-1), Register::from_i16(-2)),
-                Instruction::branch(BranchOffset::from(1)),
+                Instruction::branch_table_target(
+                    RegisterSpan::new(Register::from(1)),
+                    BranchOffset::from(1),
+                ),
                 Instruction::Trap(TrapCode::UnreachableCodeReached),
             ])
             .consts([10.0_f32, 20.0_f32]),
@@ -422,33 +430,23 @@ fn fuzz_regression_15_03() {
                 Instruction::global_get(Register::from_i16(2), GlobalIdx::from(0)),
                 Instruction::i32_wrap_i64(Register::from_i16(3), Register::from_i16(0)),
                 Instruction::branch_table_2(Register::from_i16(3), 4),
-                Instruction::copy2(
-                    RegisterSpan::new(Register::from(1)),
-                    Register::from(-1),
-                    Register::from(-2),
+                Instruction::register2(Register::from(-1), Register::from(-2)),
+                Instruction::branch_table_target(
+                    RegisterSpan::new(Register::from(3)),
+                    BranchOffset::from(4),
                 ),
-                Instruction::branch(BranchOffset::from(4)),
-                Instruction::branch(BranchOffset::from(5)),
-                Instruction::branch(BranchOffset::from(2)),
-                Instruction::branch(BranchOffset::from(5)),
-                // Instruction::copy2(
-                //     RegisterSpan::new(Register::from_i16(3)),
-                //     Register::from_i16(-1),
-                //     Register::from_i16(-2),
-                // ),
-                // Instruction::branch(BranchOffset::from(5)),
-                // Instruction::copy2(
-                //     RegisterSpan::new(Register::from_i16(2)),
-                //     Register::from_i16(-1),
-                //     Register::from_i16(-2),
-                // ),
-                // Instruction::branch(BranchOffset::from(5)),
-                // Instruction::copy2(
-                //     RegisterSpan::new(Register::from_i16(1)),
-                //     Register::from_i16(-1),
-                //     Register::from_i16(-2),
-                // ),
-                // Instruction::branch(BranchOffset::from(5)),
+                Instruction::branch_table_target(
+                    RegisterSpan::new(Register::from(2)),
+                    BranchOffset::from(5),
+                ),
+                Instruction::branch_table_target(
+                    RegisterSpan::new(Register::from(3)),
+                    BranchOffset::from(2),
+                ),
+                Instruction::branch_table_target(
+                    RegisterSpan::new(Register::from(1)),
+                    BranchOffset::from(5),
+                ),
                 Instruction::i32_add(
                     Register::from_i16(3),
                     Register::from_i16(3),

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -63,14 +63,7 @@ fn fuzz_regression_3() {
                 RegisterSpan::new(Register::from_i16(3)),
                 EngineFunc::from_u32(0),
             ),
-            Instruction::branch_table(Register::from_i16(5), 2),
-            Instruction::copy_span_non_overlapping(
-                RegisterSpan::new(Register::from_i16(0)),
-                RegisterSpan::new(Register::from_i16(2)),
-                3,
-            ),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter_u16(3)),
-            Instruction::return_span(RegisterSpan::new(Register::from_i16(0)).iter_u16(3)),
+            Instruction::return_reg3(2, 3, 4),
         ])
         .run()
 }
@@ -355,10 +348,10 @@ fn fuzz_regression_15_01_codegen() {
             //   stores its `index` result.
             ExpectedFunc::new([
                 Instruction::i32_wrap_i64(Register::from_i16(1), Register::from_i16(0)),
-                Instruction::branch_table(Register::from_i16(1), 3),
+                Instruction::branch_table_1(Register::from_i16(1), 3),
                 Instruction::copy_imm32(Register::from_i16(1), 10.0_f32),
                 Instruction::branch(BranchOffset::from(3)),
-                Instruction::return_reg(1),
+                Instruction::return_imm32(10.0_f32),
                 Instruction::branch(BranchOffset::from(1)),
                 Instruction::Trap(TrapCode::UnreachableCodeReached),
             ]),
@@ -401,14 +394,14 @@ fn fuzz_regression_15_02() {
             // Note: The bug is that `copy2` overwrites `i32_wrap_i64` which is the `index` of the `br_table`.
             ExpectedFunc::new([
                 Instruction::i32_wrap_i64(Register::from_i16(1), Register::from_i16(0)),
-                Instruction::branch_table(Register::from_i16(1), 3),
+                Instruction::branch_table_2(Register::from_i16(1), 3),
                 Instruction::copy2(
                     RegisterSpan::new(Register::from_i16(1)),
                     Register::from_i16(-1),
                     Register::from_i16(-2),
                 ),
                 Instruction::branch(BranchOffset::from(3)),
-                Instruction::return_span(RegisterSpan::new(Register::from_i16(1)).iter_u16(2)),
+                Instruction::return_reg2(Register::from_i16(-1), Register::from_i16(-2)),
                 Instruction::branch(BranchOffset::from(1)),
                 Instruction::Trap(TrapCode::UnreachableCodeReached),
             ])
@@ -428,29 +421,34 @@ fn fuzz_regression_15_03() {
                 Instruction::global_get(Register::from_i16(1), GlobalIdx::from(0)),
                 Instruction::global_get(Register::from_i16(2), GlobalIdx::from(0)),
                 Instruction::i32_wrap_i64(Register::from_i16(3), Register::from_i16(0)),
-                Instruction::branch_table(Register::from_i16(3), 4),
+                Instruction::branch_table_2(Register::from_i16(3), 4),
+                Instruction::copy2(
+                    RegisterSpan::new(Register::from(1)),
+                    Register::from(-1),
+                    Register::from(-2),
+                ),
                 Instruction::branch(BranchOffset::from(4)),
                 Instruction::branch(BranchOffset::from(5)),
                 Instruction::branch(BranchOffset::from(2)),
                 Instruction::branch(BranchOffset::from(5)),
-                Instruction::copy2(
-                    RegisterSpan::new(Register::from_i16(3)),
-                    Register::from_i16(-1),
-                    Register::from_i16(-2),
-                ),
-                Instruction::branch(BranchOffset::from(5)),
-                Instruction::copy2(
-                    RegisterSpan::new(Register::from_i16(2)),
-                    Register::from_i16(-1),
-                    Register::from_i16(-2),
-                ),
-                Instruction::branch(BranchOffset::from(5)),
-                Instruction::copy2(
-                    RegisterSpan::new(Register::from_i16(1)),
-                    Register::from_i16(-1),
-                    Register::from_i16(-2),
-                ),
-                Instruction::branch(BranchOffset::from(5)),
+                // Instruction::copy2(
+                //     RegisterSpan::new(Register::from_i16(3)),
+                //     Register::from_i16(-1),
+                //     Register::from_i16(-2),
+                // ),
+                // Instruction::branch(BranchOffset::from(5)),
+                // Instruction::copy2(
+                //     RegisterSpan::new(Register::from_i16(2)),
+                //     Register::from_i16(-1),
+                //     Register::from_i16(-2),
+                // ),
+                // Instruction::branch(BranchOffset::from(5)),
+                // Instruction::copy2(
+                //     RegisterSpan::new(Register::from_i16(1)),
+                //     Register::from_i16(-1),
+                //     Register::from_i16(-2),
+                // ),
+                // Instruction::branch(BranchOffset::from(5)),
                 Instruction::i32_add(
                     Register::from_i16(3),
                     Register::from_i16(3),

--- a/crates/wasmi/src/engine/translator/tests/op/br_table.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_table.rs
@@ -578,8 +578,7 @@ fn all_same_targets_1() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn reg_params_3() {
-    let wasm = &format!(
-        r"
+    let wasm = r"
         (module
             (func (param i32 i32 i32 i32) (result i32 i32 i32)
                 (block (result i32 i32 i32)
@@ -596,8 +595,7 @@ fn reg_params_3() {
                 )
                 (return (i32.add (i32.const 30)))
             )
-        )",
-    );
+        )";
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([
             Instruction::branch_table_3(3, 4),
@@ -628,8 +626,7 @@ fn reg_params_3() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn reg_params_4_span() {
-    let wasm = &format!(
-        r"
+    let wasm = r"
         (module
             (func (param i32 i32 i32 i32 i32) (result i32 i32 i32 i32)
                 (block (result i32 i32 i32 i32)
@@ -648,8 +645,7 @@ fn reg_params_4_span() {
                 )
                 (return (i32.add (i32.const 30)))
             )
-        )",
-    );
+        )";
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([
             Instruction::i32_popcnt(Register::from(5), Register::from(0)),
@@ -681,8 +677,7 @@ fn reg_params_4_span() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn reg_params_4_many() {
-    let wasm = &format!(
-        r"
+    let wasm = r"
         (module
             (func (param i32 i32 i32 i32 i32) (result i32 i32 i32 i32)
                 (block (result i32 i32 i32 i32)
@@ -701,8 +696,7 @@ fn reg_params_4_many() {
                 )
                 (return (i32.add (i32.const 30)))
             )
-        )",
-    );
+        )";
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([
             Instruction::i32_popcnt(Register::from(5), Register::from(0)),

--- a/crates/wasmi/src/engine/translator/tests/op/br_table.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_table.rs
@@ -109,7 +109,7 @@ fn reg_params_0() {
         )";
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([
-            Instruction::branch_table(Register::from_i16(0), 4),
+            Instruction::branch_table_0(Register::from_i16(0), 4),
             Instruction::branch(BranchOffset::from(7)),
             Instruction::branch(BranchOffset::from(5)),
             Instruction::branch(BranchOffset::from(3)),
@@ -146,7 +146,7 @@ fn reg_params_0_return() {
         )";
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([
-            Instruction::branch_table(Register::from_i16(0), 5),
+            Instruction::branch_table_0(Register::from_i16(0), 5),
             Instruction::Return,
             Instruction::branch(BranchOffset::from(10)),
             Instruction::branch(BranchOffset::from(7)),

--- a/crates/wasmi/src/engine/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/translator/visit_register.rs
@@ -46,6 +46,9 @@ impl VisitInputRegisters for Instruction {
             Instruction::Register2(registers) => registers.visit_input_registers(f),
             Instruction::Register3(registers) |
             Instruction::RegisterList(registers) => registers.visit_input_registers(f),
+            Instruction::RegisterSpan(registers) => registers.visit_input_registers(f),
+            Instruction::BranchTableTarget { .. } |
+            Instruction::BranchTableTargetNonOverlapping { .. } => {},
             Instruction::Trap(_) |
             Instruction::ConsumeFuel(_) |
             Instruction::Return => {},
@@ -82,6 +85,7 @@ impl VisitInputRegisters for Instruction {
             Instruction::BranchTable0 { index, .. } |
             Instruction::BranchTable1 { index, .. } |
             Instruction::BranchTable2 { index, .. } |
+            Instruction::BranchTable3 { index, .. } |
             Instruction::BranchTableSpan { index, .. } |
             Instruction::BranchTableMany { index, .. } => f(index),
 

--- a/crates/wasmi/src/engine/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/translator/visit_register.rs
@@ -79,7 +79,11 @@ impl VisitInputRegisters for Instruction {
                 values.visit_input_registers(f);
             }
             Instruction::Branch { .. } => {},
-            Instruction::BranchTable { index, .. } => f(index),
+            Instruction::BranchTable0 { index, .. } |
+            Instruction::BranchTable1 { index, .. } |
+            Instruction::BranchTable2 { index, .. } |
+            Instruction::BranchTableSpan { index, .. } |
+            Instruction::BranchTableMany { index, .. } => f(index),
 
             Instruction::BranchCmpFallback { lhs, rhs, .. } => visit_registers!(f, lhs, rhs),
             Instruction::BranchI32And(instr) => instr.visit_input_registers(f),


### PR DESCRIPTION
This new `br_table` design fixes a pathological encoding scheme with the old `br_table` instruction when the branches required to copy values into different branch destination registers. The new design no longer has this pathological translation case and thus should use a lot less encoding space and be more efficient in some cases.

The downside is that this increased complexity in both, the Wasmi translator and also in the Wasmi bytecode executor to some extend. However, it could also be argued that the translation of the new `br_table` instructions is a bit simpler overall since the pathological case no longer has to be handled.

# TODO

- [x] Properly emit `Instruction::BranchTableTargetNonOverlapping` in cases where possible.
- [x] Write missing docs for the new definitions.
- [x] New Wasmi translation unit tests featuring the new encoding schemes.