### PR TITLE
Add optional `extra-checks` to Wasmi executor and make checking more consistent

### DIFF
--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -57,6 +57,18 @@ std = [
 # An example of such an environment is `wasm32-unknown-unknown`.
 no-hash-maps = ["wasmi_collections/no-hash-maps"]
 
+# Enables extra checks performed during Wasmi bytecode execution.
+#
+# These checks are unnecessary as long as Wasmi translation works as intended.
+# If Wasmi translation invariants are broken due to bugs, these checks prevent
+# Wasmi execution to exhibit undefined behavior (UB) in certain cases.
+#
+# Expected execution overhead is upt to 20%, if enabled.
+#
+# - Enable if your focus is on safety.
+# - Disable if your focus is on execution speed.
+extra-checks = []
+
 [[bench]]
 name = "benches"
 harness = false

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -487,7 +487,9 @@ impl FuncEntity {
                 // Safety: we just asserted that `self` must be an uncompiled function
                 //         since otherwise we would have returned `None` above.
                 //         Since this is a performance critical path we need to leave out this check.
-                unsafe { core::hint::unreachable_unchecked() }
+                unsafe {
+                    unreachable_unchecked!("expected uncompiled function but found: {self:?}")
+                }
             }
         }
     }

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -7,6 +7,7 @@ use crate::{
         bytecode::{index, BlockFuel, Const16, Instruction, Reg},
         code_map::CodeMap,
         executor::stack::{CallFrame, FrameRegisters, ValueStack},
+        utils::unreachable_unchecked,
         DedupFuncType,
         EngineFunc,
     },
@@ -1418,9 +1419,14 @@ macro_rules! get_entity {
                 unsafe { self.cache.$name(index) }
                     .unwrap_or_else(|| {
                         const ENTITY_NAME: &'static str = ::core::stringify!($id_ty);
-                        ::core::unreachable!(
-                            "missing {ENTITY_NAME} at index {index:?} for the currently used instance",
-                        )
+                        // Safety: within the Wasmi executor it is assumed that store entity
+                        //         indices within the Wasmi bytecode are always valid for the
+                        //         store. This is an invariant of the Wasmi translation.
+                        unsafe {
+                            unreachable_unchecked!(
+                                "missing {ENTITY_NAME} at index {index:?} for the currently used instance",
+                            )
+                        }
                     })
             }
         )*

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1733,7 +1733,13 @@ impl<'engine> Executor<'engine> {
     /// This includes [`Instruction`] variants such as [`Instruction::TableIndex`]
     /// that primarily carry parameters for actually executable [`Instruction`].
     fn invalid_instruction_word(&mut self) -> Result<(), Error> {
-        self.execute_trap(TrapCode::UnreachableCodeReached)
+        // Safety: Wasmi translation guarantees that branches are never taken to instruction parameters directly.
+        unsafe {
+            unreachable_unchecked!(
+                "expected instruction but found instruction parameter: {:?}",
+                *self.ip.get()
+            )
+        }
     }
 
     /// Executes a Wasm `unreachable` instruction.

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -5,6 +5,7 @@ use crate::{
         bytecode::{index, Instruction, Reg, RegSpan},
         code_map::CompiledFuncRef,
         executor::stack::{CallFrame, FrameParams, ValueStack},
+        utils::unreachable_unchecked,
         EngineFunc,
         FuncParams,
     },
@@ -184,9 +185,14 @@ impl<'engine> Executor<'engine> {
                 let index = u32::from(self.get_register(index));
                 (index, table)
             }
-            unexpected => unreachable!(
-                "expected `Instruction::CallIndirectParams[Imm16]` but found {unexpected:?}"
-            ),
+            unexpected => {
+                // Safety: Wasmi translation guarantees that correct instruction parameter follows.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected `Instruction::CallIndirectParams` but found {unexpected:?}"
+                    )
+                }
+            }
         }
     }
 
@@ -208,9 +214,14 @@ impl<'engine> Executor<'engine> {
                 let index = u32::from(index);
                 (index, table)
             }
-            unexpected => unreachable!(
-                "expected `Instruction::CallIndirectParams[Imm16]` but found {unexpected:?}"
-            ),
+            unexpected => {
+                // Safety: Wasmi translation guarantees that correct instruction parameter follows.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected `Instruction::CallIndirectParamsImm16` but found {unexpected:?}"
+                    )
+                }
+            }
         }
     }
 
@@ -260,9 +271,12 @@ impl<'engine> Executor<'engine> {
                 self.copy_regs(uninit_params, regs);
             }
             unexpected => {
-                unreachable!(
-                    "unexpected Instruction found while copying call parameters: {unexpected:?}"
-                )
+                // Safety: Wasmi translation guarantees that register list finalizer exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected register-list finalizer but found: {unexpected:?}"
+                    )
+                }
             }
         }
     }

--- a/crates/wasmi/src/engine/executor/instrs/load.rs
+++ b/crates/wasmi/src/engine/executor/instrs/load.rs
@@ -4,6 +4,7 @@ use crate::{
     engine::{
         bytecode::{Const16, Reg},
         executor::instr_ptr::InstructionPtr,
+        utils::unreachable_unchecked,
     },
     ir::{index::Memory, Instruction},
     store::StoreInner,
@@ -22,7 +23,12 @@ impl<'engine> Executor<'engine> {
         match *addr.get() {
             Instruction::RegisterAndImm32 { reg, imm } => (reg, u32::from(imm)),
             instr => {
-                unreachable!("expected an `Instruction::RegisterAndImm32` but found: {instr:?}")
+                // Safety: Wasmi translation guarantees that `Instruction::RegisterAndImm32` exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected an `Instruction::RegisterAndImm32` but found: {instr:?}"
+                    )
+                }
             }
         }
     }

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -1,7 +1,10 @@
 use super::{Executor, InstructionPtr};
 use crate::{
     core::TrapCode,
-    engine::bytecode::{index::Data, Const16, Instruction, Reg},
+    engine::{
+        bytecode::{index::Data, Const16, Instruction, Reg},
+        utils::unreachable_unchecked,
+    },
     error::EntityGrowError,
     ir::index::Memory,
     store::{ResourceLimiterRef, StoreInner},
@@ -17,7 +20,12 @@ impl<'engine> Executor<'engine> {
         match *addr.get() {
             Instruction::MemoryIndex { index } => index,
             unexpected => {
-                unreachable!("expected `Instruction::MemoryIndex` but found: {unexpected:?}")
+                // Safety: Wasmi translation guarantees that [`Instruction::MemoryIndex`] exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected `Instruction::MemoryIndex` but found: {unexpected:?}"
+                    )
+                }
             }
         }
     }
@@ -29,7 +37,12 @@ impl<'engine> Executor<'engine> {
         match *addr.get() {
             Instruction::DataIndex { index } => index,
             unexpected => {
-                unreachable!("expected `Instruction::DataIndex` but found: {unexpected:?}")
+                // Safety: Wasmi translation guarantees that [`Instruction::DataIndex`] exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected `Instruction::DataIndex` but found: {unexpected:?}"
+                    )
+                }
             }
         }
     }

--- a/crates/wasmi/src/engine/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/executor/instrs/return_.rs
@@ -4,6 +4,7 @@ use crate::{
     engine::{
         bytecode::{AnyConst32, BoundedRegSpan, Const32, Instruction, Reg, RegSpan},
         executor::stack::FrameRegisters,
+        utils::unreachable_unchecked,
     },
     store::StoreInner,
 };
@@ -236,7 +237,14 @@ impl<'engine> Executor<'engine> {
             Instruction::Register { reg } => slice::from_ref(reg),
             Instruction::Register2 { regs } => regs,
             Instruction::Register3 { regs } => regs,
-            unexpected => unreachable!("unexpected `Instruction` found while executing `Instruction::ReturnMany`: {unexpected:?}"),
+            unexpected => {
+                // Safety: Wasmi translation guarantees that a register-list finalizer exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "unexpected register-list finalizer but found: {unexpected:?}"
+                    )
+                }
+            }
         };
         copy_results(values);
     }

--- a/crates/wasmi/src/engine/executor/instrs/select.rs
+++ b/crates/wasmi/src/engine/executor/instrs/select.rs
@@ -1,7 +1,10 @@
 use super::{Executor, InstructionPtr};
 use crate::{
     core::UntypedVal,
-    engine::bytecode::{AnyConst32, Const32, Instruction, Reg},
+    engine::{
+        bytecode::{AnyConst32, Const32, Instruction, Reg},
+        utils::unreachable_unchecked,
+    },
 };
 
 impl<'engine> Executor<'engine> {
@@ -12,7 +15,12 @@ impl<'engine> Executor<'engine> {
         match *addr.get() {
             Instruction::Register2 { regs: [reg0, reg1] } => (reg0, reg1),
             unexpected => {
-                unreachable!("expected `Instruction::Register2` but found {unexpected:?}")
+                // Safety: Wasmi translation guarantees that [`Instruction::Register2`] exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected `Instruction::Register2` but found {unexpected:?}"
+                    )
+                }
             }
         }
     }
@@ -27,7 +35,12 @@ impl<'engine> Executor<'engine> {
         match *addr.get() {
             Instruction::RegisterAndImm32 { reg, imm } => (reg, T::from(imm)),
             unexpected => {
-                unreachable!("expected `Instruction::RegisterAndImm32` but found {unexpected:?}")
+                // Safety: Wasmi translation guarantees that [`Instruction::RegisterAndImm32`] exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected `Instruction::RegisterAndImm32` but found {unexpected:?}"
+                    )
+                }
             }
         }
     }

--- a/crates/wasmi/src/engine/executor/instrs/store.rs
+++ b/crates/wasmi/src/engine/executor/instrs/store.rs
@@ -1,7 +1,10 @@
 use super::{Executor, InstructionPtr};
 use crate::{
     core::{TrapCode, UntypedVal},
-    engine::bytecode::{Const16, Instruction, Reg},
+    engine::{
+        bytecode::{Const16, Instruction, Reg},
+        utils::unreachable_unchecked,
+    },
     ir::{index::Memory, AnyConst16},
     store::StoreInner,
     Error,
@@ -22,8 +25,13 @@ impl<'engine> Executor<'engine> {
         addr.add(1);
         match *addr.get() {
             Instruction::RegisterAndImm32 { reg, imm } => (reg, u32::from(imm)),
-            instr => {
-                unreachable!("expected an `Instruction::RegisterAndImm32` but found: {instr:?}")
+            unexpected => {
+                // Safety: Wasmi translation guarantees that [`Instruction::RegisterAndImm32`] exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected `Instruction::RegisterAndImm32` but found {unexpected:?}"
+                    )
+                }
             }
         }
     }
@@ -37,8 +45,13 @@ impl<'engine> Executor<'engine> {
         addr.add(1);
         match *addr.get() {
             Instruction::Imm16AndImm32 { imm16, imm32 } => (T::from(imm16), u32::from(imm32)),
-            instr => {
-                unreachable!("expected an `Instruction::Imm16AndImm32` but found: {instr:?}")
+            unexpected => {
+                // Safety: Wasmi translation guarantees that [`Instruction::Imm16AndImm32`] exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected `Instruction::Imm16AndImm32` but found {unexpected:?}"
+                    )
+                }
             }
         }
     }

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -1,11 +1,14 @@
 use super::{Executor, InstructionPtr};
 use crate::{
     core::TrapCode,
-    engine::bytecode::{
-        index::{Elem, Table},
-        Const16,
-        Instruction,
-        Reg,
+    engine::{
+        bytecode::{
+            index::{Elem, Table},
+            Const16,
+            Instruction,
+            Reg,
+        },
+        utils::unreachable_unchecked,
     },
     error::EntityGrowError,
     store::{ResourceLimiterRef, StoreInner},
@@ -22,7 +25,12 @@ impl<'engine> Executor<'engine> {
         match *addr.get() {
             Instruction::TableIndex { index } => index,
             unexpected => {
-                unreachable!("expected `Instruction::TableIndex` but found: {unexpected:?}")
+                // Safety: Wasmi translation guarantees that [`Instruction::TableIndex`] exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected `Instruction::TableIndex` but found: {unexpected:?}"
+                    )
+                }
             }
         }
     }
@@ -34,7 +42,12 @@ impl<'engine> Executor<'engine> {
         match *addr.get() {
             Instruction::ElemIndex { index } => index,
             unexpected => {
-                unreachable!("expected `Instruction::ElemIndex` but found: {unexpected:?}")
+                // Safety: Wasmi translation guarantees that [`Instruction::ElemIndex`] exists.
+                unsafe {
+                    unreachable_unchecked!(
+                        "expected `Instruction::ElemIndex` but found: {unexpected:?}"
+                    )
+                }
             }
         }
     }

--- a/crates/wasmi/src/engine/utils.rs
+++ b/crates/wasmi/src/engine/utils.rs
@@ -4,7 +4,7 @@
 /// - [`core::hint::unreachable_unchecked`], otherwise.
 macro_rules! unreachable_unchecked {
     ($($arg:tt)*) => {{
-        match cfg!(debug_assertions) {
+        match cfg!(debug_assertions) || cfg!(feature = "extra-checks") {
             true => ::core::unreachable!( $($arg)* ),
             false => ::core::hint::unreachable_unchecked(),
         }


### PR DESCRIPTION
This PR

- adds a new crate feature: `extra-checks`
- improves asserts and their messages for builds with `debug-assertions` or `extra-checks` enabled.
- removes certain Wasmi executor checks that rely on Wasmi translation invariants if `debug-assertions` and `extra-checks` are disabled.
- benchmarks conducted locally show a maximum performance penalty for enabled checks of up to 20%. However, it depends on the exact workload.

New crate feature: `extra-checks`

```toml
# Enables extra checks performed during Wasmi bytecode execution.
#
# These checks are unnecessary as long as Wasmi translation works as intended.
# If Wasmi translation invariants are broken due to bugs, these checks prevent
# Wasmi execution to exhibit undefined behavior (UB) in certain cases.
#
# Expected execution overhead is upt to 20%, if enabled.
#
# - Enable if your focus is on safety.
# - Disable if your focus is on execution speed.
extra-checks = []
```