### PR TITLE
Use Rust's `ControlFlow` type in `return` instructions execution handlers

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -43,7 +43,7 @@ mod unary;
 
 macro_rules! forward_return {
     ($expr:expr) => {{
-        if $expr.is_break() {
+        if hint::unlikely($expr.is_break()) {
             return Ok(());
         }
     }};

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1,5 +1,4 @@
 pub use self::call::{dispatch_host_func, ResumableHostError};
-use self::return_::ReturnOutcome;
 use super::{cache::CachedInstance, InstructionPtr, Stack};
 use crate::{
     core::{hint, TrapCode, UntypedVal},
@@ -44,7 +43,7 @@ mod unary;
 
 macro_rules! forward_return {
     ($expr:expr) => {{
-        if let ReturnOutcome::Host = $expr {
+        if $expr.is_break() {
             return Ok(());
         }
     }};

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -49,15 +49,11 @@ macro_rules! forward_return {
     }};
 }
 
-/// Executes compiled function instructions until either
-///
-/// - returning from the root function
-/// - calling a host function
-/// - encountering a trap
+/// Executes compiled function instructions until execution returns from the root function.
 ///
 /// # Errors
 ///
-/// If the execution traps.
+/// If the execution encounters a trap.
 #[inline(never)]
 pub fn execute_instrs<'engine, T>(
     store: &mut Store<T>,


### PR DESCRIPTION
This removes the kinda useless `ReturnOutcome` without any real performance or semantics change.