### PR TITLE
Move `InstructionPtr` into the executor sub-module

### DIFF
--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -1,6 +1,5 @@
 mod construct;
 mod immediate;
-mod instr_ptr;
 mod provider;
 mod utils;
 
@@ -9,7 +8,6 @@ mod tests;
 
 pub(crate) use self::{
     immediate::{AnyConst16, AnyConst32, Const16, Const32},
-    instr_ptr::InstructionPtr,
     provider::{Provider, ProviderSliceStack, UntypedProvider},
     utils::{
         BlockFuel,

--- a/crates/wasmi/src/engine/executor/instr_ptr.rs
+++ b/crates/wasmi/src/engine/executor/instr_ptr.rs
@@ -1,4 +1,4 @@
-use super::Instruction;
+use crate::engine::bytecode::Instruction;
 
 /// The instruction pointer to the instruction of a function on the call stack.
 #[derive(Debug, Copy, Clone)]

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1,6 +1,6 @@
 pub use self::call::{dispatch_host_func, ResumableHostError};
 use self::return_::ReturnOutcome;
-use super::{cache::CachedInstance, Stack};
+use super::{cache::CachedInstance, InstructionPtr, Stack};
 use crate::{
     core::{TrapCode, UntypedVal},
     engine::{
@@ -13,7 +13,6 @@ use crate::{
             FuncIdx,
             GlobalIdx,
             Instruction,
-            InstructionPtr,
             Reg,
             SignatureIdx,
             TableIdx,

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -1,8 +1,8 @@
-use super::Executor;
+use super::{Executor, InstructionPtr};
 use crate::{
     core::TrapCode,
     engine::{
-        bytecode::{FuncIdx, Instruction, InstructionPtr, Reg, RegSpan, SignatureIdx, TableIdx},
+        bytecode::{FuncIdx, Instruction, Reg, RegSpan, SignatureIdx, TableIdx},
         code_map::CompiledFuncRef,
         executor::stack::{CallFrame, FrameParams, ValueStack},
         EngineFunc,

--- a/crates/wasmi/src/engine/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/executor/instrs/copy.rs
@@ -1,7 +1,7 @@
-use super::Executor;
+use super::{Executor, InstructionPtr};
 use crate::{
     core::UntypedVal,
-    engine::bytecode::{AnyConst32, Const32, Instruction, InstructionPtr, Reg, RegSpan},
+    engine::bytecode::{AnyConst32, Const32, Instruction, Reg, RegSpan},
 };
 use core::slice;
 use smallvec::SmallVec;

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -1,7 +1,7 @@
-use super::Executor;
+use super::{Executor, InstructionPtr};
 use crate::{
     core::TrapCode,
-    engine::bytecode::{Const16, DataSegmentIdx, Instruction, InstructionPtr, Reg},
+    engine::bytecode::{Const16, DataSegmentIdx, Instruction, Reg},
     error::EntityGrowError,
     store::{ResourceLimiterRef, StoreInner},
     Error,

--- a/crates/wasmi/src/engine/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/executor/instrs/return_.rs
@@ -1,8 +1,8 @@
-use super::Executor;
+use super::{Executor, InstructionPtr};
 use crate::{
     core::UntypedVal,
     engine::{
-        bytecode::{AnyConst32, Const32, Instruction, InstructionPtr, Reg, RegSpan, RegSpanIter},
+        bytecode::{AnyConst32, Const32, Instruction, Reg, RegSpan, RegSpanIter},
         executor::stack::FrameRegisters,
     },
     store::StoreInner,

--- a/crates/wasmi/src/engine/executor/instrs/select.rs
+++ b/crates/wasmi/src/engine/executor/instrs/select.rs
@@ -1,7 +1,7 @@
-use super::Executor;
+use super::{Executor, InstructionPtr};
 use crate::{
     core::UntypedVal,
-    engine::bytecode::{AnyConst32, Const32, Instruction, InstructionPtr, Reg},
+    engine::bytecode::{AnyConst32, Const32, Instruction, Reg},
 };
 
 impl<'engine> Executor<'engine> {

--- a/crates/wasmi/src/engine/executor/instrs/store.rs
+++ b/crates/wasmi/src/engine/executor/instrs/store.rs
@@ -1,7 +1,7 @@
-use super::Executor;
+use super::{Executor, InstructionPtr};
 use crate::{
     core::{TrapCode, UntypedVal},
-    engine::bytecode::{Const16, Instruction, InstructionPtr, Reg},
+    engine::bytecode::{Const16, Instruction, Reg},
     Error,
 };
 

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -1,7 +1,7 @@
-use super::Executor;
+use super::{Executor, InstructionPtr};
 use crate::{
     core::TrapCode,
-    engine::bytecode::{Const16, ElementSegmentIdx, Instruction, InstructionPtr, Reg, TableIdx},
+    engine::bytecode::{Const16, ElementSegmentIdx, Instruction, Reg, TableIdx},
     error::EntityGrowError,
     store::{ResourceLimiterRef, StoreInner},
     table::TableEntity,

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -1,12 +1,13 @@
 pub use self::instrs::ResumableHostError;
 pub(crate) use self::stack::Stack;
 use self::{
+    instr_ptr::InstructionPtr,
     instrs::{dispatch_host_func, execute_instrs},
     stack::CallFrame,
 };
 use crate::{
     engine::{
-        bytecode::{InstructionPtr, Reg, RegSpan},
+        bytecode::{Reg, RegSpan},
         CallParams,
         CallResults,
         EngineInner,
@@ -28,6 +29,7 @@ use crate::engine::StackLimits;
 use super::code_map::CodeMap;
 
 mod cache;
+mod instr_ptr;
 mod instrs;
 mod stack;
 

--- a/crates/wasmi/src/engine/executor/stack/calls.rs
+++ b/crates/wasmi/src/engine/executor/stack/calls.rs
@@ -2,7 +2,7 @@ use super::{err_stack_overflow, BaseValueStackOffset, FrameValueStackOffset};
 use crate::{
     collections::HeadVec,
     core::TrapCode,
-    engine::bytecode::{InstructionPtr, RegSpan},
+    engine::{bytecode::RegSpan, executor::InstructionPtr},
     Instance,
 };
 use std::vec::Vec;


### PR DESCRIPTION
Simplifies integration of https://github.com/wasmi-labs/wasmi/pull/1152.