### PR TITLE
Add `no-hash-maps` crate feature to `wasmi_cli` + enable by default

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,7 +16,7 @@ exclude.workspace = true
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-wasmi = { workspace = true }
+wasmi = { workspace = true, features = ["no-hash-maps"] }
 wasmi_wasi = { workspace = true }
 wat = "1"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,12 +16,16 @@ exclude.workspace = true
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-wasmi = { workspace = true, features = ["no-hash-maps"] }
+wasmi = { workspace = true }
 wasmi_wasi = { workspace = true }
 wat = "1"
 
 [dev-dependencies]
 assert_cmd = "2.0.7"
+
+[features]
+default = ["no-hash-maps"]
+no-hash-maps = ["wasmi/no-hash-maps"]
 
 # We need to put this [profile.release] section due to this bug in Cargo:
 # https://github.com/rust-lang/cargo/issues/8264

--- a/crates/collections/Cargo.toml
+++ b/crates/collections/Cargo.toml
@@ -19,7 +19,7 @@ string-interner = { version = "0.17", default-features = false, features = ["inl
 ahash = { version = "0.8.11", default-features = false }
 
 [features]
-default = ["std"]
+default = ["std", "no-hash-maps"]
 std = ["string-interner/std"]
 # Tells the `wasmi_collections` crate to avoid using hash based maps and sets.
 # 

--- a/crates/collections/Cargo.toml
+++ b/crates/collections/Cargo.toml
@@ -29,3 +29,9 @@ std = ["string-interner/std"]
 #
 # An example of such an environment is `wasm32-unknown-unknown`.
 no-hash-maps = []
+
+[package.metadata.cargo-udeps.ignore]
+normal = [
+    # The string-interner dependency is always specified even though it is unused when no-hash-maps is enabled.
+    "string-interner"
+]

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -40,7 +40,7 @@ anyhow = "1.0"
 criterion = { version = "0.5", default-features = false }
 
 [features]
-default = ["std"]
+default = ["std", "no-hash-maps"]
 std = [
     "wasmi_core/std",
     "wasmi_collections/std",


### PR DESCRIPTION
This usually has a positive effect on performance and memory usage, especially on smaller and medium sized Wasm binaries.