### PR TITLE
Fix `table.init` from imported `global.get` values

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -410,23 +410,11 @@ impl<'engine> Executor<'engine> {
     ) -> Result<(), Error> {
         let table_index = self.fetch_table_index(1);
         let element_index = self.fetch_element_segment_index(2);
-        let (instance, table, element, fuel) = store.resolve_table_init_params(
-            self.stack.calls.instance_expect(),
+        let (table, element, fuel) = store.resolve_table_init_params(
             &self.get_table(table_index),
             &self.get_element_segment(element_index),
         );
-        table.init(
-            dst_index,
-            element,
-            src_index,
-            len,
-            Some(fuel),
-            |func_index| {
-                instance
-                    .get_func(func_index)
-                    .unwrap_or_else(|| panic!("missing function at index {func_index}"))
-            },
-        )?;
+        table.init(dst_index, element, src_index, len, Some(fuel))?;
         self.try_next_instr_at(3)
     }
 

--- a/crates/wasmi/src/module/element.rs
+++ b/crates/wasmi/src/module/element.rs
@@ -133,7 +133,7 @@ impl ElementSegment {
     }
 
     /// Returns the element items of the [`ElementSegment`].
-    pub fn items_cloned(&self) -> ElementSegmentItems {
-        self.items.clone()
+    pub fn items(&self) -> &[ConstExpr] {
+        self.items.items()
     }
 }

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -29,7 +29,7 @@ pub use self::{
 };
 pub(crate) use self::{
     data::{DataSegment, DataSegments, InitDataSegment, PassiveDataSegmentBytes},
-    element::{ElementSegment, ElementSegmentItems, ElementSegmentKind},
+    element::{ElementSegment, ElementSegmentKind},
     init_expr::ConstExpr,
     utils::WasmiValueType,
 };

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -608,6 +608,26 @@ impl StoreInner {
         Self::resolve_mut(idx, &mut self.tables)
     }
 
+    /// Returns an exclusive reference to the [`TableEntity`] and [`ElementSegmentEntity`] associated to `table` and `elem`.
+    ///
+    /// # Panics
+    ///
+    /// - If the [`Table`] does not originate from this [`Store`].
+    /// - If the [`Table`] cannot be resolved to its entity.
+    /// - If the [`ElementSegment`] does not originate from this [`Store`].
+    /// - If the [`ElementSegment`] cannot be resolved to its entity.
+    pub fn resolve_table_and_element_mut(
+        &mut self,
+        table: &Table,
+        elem: &ElementSegment,
+    ) -> (&mut TableEntity, &mut ElementSegmentEntity) {
+        let table_idx = self.unwrap_stored(table.as_inner());
+        let elem_idx = self.unwrap_stored(elem.as_inner());
+        let table = Self::resolve_mut(table_idx, &mut self.tables);
+        let elem = Self::resolve_mut(elem_idx, &mut self.elems);
+        (table, elem)
+    }
+
     /// Returns both
     ///
     /// - an exclusive reference to the [`TableEntity`] associated to the given [`Table`]
@@ -644,18 +664,6 @@ impl StoreInner {
         (fst, snd, fuel)
     }
 
-    /// Returns an exclusive reference to the [`ElementSegmentEntity`] associated to the given [`ElementSegment`].
-    ///
-    /// # Panics
-    ///
-    /// - If the [`ElementSegment`] does not originate from this [`Store`].
-    /// - If the [`ElementSegment`] cannot be resolved to its entity.
-    pub(super) fn resolve_table_element(&self, segment: &ElementSegment) -> &ElementSegmentEntity {
-        let elem_idx = segment.as_inner();
-        let elem = self.resolve(elem_idx, &self.elems);
-        elem
-    }
-
     /// Returns the following data:
     ///
     /// - A shared reference to the [`InstanceEntity`] associated to the given [`Instance`].
@@ -678,23 +686,15 @@ impl StoreInner {
     /// - If the [`ElementSegment`] cannot be resolved to its entity.
     pub(super) fn resolve_table_init_params(
         &mut self,
-        instance: &Instance,
         table: &Table,
         segment: &ElementSegment,
-    ) -> (
-        &InstanceEntity,
-        &mut TableEntity,
-        &ElementSegmentEntity,
-        &mut Fuel,
-    ) {
+    ) -> (&mut TableEntity, &ElementSegmentEntity, &mut Fuel) {
         let mem_idx = self.unwrap_stored(table.as_inner());
         let data_idx = segment.as_inner();
-        let instance_idx = instance.as_inner();
-        let instance = self.resolve(instance_idx, &self.instances);
         let data = self.resolve(data_idx, &self.elems);
         let mem = Self::resolve_mut(mem_idx, &mut self.tables);
         let fuel = &mut self.fuel;
-        (instance, mem, data, fuel)
+        (mem, data, fuel)
     }
 
     /// Returns a shared reference to the [`ElementSegmentEntity`] associated to the given [`ElementSegment`].

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -644,32 +644,16 @@ impl StoreInner {
         (fst, snd, fuel)
     }
 
-    /// Returns a triple of:
-    ///
-    /// - An exclusive reference to the [`TableEntity`] associated to the given [`Table`].
-    /// - A shared reference to the [`ElementSegmentEntity`] associated to the given [`ElementSegment`].
-    ///
-    /// # Note
-    ///
-    /// This method exists to properly handle use cases where
-    /// otherwise the Rust borrow-checker would not accept.
+    /// Returns an exclusive reference to the [`ElementSegmentEntity`] associated to the given [`ElementSegment`].
     ///
     /// # Panics
     ///
-    /// - If the [`Table`] does not originate from this [`Store`].
-    /// - If the [`Table`] cannot be resolved to its entity.
     /// - If the [`ElementSegment`] does not originate from this [`Store`].
     /// - If the [`ElementSegment`] cannot be resolved to its entity.
-    pub(super) fn resolve_table_element(
-        &mut self,
-        table: &Table,
-        segment: &ElementSegment,
-    ) -> (&mut TableEntity, &ElementSegmentEntity) {
-        let table_idx = self.unwrap_stored(table.as_inner());
+    pub(super) fn resolve_table_element(&self, segment: &ElementSegment) -> &ElementSegmentEntity {
         let elem_idx = segment.as_inner();
         let elem = self.resolve(elem_idx, &self.elems);
-        let table = Self::resolve_mut(table_idx, &mut self.tables);
-        (table, elem)
+        elem
     }
 
     /// Returns the following data:

--- a/crates/wasmi/src/table/mod.rs
+++ b/crates/wasmi/src/table/mod.rs
@@ -337,21 +337,59 @@ impl TableEntity {
         Ok(())
     }
 
-    /// Initialize `len` elements from `src_element[src_index..]` into
-    /// `dst_table[dst_index..]`.
-    ///
-    /// Uses the `instance` to resolve function indices of the element to [`Func`][`crate::Func`].
+    /// Initialize `self[dst_index..]` from `elements`.
     ///
     /// # Errors
     ///
-    /// Returns an error if the range is out of bounds
-    /// of either the source or destination tables.
+    /// Returns an error if the range is out of bounds of either the source or destination tables.
     ///
     /// # Panics
     ///
     /// - Panics if the `instance` cannot resolve all the `element` func indices.
     /// - If the [`ElementSegmentEntity`] element type does not match the [`Table`] element type.
     ///   Note: This is a panic instead of an error since it is asserted at Wasm validation time.
+    pub fn init_untyped(
+        &mut self,
+        dst_index: u32,
+        elements: &[UntypedVal],
+        fuel: Option<&mut Fuel>,
+    ) -> Result<(), TrapCode> {
+        let table_type = self.ty();
+        assert!(
+            table_type.element().is_ref(),
+            "table.init currently only works on reftypes"
+        );
+        // Convert parameters to indices.
+        let dst_index = dst_index as usize;
+        let len = elements.len();
+        let dst_items = self
+            .elements
+            .get_mut(dst_index..)
+            .and_then(|items| items.get_mut(..len))
+            .ok_or(TrapCode::TableOutOfBounds)?;
+        if len == 0 {
+            // Bail out early if nothing needs to be initialized.
+            // The Wasm spec demands to still perform the bounds check
+            // so we cannot bail out earlier.
+            return Ok(());
+        }
+        if let Some(fuel) = fuel {
+            fuel.consume_fuel_if(|costs| costs.fuel_for_copies(len as u64))?;
+        }
+        dst_items.copy_from_slice(elements);
+        Ok(())
+    }
+
+    /// Initialize `len` elements from `src_element[src_index..]` into `self[dst_index..]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the range is out of bounds of either the source or destination tables.
+    ///
+    /// # Panics
+    ///
+    /// If the [`ElementSegmentEntity`] element type does not match the [`Table`] element type.
+    /// Note: This is a panic instead of an error since it is asserted at Wasm validation time.
     pub fn init(
         &mut self,
         dst_index: u32,


### PR DESCRIPTION
This fixes an issue with instantiation of Wasm tables when using `global.get` as element items of globals from another Wasm module.

From the Wasm spec testsuite: Now passes with this PR.

```wast

;; Initializing a table with imported funcref global

(module $module4
  (func (result i32)
    i32.const 42
  )
  (global (export "f") funcref (ref.func 0))
)

(register "module4" $module4)

(module
  (import "module4" "f" (global funcref))
  (type $out-i32 (func (result i32)))
  (table 10 funcref)
  (elem (offset (i32.const 0)) funcref (global.get 0))
  (func (export "call_imported_elem") (type $out-i32)
    (call_indirect (type $out-i32) (i32.const 0))
  )
)

(assert_return (invoke "call_imported_elem") (i32.const 42))
```