### PR TITLE
Optimize Wasmi executor

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1697,6 +1697,26 @@ impl<'engine> Executor<'engine> {
         ip.add(1);
         ip
     }
+
+    /// Returns the optional `memory` parameter for a `load_at` [`Instruction`].
+    ///
+    /// # Note
+    ///
+    /// - Returns the default [`index::Memory`] if the parameter is missing.
+    /// - Bumps `self.ip` if a [`Instruction::MemoryIndex`] parameter was found.
+    #[inline(always)]
+    fn fetch_optional_memory(&mut self) -> index::Memory {
+        let mut addr: InstructionPtr = self.ip;
+        addr.add(1);
+        match *addr.get() {
+            Instruction::MemoryIndex { index } => {
+                hint::cold();
+                self.ip = addr;
+                index
+            }
+            _ => index::Memory::from(0),
+        }
+    }
 }
 
 impl<'engine> Executor<'engine> {
@@ -1736,26 +1756,6 @@ impl<'engine> Executor<'engine> {
         let funcref = FuncRef::new(func);
         self.set_register(result, funcref);
         self.next_instr();
-    }
-
-    /// Returns the optional `memory` parameter for a `load_at` [`Instruction`].
-    ///
-    /// # Note
-    ///
-    /// - Returns the default [`index::Memory`] if the parameter is missing.
-    /// - Bumps `self.ip` if a [`Instruction::MemoryIndex`] parameter was found.
-    #[inline(always)]
-    fn fetch_optional_memory(&mut self) -> index::Memory {
-        let mut addr: InstructionPtr = self.ip;
-        addr.add(1);
-        match *addr.get() {
-            Instruction::MemoryIndex { index } => {
-                hint::cold();
-                self.ip = addr;
-                index
-            }
-            _ => index::Memory::from(0),
-        }
     }
 }
 

--- a/crates/wasmi/src/engine/executor/instrs/binary.rs
+++ b/crates/wasmi/src/engine/executor/instrs/binary.rs
@@ -13,7 +13,6 @@ macro_rules! impl_binary {
     ( $( (Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Reg) {
                 self.execute_binary(result, lhs, rhs, $op)
             }
@@ -73,7 +72,6 @@ macro_rules! impl_binary_imm16 {
     ( $( ($ty:ty, Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Const16<$ty>) {
                 self.execute_binary_imm16(result, lhs, rhs, $op)
             }
@@ -116,7 +114,6 @@ macro_rules! impl_binary_imm16_rev {
     ( $( ($ty:ty, Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, lhs: Const16<$ty>, rhs: Reg) {
                 self.execute_binary_imm16_rev(result, lhs, rhs, $op)
             }
@@ -146,7 +143,6 @@ macro_rules! impl_fallible_binary {
     ( $( (Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Reg) -> Result<(), Error> {
                 self.try_execute_binary(result, lhs, rhs, $op).map_err(Into::into)
             }
@@ -238,7 +234,6 @@ macro_rules! impl_divrem_s_imm16 {
     ( $( ($ty:ty, Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Const16<$ty>) -> Result<(), Error> {
                 self.try_execute_divrem_imm16(result, lhs, rhs, $op)
             }
@@ -259,7 +254,6 @@ macro_rules! impl_divrem_u_imm16 {
     ( $( ($ty:ty, Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Const16<$ty>) {
                 self.execute_divrem_imm16(result, lhs, rhs, $op)
             }
@@ -280,7 +274,6 @@ macro_rules! impl_fallible_binary_imm16_rev {
     ( $( ($ty:ty, Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, lhs: Const16<$ty>, rhs: Reg) -> Result<(), Error> {
                 self.try_execute_binary_imm16_rev(result, lhs, rhs, $op).map_err(Into::into)
             }
@@ -303,7 +296,6 @@ impl<'engine> Executor<'engine> {
 
 impl<'engine> Executor<'engine> {
     /// Executes an [`Instruction::F32CopysignImm`].
-    #[inline(always)]
     pub fn execute_f32_copysign_imm(&mut self, result: Reg, lhs: Reg, rhs: Sign<f32>) {
         let lhs = self.get_register(lhs);
         let rhs = f32::from(rhs);
@@ -312,7 +304,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::F64CopysignImm`].
-    #[inline(always)]
     pub fn execute_f64_copysign_imm(&mut self, result: Reg, lhs: Reg, rhs: Sign<f64>) {
         let lhs = self.get_register(lhs);
         let rhs = f64::from(rhs);

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -19,7 +19,6 @@ impl<'engine> Executor<'engine> {
     /// # Note
     ///
     /// Offsets the instruction pointer using the given [`BranchOffset`].
-    #[inline(always)]
     fn branch_to(&mut self, offset: BranchOffset) {
         self.ip.offset(offset.to_i32() as isize)
     }
@@ -29,12 +28,10 @@ impl<'engine> Executor<'engine> {
     /// # Note
     ///
     /// Offsets the instruction pointer using the given [`BranchOffset`].
-    #[inline(always)]
     fn branch_to16(&mut self, offset: BranchOffset16) {
         self.ip.offset(offset.to_i16() as isize)
     }
 
-    #[inline(always)]
     pub fn execute_branch(&mut self, offset: BranchOffset) {
         self.branch_to(offset)
     }
@@ -48,13 +45,11 @@ impl<'engine> Executor<'engine> {
         cmp::min(index, max_index) as usize + 1
     }
 
-    #[inline(always)]
     pub fn execute_branch_table_0(&mut self, index: Reg, len_targets: u32) {
         let offset = self.fetch_branch_table_offset(index, len_targets);
         self.ip.add(offset);
     }
 
-    #[inline(always)]
     pub fn execute_branch_table_1(&mut self, index: Reg, len_targets: u32) {
         let offset = self.fetch_branch_table_offset(index, len_targets);
         self.ip.add(1);
@@ -74,7 +69,6 @@ impl<'engine> Executor<'engine> {
         }
     }
 
-    #[inline(always)]
     pub fn execute_branch_table_2(&mut self, index: Reg, len_targets: u32) {
         let offset = self.fetch_branch_table_offset(index, len_targets);
         self.ip.add(1);
@@ -94,7 +88,6 @@ impl<'engine> Executor<'engine> {
         }
     }
 
-    #[inline(always)]
     pub fn execute_branch_table_3(&mut self, index: Reg, len_targets: u32) {
         let offset = self.fetch_branch_table_offset(index, len_targets);
         self.ip.add(1);
@@ -114,7 +107,6 @@ impl<'engine> Executor<'engine> {
         }
     }
 
-    #[inline(always)]
     pub fn execute_branch_table_span(&mut self, index: Reg, len_targets: u32) {
         let offset = self.fetch_branch_table_offset(index, len_targets);
         self.ip.add(1);
@@ -139,7 +131,6 @@ impl<'engine> Executor<'engine> {
         }
     }
 
-    #[inline(always)]
     pub fn execute_branch_table_many(&mut self, index: Reg, len_targets: u32) {
         let offset = self.fetch_branch_table_offset(index, len_targets) - 1;
         self.ip.add(1);
@@ -168,7 +159,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic fused compare and branch instruction with raw inputs.
-    #[inline(always)]
     fn execute_branch_binop<T>(
         &mut self,
         lhs: Reg,
@@ -187,7 +177,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic fused compare and branch instruction with immediate `rhs` operand.
-    #[inline(always)]
     fn execute_branch_binop_imm<T>(
         &mut self,
         lhs: Reg,
@@ -277,7 +266,6 @@ macro_rules! impl_execute_branch_binop {
         impl<'engine> Executor<'engine> {
             $(
                 #[doc = concat!("Executes an [`Instruction::", stringify!($op_name), "`].")]
-                #[inline(always)]
                 pub fn $fn_name(&mut self, lhs: Reg, rhs: Reg, offset: BranchOffset16) {
                     self.execute_branch_binop::<$ty>(lhs, rhs, offset, $op)
                 }
@@ -334,7 +322,6 @@ macro_rules! impl_execute_branch_binop_imm {
         impl<'engine> Executor<'engine> {
             $(
                 #[doc = concat!("Executes an [`Instruction::", stringify!($op_name), "`].")]
-                #[inline(always)]
                 pub fn $fn_name(&mut self, lhs: Reg, rhs: Const16<$ty>, offset: BranchOffset16) {
                     self.execute_branch_binop_imm::<$ty>(lhs, rhs, offset, $op)
                 }

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -27,7 +27,6 @@ use std::fmt;
 /// # Errors
 ///
 /// Returns the error of the host function if an error occurred.
-#[inline(always)]
 pub fn dispatch_host_func<T>(
     store: &mut Store<T>,
     value_stack: &mut ValueStack,
@@ -155,7 +154,6 @@ impl<'engine> Executor<'engine> {
     /// # Note
     ///
     /// The `offset` denotes how many [`Instruction`] words make up the call instruction.
-    #[inline(always)]
     fn update_instr_ptr_at(&mut self, offset: usize) {
         // Note: we explicitly do not mutate `self.ip` since that would make
         // other parts of the code more fragile with respect to instruction ordering.
@@ -217,7 +215,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Creates a [`CallFrame`] for calling the [`EngineFunc`].
-    #[inline(always)]
     fn dispatch_compiled_func<C: CallContext>(
         &mut self,
         results: RegSpan,
@@ -247,7 +244,6 @@ impl<'engine> Executor<'engine> {
     ///
     /// This will also adjust the instruction pointer to point to the
     /// last call parameter [`Instruction`] if any.
-    #[inline(always)]
     fn copy_call_params(&mut self, uninit_params: &mut FrameParams) {
         self.ip.add(1);
         if let Instruction::RegisterList { .. } = self.ip.get() {
@@ -272,7 +268,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Copies an array of [`Reg`] to the `dst` [`Reg`] span.
-    #[inline(always)]
     fn copy_regs<const N: usize>(&self, uninit_params: &mut FrameParams, regs: &[Reg; N]) {
         for value in regs {
             let value = self.get_register(*value);
@@ -289,7 +284,6 @@ impl<'engine> Executor<'engine> {
     ///
     /// This will make the [`InstructionPtr`] point to the [`Instruction`] following the
     /// last [`Instruction::RegisterList`] if any.
-    #[inline(always)]
     #[cold]
     fn copy_call_params_list(&mut self, uninit_params: &mut FrameParams) {
         while let Instruction::RegisterList { regs } = self.ip.get() {
@@ -299,7 +293,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Prepares a [`EngineFunc`] call with optional call parameters.
-    #[inline(always)]
     fn prepare_compiled_func_call<C: CallContext>(
         &mut self,
         store: &mut StoreInner,
@@ -337,7 +330,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::ReturnCallInternal0`].
-    #[inline(always)]
     pub fn execute_return_call_internal_0(
         &mut self,
         store: &mut StoreInner,
@@ -347,7 +339,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::ReturnCallInternal`].
-    #[inline(always)]
     pub fn execute_return_call_internal(
         &mut self,
         store: &mut StoreInner,
@@ -383,7 +374,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallInternal0`].
-    #[inline(always)]
     pub fn execute_call_internal_0(
         &mut self,
         store: &mut StoreInner,
@@ -394,7 +384,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallInternal`].
-    #[inline(always)]
     pub fn execute_call_internal(
         &mut self,
         store: &mut StoreInner,
@@ -405,7 +394,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::ReturnCallImported0`].
-    #[inline(always)]
     pub fn execute_return_call_imported_0<T>(
         &mut self,
         store: &mut Store<T>,
@@ -415,7 +403,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::ReturnCallImported`].
-    #[inline(always)]
     pub fn execute_return_call_imported<T>(
         &mut self,
         store: &mut Store<T>,
@@ -436,7 +423,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallImported0`].
-    #[inline(always)]
     pub fn execute_call_imported_0<T>(
         &mut self,
         store: &mut Store<T>,
@@ -448,7 +434,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallImported`].
-    #[inline(always)]
     pub fn execute_call_imported<T>(
         &mut self,
         store: &mut Store<T>,
@@ -501,7 +486,6 @@ impl<'engine> Executor<'engine> {
     /// execution at a later point in time.
     ///
     /// [`ErrorKind::ResumableHost`]: crate::error::ErrorKind::ResumableHost
-    #[inline(always)]
     fn execute_host_func<C: CallContext, T>(
         &mut self,
         store: &mut Store<T>,
@@ -554,7 +538,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Convenience forwarder to [`dispatch_host_func`].
-    #[inline(always)]
     fn dispatch_host_func<T>(
         &mut self,
         store: &mut Store<T>,
@@ -565,7 +548,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect0`].
-    #[inline(always)]
     pub fn execute_return_call_indirect_0<T>(
         &mut self,
         store: &mut Store<T>,
@@ -579,7 +561,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect0Imm16`].
-    #[inline(always)]
     pub fn execute_return_call_indirect_0_imm16<T>(
         &mut self,
         store: &mut Store<T>,
@@ -593,7 +574,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect0`].
-    #[inline(always)]
     pub fn execute_return_call_indirect<T>(
         &mut self,
         store: &mut Store<T>,
@@ -607,7 +587,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect0Imm16`].
-    #[inline(always)]
     pub fn execute_return_call_indirect_imm16<T>(
         &mut self,
         store: &mut Store<T>,
@@ -621,7 +600,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect0`].
-    #[inline(always)]
     pub fn execute_call_indirect_0<T>(
         &mut self,
         store: &mut Store<T>,
@@ -635,7 +613,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect0Imm16`].
-    #[inline(always)]
     pub fn execute_call_indirect_0_imm16<T>(
         &mut self,
         store: &mut Store<T>,
@@ -649,7 +626,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirect`].
-    #[inline(always)]
     pub fn execute_call_indirect<T>(
         &mut self,
         store: &mut Store<T>,
@@ -663,7 +639,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CallIndirectImm16`].
-    #[inline(always)]
     pub fn execute_call_indirect_imm16<T>(
         &mut self,
         store: &mut Store<T>,

--- a/crates/wasmi/src/engine/executor/instrs/comparison.rs
+++ b/crates/wasmi/src/engine/executor/instrs/comparison.rs
@@ -11,7 +11,6 @@ macro_rules! impl_comparison {
     ( $( (Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Reg) {
                 self.execute_binary(result, lhs, rhs, $op)
             }
@@ -63,7 +62,6 @@ macro_rules! impl_comparison_imm16 {
     ( $( ($ty:ty, Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Const16<$ty>) {
                 self.execute_binary_imm16(result, lhs, rhs, $op)
             }

--- a/crates/wasmi/src/engine/executor/instrs/conversion.rs
+++ b/crates/wasmi/src/engine/executor/instrs/conversion.rs
@@ -8,7 +8,6 @@ macro_rules! impl_conversion_impls {
     ( $( (Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, input: Reg) {
                 self.execute_unary(result, input, $op)
             }
@@ -20,7 +19,6 @@ macro_rules! impl_fallible_conversion_impls {
     ( $( (Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, input: Reg) -> Result<(), Error> {
                 self.try_execute_unary(result, input, $op)
             }

--- a/crates/wasmi/src/engine/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/executor/instrs/copy.rs
@@ -8,7 +8,6 @@ use smallvec::SmallVec;
 
 impl<'engine> Executor<'engine> {
     /// Executes a generic `copy` [`Instruction`].
-    #[inline(always)]
     fn execute_copy_impl<T>(&mut self, result: Reg, value: T, f: fn(&mut Self, T) -> UntypedVal) {
         let value = f(self, value);
         self.set_register(result, value);
@@ -16,20 +15,17 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::Copy`].
-    #[inline(always)]
     pub fn execute_copy(&mut self, result: Reg, value: Reg) {
         self.execute_copy_impl(result, value, |this, value| this.get_register(value))
     }
 
     /// Executes an [`Instruction::Copy2`].
-    #[inline(always)]
     pub fn execute_copy_2(&mut self, results: FixedRegSpan<2>, values: [Reg; 2]) {
         self.execute_copy_2_impl(results, values);
         self.next_instr()
     }
 
     /// Internal implementation of [`Instruction::Copy2`] execution.
-    #[inline(always)]
     fn execute_copy_2_impl(&mut self, results: FixedRegSpan<2>, values: [Reg; 2]) {
         let result0 = results.span().head();
         let result1 = result0.next();
@@ -40,19 +36,16 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CopyImm32`].
-    #[inline(always)]
     pub fn execute_copy_imm32(&mut self, result: Reg, value: AnyConst32) {
         self.execute_copy_impl(result, value, |_, value| UntypedVal::from(u32::from(value)))
     }
 
     /// Executes an [`Instruction::CopyI64Imm32`].
-    #[inline(always)]
     pub fn execute_copy_i64imm32(&mut self, result: Reg, value: Const32<i64>) {
         self.execute_copy_impl(result, value, |_, value| UntypedVal::from(i64::from(value)))
     }
 
     /// Executes an [`Instruction::CopyF64Imm32`].
-    #[inline(always)]
     pub fn execute_copy_f64imm32(&mut self, result: Reg, value: Const32<f64>) {
         self.execute_copy_impl(result, value, |_, value| UntypedVal::from(f64::from(value)))
     }
@@ -65,14 +58,12 @@ impl<'engine> Executor<'engine> {
     ///   and thus requires a costly temporary buffer to avoid overwriting
     ///   intermediate copy results.
     /// - If `results` and `values` do _not_ overlap [`Instruction::CopySpanNonOverlapping`] is used.
-    #[inline(always)]
     pub fn execute_copy_span(&mut self, results: RegSpan, values: RegSpan, len: u16) {
         self.execute_copy_span_impl(results, values, len);
         self.next_instr();
     }
 
     /// Internal implementation of [`Instruction::CopySpan`] execution.
-    #[inline(always)]
     pub fn execute_copy_span_impl(&mut self, results: RegSpan, values: RegSpan, len: u16) {
         let results = results.iter(len);
         let values = values.iter(len);
@@ -90,7 +81,6 @@ impl<'engine> Executor<'engine> {
     /// - This instruction assumes that `results` and `values` do _not_ overlap
     ///   and thus can copy all the elements without a costly temporary buffer.
     /// - If `results` and `values` _do_ overlap [`Instruction::CopySpan`] is used.
-    #[inline(always)]
     pub fn execute_copy_span_non_overlapping(
         &mut self,
         results: RegSpan,
@@ -102,7 +92,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Internal implementation of [`Instruction::CopySpanNonOverlapping`] execution.
-    #[inline(always)]
     pub fn execute_copy_span_non_overlapping_impl(
         &mut self,
         results: RegSpan,
@@ -118,7 +107,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CopyMany`].
-    #[inline(always)]
     pub fn execute_copy_many(&mut self, results: RegSpan, values: [Reg; 2]) {
         self.ip.add(1);
         self.ip = self.execute_copy_many_impl(self.ip, results, &values);
@@ -126,7 +114,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Internal implementation of [`Instruction::CopyMany`] execution.
-    #[inline(always)]
     pub fn execute_copy_many_impl(
         &mut self,
         ip: InstructionPtr,
@@ -157,7 +144,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::CopyManyNonOverlapping`].
-    #[inline(always)]
     pub fn execute_copy_many_non_overlapping(&mut self, results: RegSpan, values: [Reg; 2]) {
         self.ip.add(1);
         self.ip = self.execute_copy_many_non_overlapping_impl(self.ip, results, &values);
@@ -165,7 +151,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Internal implementation of [`Instruction::CopyManyNonOverlapping`] execution.
-    #[inline(always)]
     pub fn execute_copy_many_non_overlapping_impl(
         &mut self,
         ip: InstructionPtr,

--- a/crates/wasmi/src/engine/executor/instrs/global.rs
+++ b/crates/wasmi/src/engine/executor/instrs/global.rs
@@ -10,7 +10,6 @@ use crate::engine::bytecode::Instruction;
 
 impl<'engine> Executor<'engine> {
     /// Executes an [`Instruction::GlobalGet`].
-    #[inline(always)]
     pub fn execute_global_get(&mut self, store: &StoreInner, result: Reg, global: index::Global) {
         let value = match u32::from(global) {
             0 => unsafe { self.cache.global.get() },
@@ -25,7 +24,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::GlobalSet`].
-    #[inline(always)]
     pub fn execute_global_set(
         &mut self,
         store: &mut StoreInner,
@@ -37,7 +35,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::GlobalSetI32Imm16`].
-    #[inline(always)]
     pub fn execute_global_set_i32imm16(
         &mut self,
         store: &mut StoreInner,
@@ -49,7 +46,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::GlobalSetI64Imm16`].
-    #[inline(always)]
     pub fn execute_global_set_i64imm16(
         &mut self,
         store: &mut StoreInner,
@@ -61,7 +57,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `global.set` instruction.
-    #[inline(always)]
     fn execute_global_set_impl(
         &mut self,
         store: &mut StoreInner,

--- a/crates/wasmi/src/engine/executor/instrs/load.rs
+++ b/crates/wasmi/src/engine/executor/instrs/load.rs
@@ -16,7 +16,6 @@ type WasmLoadOp =
 
 impl<'engine> Executor<'engine> {
     /// Returns the `ptr` and `offset` parameters for a `load` [`Instruction`].
-    #[inline(always)]
     fn fetch_ptr_and_offset(&self) -> (Reg, u32) {
         let mut addr: InstructionPtr = self.ip;
         addr.add(1);
@@ -29,7 +28,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Fetches the bytes of the default memory at index 0.
-    #[inline(always)]
     fn fetch_default_memory_bytes(&self) -> &[u8] {
         // Safety: the `self.cache.memory` pointer is always synchronized
         //         conservatively whenever it could have been invalidated.
@@ -37,7 +35,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Fetches the bytes of the given `memory`.
-    #[inline(always)]
     fn fetch_memory_bytes<'exec, 'store, 'bytes>(
         &'exec self,
         memory: Memory,
@@ -86,7 +83,6 @@ impl<'engine> Executor<'engine> {
     /// - `{i32, i64}.load16_u`
     /// - `i64.load32_s`
     /// - `i64.load32_u`
-    #[inline(always)]
     fn execute_load_extend(
         &mut self,
         store: &StoreInner,
@@ -115,7 +111,6 @@ impl<'engine> Executor<'engine> {
     /// - `{i32, i64}.load16_u`
     /// - `i64.load32_s`
     /// - `i64.load32_u`
-    #[inline(always)]
     fn execute_load_extend_mem0(
         &mut self,
         result: Reg,
@@ -130,7 +125,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `load` [`Instruction`].
-    #[inline(always)]
     fn execute_load_impl(
         &mut self,
         store: &StoreInner,
@@ -145,7 +139,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `load_at` [`Instruction`].
-    #[inline(always)]
     fn execute_load_at_impl(
         &mut self,
         store: &StoreInner,
@@ -167,7 +160,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `load_offset16` [`Instruction`].
-    #[inline(always)]
     fn execute_load_offset16_impl(
         &mut self,
         result: Reg,
@@ -193,19 +185,16 @@ macro_rules! impl_execute_load {
     ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_load), "`].")]
-            #[inline(always)]
             pub fn $fn_load(&mut self, store: &StoreInner, result: Reg, memory: Memory) -> Result<(), Error> {
                 self.execute_load_impl(store, result, memory, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_load_at), "`].")]
-            #[inline(always)]
             pub fn $fn_load_at(&mut self, store: &StoreInner, result: Reg, address: u32) -> Result<(), Error> {
                 self.execute_load_at_impl(store, result, address, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_load_off16), "`].")]
-            #[inline(always)]
             pub fn $fn_load_off16(&mut self, result: Reg, ptr: Reg, offset: Const16<u32>) -> Result<(), Error> {
                 self.execute_load_offset16_impl(result, ptr, offset, $impl_fn)
             }

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -35,7 +35,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::DataDrop`].
-    #[inline(always)]
     pub fn execute_data_drop(&mut self, store: &mut StoreInner, segment_index: Data) {
         let segment = self.get_data_segment(segment_index);
         store.resolve_data_segment_mut(&segment).drop_bytes();
@@ -43,14 +42,12 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemorySize`].
-    #[inline(always)]
     pub fn execute_memory_size(&mut self, store: &StoreInner, result: Reg, memory: Memory) {
         self.execute_memory_size_impl(store, result, memory);
         self.next_instr()
     }
 
     /// Underlying implementation of [`Instruction::MemorySize`].
-    #[inline(always)]
     fn execute_memory_size_impl(&mut self, store: &StoreInner, result: Reg, memory: Memory) {
         let memory = self.get_memory(memory);
         let size = store.resolve_memory(&memory).size();
@@ -58,7 +55,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryGrow`].
-    #[inline(always)]
     pub fn execute_memory_grow<T>(
         &mut self,
         store: &mut Store<T>,
@@ -71,7 +67,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryGrowBy`].
-    #[inline(always)]
     pub fn execute_memory_grow_by<T>(
         &mut self,
         store: &mut Store<T>,
@@ -120,7 +115,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryCopy`].
-    #[inline(always)]
     pub fn execute_memory_copy(
         &mut self,
         store: &mut StoreInner,
@@ -135,7 +129,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryCopyTo`].
-    #[inline(always)]
     pub fn execute_memory_copy_to(
         &mut self,
         store: &mut StoreInner,
@@ -150,7 +143,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryCopyFrom`].
-    #[inline(always)]
     pub fn execute_memory_copy_from(
         &mut self,
         store: &mut StoreInner,
@@ -165,7 +157,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryCopyFromTo`].
-    #[inline(always)]
     pub fn execute_memory_copy_from_to(
         &mut self,
         store: &mut StoreInner,
@@ -180,7 +171,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryCopyExact`].
-    #[inline(always)]
     pub fn execute_memory_copy_exact(
         &mut self,
         store: &mut StoreInner,
@@ -195,7 +185,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryCopyToExact`].
-    #[inline(always)]
     pub fn execute_memory_copy_to_exact(
         &mut self,
         store: &mut StoreInner,
@@ -210,7 +199,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryCopyFromExact`].
-    #[inline(always)]
     pub fn execute_memory_copy_from_exact(
         &mut self,
         store: &mut StoreInner,
@@ -225,7 +213,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryCopyFromToExact`].
-    #[inline(always)]
     pub fn execute_memory_copy_from_to_exact(
         &mut self,
         store: &mut StoreInner,
@@ -303,7 +290,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryFill`].
-    #[inline(always)]
     pub fn execute_memory_fill(
         &mut self,
         store: &mut StoreInner,
@@ -318,7 +304,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryFillAt`].
-    #[inline(always)]
     pub fn execute_memory_fill_at(
         &mut self,
         store: &mut StoreInner,
@@ -333,7 +318,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryFillImm`].
-    #[inline(always)]
     pub fn execute_memory_fill_imm(
         &mut self,
         store: &mut StoreInner,
@@ -347,7 +331,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryFillAtImm`].
-    #[inline(always)]
     pub fn execute_memory_fill_at_imm(
         &mut self,
         store: &mut StoreInner,
@@ -361,7 +344,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryFillExact`].
-    #[inline(always)]
     pub fn execute_memory_fill_exact(
         &mut self,
         store: &mut StoreInner,
@@ -376,7 +358,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryFillAtExact`].
-    #[inline(always)]
     pub fn execute_memory_fill_at_exact(
         &mut self,
         store: &mut StoreInner,
@@ -391,7 +372,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryFillImmExact`].
-    #[inline(always)]
     pub fn execute_memory_fill_imm_exact(
         &mut self,
         store: &mut StoreInner,
@@ -405,7 +385,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryFillAtImmExact`].
-    #[inline(always)]
     pub fn execute_memory_fill_at_imm_exact(
         &mut self,
         store: &mut StoreInner,
@@ -443,7 +422,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryInit`].
-    #[inline(always)]
     pub fn execute_memory_init(
         &mut self,
         store: &mut StoreInner,
@@ -458,7 +436,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryInitTo`].
-    #[inline(always)]
     pub fn execute_memory_init_to(
         &mut self,
         store: &mut StoreInner,
@@ -473,7 +450,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryInitFrom`].
-    #[inline(always)]
     pub fn execute_memory_init_from(
         &mut self,
         store: &mut StoreInner,
@@ -488,7 +464,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryInitFromTo`].
-    #[inline(always)]
     pub fn execute_memory_init_from_to(
         &mut self,
         store: &mut StoreInner,
@@ -503,7 +478,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryInitExact`].
-    #[inline(always)]
     pub fn execute_memory_init_exact(
         &mut self,
         store: &mut StoreInner,
@@ -518,7 +492,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryInitToExact`].
-    #[inline(always)]
     pub fn execute_memory_init_to_exact(
         &mut self,
         store: &mut StoreInner,
@@ -533,7 +506,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryInitFromExact`].
-    #[inline(always)]
     pub fn execute_memory_init_from_exact(
         &mut self,
         store: &mut StoreInner,
@@ -548,7 +520,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::MemoryInitFromToExact`].
-    #[inline(always)]
     pub fn execute_memory_init_from_to_exact(
         &mut self,
         store: &mut StoreInner,

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -83,6 +83,7 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `memory.grow` instruction.
+    #[inline(never)]
     fn execute_memory_grow_impl<'store>(
         &mut self,
         store: &'store mut StoreInner,

--- a/crates/wasmi/src/engine/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/executor/instrs/return_.rs
@@ -23,7 +23,6 @@ impl<'engine> Executor<'engine> {
     ///
     /// Any return values are expected to already have been transferred
     /// from the returning callee to the caller.
-    #[inline(always)]
     fn return_impl(&mut self, store: &mut StoreInner) -> ReturnOutcome {
         let (returned, popped_instance) = self
             .stack
@@ -50,7 +49,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::Return`].
-    #[inline(always)]
     pub fn execute_return(&mut self, store: &mut StoreInner) -> ReturnOutcome {
         self.return_impl(store)
     }
@@ -58,7 +56,6 @@ impl<'engine> Executor<'engine> {
     /// Returns the [`FrameRegisters`] of the caller and the [`RegSpan`] of the results.
     ///
     /// The returned [`FrameRegisters`] is valid for all [`Reg`] in the returned [`RegSpan`].
-    #[inline(always)]
     fn return_caller_results(&mut self) -> (FrameRegisters, RegSpan) {
         let (callee, caller) = self
             .stack
@@ -91,7 +88,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute a generic return [`Instruction`] returning a single value.
-    #[inline(always)]
     fn execute_return_value<T>(
         &mut self,
         store: &mut StoreInner,
@@ -109,13 +105,11 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnReg`] returning a single [`Reg`] value.
-    #[inline(always)]
     pub fn execute_return_reg(&mut self, store: &mut StoreInner, value: Reg) -> ReturnOutcome {
         self.execute_return_value(store, value, Self::get_register)
     }
 
     /// Execute an [`Instruction::ReturnReg2`] returning two [`Reg`] values.
-    #[inline(always)]
     pub fn execute_return_reg2(
         &mut self,
         store: &mut StoreInner,
@@ -125,7 +119,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnReg3`] returning three [`Reg`] values.
-    #[inline(always)]
     pub fn execute_return_reg3(
         &mut self,
         store: &mut StoreInner,
@@ -135,7 +128,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::ReturnReg2`] or [`Instruction::ReturnReg3`] generically.
-    #[inline(always)]
     fn execute_return_reg_n_impl<const N: usize>(
         &mut self,
         store: &mut StoreInner,
@@ -155,7 +147,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnImm32`] returning a single 32-bit value.
-    #[inline(always)]
     pub fn execute_return_imm32(
         &mut self,
         store: &mut StoreInner,
@@ -165,7 +156,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnI64Imm32`] returning a single 32-bit encoded `i64` value.
-    #[inline(always)]
     pub fn execute_return_i64imm32(
         &mut self,
         store: &mut StoreInner,
@@ -175,7 +165,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnF64Imm32`] returning a single 32-bit encoded `f64` value.
-    #[inline(always)]
     pub fn execute_return_f64imm32(
         &mut self,
         store: &mut StoreInner,
@@ -185,7 +174,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnSpan`] returning many values.
-    #[inline(always)]
     pub fn execute_return_span(
         &mut self,
         store: &mut StoreInner,
@@ -205,7 +193,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnMany`] returning many values.
-    #[inline(always)]
     pub fn execute_return_many(
         &mut self,
         store: &mut StoreInner,
@@ -255,7 +242,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute a generic conditional return [`Instruction`].
-    #[inline(always)]
     fn execute_return_nez_impl<T>(
         &mut self,
         store: &mut StoreInner,
@@ -274,7 +260,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::Return`].
-    #[inline(always)]
     pub fn execute_return_nez(&mut self, store: &mut StoreInner, condition: Reg) -> ReturnOutcome {
         self.execute_return_nez_impl(store, condition, (), |this, store, _| {
             this.execute_return(store)
@@ -282,7 +267,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnNezReg`] returning a single [`Reg`] value.
-    #[inline(always)]
     pub fn execute_return_nez_reg(
         &mut self,
         store: &mut StoreInner,
@@ -293,7 +277,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnNezReg`] returning a single [`Reg`] value.
-    #[inline(always)]
     pub fn execute_return_nez_reg2(
         &mut self,
         store: &mut StoreInner,
@@ -304,7 +287,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnNezImm32`] returning a single 32-bit constant value.
-    #[inline(always)]
     pub fn execute_return_nez_imm32(
         &mut self,
         store: &mut StoreInner,
@@ -315,7 +297,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnNezI64Imm32`] returning a single 32-bit encoded constant `i64` value.
-    #[inline(always)]
     pub fn execute_return_nez_i64imm32(
         &mut self,
         store: &mut StoreInner,
@@ -326,7 +307,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnNezF64Imm32`] returning a single 32-bit encoded constant `f64` value.
-    #[inline(always)]
     pub fn execute_return_nez_f64imm32(
         &mut self,
         store: &mut StoreInner,
@@ -337,7 +317,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnNezSpan`] returning many values.
-    #[inline(always)]
     pub fn execute_return_nez_span(
         &mut self,
         store: &mut StoreInner,
@@ -348,7 +327,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Execute an [`Instruction::ReturnNezMany`] returning many values.
-    #[inline(always)]
     pub fn execute_return_nez_many(
         &mut self,
         store: &mut StoreInner,

--- a/crates/wasmi/src/engine/executor/instrs/store.rs
+++ b/crates/wasmi/src/engine/executor/instrs/store.rs
@@ -17,7 +17,6 @@ type WasmStoreOp = fn(
 
 impl<'engine> Executor<'engine> {
     /// Returns the register `value` and `offset` parameters for a `load` [`Instruction`].
-    #[inline(always)]
     fn fetch_value_and_offset(&self) -> (Reg, u32) {
         let mut addr: InstructionPtr = self.ip;
         addr.add(1);
@@ -30,7 +29,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Returns the immediate `value` and `offset` parameters for a `load` [`Instruction`].
-    #[inline(always)]
     fn fetch_value_and_offset_imm<T>(&self) -> (T, u32)
     where
         T: From<AnyConst16>,
@@ -46,7 +44,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Fetches the bytes of the default memory at index 0.
-    #[inline(always)]
     fn fetch_default_memory_bytes_mut(&mut self) -> &mut [u8] {
         // Safety: the `self.cache.memory` pointer is always synchronized
         //         conservatively whenever it could have been invalidated.
@@ -54,7 +51,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Fetches the bytes of the given `memory`.
-    #[inline(always)]
     fn fetch_memory_bytes_mut<'exec, 'store, 'bytes>(
         &'exec mut self,
         memory: Memory,
@@ -100,7 +96,6 @@ impl<'engine> Executor<'engine> {
     /// - `{i32, i64}.store8`
     /// - `{i32, i64}.store16`
     /// - `i64.store32`
-    #[inline(always)]
     fn execute_store_wrap(
         &mut self,
         store: &mut StoreInner,
@@ -125,7 +120,6 @@ impl<'engine> Executor<'engine> {
     /// - `{i32, i64}.store8`
     /// - `{i32, i64}.store16`
     /// - `i64.store32`
-    #[inline(always)]
     fn execute_store_wrap_mem0(
         &mut self,
         address: UntypedVal,
@@ -138,7 +132,6 @@ impl<'engine> Executor<'engine> {
         Ok(())
     }
 
-    #[inline(always)]
     fn execute_store(
         &mut self,
         store: &mut StoreInner,
@@ -158,7 +151,6 @@ impl<'engine> Executor<'engine> {
         self.try_next_instr_at(2)
     }
 
-    #[inline(always)]
     fn execute_store_imm<T>(
         &mut self,
         store: &mut StoreInner,
@@ -181,7 +173,6 @@ impl<'engine> Executor<'engine> {
         self.try_next_instr_at(2)
     }
 
-    #[inline(always)]
     fn execute_store_offset16(
         &mut self,
         ptr: Reg,
@@ -198,7 +189,6 @@ impl<'engine> Executor<'engine> {
         self.try_next_instr()
     }
 
-    #[inline(always)]
     fn execute_store_offset16_imm16<T, V>(
         &mut self,
         ptr: Reg,
@@ -218,7 +208,6 @@ impl<'engine> Executor<'engine> {
         self.try_next_instr()
     }
 
-    #[inline(always)]
     fn execute_store_at(
         &mut self,
         store: &mut StoreInner,
@@ -238,7 +227,6 @@ impl<'engine> Executor<'engine> {
         self.try_next_instr()
     }
 
-    #[inline(always)]
     fn execute_store_at_imm16<T, V>(
         &mut self,
         store: &mut StoreInner,
@@ -277,19 +265,16 @@ macro_rules! impl_execute_istore {
     ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store), "`].")]
-            #[inline(always)]
             pub fn $fn_store(&mut self, store: &mut StoreInner, ptr: Reg, memory: Memory) -> Result<(), Error> {
                 self.execute_store(store, ptr, memory, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_imm), "`].")]
-            #[inline(always)]
             pub fn $fn_store_imm(&mut self, store: &mut StoreInner, ptr: Reg, memory: Memory) -> Result<(), Error> {
                 self.execute_store_imm::<$to_ty>(store, ptr, memory, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_off16), "`].")]
-            #[inline(always)]
             pub fn $fn_store_off16(
                 &mut self,
                 ptr: Reg,
@@ -300,7 +285,6 @@ macro_rules! impl_execute_istore {
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_off16_imm16), "`].")]
-            #[inline(always)]
             pub fn $fn_store_off16_imm16(
                 &mut self,
                 ptr: Reg,
@@ -311,13 +295,11 @@ macro_rules! impl_execute_istore {
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_at), "`].")]
-            #[inline(always)]
             pub fn $fn_store_at(&mut self, store: &mut StoreInner, address: u32, value: Reg) -> Result<(), Error> {
                 self.execute_store_at(store, address, value, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_at_imm16), "`].")]
-            #[inline(always)]
             pub fn $fn_store_at_imm16(
                 &mut self,
                 store: &mut StoreInner,
@@ -415,13 +397,11 @@ macro_rules! impl_execute_fstore {
     ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store), "`].")]
-            #[inline(always)]
             pub fn $fn_store(&mut self, store: &mut StoreInner, ptr: Reg, memory: Memory) -> Result<(), Error> {
                 self.execute_store(store, ptr, memory, $impl_fn)
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_off16), "`].")]
-            #[inline(always)]
             pub fn $fn_store_off16(
                 &mut self,
                 ptr: Reg,
@@ -432,7 +412,6 @@ macro_rules! impl_execute_fstore {
             }
 
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_store_at), "`].")]
-            #[inline(always)]
             pub fn $fn_store_at(&mut self, store: &mut StoreInner,address: u32, value: Reg) -> Result<(), Error> {
                 self.execute_store_at(store, address, value, $impl_fn)
             }

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -40,7 +40,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableGet`].
-    #[inline(always)]
     pub fn execute_table_get(
         &mut self,
         store: &StoreInner,
@@ -52,7 +51,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableGetImm`].
-    #[inline(always)]
     pub fn execute_table_get_imm(
         &mut self,
         store: &StoreInner,
@@ -80,7 +78,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableSize`].
-    #[inline(always)]
     pub fn execute_table_size(&mut self, store: &StoreInner, result: Reg, table_index: Table) {
         self.execute_table_size_impl(store, result, table_index);
         self.next_instr();
@@ -94,7 +91,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableSet`].
-    #[inline(always)]
     pub fn execute_table_set(
         &mut self,
         store: &mut StoreInner,
@@ -106,7 +102,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableSetAt`].
-    #[inline(always)]
     pub fn execute_table_set_at(
         &mut self,
         store: &mut StoreInner,
@@ -134,7 +129,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableCopy`].
-    #[inline(always)]
     pub fn execute_table_copy(
         &mut self,
         store: &mut StoreInner,
@@ -149,7 +143,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableCopyTo`].
-    #[inline(always)]
     pub fn execute_table_copy_to(
         &mut self,
         store: &mut StoreInner,
@@ -164,7 +157,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableCopyFrom`].
-    #[inline(always)]
     pub fn execute_table_copy_from(
         &mut self,
         store: &mut StoreInner,
@@ -179,7 +171,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableCopyFromTo`].
-    #[inline(always)]
     pub fn execute_table_copy_from_to(
         &mut self,
         store: &mut StoreInner,
@@ -194,7 +185,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableCopyExact`].
-    #[inline(always)]
     pub fn execute_table_copy_exact(
         &mut self,
         store: &mut StoreInner,
@@ -209,7 +199,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableCopyToExact`].
-    #[inline(always)]
     pub fn execute_table_copy_to_exact(
         &mut self,
         store: &mut StoreInner,
@@ -224,7 +213,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableCopyFromExact`].
-    #[inline(always)]
     pub fn execute_table_copy_from_exact(
         &mut self,
         store: &mut StoreInner,
@@ -239,7 +227,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableCopyFromToExact`].
-    #[inline(always)]
     pub fn execute_table_copy_from_to_exact(
         &mut self,
         store: &mut StoreInner,
@@ -282,7 +269,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableInit`].
-    #[inline(always)]
     pub fn execute_table_init(
         &mut self,
         store: &mut StoreInner,
@@ -297,7 +283,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableInitTo`].
-    #[inline(always)]
     pub fn execute_table_init_to(
         &mut self,
         store: &mut StoreInner,
@@ -312,7 +297,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableInitFrom`].
-    #[inline(always)]
     pub fn execute_table_init_from(
         &mut self,
         store: &mut StoreInner,
@@ -327,7 +311,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableInitFromTo`].
-    #[inline(always)]
     pub fn execute_table_init_from_to(
         &mut self,
         store: &mut StoreInner,
@@ -342,7 +325,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableInitExact`].
-    #[inline(always)]
     pub fn execute_table_init_exact(
         &mut self,
         store: &mut StoreInner,
@@ -357,7 +339,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableInitToExact`].
-    #[inline(always)]
     pub fn execute_table_init_to_exact(
         &mut self,
         store: &mut StoreInner,
@@ -372,7 +353,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableInitFromExact`].
-    #[inline(always)]
     pub fn execute_table_init_from_exact(
         &mut self,
         store: &mut StoreInner,
@@ -387,7 +367,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableInitFromToExact`].
-    #[inline(always)]
     pub fn execute_table_init_from_to_exact(
         &mut self,
         store: &mut StoreInner,
@@ -421,7 +400,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableFill`].
-    #[inline(always)]
     pub fn execute_table_fill(
         &mut self,
         store: &mut StoreInner,
@@ -435,7 +413,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableFillAt`].
-    #[inline(always)]
     pub fn execute_table_fill_at(
         &mut self,
         store: &mut StoreInner,
@@ -449,7 +426,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableFillExact`].
-    #[inline(always)]
     pub fn execute_table_fill_exact(
         &mut self,
         store: &mut StoreInner,
@@ -463,7 +439,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableFillAtExact`].
-    #[inline(always)]
     pub fn execute_table_fill_at_exact(
         &mut self,
         store: &mut StoreInner,
@@ -494,7 +469,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableGrow`].
-    #[inline(always)]
     pub fn execute_table_grow<T>(
         &mut self,
         store: &mut Store<T>,
@@ -508,7 +482,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::TableGrowImm`].
-    #[inline(always)]
     pub fn execute_table_grow_imm<T>(
         &mut self,
         store: &mut Store<T>,
@@ -551,7 +524,6 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes an [`Instruction::ElemDrop`].
-    #[inline(always)]
     pub fn execute_element_drop(&mut self, store: &mut StoreInner, segment_index: Elem) {
         let segment = self.get_element_segment(segment_index);
         store.resolve_element_segment_mut(&segment).drop_items();

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -254,6 +254,7 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `table.copy` instruction.
+    #[inline(never)]
     fn execute_table_copy_impl(
         &mut self,
         store: &mut StoreInner,
@@ -401,6 +402,7 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `table.init` instruction.
+    #[inline(never)]
     fn execute_table_init_impl(
         &mut self,
         store: &mut StoreInner,
@@ -475,6 +477,7 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `table.fill` instruction.
+    #[inline(never)]
     fn execute_table_fill_impl(
         &mut self,
         store: &mut StoreInner,
@@ -519,6 +522,7 @@ impl<'engine> Executor<'engine> {
     }
 
     /// Executes a generic `table.grow` instruction.
+    #[inline(never)]
     fn execute_table_grow_impl<'store>(
         &mut self,
         store: &'store mut StoreInner,

--- a/crates/wasmi/src/engine/executor/instrs/unary.rs
+++ b/crates/wasmi/src/engine/executor/instrs/unary.rs
@@ -8,7 +8,6 @@ macro_rules! impl_unary_impls {
     ( $( (Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Instruction::", stringify!($var_name), "`].")]
-            #[inline(always)]
             pub fn $fn_name(&mut self, result: Reg, input: Reg) {
                 self.execute_unary(result, input, $op)
             }


### PR DESCRIPTION
This brings Wasmi `main` executor performance roughly on par with `v0.36.2`.