### PR TITLE
Use Honggfuzz for fuzzing targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Install cargo-honggfuzz and dependencies
         run: |
           cargo install honggfuzz || true
-          apt-get update && apt-get install --yes binutils-dev libunwind-dev
+          sudo apt-get update && sudo apt-get install --yes binutils-dev libunwind-dev
       - name: Run HFuzz
         env:
           HFUZZ_RUN_ARGS: "--run_time 120 --verbose --quiet" # 2 minutes of fuzzing

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -198,9 +198,12 @@ jobs:
       - name: Check uDeps
         run: cargo udeps --all-targets
 
-  fuzz-translate:
-    name: Fuzz (Translation)
+  fuzz:
+    name: Fuzz
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fuzz_target: ['translate', 'translate_metered', 'execute', 'differential']
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -213,71 +216,16 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-directories: |
-            ~/fuzz/corpus/translate/
-            ~/fuzz/corpus/translate_metered/
-      - name: Install cargo-fuzz
+            ${{ github.workspace }}/hfuzz_target
+            ${{ github.workspace }}/hfuzz_workspace
+      - name: Install cargo-honggfuzz and dependencies
         run: |
-          # Note: We use `|| true` because cargo install returns an error
-          #       if cargo-udeps was already installed on the CI runner.
-          cargo install cargo-fuzz || true
-      - name: Build Fuzzing
-        run: cargo fuzz build translate
-      - name: Fuzz (Translation)
-        run: cargo fuzz run translate -j 2 --verbose -- -max_total_time=60 # 1 minute of fuzzing
-      - name: Fuzz (Translation) + fuel
-        run: cargo fuzz run translate_metered -j 2 --verbose -- -max_total_time=60 # 1 minute of fuzzing
-
-  fuzz-execute:
-    name: Fuzz (Execution)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          submodules: true
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          # Pin nightly so that it does not invalidate GitHub Actions cache too frequently.
-          toolchain: nightly-2024-09-24
-      - name: Set up Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-directories: |
-            ~/fuzz/corpus/execute/
-      - name: Install cargo-fuzz
-        run: |
-          # Note: We use `|| true` because cargo install returns an error
-          #       if cargo-udeps was already installed on the CI runner.
-          cargo install cargo-fuzz || true
-      - name: Build Fuzzing
-        run: cargo fuzz build execute
-      - name: Fuzz (Execution)
-        run: cargo fuzz run execute -j 2 --verbose -- -max_total_time=120 # 2 minutes of fuzzing
-
-  fuzz-differential:
-    name: Fuzz (Differential)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          submodules: true
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          # Pin nightly so that it does not invalidate GitHub Actions cache too frequently.
-          toolchain: nightly-2024-09-24
-      - name: Set up Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-directories: |
-            ~/fuzz/corpus/differential/
-      - name: Install cargo-fuzz
-        run: |
-          # Note: We use `|| true` because cargo install returns an error
-          #       if cargo-udeps was already installed on the CI runner.
-          cargo install cargo-fuzz || true
-      - name: Build Fuzzing
-        run: cargo fuzz build differential
-      - name: Fuzz (Differential)
-        run: cargo fuzz run differential -j 2 --verbose -- -max_total_time=120 # 2 minutes of fuzzing
+          cargo install honggfuzz || true
+          apt-get update && apt-get install --yes binutils-dev libunwind-dev
+      - name: Run HFuzz
+        env:
+          HFUZZ_RUN_ARGS: "--run_time 120 --verbose --quiet" # 2 minutes of fuzzing
+        run: cargo hfuzz run ${{ matrix.fuzz_target }}
 
   miri:
     name: Miri

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "honggfuzz"
+version = "0.5.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c76b6234c13c9ea73946d1379d33186151148e0da231506b964b44f3d023505"
+dependencies = [
+ "arbitrary",
+ "lazy_static",
+ "memmap2",
+ "rustc_version",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1017,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,17 +1033,6 @@ name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
-dependencies = [
- "arbitrary",
- "cc",
- "once_cell",
-]
 
 [[package]]
 name = "libm"
@@ -1083,6 +1090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
  "rustix",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1340,6 +1356,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1935,7 +1960,7 @@ name = "wasmi_fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
- "libfuzzer-sys",
+ "honggfuzz",
  "wasm-smith",
  "wasmi 0.31.2",
  "wasmi 0.38.0",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.4.7"
+honggfuzz = "0.5"
 wasmi-stack = { package = "wasmi", version = "0.31.2" }
 wasmtime = "21.0.1"
 wasmi = { workspace = true, features = ["std"] }

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -3,7 +3,7 @@ mod utils;
 use arbitrary::Unstructured;
 use honggfuzz::fuzz;
 use std::{collections::hash_map::RandomState, mem};
-use utils::{arbitrary_config, ty_to_val};
+use utils::arbitrary_config;
 use wasmi as wasmi_reg;
 use wasmi_reg::core::{F32, F64};
 
@@ -67,7 +67,15 @@ impl WasmiRegister {
     }
 
     fn type_to_value(ty: &wasmi_reg::core::ValType) -> wasmi_reg::Val {
-        ty_to_val(ty)
+        match ty {
+            wasmi_reg::core::ValType::I32 => wasmi_reg::Val::I32(1),
+            wasmi_reg::core::ValType::I64 => wasmi_reg::Val::I64(1),
+            wasmi_reg::core::ValType::F32 => wasmi_reg::Val::F32(1.0.into()),
+            wasmi_reg::core::ValType::F64 => wasmi_reg::Val::F64(1.0.into()),
+            unsupported => panic!(
+                "differential fuzzing does not support reference types, yet but found: {unsupported:?}"
+            ),
+        }
     }
 }
 
@@ -168,7 +176,7 @@ impl WasmiStack {
             ValueType::F32 => wasmi_stack::Value::F32(1.0.into()),
             ValueType::F64 => wasmi_stack::Value::F64(1.0.into()),
             unsupported => panic!(
-                "execution fuzzing does not support reference types, yet but found: {unsupported:?}"
+                "differential fuzzing does not support reference types, yet but found: {unsupported:?}"
             ),
         }
     }
@@ -253,7 +261,7 @@ impl Wasmtime {
             wasmtime::ValType::F32 => wasmtime::Val::F32(1.0_f32.to_bits()),
             wasmtime::ValType::F64 => wasmtime::Val::F64(1.0_f64.to_bits()),
             unsupported => panic!(
-                "execution fuzzing does not support reference types, yet but found: {unsupported:?}"
+                "differential fuzzing does not support reference types, yet but found: {unsupported:?}"
             ),
         }
     }

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -623,7 +623,7 @@ impl FuzzContext {
 fn main() {
     loop {
         fuzz!(|seed: &[u8]| {
-            let mut unstructured = Unstructured::new(&seed);
+            let mut unstructured = Unstructured::new(seed);
             let Ok(mut smith_module) =
                 arbitrary_config(&mut unstructured).and_then(|mut config| {
                     config.reference_types_enabled = false;

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -627,6 +627,7 @@ fn main() {
             let Ok(mut smith_module) =
                 arbitrary_config(&mut unstructured).and_then(|mut config| {
                     config.reference_types_enabled = false;
+                    config.tail_call_enabled = false;
                     wasm_smith::Module::new(config, &mut unstructured)
                 })
             else {

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -628,6 +628,7 @@ fn main() {
                 arbitrary_config(&mut unstructured).and_then(|mut config| {
                     config.reference_types_enabled = false;
                     config.tail_call_enabled = false;
+                    config.max_memories = 1;
                     wasm_smith::Module::new(config, &mut unstructured)
                 })
             else {

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use honggfuzz::fuzz;
 use std::{collections::hash_map::RandomState, mem};
-use utils::{arbitrary_exec_module, ty_to_val};
+use utils::{arbitrary_swarm_config_module, ty_to_val};
 use wasmi as wasmi_reg;
 use wasmi_reg::core::{F32, F64};
 
@@ -614,7 +614,7 @@ impl FuzzContext {
 fn main() {
     loop {
         fuzz!(|data: &[u8]| {
-            let Ok(mut smith_module) = arbitrary_exec_module(data) else {
+            let Ok(mut smith_module) = arbitrary_swarm_config_module(data) else {
                 return;
             };
             // Note: We cannot use built-in fuel metering of the different engines since that
@@ -623,7 +623,8 @@ fn main() {
                 return;
             };
             let wasm = smith_module.to_bytes();
-            let Some(wasmi_register) = <WasmiRegister as DifferentialTarget>::setup(&wasm[..]) else {
+            let Some(wasmi_register) = <WasmiRegister as DifferentialTarget>::setup(&wasm[..])
+            else {
                 return;
             };
             let Some(wasmi_stack) = <WasmiStack as DifferentialTarget>::setup(&wasm[..]) else {

--- a/fuzz/fuzz_targets/execute.rs
+++ b/fuzz/fuzz_targets/execute.rs
@@ -1,13 +1,15 @@
 mod utils;
 
+use arbitrary::Unstructured;
 use honggfuzz::fuzz;
-use utils::{arbitrary_exec_module, ty_to_val};
+use utils::{arbitrary_swarm_config_module, ty_to_val};
 use wasmi::{Engine, Linker, Module, Store, StoreLimitsBuilder};
 
 fn main() {
     loop {
-        fuzz!(|data: &[u8]| {
-            let Ok(mut smith_module) = arbitrary_exec_module(data) else {
+        fuzz!(|seed: &[u8]| {
+            let Ok(mut smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(&seed))
+            else {
                 return;
             };
 

--- a/fuzz/fuzz_targets/execute.rs
+++ b/fuzz/fuzz_targets/execute.rs
@@ -16,7 +16,8 @@ fn main() {
 
             let mut config = Config::default();
             config.consume_fuel(true);
-            config.compilation_mode(wasmi::CompilationMode::Lazy);
+            config.compilation_mode(wasmi::CompilationMode::Eager);
+
             let engine = Engine::default();
             let linker = Linker::new(&engine);
             let limiter = StoreLimitsBuilder::new()

--- a/fuzz/fuzz_targets/execute.rs
+++ b/fuzz/fuzz_targets/execute.rs
@@ -8,7 +8,7 @@ use wasmi::{Config, Engine, Linker, Module, Store, StoreLimitsBuilder};
 fn main() {
     loop {
         fuzz!(|seed: &[u8]| {
-            let mut unstructured = Unstructured::new(&seed);
+            let mut unstructured = Unstructured::new(seed);
             let Ok(smith_module) = arbitrary_swarm_config_module(&mut unstructured) else {
                 return;
             };

--- a/fuzz/fuzz_targets/execute.rs
+++ b/fuzz/fuzz_targets/execute.rs
@@ -1,57 +1,59 @@
-#![no_main]
-
 mod utils;
 
-use libfuzzer_sys::fuzz_target;
+use honggfuzz::fuzz;
 use utils::{arbitrary_exec_module, ty_to_val};
 use wasmi::{Engine, Linker, Module, Store, StoreLimitsBuilder};
 
-fuzz_target!(|data: &[u8]| {
-    let Ok(mut smith_module) = arbitrary_exec_module(data) else {
-        return;
-    };
+fn main() {
+    loop {
+        fuzz!(|data: &[u8]| {
+            let Ok(mut smith_module) = arbitrary_exec_module(data) else {
+                return;
+            };
 
-    // TODO: We could use Wasmi's built-in fuel metering instead.
-    //       This would improve test coverage and may be more efficient
-    //       given that `wasm-smith`'s fuel metering uses global variables
-    //       to communicate used fuel.
-    let Ok(_) = smith_module.ensure_termination(1000 /* fuel */) else {
-        return;
-    };
-    let wasm = smith_module.to_bytes();
-    let engine = Engine::default();
-    let linker = Linker::new(&engine);
-    let limiter = StoreLimitsBuilder::new()
-        .memory_size(1000 * 0x10000)
-        .build();
-    let mut store = Store::new(&engine, limiter);
-    store.limiter(|lim| lim);
-    let module = Module::new(store.engine(), wasm.as_slice()).unwrap();
-    let Ok(preinstance) = linker.instantiate(&mut store, &module) else {
-        return;
-    };
-    let Ok(instance) = preinstance.ensure_no_start(&mut store) else {
-        return;
-    };
+            // TODO: We could use Wasmi's built-in fuel metering instead.
+            //       This would improve test coverage and may be more efficient
+            //       given that `wasm-smith`'s fuel metering uses global variables
+            //       to communicate used fuel.
+            let Ok(_) = smith_module.ensure_termination(1000 /* fuel */) else {
+                return;
+            };
+            let wasm = smith_module.to_bytes();
+            let engine = Engine::default();
+            let linker = Linker::new(&engine);
+            let limiter = StoreLimitsBuilder::new()
+                .memory_size(1000 * 0x10000)
+                .build();
+            let mut store = Store::new(&engine, limiter);
+            store.limiter(|lim| lim);
+            let module = Module::new(store.engine(), wasm.as_slice()).unwrap();
+            let Ok(preinstance) = linker.instantiate(&mut store, &module) else {
+                return;
+            };
+            let Ok(instance) = preinstance.ensure_no_start(&mut store) else {
+                return;
+            };
 
-    let mut funcs = Vec::new();
-    let mut params = Vec::new();
-    let mut results = Vec::new();
+            let mut funcs = Vec::new();
+            let mut params = Vec::new();
+            let mut results = Vec::new();
 
-    let exports = instance.exports(&store);
-    for e in exports {
-        let Some(func) = e.into_func() else {
-            // Export is no function which we cannot execute, therefore we ignore it.
-            continue;
-        };
-        funcs.push(func);
+            let exports = instance.exports(&store);
+            for e in exports {
+                let Some(func) = e.into_func() else {
+                    // Export is no function which we cannot execute, therefore we ignore it.
+                    continue;
+                };
+                funcs.push(func);
+            }
+            for func in &funcs {
+                params.clear();
+                results.clear();
+                let ty = func.ty(&store);
+                params.extend(ty.params().iter().map(ty_to_val));
+                results.extend(ty.results().iter().map(ty_to_val));
+                _ = func.call(&mut store, &params, &mut results);
+            }
+        });
     }
-    for func in &funcs {
-        params.clear();
-        results.clear();
-        let ty = func.ty(&store);
-        params.extend(ty.params().iter().map(ty_to_val));
-        results.extend(ty.results().iter().map(ty_to_val));
-        _ = func.call(&mut store, &params, &mut results);
-    }
-});
+}

--- a/fuzz/fuzz_targets/translate.rs
+++ b/fuzz/fuzz_targets/translate.rs
@@ -1,13 +1,15 @@
 mod utils;
 
+use arbitrary::Unstructured;
 use honggfuzz::fuzz;
-use utils::arbitrary_translate_module;
+use utils::arbitrary_swarm_config_module;
 use wasmi::{Engine, Module};
 
 fn main() {
     loop {
         fuzz!(|seed: &[u8]| {
-            let Ok(smith_module) = arbitrary_translate_module(seed) else {
+            let Ok(smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(&seed))
+            else {
                 return;
             };
             let wasm = smith_module.to_bytes();

--- a/fuzz/fuzz_targets/translate.rs
+++ b/fuzz/fuzz_targets/translate.rs
@@ -8,7 +8,7 @@ use wasmi::{Engine, Module};
 fn main() {
     loop {
         fuzz!(|seed: &[u8]| {
-            let Ok(smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(&seed))
+            let Ok(smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(seed))
             else {
                 return;
             };

--- a/fuzz/fuzz_targets/translate.rs
+++ b/fuzz/fuzz_targets/translate.rs
@@ -1,16 +1,18 @@
-#![no_main]
-
 mod utils;
 
-use libfuzzer_sys::fuzz_target;
+use honggfuzz::fuzz;
 use utils::arbitrary_translate_module;
 use wasmi::{Engine, Module};
 
-fuzz_target!(|seed: &[u8]| {
-    let Ok(smith_module) = arbitrary_translate_module(seed) else {
-        return;
-    };
-    let wasm = smith_module.to_bytes();
-    let engine = Engine::default();
-    Module::new(&engine, &wasm[..]).unwrap();
-});
+fn main() {
+    loop {
+        fuzz!(|seed: &[u8]| {
+            let Ok(smith_module) = arbitrary_translate_module(seed) else {
+                return;
+            };
+            let wasm = smith_module.to_bytes();
+            let engine = Engine::default();
+            Module::new(&engine, &wasm[..]).unwrap();
+        });
+    }
+}

--- a/fuzz/fuzz_targets/translate_metered.rs
+++ b/fuzz/fuzz_targets/translate_metered.rs
@@ -8,7 +8,7 @@ use wasmi::{Config, Engine, Module};
 fn main() {
     loop {
         fuzz!(|seed: &[u8]| {
-            let Ok(smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(&seed))
+            let Ok(smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(seed))
             else {
                 return;
             };

--- a/fuzz/fuzz_targets/translate_metered.rs
+++ b/fuzz/fuzz_targets/translate_metered.rs
@@ -1,13 +1,15 @@
 mod utils;
 
+use arbitrary::Unstructured;
 use honggfuzz::fuzz;
-use utils::arbitrary_translate_module;
+use utils::arbitrary_swarm_config_module;
 use wasmi::{Config, Engine, Module};
 
 fn main() {
     loop {
         fuzz!(|seed: &[u8]| {
-            let Ok(smith_module) = arbitrary_translate_module(seed) else {
+            let Ok(smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(&seed))
+            else {
                 return;
             };
             let wasm = smith_module.to_bytes();

--- a/fuzz/fuzz_targets/translate_metered.rs
+++ b/fuzz/fuzz_targets/translate_metered.rs
@@ -1,18 +1,20 @@
-#![no_main]
-
 mod utils;
 
-use libfuzzer_sys::fuzz_target;
+use honggfuzz::fuzz;
 use utils::arbitrary_translate_module;
 use wasmi::{Config, Engine, Module};
 
-fuzz_target!(|seed: &[u8]| {
-    let Ok(smith_module) = arbitrary_translate_module(seed) else {
-        return;
-    };
-    let wasm = smith_module.to_bytes();
-    let mut config = Config::default();
-    config.consume_fuel(true);
-    let engine = Engine::new(&config);
-    Module::new(&engine, &wasm[..]).unwrap();
-});
+fn main() {
+    loop {
+        fuzz!(|seed: &[u8]| {
+            let Ok(smith_module) = arbitrary_translate_module(seed) else {
+                return;
+            };
+            let wasm = smith_module.to_bytes();
+            let mut config = Config::default();
+            config.consume_fuel(true);
+            let engine = Engine::new(&config);
+            Module::new(&engine, &wasm[..]).unwrap();
+        });
+    }
+}

--- a/fuzz/fuzz_targets/utils.rs
+++ b/fuzz/fuzz_targets/utils.rs
@@ -18,6 +18,7 @@ pub fn arbitrary_config(unstructured: &mut Unstructured) -> arbitrary::Result<wa
     Ok(config)
 }
 
+/// A module for "swarm" testing. Randomized configurations for the generated modules improves coverage.
 pub fn arbitrary_swarm_config_module(
     unstructured: &mut Unstructured,
 ) -> arbitrary::Result<wasm_smith::Module> {

--- a/fuzz/fuzz_targets/utils.rs
+++ b/fuzz/fuzz_targets/utils.rs
@@ -13,40 +13,10 @@ pub fn disable_unsupported_config(config: &mut wasm_smith::Config) {
     config.threads_enabled = false;
 }
 
-pub fn default_config() -> wasm_smith::Config {
-    let mut config = wasm_smith::Config {
-        export_everything: true,
-        allow_start_export: false,
-        reference_types_enabled: true,
-        max_imports: 0,
-        max_memory32_bytes: (1 << 16) * 1_000,
-        max_data_segments: 10_000,
-        max_element_segments: 10_000,
-        max_exports: 10_000,
-        max_elements: 10_000,
-        min_funcs: 1,
-        max_funcs: 10_000,
-        max_globals: 10_000,
-        max_table_elements: 10_000,
-        max_values: 10_000,
-        max_instructions: 100_000,
-        tail_call_enabled: false,
-        ..Default::default()
-    };
-    disable_unsupported_config(&mut config);
-    config
-}
-
 pub fn arbitrary_config(unstructured: &mut Unstructured) -> arbitrary::Result<wasm_smith::Config> {
     let mut config = wasm_smith::Config::arbitrary(unstructured)?;
     disable_unsupported_config(&mut config);
     Ok(config)
-}
-
-pub fn arbitrary_default_config_module(
-    unstructured: &mut Unstructured,
-) -> arbitrary::Result<wasm_smith::Module> {
-    wasm_smith::Module::new(default_config(), unstructured)
 }
 
 pub fn arbitrary_swarm_config_module(

--- a/fuzz/fuzz_targets/utils.rs
+++ b/fuzz/fuzz_targets/utils.rs
@@ -6,7 +6,6 @@ use wasmi::{core::ValType, ExternRef, FuncRef, Val};
 pub fn disable_unsupported_config(config: &mut wasm_smith::Config) {
     config.gc_enabled = false;
     config.exceptions_enabled = false;
-    config.memory64_enabled = false;
     config.relaxed_simd_enabled = false;
     config.simd_enabled = false;
     config.threads_enabled = false;
@@ -28,20 +27,10 @@ pub fn arbitrary_swarm_config_module(
 /// Converts a [`ValType`] into an arbitrary [`Val`]
 pub fn ty_to_arbitrary_val(ty: &ValType, u: &mut Unstructured) -> Val {
     match ty {
-        ValType::I32 => Val::I32(u.int_in_range::<i32>(i32::MIN..=i32::MAX).unwrap_or(1)),
-        ValType::I64 => Val::I64(u.int_in_range::<i64>(i64::MIN..=i64::MAX).unwrap_or(1)),
-        ValType::F32 => Val::F32(
-            u.int_in_range::<u32>(u32::MIN..=u32::MAX)
-                .map(f32::from_bits)
-                .unwrap_or(1.0)
-                .into(),
-        ),
-        ValType::F64 => Val::F64(
-            u.int_in_range::<u64>(u64::MIN..=u64::MAX)
-                .map(f64::from_bits)
-                .unwrap_or(1.0)
-                .into(),
-        ),
+        ValType::I32 => Val::I32(i32::arbitrary(u).unwrap_or(1)),
+        ValType::I64 => Val::I64(i64::arbitrary(u).unwrap_or(1)),
+        ValType::F32 => Val::F32(f32::arbitrary(u).unwrap_or(1.0).into()),
+        ValType::F64 => Val::F64(f64::arbitrary(u).unwrap_or(1.0).into()),
         ValType::FuncRef => Val::FuncRef(FuncRef::null()),
         ValType::ExternRef => Val::ExternRef(ExternRef::null()),
     }

--- a/fuzz/fuzz_targets/utils.rs
+++ b/fuzz/fuzz_targets/utils.rs
@@ -6,7 +6,6 @@ use wasmi::{core::ValType, ExternRef, FuncRef, Val};
 pub fn disable_unsupported_config(config: &mut wasm_smith::Config) {
     config.gc_enabled = false;
     config.exceptions_enabled = false;
-    config.max_memories = 1;
     config.memory64_enabled = false;
     config.relaxed_simd_enabled = false;
     config.simd_enabled = false;

--- a/fuzz/fuzz_targets/utils.rs
+++ b/fuzz/fuzz_targets/utils.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use arbitrary::{Arbitrary, Unstructured};
-use wasmi::{core::ValType, Val};
+use wasmi::{core::ValType, ExternRef, FuncRef, Val};
 
 pub fn disable_unsupported_config(config: &mut wasm_smith::Config) {
     config.gc_enabled = false;
@@ -55,21 +55,24 @@ pub fn arbitrary_swarm_config_module(
     wasm_smith::Module::new(arbitrary_config(unstructured)?, unstructured)
 }
 
-/// Converts a [`ValType`] into a [`Val`] with default initialization of 1.
-///
-/// # ToDo
-///
-/// We actually want the bytes buffer given by the `Arbitrary` crate to influence
-/// the values chosen for the resulting [`Val`]. Also we ideally want to produce
-/// zeroed, positive, negative and NaN values for their respective types.
-pub fn ty_to_val(ty: &ValType) -> Val {
+/// Converts a [`ValType`] into an arbitrary [`Val`]
+pub fn ty_to_arbitrary_val(ty: &ValType, u: &mut Unstructured) -> Val {
     match ty {
-        ValType::I32 => Val::I32(1),
-        ValType::I64 => Val::I64(1),
-        ValType::F32 => Val::F32(1.0.into()),
-        ValType::F64 => Val::F64(1.0.into()),
-        unsupported => panic!(
-            "execution fuzzing does not support reference types, yet but found: {unsupported:?}"
+        ValType::I32 => Val::I32(u.int_in_range::<i32>(i32::MIN..=i32::MAX).unwrap_or(1)),
+        ValType::I64 => Val::I64(u.int_in_range::<i64>(i64::MIN..=i64::MAX).unwrap_or(1)),
+        ValType::F32 => Val::F32(
+            u.int_in_range::<u32>(u32::MIN..=u32::MAX)
+                .map(f32::from_bits)
+                .unwrap_or(1.0)
+                .into(),
         ),
+        ValType::F64 => Val::F64(
+            u.int_in_range::<u64>(u64::MIN..=u64::MAX)
+                .map(f64::from_bits)
+                .unwrap_or(1.0)
+                .into(),
+        ),
+        ValType::FuncRef => Val::FuncRef(FuncRef::null()),
+        ValType::ExternRef => Val::ExternRef(ExternRef::null()),
     }
 }


### PR DESCRIPTION
This switches over the fuzz targets from using libfuzzer to using honggfuzz, which has a couple of nice features:

Honggfuzz detects how many cores are available on the host and launches as many processes as it can to maximize execution rate, no manual intervention is necessary here.

It also has support for hardware based feedback, like instruction/branch count, and on Intel hardware it can do edge coverage. This removes the need for compiling with instrumentation which creates a large speedup. It isn't enabled in this PR, because it looks unlikely that the github runners enable access to the perf counters for this feature, but it's available should these targets ever be run on hardware that supports it.

https://honggfuzz.dev/