### PR TITLE
Move `provider` module into the `translator` module

### DIFF
--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -1,6 +1,5 @@
 mod construct;
 mod immediate;
-mod provider;
 mod utils;
 
 #[cfg(test)]
@@ -8,7 +7,6 @@ mod tests;
 
 pub(crate) use self::{
     immediate::{AnyConst16, AnyConst32, Const16, Const32},
-    provider::{Provider, ProviderSliceStack, UntypedProvider},
     utils::{
         BlockFuel,
         BranchComparator,

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -135,7 +135,7 @@ pub enum Instruction {
     ///
     /// Returns values as stored in the [`RegSpanIter`].
     ReturnSpan {
-        /// Identifier for a [`Provider`] slice.
+        /// The underlying [`RegSpanIter`] value.
         values: RegSpanIter,
     },
     /// A Wasm `return` instruction.

--- a/crates/wasmi/src/engine/translator/control_stack.rs
+++ b/crates/wasmi/src/engine/translator/control_stack.rs
@@ -1,7 +1,7 @@
 use super::ControlFrame;
 use crate::{
     core::TypedVal,
-    engine::bytecode::{Provider, ProviderSliceStack},
+    engine::translator::{Provider, ProviderSliceStack},
     Error,
 };
 use std::vec::{Drain, Vec};

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -3,6 +3,7 @@ use super::{
     FuelInfo,
     LabelRef,
     LabelRegistry,
+    Provider,
     TypedProvider,
 };
 use crate::{
@@ -16,7 +17,6 @@ use crate::{
             Const16,
             Const32,
             Instruction,
-            Provider,
             Reg,
             RegSpan,
             RegSpanIter,

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -6,6 +6,7 @@ mod driver;
 mod error;
 mod instr_encoder;
 mod labels;
+mod provider;
 mod relink_result;
 mod stack;
 mod utils;
@@ -25,6 +26,7 @@ use self::{
     },
     control_stack::AcquiredTarget,
     labels::{LabelRef, LabelRegistry},
+    provider::{Provider, ProviderSliceStack, UntypedProvider},
     stack::ValueStack,
     utils::{WasmFloat, WasmInteger},
 };
@@ -36,10 +38,7 @@ pub use self::{
     instr_encoder::{Instr, InstrEncoder},
     stack::TypedProvider,
 };
-use super::{
-    bytecode::{BranchOffset, Provider},
-    code_map::CompiledFuncEntity,
-};
+use super::{bytecode::BranchOffset, code_map::CompiledFuncEntity};
 use crate::{
     core::{TrapCode, Typed, TypedVal, UntypedVal, ValType},
     engine::{

--- a/crates/wasmi/src/engine/translator/provider.rs
+++ b/crates/wasmi/src/engine/translator/provider.rs
@@ -1,5 +1,11 @@
-use super::{AnyConst32, Reg};
-use crate::{core::UntypedVal, engine::translator::TranslationError, Error};
+use crate::{
+    core::UntypedVal,
+    engine::{
+        bytecode::{AnyConst32, Reg},
+        translator::TranslationError,
+    },
+    Error,
+};
 use std::vec::{Drain, Vec};
 
 #[cfg(doc)]

--- a/crates/wasmi/src/engine/translator/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/stack/mod.rs
@@ -13,7 +13,8 @@ use super::{PreservedLocal, TypedVal};
 use crate::{
     core::UntypedVal,
     engine::{
-        bytecode::{Provider, Reg, RegSpan, UntypedProvider},
+        bytecode::{Reg, RegSpan},
+        translator::{Provider, UntypedProvider},
         TranslationError,
     },
     Error,

--- a/crates/wasmi/src/engine/translator/utils.rs
+++ b/crates/wasmi/src/engine/translator/utils.rs
@@ -1,6 +1,6 @@
-use super::{stack::ValueStack, TypedProvider, TypedVal};
+use super::{stack::ValueStack, Provider, TypedProvider, TypedVal};
 use crate::{
-    engine::bytecode::{AnyConst16, Const16, Provider, Reg, RegSpanIter, Sign},
+    engine::bytecode::{AnyConst16, Const16, Reg, RegSpanIter, Sign},
     Error,
 };
 

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -17,8 +17,8 @@ use super::{
 use crate::{
     core::{TrapCode, ValType, F32, F64},
     engine::{
-        bytecode::{self, Const16, Instruction, Provider, Reg, SignatureIdx},
-        translator::AcquiredTarget,
+        bytecode::{self, Const16, Instruction, Reg, SignatureIdx},
+        translator::{AcquiredTarget, Provider},
         BlockType,
         FuelCosts,
     },


### PR DESCRIPTION
Simplifies integration of https://github.com/wasmi-labs/wasmi/pull/1152.