### PR TITLE
Use named fields for `{Elem,Data}Drop` instructions

### DIFF
--- a/crates/wasmi/src/engine/bytecode/construct.rs
+++ b/crates/wasmi/src/engine/bytecode/construct.rs
@@ -464,6 +464,16 @@ impl Instruction {
         }
     }
 
+    /// Creates a new [`Instruction::DataDrop`] from the given `data`.
+    pub fn data_drop(data: impl Into<Data>) -> Self {
+        Self::DataDrop { data: data.into() }
+    }
+
+    /// Creates a new [`Instruction::ElemDrop`] from the given `elem`.
+    pub fn elem_drop(elem: impl Into<Elem>) -> Self {
+        Self::ElemDrop { elem: elem.into() }
+    }
+
     /// Creates a new [`Instruction::DataIndex`] from the given `index`.
     pub fn data_index(index: impl Into<Data>) -> Self {
         Self::DataIndex {

--- a/crates/wasmi/src/engine/bytecode/mod.rs
+++ b/crates/wasmi/src/engine/bytecode/mod.rs
@@ -5049,9 +5049,9 @@ pub enum Instruction {
     },
 
     /// A Wasm `elem.drop` equalivalent Wasmi instruction.
-    ElemDrop(Elem),
+    ElemDrop { elem: Elem },
     /// A Wasm `data.drop` equalivalent Wasmi instruction.
-    DataDrop(Data),
+    DataDrop { data: Data },
 
     /// Wasm `memory.size` instruction.
     MemorySize {

--- a/crates/wasmi/src/engine/bytecode/visit_regs.rs
+++ b/crates/wasmi/src/engine/bytecode/visit_regs.rs
@@ -586,7 +586,7 @@ impl HostVisitor for &'_ mut Instruction {
             | Instr::TableGrowImm { result, value, .. } => {
                 host_visitor!(visitor => Res(result), value)
             }
-            | Instr::ElemDrop(_) | Instr::DataDrop(_) => {}
+            | Instr::ElemDrop { .. } | Instr::DataDrop { .. } => {}
             | Instr::MemorySize { result } => host_visitor!(visitor => Res(result)),
             | Instr::MemoryGrow { result, delta } => host_visitor!(visitor => Res(result), delta),
             | Instr::MemoryGrowBy { result, .. } => host_visitor!(visitor => Res(result)),

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1224,10 +1224,8 @@ impl<'engine> Executor<'engine> {
                     delta,
                     value,
                 } => self.execute_table_grow_imm(store, result, delta, value)?,
-                Instr::ElemDrop(element_index) => {
-                    self.execute_element_drop(&mut store.inner, element_index)
-                }
-                Instr::DataDrop(data_index) => self.execute_data_drop(&mut store.inner, data_index),
+                Instr::ElemDrop { elem } => self.execute_element_drop(&mut store.inner, elem),
+                Instr::DataDrop { data } => self.execute_data_drop(&mut store.inner, data),
                 Instr::MemorySize { result } => self.execute_memory_size(&store.inner, result),
                 Instr::MemoryGrow { result, delta } => {
                     self.execute_memory_grow(store, result, delta)?

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -3077,7 +3077,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     fn visit_data_drop(&mut self, data_index: u32) -> Self::Output {
         bail_unreachable!(self);
-        self.push_fueled_instr(Instruction::DataDrop(data_index.into()), FuelCosts::entity)?;
+        self.push_fueled_instr(Instruction::data_drop(data_index), FuelCosts::entity)?;
         Ok(())
     }
 
@@ -3197,7 +3197,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     fn visit_elem_drop(&mut self, elem_index: u32) -> Self::Output {
         bail_unreachable!(self);
-        self.push_fueled_instr(Instruction::ElemDrop(elem_index.into()), FuelCosts::entity)?;
+        self.push_fueled_instr(Instruction::elem_drop(elem_index), FuelCosts::entity)?;
         Ok(())
     }
 


### PR DESCRIPTION
Simplifies integration of https://github.com/wasmi-labs/wasmi/pull/1152.