### PR TITLE
Remove `Const32<u32>` usage

### DIFF
--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -485,11 +485,8 @@ impl Instruction {
     }
 
     /// Creates a new [`Instruction::TableGetImm`] with the given `result` and `index`.
-    pub fn table_get_imm(result: Reg, index: impl Into<Const32<u32>>) -> Self {
-        Self::TableGetImm {
-            result,
-            index: index.into(),
-        }
+    pub fn table_get_imm(result: Reg, index: u32) -> Self {
+        Self::TableGetImm { result, index }
     }
 
     /// Creates a new [`Instruction::TableSize`] with the given `result` and `table`.
@@ -506,11 +503,8 @@ impl Instruction {
     }
 
     /// Creates a new [`Instruction::TableSetAt`] with the given `index` and `value`.
-    pub fn table_set_at(index: impl Into<Const32<u32>>, value: Reg) -> Self {
-        Self::TableSetAt {
-            index: index.into(),
-            value,
-        }
+    pub fn table_set_at(index: u32, value: Reg) -> Self {
+        Self::TableSetAt { index, value }
     }
 
     /// Creates a new [`Instruction::TableCopy`] with the given `dst`, `src` and `len`.
@@ -1530,7 +1524,7 @@ macro_rules! constructor_for_load_instrs {
     };
     ( @impl fn $fn_name:ident(at) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(result: Reg, address: Const32<u32>) -> Self {
+        pub fn $fn_name(result: Reg, address: u32) -> Self {
             Self::$op_code { result, address: u32::from(address) }
         }
     };
@@ -1613,13 +1607,13 @@ macro_rules! constructor_for_store_instrs {
     };
     ( @impl fn $fn_name:ident() -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(ptr: Reg, offset: Const32<u32>) -> Self {
+        pub fn $fn_name(ptr: Reg, offset: u32) -> Self {
             Self::$op_code { ptr, offset: u32::from(offset) }
         }
     };
     ( @impl fn $fn_name:ident(at) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(address: Const32<u32>, value: Reg) -> Self {
+        pub fn $fn_name(address: u32, value: Reg) -> Self {
             Self::$op_code { address: u32::from(address), value }
         }
     };
@@ -1643,13 +1637,13 @@ macro_rules! constructor_for_store_instrs {
     };
     ( @impl fn $fn_name:ident({at_imm<i8>}) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(address: Const32<u32>, value: i8) -> Self {
+        pub fn $fn_name(address: u32, value: i8) -> Self {
             Self::$op_code { address: u32::from(address), value: value.into() }
         }
     };
     ( @impl fn $fn_name:ident({at_imm<i16>}) -> Self::$op_code:ident ) => {
         #[doc = concat!("Creates a new [`Instruction::", stringify!($op_code), "`].")]
-        pub fn $fn_name(address: Const32<u32>, value: i16) -> Self {
+        pub fn $fn_name(address: u32, value: i16) -> Self {
             Self::$op_code { address: u32::from(address), value: value.into() }
         }
     };

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -4623,7 +4623,7 @@ pub enum Instruction {
         /// The register storing the result of the instruction.
         result: Reg,
         /// The constant `index` value of the table element to get.
-        index: Const32<u32>,
+        index: u32,
     },
 
     /// A Wasm `table.size` instruction.
@@ -4651,10 +4651,10 @@ pub enum Instruction {
     ///
     /// This [`Instruction`] must be followed by an [`Instruction::TableIdx`].
     TableSetAt {
-        /// The constant `index` of the instruction.
-        index: Const32<u32>,
         /// The register holding the `value` of the instruction.
         value: Reg,
+        /// The constant `index` of the instruction.
+        index: u32,
     },
 
     /// Wasm `table.copy <dst> <src>` instruction.

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -1,15 +1,7 @@
 use super::Executor;
 use crate::{
     core::TrapCode,
-    engine::bytecode::{
-        Const16,
-        Const32,
-        ElementSegmentIdx,
-        Instruction,
-        InstructionPtr,
-        Reg,
-        TableIdx,
-    },
+    engine::bytecode::{Const16, ElementSegmentIdx, Instruction, InstructionPtr, Reg, TableIdx},
     error::EntityGrowError,
     store::{ResourceLimiterRef, StoreInner},
     table::TableEntity,
@@ -56,9 +48,9 @@ impl<'engine> Executor<'engine> {
         &mut self,
         store: &StoreInner,
         result: Reg,
-        index: Const32<u32>,
+        index: u32,
     ) -> Result<(), Error> {
-        self.execute_table_get_impl(store, result, u32::from(index))
+        self.execute_table_get_impl(store, result, index)
     }
 
     /// Executes a `table.get` instruction generically.
@@ -109,10 +101,9 @@ impl<'engine> Executor<'engine> {
     pub fn execute_table_set_at(
         &mut self,
         store: &mut StoreInner,
-        index: Const32<u32>,
+        index: u32,
         value: Reg,
     ) -> Result<(), Error> {
-        let index = u32::from(index);
         self.execute_table_set_impl(store, index, value)
     }
 

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -403,7 +403,7 @@ fn fuzz_regression_16() {
             Instruction::copy(2, 0),
             Instruction::global_get(Reg::from(0), GlobalIdx::from(0)),
             Instruction::global_set(GlobalIdx::from(0), Reg::from(0)),
-            Instruction::i64_store_at(Const32::from(2147483647), Reg::from(2)),
+            Instruction::i64_store_at(2147483647, Reg::from(2)),
             Instruction::trap(TrapCode::UnreachableCodeReached),
         ])
         .run()
@@ -421,7 +421,7 @@ fn fuzz_regression_17() {
             Instruction::copy(2, 0),
             Instruction::copy_i64imm32(Reg::from(0), 2),
             Instruction::copy_imm32(Reg::from(1), -1.0_f32),
-            Instruction::i64_store_at(Const32::from(4294967295), Reg::from(2)),
+            Instruction::i64_store_at(4294967295, Reg::from(2)),
             Instruction::trap(TrapCode::UnreachableCodeReached),
         ])
         .run()

--- a/crates/wasmi/src/engine/translator/tests/op/load.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/load.rs
@@ -58,7 +58,7 @@ fn test_load_at(
     wasm_op: WasmOp,
     ptr: u32,
     offset: u32,
-    make_instr_at: fn(result: Reg, address: Const32<u32>) -> Instruction,
+    make_instr_at: fn(result: Reg, address: u32) -> Instruction,
 ) {
     let result_ty = wasm_op.result_ty();
     let wasm = format!(
@@ -77,7 +77,7 @@ fn test_load_at(
         .expect("ptr+offset must be valid in this testcase");
     TranslationTest::from_wat(&wasm)
         .expect_func_instrs([
-            make_instr_at(Reg::from(0), Const32::from(address)),
+            make_instr_at(Reg::from(0), address),
             Instruction::return_reg(Reg::from(0)),
         ])
         .run();


### PR DESCRIPTION
Simplifies integration of https://github.com/wasmi-labs/wasmi/pull/1152.

This is no longer required since we moved to named fields for the `Instruction` enum.