### PR TITLE
New reg span types & replace `RegSpanIter` with `BoundedRegSpan`

### DIFF
--- a/crates/wasmi/src/engine/bytecode/error.rs
+++ b/crates/wasmi/src/engine/bytecode/error.rs
@@ -1,0 +1,28 @@
+use core::fmt;
+
+/// An error that may be occurred when operating with some Wasmi IR primitives.
+#[derive(Debug)]
+pub enum Error {
+    /// Encountered when trying to create a [`Reg`](crate::Reg) from an out of bounds integer.
+    RegisterOutOfBounds,
+    /// Encountered when trying to create a [`BranchOffset`](crate::BranchOffset) from an out of bounds integer.
+    BranchOffsetOutOfBounds,
+    /// Encountered when trying to create a [`Comparator`](crate::Comparator) from an out of bounds integer.
+    ComparatorOutOfBounds,
+    /// Encountered when trying to create a [`BlockFuel`](crate::BlockFuel) from an out of bounds integer.
+    BlockFuelOutOfBounds,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RegisterOutOfBounds => write!(f, "register out of bounds"),
+            Self::BranchOffsetOutOfBounds => write!(f, "branch offset out of bounds"),
+            Self::ComparatorOutOfBounds => write!(f, "comparator out of bounds"),
+            Self::BlockFuelOutOfBounds => write!(f, "block fuel out of bounds"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/crates/wasmi/src/engine/bytecode/error.rs
+++ b/crates/wasmi/src/engine/bytecode/error.rs
@@ -3,13 +3,13 @@ use core::fmt;
 /// An error that may be occurred when operating with some Wasmi IR primitives.
 #[derive(Debug)]
 pub enum Error {
-    /// Encountered when trying to create a [`Reg`](crate::Reg) from an out of bounds integer.
+    /// Encountered when trying to create a register from an out of bounds integer.
     RegisterOutOfBounds,
-    /// Encountered when trying to create a [`BranchOffset`](crate::BranchOffset) from an out of bounds integer.
+    /// Encountered when trying to create a branch offset from an out of bounds integer.
     BranchOffsetOutOfBounds,
-    /// Encountered when trying to create a [`Comparator`](crate::Comparator) from an out of bounds integer.
+    /// Encountered when trying to create a comparator from an out of bounds integer.
     ComparatorOutOfBounds,
-    /// Encountered when trying to create a [`BlockFuel`](crate::BlockFuel) from an out of bounds integer.
+    /// Encountered when trying to create block fuel from an out of bounds integer.
     BlockFuelOutOfBounds,
 }
 

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -17,7 +17,7 @@ pub mod index {
 pub use self::{
     error::Error as IrError,
     immediate::{AnyConst32, Const16, Const32},
-    span::{BoundedRegSpan, FixedRegSpan, RegSpan, RegSpanIter},
+    span::{BoundedRegSpan, FixedRegSpan, RegSpan},
     utils::{
         BlockFuel,
         BranchOffset,
@@ -142,10 +142,10 @@ pub enum Instruction {
     ///
     /// # Note
     ///
-    /// Returns values as stored in the [`RegSpanIter`].
+    /// Returns values as stored in the [`BoundedRegSpan`].
     ReturnSpan {
-        /// The underlying [`RegSpanIter`] value.
-        values: RegSpanIter,
+        /// The underlying [`BoundedRegSpan`] value.
+        values: BoundedRegSpan,
     },
     /// A Wasm `return` instruction.
     ///
@@ -246,7 +246,7 @@ pub enum Instruction {
         /// The register holding the condition to evaluate against zero.
         condition: Reg,
         /// The returned values.
-        values: RegSpanIter,
+        values: BoundedRegSpan,
     },
     /// A conditional `return` instruction.
     ///
@@ -1118,7 +1118,7 @@ pub enum Instruction {
     /// This is a Wasmi utility instruction used to translate Wasm control flow.
     Copy2 {
         /// The registers holding the result of the instruction.
-        results: RegSpan,
+        results: FixedRegSpan<2>,
         /// The registers holding the values to copy.
         values: [Reg; 2],
     },
@@ -5446,8 +5446,8 @@ pub enum Instruction {
         /// The 32-bit immediate value.
         imm: AnyConst32,
     },
-    /// A [`RegSpanIter`] instruction parameter.
-    RegisterSpan { span: RegSpanIter },
+    /// A [`BoundedRegSpan`] instruction parameter.
+    RegisterSpan { span: BoundedRegSpan },
     /// A [`Reg`] instruction parameter.
     ///
     /// # Note

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -1,5 +1,7 @@
 mod construct;
+mod error;
 mod immediate;
+mod span;
 mod utils;
 mod visit_regs;
 
@@ -13,7 +15,9 @@ pub mod index {
 
 #[doc(inline)]
 pub use self::{
+    error::Error as IrError,
     immediate::{AnyConst32, Const16, Const32},
+    span::{BoundedRegSpan, FixedRegSpan, RegSpan, RegSpanIter},
     utils::{
         BlockFuel,
         BranchOffset,
@@ -26,8 +30,6 @@ pub use self::{
         FuncType,
         Global,
         Reg,
-        RegSpan,
-        RegSpanIter,
         Sign,
         Table,
     },

--- a/crates/wasmi/src/engine/bytecode/span.rs
+++ b/crates/wasmi/src/engine/bytecode/span.rs
@@ -42,6 +42,18 @@ impl RegSpan {
     pub fn head_mut(&mut self) -> &mut Reg {
         &mut self.0
     }
+
+    /// Returns `true` if `copy_span results <- values` has overlapping copies.
+    ///
+    /// # Examples
+    ///
+    /// - `[ ]`: empty never overlaps
+    /// - `[ 1 <- 0 ]`: single element never overlaps
+    /// - `[ 0 <- 1, 1 <- 2, 2 <- 3 ]`: no overlap
+    /// - `[ 1 <- 0, 2 <- 1 ]`: overlaps!
+    pub fn has_overlapping_copies(results: Self, values: Self, len: u16) -> bool {
+        RegSpanIter::has_overlapping_copies(results.iter(len), values.iter(len))
+    }
 }
 
 /// A [`RegSpan`] with a statically known number of [`Reg`].

--- a/crates/wasmi/src/engine/bytecode/span.rs
+++ b/crates/wasmi/src/engine/bytecode/span.rs
@@ -1,0 +1,316 @@
+use crate::engine::bytecode::{IrError, Reg};
+
+/// A [`RegSpan`] of contiguous [`Reg`] indices.
+///
+/// # Note
+///
+/// - Represents an amount of contiguous [`Reg`] indices.
+/// - For the sake of space efficiency the actual number of [`Reg`]
+///   of the [`RegSpan`] is stored externally and provided in
+///   [`RegSpan::iter`] when there is a need to iterate over
+///   the [`Reg`] of the [`RegSpan`].
+///
+/// The caller is responsible for providing the correct length.
+/// Due to Wasm validation guided bytecode construction we assert
+/// that the externally stored length is valid.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct RegSpan(Reg);
+
+impl RegSpan {
+    /// Creates a new [`RegSpan`] starting with the given `start` [`Reg`].
+    pub fn new(head: Reg) -> Self {
+        Self(head)
+    }
+
+    /// Returns a [`RegSpanIter`] yielding `len` [`Reg`]s.
+    pub fn iter_sized(self, len: usize) -> RegSpanIter {
+        RegSpanIter::new(self.0, len)
+    }
+
+    /// Returns a [`RegSpanIter`] yielding `len` [`Reg`]s.
+    pub fn iter(self, len: u16) -> RegSpanIter {
+        RegSpanIter::new_u16(self.0, len)
+    }
+
+    /// Returns the head [`Reg`] of the [`RegSpan`].
+    pub fn head(self) -> Reg {
+        self.0
+    }
+
+    /// Returns an exclusive reference to the head [`Reg`] of the [`RegSpan`].
+    pub fn head_mut(&mut self) -> &mut Reg {
+        &mut self.0
+    }
+}
+
+/// A [`RegSpan`] with a statically known number of [`Reg`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct FixedRegSpan<const N: u16> {
+    /// The underlying [`RegSpan`] without the known length.
+    span: RegSpan,
+}
+
+impl<const N: u16> FixedRegSpan<N> {
+    /// Creates a new [`RegSpan`] starting with the given `start` [`Reg`].
+    pub fn new(span: RegSpan) -> Result<Self, IrError> {
+        let head = span.head();
+        if head >= head.next_n(N) {
+            return Err(IrError::RegisterOutOfBounds);
+        }
+        Ok(Self { span })
+    }
+
+    /// Returns a [`RegSpanIter`] yielding `N` [`Reg`]s.
+    pub fn iter(&self) -> RegSpanIter {
+        self.span.iter(self.len())
+    }
+
+    /// Creates a new [`BoundedRegSpan`] from `self`.
+    pub fn bounded(self) -> BoundedRegSpan {
+        BoundedRegSpan {
+            span: self.span,
+            len: N,
+        }
+    }
+
+    /// Returns the underlying [`RegSpan`] of `self`.
+    pub fn span(self) -> RegSpan {
+        self.span
+    }
+
+    /// Returns an exclusive reference to the underlying [`RegSpan`] of `self`.
+    pub fn span_mut(&mut self) -> &mut RegSpan {
+        &mut self.span
+    }
+
+    /// Returns `true` if the [`Reg`] is contained in `self`.
+    pub fn contains(self, reg: Reg) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+        let min = self.span.head();
+        let max = min.next_n(N);
+        min <= reg && reg < max
+    }
+
+    /// Returns the number of [`Reg`]s in `self`.
+    pub fn len(self) -> u16 {
+        N
+    }
+
+    /// Returns `true` if `self` is empty.
+    pub fn is_empty(self) -> bool {
+        N == 0
+    }
+}
+
+impl<'a, const N: u16> IntoIterator for &'a FixedRegSpan<N> {
+    type Item = Reg;
+    type IntoIter = RegSpanIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<const N: u16> IntoIterator for FixedRegSpan<N> {
+    type Item = Reg;
+    type IntoIter = RegSpanIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// A [`RegSpan`] with a known number of [`Reg`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BoundedRegSpan {
+    /// The first [`Reg`] in `self`.
+    span: RegSpan,
+    /// The number of [`Reg`] in `self`.
+    len: u16,
+}
+
+impl BoundedRegSpan {
+    /// Creates a new [`BoundedRegSpan`] from the given `span` and `len`.
+    pub fn new(span: RegSpan, len: u16) -> Self {
+        Self { span, len }
+    }
+
+    /// Returns a [`RegSpanIter`] yielding `len` [`Reg`]s.
+    pub fn iter(&self) -> RegSpanIter {
+        self.span.iter(self.len())
+    }
+
+    /// Returns `self` as unbounded [`RegSpan`].
+    pub fn span(&self) -> RegSpan {
+        self.span
+    }
+
+    /// Returns a mutable reference to the underlying [`RegSpan`].
+    pub fn span_mut(&mut self) -> &mut RegSpan {
+        &mut self.span
+    }
+
+    /// Returns `true` if the [`Reg`] is contained in `self`.
+    pub fn contains(self, reg: Reg) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+        let min = self.span.head();
+        let max = min.next_n(self.len);
+        min <= reg && reg < max
+    }
+
+    /// Returns the number of [`Reg`] in `self`.
+    pub fn len(&self) -> u16 {
+        self.len
+    }
+
+    /// Returns `true` if `self` is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<'a> IntoIterator for &'a BoundedRegSpan {
+    type Item = Reg;
+    type IntoIter = RegSpanIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl IntoIterator for BoundedRegSpan {
+    type Item = Reg;
+    type IntoIter = RegSpanIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// A [`RegSpanIter`] iterator yielding contiguous [`Reg`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RegSpanIter {
+    /// The next [`Reg`] in the [`RegSpanIter`].
+    next: Reg,
+    /// The last [`Reg`] in the [`RegSpanIter`].
+    last: Reg,
+}
+
+impl RegSpanIter {
+    /// Creates a [`RegSpanIter`] from then given raw `start` and `end` [`Reg`].
+    pub fn from_raw_parts(start: Reg, end: Reg) -> Self {
+        debug_assert!(i16::from(start) <= i16::from(end));
+        Self {
+            next: start,
+            last: end,
+        }
+    }
+
+    /// Creates a new [`RegSpanIter`] for the given `start` [`Reg`] and length `len`.
+    ///
+    /// # Panics
+    ///
+    /// If the `start..end` [`Reg`] span indices are out of bounds.
+    fn new(start: Reg, len: usize) -> Self {
+        let len = u16::try_from(len)
+            .unwrap_or_else(|_| panic!("out of bounds length for register span: {len}"));
+        Self::new_u16(start, len)
+    }
+
+    /// Creates a new [`RegSpanIter`] for the given `start` [`Reg`] and length `len`.
+    ///
+    /// # Panics
+    ///
+    /// If the `start..end` [`Reg`] span indices are out of bounds.
+    fn new_u16(start: Reg, len: u16) -> Self {
+        let next = start;
+        let last = start
+            .0
+            .checked_add_unsigned(len)
+            .map(Reg)
+            .expect("overflowing register index for register span");
+        Self::from_raw_parts(next, last)
+    }
+
+    /// Creates a [`RegSpan`] from this [`RegSpanIter`].
+    pub fn span(self) -> RegSpan {
+        RegSpan(self.next)
+    }
+
+    /// Returns the remaining number of [`Reg`]s yielded by the [`RegSpanIter`].
+    pub fn len_as_u16(&self) -> u16 {
+        self.last.0.abs_diff(self.next.0)
+    }
+
+    /// Returns `true` if `self` yields no more [`Reg`]s.
+    pub fn is_empty(&self) -> bool {
+        self.len_as_u16() == 0
+    }
+
+    /// Returns `true` if `copy_span results <- values` has overlapping copies.
+    ///
+    /// # Examples
+    ///
+    /// - `[ ]`: empty never overlaps
+    /// - `[ 1 <- 0 ]`: single element never overlaps
+    /// - `[ 0 <- 1, 1 <- 2, 2 <- 3 ]`: no overlap
+    /// - `[ 1 <- 0, 2 <- 1 ]`: overlaps!
+    pub fn has_overlapping_copies(results: Self, values: Self) -> bool {
+        assert_eq!(
+            results.len(),
+            values.len(),
+            "cannot copy between different sized register spans"
+        );
+        let len = results.len();
+        if len <= 1 {
+            // Empty spans or single-element spans can never overlap.
+            return false;
+        }
+        let first_value = values.span().head();
+        let first_result = results.span().head();
+        if first_value >= first_result {
+            // This case can never result in overlapping copies.
+            return false;
+        }
+        let mut values = values;
+        let last_value = values
+            .next_back()
+            .expect("span is non empty and thus must return");
+        last_value >= first_result
+    }
+}
+
+impl Iterator for RegSpanIter {
+    type Item = Reg;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next == self.last {
+            return None;
+        }
+        let reg = self.next;
+        self.next = self.next.next();
+        Some(reg)
+    }
+}
+
+impl DoubleEndedIterator for RegSpanIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.next == self.last {
+            return None;
+        }
+        self.last = self.last.prev();
+        Some(self.last)
+    }
+}
+
+impl ExactSizeIterator for RegSpanIter {
+    fn len(&self) -> usize {
+        usize::from(RegSpanIter::len_as_u16(self))
+    }
+}

--- a/crates/wasmi/src/engine/bytecode/tests.rs
+++ b/crates/wasmi/src/engine/bytecode/tests.rs
@@ -14,7 +14,7 @@ fn has_overlapping_copy_spans_works() {
     }
 
     fn has_overlapping_copy_spans(results: RegSpan, values: RegSpan, len: u16) -> bool {
-        RegSpanIter::has_overlapping_copies(results.iter(len), values.iter(len))
+        RegSpan::has_overlapping_copies(results, values, len)
     }
 
     // len == 0

--- a/crates/wasmi/src/engine/bytecode/utils.rs
+++ b/crates/wasmi/src/engine/bytecode/utils.rs
@@ -10,7 +10,7 @@ use super::Instruction;
 
 /// An index into a register.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Reg(i16);
+pub struct Reg(pub(super) i16);
 
 impl From<i16> for Reg {
     fn from(index: i16) -> Self {
@@ -35,189 +35,39 @@ impl TryFrom<u32> for Reg {
 }
 
 impl Reg {
-    /// Returns `true` if this [`Reg`] refers to a function local constant value.
-    pub fn is_const(self) -> bool {
-        self.0.is_negative()
+    /// Returns the n-th next [`Reg`] from `self` with contigous index.
+    ///
+    /// # Note
+    ///
+    /// - Calling this with `n == 0` just returns `self`.
+    /// - This has wrapping semantics with respect to the underlying index.
+    pub fn next_n(self, n: u16) -> Self {
+        Self(self.0.wrapping_add_unsigned(n))
+    }
+
+    /// Returns the n-th previous [`Reg`] from `self` with contigous index.
+    ///
+    /// # Note
+    ///
+    /// - Calling this with `n == 0` just returns `self`.
+    /// - This has wrapping semantics with respect to the underlying index.
+    pub fn prev_n(self, n: u16) -> Self {
+        Self(self.0.wrapping_sub_unsigned(n))
     }
 
     /// Returns the [`Reg`] with the next contiguous index.
-    pub fn next(self) -> Reg {
-        Self(self.0.wrapping_add(1))
+    pub fn next(self) -> Self {
+        self.next_n(1)
     }
 
     /// Returns the [`Reg`] with the previous contiguous index.
-    pub fn prev(self) -> Reg {
-        Self(self.0.wrapping_sub(1))
-    }
-}
-
-/// A [`RegSpan`] of contiguous [`Reg`] indices.
-///
-/// # Note
-///
-/// - Represents an amount of contiguous [`Reg`] indices.
-/// - For the sake of space efficiency the actual number of [`Reg`]
-///   of the [`RegSpan`] is stored externally and provided in
-///   [`RegSpan::iter`] when there is a need to iterate over
-///   the [`Reg`] of the [`RegSpan`].
-///
-/// The caller is responsible for providing the correct length.
-/// Due to Wasm validation guided bytecode construction we assert
-/// that the externally stored length is valid.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RegSpan(Reg);
-
-impl RegSpan {
-    /// Creates a new [`RegSpan`] starting with the given `start` [`Reg`].
-    pub fn new(start: Reg) -> Self {
-        Self(start)
+    pub fn prev(self) -> Self {
+        self.prev_n(1)
     }
 
-    /// Returns a [`RegSpanIter`] yielding `len` [`Reg`].
-    pub fn iter_sized(self, len: usize) -> RegSpanIter {
-        RegSpanIter::new(self.0, len)
-    }
-
-    /// Returns a [`RegSpanIter`] yielding `len` [`Reg`].
-    pub fn iter(self, len: u16) -> RegSpanIter {
-        RegSpanIter::new_u16(self.0, len)
-    }
-
-    /// Returns the head [`Reg`] of the [`RegSpan`].
-    pub fn head(self) -> Reg {
-        self.0
-    }
-
-    /// Returns an exclusive reference to the head [`Reg`] of the [`RegSpan`].
-    pub fn head_mut(&mut self) -> &mut Reg {
-        &mut self.0
-    }
-}
-
-/// A [`RegSpanIter`] iterator yielding contiguous [`Reg`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RegSpanIter {
-    /// The next [`Reg`] in the [`RegSpanIter`].
-    next: Reg,
-    /// The last [`Reg`] in the [`RegSpanIter`].
-    last: Reg,
-}
-
-impl RegSpanIter {
-    /// Creates a [`RegSpanIter`] from then given raw `start` and `end` [`Reg`].
-    pub fn from_raw_parts(start: Reg, end: Reg) -> Self {
-        debug_assert!(i16::from(start) <= i16::from(end));
-        Self {
-            next: start,
-            last: end,
-        }
-    }
-
-    /// Creates a new [`RegSpanIter`] for the given `start` [`Reg`] and length `len`.
-    ///
-    /// # Panics
-    ///
-    /// If the `start..end` [`Reg`] span indices are out of bounds.
-    fn new(start: Reg, len: usize) -> Self {
-        let len = u16::try_from(len)
-            .unwrap_or_else(|_| panic!("out of bounds length for register span: {len}"));
-        Self::new_u16(start, len)
-    }
-
-    /// Creates a new [`RegSpanIter`] for the given `start` [`Reg`] and length `len`.
-    ///
-    /// # Panics
-    ///
-    /// If the `start..end` [`Reg`] span indices are out of bounds.
-    fn new_u16(start: Reg, len: u16) -> Self {
-        let next = start;
-        let last = start
-            .0
-            .checked_add_unsigned(len)
-            .map(Reg)
-            .expect("overflowing register index for register span");
-        Self::from_raw_parts(next, last)
-    }
-
-    /// Creates a [`RegSpan`] from this [`RegSpanIter`].
-    pub fn span(self) -> RegSpan {
-        RegSpan(self.next)
-    }
-
-    /// Returns the remaining length of the [`RegSpanIter`] as `u16`.
-    pub fn len_as_u16(self) -> u16 {
-        self.last.0.abs_diff(self.next.0)
-    }
-
-    /// Returns `true` if the [`RegSpanIter`] is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Returns `true` if `copy_span results <- values` has overlapping copies.
-    ///
-    /// # Examples
-    ///
-    /// - `[ ]`: empty never overlaps
-    /// - `[ 1 <- 0 ]`: single element never overlaps
-    /// - `[ 0 <- 1, 1 <- 2, 2 <- 3 ]``: no overlap
-    /// - `[ 1 <- 0, 2 <- 1 ]`: overlaps!
-    pub fn has_overlapping_copies(results: Self, values: Self) -> bool {
-        assert_eq!(
-            results.len_as_u16(),
-            values.len_as_u16(),
-            "cannot copy between different sized register spans"
-        );
-        let len = results.len_as_u16();
-        if len <= 1 {
-            // Empty spans or single-element spans can never overlap.
-            return false;
-        }
-        let first_value = values.span().head();
-        let first_result = results.span().head();
-        if first_value >= first_result {
-            // This case can never result in overlapping copies.
-            return false;
-        }
-        let mut values = values;
-        let last_value = values
-            .next_back()
-            .expect("span is non empty and thus must return");
-        last_value >= first_result
-    }
-}
-
-impl Iterator for RegSpanIter {
-    type Item = Reg;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.next == self.last {
-            return None;
-        }
-        let reg = self.next;
-        self.next = self.next.next();
-        Some(reg)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.len_as_u16() as usize;
-        (remaining, Some(remaining))
-    }
-}
-
-impl DoubleEndedIterator for RegSpanIter {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.next == self.last {
-            return None;
-        }
-        self.last = self.last.prev();
-        Some(self.last)
-    }
-}
-
-impl ExactSizeIterator for RegSpanIter {
-    fn len(&self) -> usize {
-        usize::from(self.len_as_u16())
+    /// Returns `true` if this [`Reg`] refers to a function local constant value.
+    pub fn is_const(self) -> bool {
+        self.0.is_negative()
     }
 }
 

--- a/crates/wasmi/src/engine/bytecode/visit_regs.rs
+++ b/crates/wasmi/src/engine/bytecode/visit_regs.rs
@@ -1,4 +1,4 @@
-use super::{BoundedRegSpan, FixedRegSpan, Instruction, Reg, RegSpan, RegSpanIter};
+use super::{BoundedRegSpan, FixedRegSpan, Instruction, Reg, RegSpan};
 
 impl Instruction {
     /// Visit [`Reg`]s of `self` via the `visitor`.
@@ -58,16 +58,6 @@ impl<const N: u16> HostVisitor for &'_ mut FixedRegSpan<N> {
     }
 }
 
-impl HostVisitor for &'_ mut RegSpanIter {
-    fn host_visitor<V: VisitRegs>(self, _visitor: &mut V) {
-        // let len = self.len_as_u16();
-        // let mut span = self.span();
-        // visitor.visit_input_regs(&mut span, Some(len));
-        // *self = span.iter(len);
-        todo!()
-    }
-}
-
 /// Type-wrapper to signal that the wrapped [`Reg`], [`RegSpan`] (etc.) is a result.
 pub struct Res<T>(T);
 
@@ -80,6 +70,19 @@ impl HostVisitor for Res<&'_ mut Reg> {
 impl HostVisitor for Res<&'_ mut RegSpan> {
     fn host_visitor<V: VisitRegs>(self, visitor: &mut V) {
         visitor.visit_result_regs(self.0, None);
+    }
+}
+
+impl HostVisitor for Res<&'_ mut BoundedRegSpan> {
+    fn host_visitor<V: VisitRegs>(self, visitor: &mut V) {
+        let len = self.0.len();
+        visitor.visit_result_regs(self.0.span_mut(), Some(len));
+    }
+}
+
+impl<const N: u16> HostVisitor for Res<&'_ mut FixedRegSpan<N>> {
+    fn host_visitor<V: VisitRegs>(self, visitor: &mut V) {
+        visitor.visit_result_regs(self.0.span_mut(), Some(N));
     }
 }
 

--- a/crates/wasmi/src/engine/bytecode/visit_regs.rs
+++ b/crates/wasmi/src/engine/bytecode/visit_regs.rs
@@ -1,4 +1,4 @@
-use super::{Instruction, Reg, RegSpan, RegSpanIter};
+use super::{BoundedRegSpan, FixedRegSpan, Instruction, Reg, RegSpan, RegSpanIter};
 
 impl Instruction {
     /// Visit [`Reg`]s of `self` via the `visitor`.
@@ -45,12 +45,26 @@ impl HostVisitor for &'_ mut RegSpan {
     }
 }
 
-impl HostVisitor for &'_ mut RegSpanIter {
+impl HostVisitor for &'_ mut BoundedRegSpan {
     fn host_visitor<V: VisitRegs>(self, visitor: &mut V) {
-        let len = self.len_as_u16();
-        let mut span = self.span();
-        visitor.visit_input_regs(&mut span, Some(len));
-        *self = span.iter(len);
+        let len = self.len();
+        visitor.visit_input_regs(self.span_mut(), Some(len));
+    }
+}
+
+impl<const N: u16> HostVisitor for &'_ mut FixedRegSpan<N> {
+    fn host_visitor<V: VisitRegs>(self, visitor: &mut V) {
+        visitor.visit_input_regs(self.span_mut(), Some(N));
+    }
+}
+
+impl HostVisitor for &'_ mut RegSpanIter {
+    fn host_visitor<V: VisitRegs>(self, _visitor: &mut V) {
+        // let len = self.len_as_u16();
+        // let mut span = self.span();
+        // visitor.visit_input_regs(&mut span, Some(len));
+        // *self = span.iter(len);
+        todo!()
     }
 }
 

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -121,7 +121,7 @@ impl<'engine> Executor<'engine> {
         let Instruction::RegisterSpan { span: values } = *self.ip.get() else {
             unreachable!()
         };
-        let len = values.len_as_u16();
+        let len = values.len();
         let values = values.span();
         self.ip.add(offset);
         match *self.ip.get() {

--- a/crates/wasmi/src/engine/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/executor/instrs/copy.rs
@@ -1,7 +1,7 @@
 use super::{Executor, InstructionPtr};
 use crate::{
     core::UntypedVal,
-    engine::bytecode::{AnyConst32, Const32, Instruction, Reg, RegSpan},
+    engine::bytecode::{AnyConst32, Const32, FixedRegSpan, Instruction, Reg, RegSpan},
 };
 use core::slice;
 use smallvec::SmallVec;
@@ -23,15 +23,15 @@ impl<'engine> Executor<'engine> {
 
     /// Executes an [`Instruction::Copy2`].
     #[inline(always)]
-    pub fn execute_copy_2(&mut self, results: RegSpan, values: [Reg; 2]) {
+    pub fn execute_copy_2(&mut self, results: FixedRegSpan<2>, values: [Reg; 2]) {
         self.execute_copy_2_impl(results, values);
         self.next_instr()
     }
 
     /// Internal implementation of [`Instruction::Copy2`] execution.
     #[inline(always)]
-    fn execute_copy_2_impl(&mut self, results: RegSpan, values: [Reg; 2]) {
-        let result0 = results.head();
+    fn execute_copy_2_impl(&mut self, results: FixedRegSpan<2>, values: [Reg; 2]) {
+        let result0 = results.span().head();
         let result1 = result0.next();
         // We need `tmp` in case `results[0] == values[1]` to avoid overwriting `values[1]` before reading it.
         let tmp = self.get_register(values[1]);

--- a/crates/wasmi/src/engine/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/executor/instrs/return_.rs
@@ -2,7 +2,7 @@ use super::{Executor, InstructionPtr};
 use crate::{
     core::UntypedVal,
     engine::{
-        bytecode::{AnyConst32, Const32, Instruction, Reg, RegSpan, RegSpanIter},
+        bytecode::{AnyConst32, BoundedRegSpan, Const32, Instruction, Reg, RegSpan},
         executor::stack::FrameRegisters,
     },
     store::StoreInner,
@@ -189,10 +189,10 @@ impl<'engine> Executor<'engine> {
     pub fn execute_return_span(
         &mut self,
         store: &mut StoreInner,
-        values: RegSpanIter,
+        values: BoundedRegSpan,
     ) -> ReturnOutcome {
         let (mut caller_sp, results) = self.return_caller_results();
-        let results = results.iter(values.len_as_u16());
+        let results = results.iter(values.len());
         for (result, value) in results.zip(values) {
             // Safety: The `callee.results()` always refer to a span of valid
             //         registers of the `caller` that does not overlap with the
@@ -342,7 +342,7 @@ impl<'engine> Executor<'engine> {
         &mut self,
         store: &mut StoreInner,
         condition: Reg,
-        values: RegSpanIter,
+        values: BoundedRegSpan,
     ) -> ReturnOutcome {
         self.execute_return_nez_impl(store, condition, values, Self::execute_return_span)
     }

--- a/crates/wasmi/src/engine/translator/control_frame.rs
+++ b/crates/wasmi/src/engine/translator/control_frame.rs
@@ -5,7 +5,7 @@ use super::LabelRef;
 use super::ValueStack;
 use crate::{
     engine::{
-        bytecode::{RegSpan, RegSpanIter},
+        bytecode::{BoundedRegSpan, RegSpan},
         BlockType,
         Instr,
         TranslationError,
@@ -106,9 +106,8 @@ impl BlockControlFrame {
     }
 
     /// Returns an iterator over the registers holding the branching parameters of the [`BlockControlFrame`].
-    pub fn branch_params(&self, engine: &Engine) -> RegSpanIter {
-        self.branch_params
-            .iter(self.block_type().len_results(engine))
+    pub fn branch_params(&self, engine: &Engine) -> BoundedRegSpan {
+        BoundedRegSpan::new(self.branch_params, self.block_type().len_results(engine))
     }
 
     /// Returns the label for the branch destination of the [`BlockControlFrame`].
@@ -211,9 +210,8 @@ impl LoopControlFrame {
     }
 
     /// Returns an iterator over the registers holding the branching parameters of the [`LoopControlFrame`].
-    pub fn branch_params(&self, engine: &Engine) -> RegSpanIter {
-        self.branch_params
-            .iter(self.block_type().len_params(engine))
+    pub fn branch_params(&self, engine: &Engine) -> BoundedRegSpan {
+        BoundedRegSpan::new(self.branch_params, self.block_type().len_params(engine))
     }
 
     /// Returns the label for the branch destination of the [`LoopControlFrame`].
@@ -381,9 +379,8 @@ impl IfControlFrame {
     }
 
     /// Returns an iterator over the registers holding the branching parameters of the [`IfControlFrame`].
-    pub fn branch_params(&self, engine: &Engine) -> RegSpanIter {
-        self.branch_params
-            .iter(self.block_type().len_results(engine))
+    pub fn branch_params(&self, engine: &Engine) -> BoundedRegSpan {
+        BoundedRegSpan::new(self.branch_params, self.block_type().len_results(engine))
     }
 
     /// Returns the label for the branch destination of the [`IfControlFrame`].
@@ -602,7 +599,7 @@ impl ControlFrame {
     }
 
     /// Returns an iterator over the registers holding the branch parameters of the [`ControlFrame`].
-    pub fn branch_params(&self, engine: &Engine) -> RegSpanIter {
+    pub fn branch_params(&self, engine: &Engine) -> BoundedRegSpan {
         match self {
             Self::Block(frame) => frame.branch_params(engine),
             Self::Loop(frame) => frame.branch_params(engine),

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -39,13 +39,13 @@ pub use self::{
     stack::TypedProvider,
 };
 use super::{
-    bytecode::{index, BranchOffset},
+    bytecode::{index, BoundedRegSpan, BranchOffset},
     code_map::CompiledFuncEntity,
 };
 use crate::{
     core::{TrapCode, Typed, TypedVal, UntypedVal, ValType},
     engine::{
-        bytecode::{Const16, Const32, Instruction, Reg, RegSpan, RegSpanIter, Sign},
+        bytecode::{Const16, Const32, Instruction, Reg, RegSpan, Sign},
         config::FuelCosts,
         BlockType,
         EngineFunc,
@@ -824,8 +824,14 @@ impl FuncTranslator {
             (i16::from(b.preserved) - i16::from(a.preserved)) == 1
         });
         for copy_group in copy_groups {
-            let len = copy_group.len();
-            let results = RegSpan::new(copy_group[0].preserved).iter_sized(len);
+            let len = u16::try_from(copy_group.len()).unwrap_or_else(|error| {
+                panic!(
+                    "too many ({}) registers in copy group: {}",
+                    copy_group.len(),
+                    error
+                )
+            });
+            let results = BoundedRegSpan::new(RegSpan::new(copy_group[0].preserved), len);
             let providers = &mut self.alloc.buffer.providers;
             providers.clear();
             providers.extend(
@@ -848,14 +854,16 @@ impl FuncTranslator {
     }
 
     /// Convenience function to copy the parameters when branching to a control frame.
-    fn translate_copy_branch_params(&mut self, branch_params: RegSpanIter) -> Result<(), Error> {
+    fn translate_copy_branch_params(&mut self, branch_params: BoundedRegSpan) -> Result<(), Error> {
         if branch_params.is_empty() {
             // If the block does not have branch parameters there is no need to copy anything.
             return Ok(());
         }
         let fuel_info = self.fuel_info();
         let params = &mut self.alloc.buffer.providers;
-        self.alloc.stack.pop_n(branch_params.len(), params);
+        self.alloc
+            .stack
+            .pop_n(usize::from(branch_params.len()), params);
         self.alloc.instr_encoder.encode_copies(
             &mut self.alloc.stack,
             branch_params,
@@ -2504,7 +2512,7 @@ impl FuncTranslator {
     fn translate_br_table_targets(
         &mut self,
         values: &[TypedProvider],
-        make_target: impl Fn(RegSpanIter, BranchOffset) -> Instruction,
+        make_target: impl Fn(BoundedRegSpan, BranchOffset) -> Instruction,
     ) -> Result<(), Error> {
         let engine = self.engine().clone();
         let fuel_info = self.fuel_info();
@@ -2641,18 +2649,18 @@ impl FuncTranslator {
     }
 
     /// Translates a Wasm `br_table` instruction with 4 or more inputs.
-    fn translate_br_table_n(&mut self, index: Reg, len_values: usize) -> Result<(), Error> {
+    fn translate_br_table_n(&mut self, index: Reg, len_values: u16) -> Result<(), Error> {
         debug_assert!(len_values > 3);
         let values = &mut self.alloc.buffer.providers;
-        self.alloc.stack.pop_n(len_values, values);
-        match RegSpanIter::from_providers(values) {
+        self.alloc.stack.pop_n(usize::from(len_values), values);
+        match BoundedRegSpan::from_providers(values) {
             Some(span) => self.translate_br_table_span(index, span),
             None => self.translate_br_table_many(index),
         }
     }
 
     /// Translates a Wasm `br_table` instruction with 4 or more inputs that form a [`RegSpan`].
-    fn translate_br_table_span(&mut self, index: Reg, values: RegSpanIter) -> Result<(), Error> {
+    fn translate_br_table_span(&mut self, index: Reg, values: BoundedRegSpan) -> Result<(), Error> {
         debug_assert!(values.len() > 3);
         let fuel_info = self.fuel_info();
         let targets = &mut self.alloc.buffer.br_table_targets;

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -449,7 +449,7 @@ fn audit_0_codegen() {
                 Instruction::branch_table_target(RegSpan::new(Reg::from(0)), BranchOffset::from(3)),
                 Instruction::Return,
                 Instruction::Return,
-                Instruction::return_span(RegSpan::new(Reg::from(0)).iter(4)),
+                Instruction::return_span(bspan(0, 4)),
             ])
             .consts([0]),
         )

--- a/crates/wasmi/src/engine/translator/tests/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/mod.rs
@@ -12,7 +12,7 @@ use self::{
 };
 use crate::{
     core::UntypedVal,
-    engine::bytecode::{AnyConst32, Const16, Const32, Instruction, Reg},
+    engine::bytecode::{AnyConst32, BoundedRegSpan, Const16, Const32, Instruction, Reg, RegSpan},
     Config,
     Engine,
     Module,
@@ -60,6 +60,11 @@ where
         testcase.expect_func_instrs(instrs);
     }
     testcase.run();
+}
+
+/// Creates a new [`BoundedRegSpan`] starting with `reg` and with `len`.
+fn bspan(reg: impl Into<Reg>, len: u16) -> BoundedRegSpan {
+    BoundedRegSpan::new(RegSpan::new(reg.into()), len)
 }
 
 /// Identifier for a Wasm operator.

--- a/crates/wasmi/src/engine/translator/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_if.rs
@@ -542,7 +542,7 @@ fn return_if_results_3_span() {
         )";
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([
-            Instruction::return_nez_span(Reg::from(3), RegSpan::new(Reg::from(0)).iter(3)),
+            Instruction::return_nez_span(Reg::from(3), bspan(0, 3)),
             Instruction::return_reg3(0, 1, 2),
         ])
         .run()
@@ -614,8 +614,8 @@ fn return_if_results_4_span() {
         )";
     TranslationTest::from_wat(wasm)
         .expect_func_instrs([
-            Instruction::return_nez_span(Reg::from(4), RegSpan::new(Reg::from(0)).iter(4)),
-            Instruction::return_span(RegSpan::new(Reg::from(0)).iter(4)),
+            Instruction::return_nez_span(Reg::from(4), bspan(0, 4)),
+            Instruction::return_span(bspan(0, 4)),
         ])
         .run()
 }
@@ -954,7 +954,7 @@ fn branch_if_results_4_mixed_1() {
                 Instruction::branch(BranchOffset::from(3)),
                 Instruction::copy_many_non_overlapping(RegSpan::new(Reg::from(3)), -1, 0),
                 Instruction::register2(1, -2),
-                Instruction::return_span(RegSpan::new(Reg::from(3)).iter(4)),
+                Instruction::return_span(bspan(3, 4)),
             ])
             .consts([10_i32, 20]),
         )
@@ -987,7 +987,7 @@ fn branch_if_results_4_mixed_2() {
             Instruction::branch(BranchOffset::from(3)),
             Instruction::copy_many_non_overlapping(RegSpan::new(Reg::from(3)), 0, 0),
             Instruction::register2(1, 1),
-            Instruction::return_span(RegSpan::new(Reg::from(3)).iter(4)),
+            Instruction::return_span(bspan(3, 4)),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/op/br_table.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_table.rs
@@ -616,12 +616,12 @@ fn reg_params_4_span() {
         .expect_func_instrs([
             Instruction::i32_popcnt(Reg::from(5), Reg::from(0)),
             Instruction::branch_table_span(4, 4),
-            Instruction::register_span(RegSpan::new(Reg::from(0)).iter(4)),
+            Instruction::register_span(bspan(0, 4)),
             Instruction::branch_table_target_non_overlapping(
                 RegSpan::new(Reg::from(5)),
                 BranchOffset::from(8),
             ),
-            Instruction::return_span(RegSpan::new(Reg::from(0)).iter(4)),
+            Instruction::return_span(bspan(0, 4)),
             Instruction::branch_table_target_non_overlapping(
                 RegSpan::new(Reg::from(5)),
                 BranchOffset::from(4),
@@ -631,11 +631,11 @@ fn reg_params_4_span() {
                 BranchOffset::from(1),
             ),
             Instruction::i32_add_imm16(Reg::from(9), Reg::from(9), 10_i16),
-            Instruction::return_span(RegSpan::new(Reg::from(6)).iter(4)),
+            Instruction::return_span(bspan(6, 4)),
             Instruction::i32_add_imm16(Reg::from(8), Reg::from(8), 20_i16),
-            Instruction::return_span(RegSpan::new(Reg::from(5)).iter(4)),
+            Instruction::return_span(bspan(5, 4)),
             Instruction::i32_add_imm16(Reg::from(8), Reg::from(8), 30_i16),
-            Instruction::return_span(RegSpan::new(Reg::from(5)).iter(4)),
+            Instruction::return_span(bspan(5, 4)),
         ])
         .run()
 }
@@ -683,11 +683,11 @@ fn reg_params_4_many() {
                 BranchOffset::from(1),
             ),
             Instruction::i32_add_imm16(Reg::from(9), Reg::from(9), 10_i16),
-            Instruction::return_span(RegSpan::new(Reg::from(6)).iter(4)),
+            Instruction::return_span(bspan(6, 4)),
             Instruction::i32_add_imm16(Reg::from(8), Reg::from(8), 20_i16),
-            Instruction::return_span(RegSpan::new(Reg::from(5)).iter(4)),
+            Instruction::return_span(bspan(5, 4)),
             Instruction::i32_add_imm16(Reg::from(8), Reg::from(8), 30_i16),
-            Instruction::return_span(RegSpan::new(Reg::from(5)).iter(4)),
+            Instruction::return_span(bspan(5, 4)),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/op/call/imported.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/call/imported.rs
@@ -214,7 +214,7 @@ fn params7_reg() {
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
             Instruction::register(6),
-            Instruction::return_span(RegSpan::new(Reg::from(7)).iter(7)),
+            Instruction::return_span(bspan(7, 7)),
         ])
         .run();
 }
@@ -244,7 +244,7 @@ fn params7_reg_rev() {
             Instruction::register_list(6, 5, 4),
             Instruction::register_list(3, 2, 1),
             Instruction::register(0),
-            Instruction::return_span(RegSpan::new(Reg::from(7)).iter(7)),
+            Instruction::return_span(bspan(7, 7)),
         ])
         .run();
 }
@@ -275,7 +275,7 @@ fn params7_imm() {
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register(-7),
-                Instruction::return_span(RegSpan::new(Reg::from(0)).iter(7)),
+                Instruction::return_span(bspan(0, 7)),
             ])
             .consts([10, 20, 30, 40, 50, 60, 70]),
         )
@@ -308,7 +308,7 @@ fn params8_reg() {
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
             Instruction::register2(6, 7),
-            Instruction::return_span(RegSpan::new(Reg::from(8)).iter(8)),
+            Instruction::return_span(bspan(8, 8)),
         ])
         .run();
 }
@@ -339,7 +339,7 @@ fn params8_reg_rev() {
             Instruction::register_list(7, 6, 5),
             Instruction::register_list(4, 3, 2),
             Instruction::register2(1, 0),
-            Instruction::return_span(RegSpan::new(Reg::from(8)).iter(8)),
+            Instruction::return_span(bspan(8, 8)),
         ])
         .run();
 }
@@ -371,7 +371,7 @@ fn params8_imm() {
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register2(-7, -8),
-                Instruction::return_span(RegSpan::new(Reg::from(0)).iter(8)),
+                Instruction::return_span(bspan(0, 8)),
             ])
             .consts([10, 20, 30, 40, 50, 60, 70, 80]),
         )
@@ -405,7 +405,7 @@ fn params9_reg() {
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
             Instruction::register3(6, 7, 8),
-            Instruction::return_span(RegSpan::new(Reg::from(9)).iter(9)),
+            Instruction::return_span(bspan(9, 9)),
         ])
         .run();
 }
@@ -437,7 +437,7 @@ fn params9_reg_rev() {
             Instruction::register_list(8, 7, 6),
             Instruction::register_list(5, 4, 3),
             Instruction::register3(2, 1, 0),
-            Instruction::return_span(RegSpan::new(Reg::from(9)).iter(9)),
+            Instruction::return_span(bspan(9, 9)),
         ])
         .run();
 }
@@ -470,7 +470,7 @@ fn params9_imm() {
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register3(-7, -8, -9),
-                Instruction::return_span(RegSpan::new(Reg::from(0)).iter(9)),
+                Instruction::return_span(bspan(0, 9)),
             ])
             .consts([10, 20, 30, 40, 50, 60, 70, 80, 90]),
         )

--- a/crates/wasmi/src/engine/translator/tests/op/call/indirect.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/call/indirect.rs
@@ -606,7 +606,7 @@ fn params7_reg_index_local() {
             Instruction::register_list(1, 2, 3),
             Instruction::register_list(4, 5, 6),
             Instruction::register(7),
-            Instruction::return_span(RegSpan::new(Reg::from(8)).iter(7)),
+            Instruction::return_span(bspan(8, 7)),
         ])
         .run();
 }
@@ -639,7 +639,7 @@ fn params7_imm_index_local() {
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register(-7),
-                Instruction::return_span(RegSpan::new(Reg::from(1)).iter(7)),
+                Instruction::return_span(bspan(1, 7)),
             ])
             .consts([10_i32, 20, 30, 40, 50, 60, 70]),
         )
@@ -674,7 +674,7 @@ fn params8_reg_index_local() {
             Instruction::register_list(1, 2, 3),
             Instruction::register_list(4, 5, 6),
             Instruction::register2(7, 8),
-            Instruction::return_span(RegSpan::new(Reg::from(9)).iter(8)),
+            Instruction::return_span(bspan(9, 8)),
         ])
         .run();
 }
@@ -708,7 +708,7 @@ fn params8_imm_index_local() {
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register2(-7, -8),
-                Instruction::return_span(RegSpan::new(Reg::from(1)).iter(8)),
+                Instruction::return_span(bspan(1, 8)),
             ])
             .consts([10_i32, 20, 30, 40, 50, 60, 70, 80]),
         )
@@ -744,7 +744,7 @@ fn params9_reg_index_local() {
             Instruction::register_list(1, 2, 3),
             Instruction::register_list(4, 5, 6),
             Instruction::register3(7, 8, 9),
-            Instruction::return_span(RegSpan::new(Reg::from(10)).iter(9)),
+            Instruction::return_span(bspan(10, 9)),
         ])
         .run();
 }
@@ -779,7 +779,7 @@ fn params9_imm_index_local() {
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register3(-7, -8, -9),
-                Instruction::return_span(RegSpan::new(Reg::from(1)).iter(9)),
+                Instruction::return_span(bspan(1, 9)),
             ])
             .consts([10_i32, 20, 30, 40, 50, 60, 70, 80, 90]),
         )

--- a/crates/wasmi/src/engine/translator/tests/op/call/internal.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/call/internal.rs
@@ -251,13 +251,13 @@ fn params7_reg() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(7))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(7)), EngineFunc::from_u32(0)),
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
             Instruction::register(6),
-            Instruction::return_span(RegSpan::new(Reg::from(7)).iter(7)),
+            Instruction::return_span(bspan(7, 7)),
         ])
         .run();
 }
@@ -290,13 +290,13 @@ fn params7_reg_rev() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(7))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(7)), EngineFunc::from_u32(0)),
             Instruction::register_list(6, 5, 4),
             Instruction::register_list(3, 2, 1),
             Instruction::register(0),
-            Instruction::return_span(RegSpan::new(Reg::from(7)).iter(7)),
+            Instruction::return_span(bspan(7, 7)),
         ])
         .run();
 }
@@ -329,14 +329,14 @@ fn params7_imm() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(7))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_internal(RegSpan::new(Reg::from(0)), EngineFunc::from_u32(0)),
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register(-7),
-                Instruction::return_span(RegSpan::new(Reg::from(0)).iter(7)),
+                Instruction::return_span(bspan(0, 7)),
             ])
             .consts([10, 20, 30, 40, 50, 60, 70]),
         )
@@ -373,13 +373,13 @@ fn params8_reg() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(8))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(8)), EngineFunc::from_u32(0)),
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
             Instruction::register2(6, 7),
-            Instruction::return_span(RegSpan::new(Reg::from(8)).iter(8)),
+            Instruction::return_span(bspan(8, 8)),
         ])
         .run();
 }
@@ -414,13 +414,13 @@ fn params8_reg_rev() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(8))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(8)), EngineFunc::from_u32(0)),
             Instruction::register_list(7, 6, 5),
             Instruction::register_list(4, 3, 2),
             Instruction::register2(1, 0),
-            Instruction::return_span(RegSpan::new(Reg::from(8)).iter(8)),
+            Instruction::return_span(bspan(8, 8)),
         ])
         .run();
 }
@@ -455,14 +455,14 @@ fn params8_imm() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(8))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_internal(RegSpan::new(Reg::from(0)), EngineFunc::from_u32(0)),
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register2(-7, -8),
-                Instruction::return_span(RegSpan::new(Reg::from(0)).iter(8)),
+                Instruction::return_span(bspan(0, 8)),
             ])
             .consts([10, 20, 30, 40, 50, 60, 70, 80]),
         )
@@ -501,13 +501,13 @@ fn params9_reg() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(9))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(9)), EngineFunc::from_u32(0)),
             Instruction::register_list(0, 1, 2),
             Instruction::register_list(3, 4, 5),
             Instruction::register3(6, 7, 8),
-            Instruction::return_span(RegSpan::new(Reg::from(9)).iter(9)),
+            Instruction::return_span(bspan(9, 9)),
         ])
         .run();
 }
@@ -544,13 +544,13 @@ fn params9_reg_rev() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(9))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(9)), EngineFunc::from_u32(0)),
             Instruction::register_list(8, 7, 6),
             Instruction::register_list(5, 4, 3),
             Instruction::register3(2, 1, 0),
-            Instruction::return_span(RegSpan::new(Reg::from(9)).iter(9)),
+            Instruction::return_span(bspan(9, 9)),
         ])
         .run();
 }
@@ -587,14 +587,14 @@ fn params9_imm() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(9))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_internal(RegSpan::new(Reg::from(0)), EngineFunc::from_u32(0)),
                 Instruction::register_list(-1, -2, -3),
                 Instruction::register_list(-4, -5, -6),
                 Instruction::register3(-7, -8, -9),
-                Instruction::return_span(RegSpan::new(Reg::from(0)).iter(9)),
+                Instruction::return_span(bspan(0, 9)),
             ])
             .consts([10, 20, 30, 40, 50, 60, 70, 80, 90]),
         )

--- a/crates/wasmi/src/engine/translator/tests/op/loop_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/loop_.rs
@@ -180,7 +180,7 @@ fn identity_loop_4_mixed_1() {
             ExpectedFunc::new([
                 Instruction::copy_many_non_overlapping(RegSpan::new(Reg::from(2)), -1, 0),
                 Instruction::register2(1, -2),
-                Instruction::return_span(RegSpan::new(Reg::from(2)).iter(4)),
+                Instruction::return_span(bspan(2, 4)),
             ])
             .consts([10_i32, 20]),
         )
@@ -204,7 +204,7 @@ fn identity_loop_4_mixed_2() {
         .expect_func_instrs([
             Instruction::copy_many_non_overlapping(RegSpan::new(Reg::from(2)), 0, 0),
             Instruction::register2(1, 1),
-            Instruction::return_span(RegSpan::new(Reg::from(2)).iter(4)),
+            Instruction::return_span(bspan(2, 4)),
         ])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/op/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/mod.rs
@@ -24,6 +24,7 @@ mod table;
 mod unary;
 
 use super::{
+    bspan,
     display_wasm::DisplayValueType,
     driver::ExpectedFunc,
     swap_ops,

--- a/crates/wasmi/src/engine/translator/tests/op/return_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/return_.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::engine::{bytecode::RegSpan, translator::tests::wasm_type::WasmTy};
+use crate::engine::translator::tests::wasm_type::WasmTy;
 use core::fmt::Display;
 
 #[test]
@@ -264,7 +264,7 @@ fn return_4_span() {
             )
         )";
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(4))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 4))])
         .run()
 }
 
@@ -301,7 +301,7 @@ fn return_5_span() {
             )
         )";
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(5))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 5))])
         .run()
 }
 

--- a/crates/wasmi/src/engine/translator/tests/op/return_call/internal.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/return_call/internal.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::engine::{EngineFunc, RegSpan};
+use crate::engine::EngineFunc;
 
 #[test]
 #[cfg_attr(miri, ignore)]
@@ -240,7 +240,7 @@ fn params7_reg() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(7))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(0, 1, 2),
@@ -278,7 +278,7 @@ fn params7_reg_rev() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(7))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(6, 5, 4),
@@ -316,7 +316,7 @@ fn params7_imm() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(7))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -359,7 +359,7 @@ fn params8_reg() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(8))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(0, 1, 2),
@@ -399,7 +399,7 @@ fn params8_reg_rev() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(8))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(7, 6, 5),
@@ -439,7 +439,7 @@ fn params8_imm() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(8))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -484,7 +484,7 @@ fn params9_reg() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(9))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(0, 1, 2),
@@ -526,7 +526,7 @@ fn params9_reg_rev() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(9))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
             Instruction::register_list(8, 7, 6),
@@ -568,7 +568,7 @@ fn params9_imm() {
         )
     "#;
     TranslationTest::from_wat(wasm)
-        .expect_func_instrs([Instruction::return_span(RegSpan::new(Reg::from(0)).iter(9))])
+        .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_internal(EngineFunc::from_u32(0)),

--- a/crates/wasmi/src/engine/translator/visit_register.rs
+++ b/crates/wasmi/src/engine/translator/visit_register.rs
@@ -35,7 +35,7 @@ impl VisitInputRegisters for Instruction {
         //       their results because preserved registers might be populating them.
         match self {
             | Self::Copy { result, .. } => f(result),
-            | Self::Copy2 { results, .. }
+            | Self::Copy2 { results, .. } => f(results.span_mut().head_mut()),
             | Self::CopySpan { results, .. }
             | Self::CopySpanNonOverlapping { results, .. }
             | Self::CopyMany { results, .. }

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -4,6 +4,7 @@ use super::errors::{
     FuncError,
     GlobalError,
     InstantiationError,
+    IrError,
     LinkerError,
     MemoryError,
     TableError,
@@ -189,6 +190,8 @@ pub enum ErrorKind {
     Translation(TranslationError),
     /// Encountered when an enforced limit is exceeded.
     Limits(EnforcedLimitsError),
+    /// Encountered for Wasmi bytecode related errors.
+    Ir(IrError),
 }
 
 impl ErrorKind {
@@ -255,6 +258,7 @@ impl Display for ErrorKind {
             Self::Translation(error) => Display::fmt(error, f),
             Self::Limits(error) => Display::fmt(error, f),
             Self::ResumableHost(error) => Display::fmt(error, f),
+            Self::Ir(error) => Display::fmt(error, f),
         }
     }
 }
@@ -286,6 +290,7 @@ impl_from! {
     impl From<FuncError> for Error::Func;
     impl From<EnforcedLimitsError> for Error::Limits;
     impl From<ResumableHostError> for Error::ResumableHost;
+    impl From<IrError> for Error::Ir;
 }
 
 /// An error that can occur upon `memory.grow` or `table.grow`.

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -113,7 +113,7 @@ use wasmi_collections as collections;
 /// Defines some errors that may occur upon interaction with Wasmi.
 pub mod errors {
     pub use super::{
-        engine::EnforcedLimitsError,
+        engine::{bytecode::IrError, EnforcedLimitsError},
         error::ErrorKind,
         func::FuncError,
         global::GlobalError,


### PR DESCRIPTION
This also simplifies integration of https://github.com/wasmi-labs/wasmi/pull/1152.