### PR TITLE
Add more translation tests for fused-`i32_eqz` and `cmp+br` instrs

### DIFF
--- a/crates/ir/src/primitive.rs
+++ b/crates/ir/src/primitive.rs
@@ -346,7 +346,7 @@ impl ComparatorAndOffset {
     pub fn as_u64(&self) -> u64 {
         let hi = self.cmp as u64;
         let lo = self.offset.to_i32() as u64;
-        hi << 32 & lo
+        hi << 32 | lo
     }
 }
 

--- a/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
@@ -226,7 +226,7 @@ fn loop_backward_imm_eqz() {
                 (func (param i32 i32)
                     (loop
                         (local.get 0)
-                        (i32.const 0)
+                        (i32.const 1)
                         (i32.{op})
                         (br_if 0)
                     )
@@ -235,13 +235,16 @@ fn loop_backward_imm_eqz() {
         );
         TranslationTest::from_wat(&wasm)
             .expect_func_instrs([
-                expect_instr(Reg::from(0), 0, BranchOffset16::from(0_i16)),
+                expect_instr(Reg::from(0), 1, BranchOffset16::from(0_i16)),
                 Instruction::Return,
             ])
             .run()
     }
     test_for("eq", Instruction::branch_i32_eq_imm16);
     test_for("ne", Instruction::branch_i32_ne_imm16);
+    test_for("and", Instruction::branch_i32_and_imm16);
+    test_for("or", Instruction::branch_i32_or_imm16);
+    test_for("xor", Instruction::branch_i32_xor_imm16);
 }
 
 #[test]
@@ -679,6 +682,8 @@ fn block_i32_eqz_fuse() {
             .run()
     }
 
+    test_for("eq", Instruction::branch_i32_ne);
+    test_for("ne", Instruction::branch_i32_eq);
     test_for("and", Instruction::branch_i32_and_eqz);
     test_for("or", Instruction::branch_i32_or_eqz);
     test_for("xor", Instruction::branch_i32_xor_eqz);
@@ -707,6 +712,8 @@ fn if_i32_eqz_fuse() {
             .run()
     }
 
+    test_for("eq", Instruction::branch_i32_eq);
+    test_for("ne", Instruction::branch_i32_ne);
     test_for("and", Instruction::branch_i32_and);
     test_for("or", Instruction::branch_i32_or);
     test_for("xor", Instruction::branch_i32_xor);

--- a/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
@@ -121,7 +121,7 @@ fn loop_backward() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn loop_backward_imm() {
+fn loop_backward_imm_rhs() {
     fn test_for<T>(
         op: &str,
         value: T,

--- a/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
@@ -832,7 +832,8 @@ fn if_i64_eqz_fuse() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn cmp_br_fallback() {
-    let len_adds = 0x1 << 16;
+    // Required amount of instructions to trigger the `cmp+br` fallback instruction generation.
+    let len_adds = 1 << 15 + 1;
     let wasm = generate_cmp_br_fallback_wasm(len_adds).unwrap();
     let expected_instrs = {
         let mut instrs = std::vec![

--- a/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
@@ -833,7 +833,7 @@ fn if_i64_eqz_fuse() {
 #[cfg_attr(miri, ignore)]
 fn cmp_br_fallback() {
     // Required amount of instructions to trigger the `cmp+br` fallback instruction generation.
-    let len_adds = 1 << 15 + 1;
+    let len_adds = (1 << 15) + 1;
     let wasm = generate_cmp_br_fallback_wasm(len_adds).unwrap();
     let expected_instrs = {
         let mut instrs = std::vec![

--- a/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
@@ -315,37 +315,6 @@ fn loop_backward_imm_lhs() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn loop_backward_imm_eqz() {
-    fn test_for(op: &str, expect_instr: fn(Reg, i16, BranchOffset16) -> Instruction) {
-        let wasm = format!(
-            r"
-            (module
-                (func (param i32 i32)
-                    (loop
-                        (local.get 0)
-                        (i32.const 1)
-                        (i32.{op})
-                        (br_if 0)
-                    )
-                )
-            )",
-        );
-        TranslationTest::from_wat(&wasm)
-            .expect_func_instrs([
-                expect_instr(Reg::from(0), 1, BranchOffset16::from(0_i16)),
-                Instruction::Return,
-            ])
-            .run()
-    }
-    test_for("eq", Instruction::branch_i32_eq_imm16);
-    test_for("ne", Instruction::branch_i32_ne_imm16);
-    test_for("and", Instruction::branch_i32_and_imm16);
-    test_for("or", Instruction::branch_i32_or_imm16);
-    test_for("xor", Instruction::branch_i32_xor_imm16);
-}
-
-#[test]
-#[cfg_attr(miri, ignore)]
 fn block_forward() {
     fn test_for(ty: ValType, op: &str, expect_instr: fn(Reg, Reg, BranchOffset16) -> Instruction) {
         let ty = DisplayValueType::from(ty);

--- a/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
@@ -847,9 +847,10 @@ fn cmp_br_fallback() {
         ]);
         instrs
     };
+    let offset = len_adds as i32 + 1;
     let param0: ComparatorAndOffset =
-        ComparatorAndOffset::new(Comparator::I32Ne, BranchOffset::from(65537));
-    let param1 = ComparatorAndOffset::new(Comparator::I32Ne, BranchOffset::from(-65537));
+        ComparatorAndOffset::new(Comparator::I32Ne, BranchOffset::from(offset));
+    let param1 = ComparatorAndOffset::new(Comparator::I32Ne, BranchOffset::from(-offset));
     TranslationTest::from_wat(&wasm)
         .expect_func(ExpectedFunc::new(expected_instrs).consts([
             UntypedVal::from(0_i64),  // reg(-1)

--- a/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
@@ -49,7 +49,6 @@ fn binop_i32_eqz() {
         ("i32", "gt_u", Instruction::i32_le_u),
         ("i32", "ge_s", Instruction::i32_lt_s),
         ("i32", "ge_u", Instruction::i32_lt_u),
-
         ("i64", "eq", Instruction::i64_ne),
         ("i64", "ne", Instruction::i64_eq),
         ("i64", "lt_s", swap_ops!(Instruction::i64_le_s)),
@@ -60,7 +59,6 @@ fn binop_i32_eqz() {
         ("i64", "gt_u", Instruction::i64_le_u),
         ("i64", "ge_s", Instruction::i64_lt_s),
         ("i64", "ge_u", Instruction::i64_lt_u),
-
         ("f32", "eq", Instruction::f32_ne),
         ("f32", "ne", Instruction::f32_eq),
         ("f64", "eq", Instruction::f64_ne),

--- a/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
@@ -71,7 +71,7 @@ macro_rules! test_for_imm {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn binop_imm_i32_eqz() {
+fn binop_imm_i32_eqz_rhs() {
     fn test_for<T>(
         op: &str,
         value: T,
@@ -106,6 +106,8 @@ fn binop_imm_i32_eqz() {
             .run()
     }
     test_for_imm!(
+        (i32, "eq", Instruction::i32_ne_imm16),
+        (i32, "ne", Instruction::i32_eq_imm16),
         (i32, "and", Instruction::i32_and_eqz_imm16),
         (i32, "or", Instruction::i32_or_eqz_imm16),
         (i32, "xor", Instruction::i32_xor_eqz_imm16),
@@ -125,5 +127,66 @@ fn binop_imm_i32_eqz() {
         (u64, "gt_u", Instruction::i64_le_u_imm16_rhs),
         (i64, "ge_s", Instruction::i64_lt_s_imm16_rhs),
         (u64, "ge_u", Instruction::i64_lt_u_imm16_rhs),
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn binop_imm_i32_eqz_lhs() {
+    fn test_for<T>(
+        op: &str,
+        value: T,
+        expect_instr: fn(result: Reg, lhs: Reg, rhs: Const16<T>) -> Instruction,
+    ) where
+        T: Display + WasmTy,
+        Const16<T>: TryFrom<T>,
+        DisplayWasm<T>: Display,
+    {
+        let input_ty = T::NAME;
+        let display_value = DisplayWasm::from(value);
+        let wasm = &format!(
+            r"
+            (module
+                (func (param {input_ty} {input_ty}) (result i32)
+                    ({input_ty}.const {display_value})
+                    (local.get 0)
+                    ({input_ty}.{op})
+                    (i32.eqz)
+                )
+            )",
+        );
+        TranslationTest::from_wat(wasm)
+            .expect_func_instrs([
+                expect_instr(
+                    Reg::from(2),
+                    Reg::from(0),
+                    Const16::try_from(value).ok().unwrap(),
+                ),
+                Instruction::return_reg(2),
+            ])
+            .run()
+    }
+    test_for_imm!(
+        (i32, "eq", Instruction::i32_ne_imm16),
+        (i32, "ne", Instruction::i32_eq_imm16),
+        (i32, "and", Instruction::i32_and_eqz_imm16),
+        (i32, "or", Instruction::i32_or_eqz_imm16),
+        (i32, "xor", Instruction::i32_xor_eqz_imm16),
+        (i32, "lt_s", Instruction::i32_le_s_imm16_rhs),
+        (u32, "lt_u", Instruction::i32_le_u_imm16_rhs),
+        (i32, "le_s", Instruction::i32_lt_s_imm16_rhs),
+        (u32, "le_u", Instruction::i32_lt_u_imm16_rhs),
+        (i32, "gt_s", swap_ops!(Instruction::i32_le_s_imm16_lhs)),
+        (u32, "gt_u", swap_ops!(Instruction::i32_le_u_imm16_lhs)),
+        (i32, "ge_s", swap_ops!(Instruction::i32_lt_s_imm16_lhs)),
+        (u32, "ge_u", swap_ops!(Instruction::i32_lt_u_imm16_lhs)),
+        (i64, "lt_s", Instruction::i64_le_s_imm16_rhs),
+        (u64, "lt_u", Instruction::i64_le_u_imm16_rhs),
+        (i64, "le_s", Instruction::i64_lt_s_imm16_rhs),
+        (u64, "le_u", Instruction::i64_lt_u_imm16_rhs),
+        (i64, "gt_s", swap_ops!(Instruction::i64_le_s_imm16_lhs)),
+        (u64, "gt_u", swap_ops!(Instruction::i64_le_u_imm16_lhs)),
+        (i64, "ge_s", swap_ops!(Instruction::i64_lt_s_imm16_lhs)),
+        (u64, "ge_u", swap_ops!(Instruction::i64_lt_u_imm16_lhs)),
     );
 }

--- a/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
@@ -36,6 +36,8 @@ fn binop_i32_eqz_i64() {
             .run()
     }
     test_for!(
+        ("i32", "eq", Instruction::i32_ne),
+        ("i32", "ne", Instruction::i32_eq),
         ("i32", "and", Instruction::i32_and_eqz),
         ("i32", "or", Instruction::i32_or_eqz),
         ("i32", "xor", Instruction::i32_xor_eqz),
@@ -47,6 +49,9 @@ fn binop_i32_eqz_i64() {
         ("i32", "gt_u", Instruction::i32_le_u),
         ("i32", "ge_s", Instruction::i32_lt_s),
         ("i32", "ge_u", Instruction::i32_lt_u),
+
+        ("i64", "eq", Instruction::i64_ne),
+        ("i64", "ne", Instruction::i64_eq),
         ("i64", "lt_s", swap_ops!(Instruction::i64_le_s)),
         ("i64", "lt_u", swap_ops!(Instruction::i64_le_u)),
         ("i64", "le_s", swap_ops!(Instruction::i64_lt_s)),
@@ -55,6 +60,7 @@ fn binop_i32_eqz_i64() {
         ("i64", "gt_u", Instruction::i64_le_u),
         ("i64", "ge_s", Instruction::i64_lt_s),
         ("i64", "ge_u", Instruction::i64_lt_u),
+
         ("f32", "eq", Instruction::f32_ne),
         ("f32", "ne", Instruction::f32_eq),
         ("f64", "eq", Instruction::f64_ne),
@@ -119,6 +125,8 @@ fn binop_imm_i32_eqz_rhs() {
         (u32, "gt_u", Instruction::i32_le_u_imm16_rhs),
         (i32, "ge_s", Instruction::i32_lt_s_imm16_rhs),
         (u32, "ge_u", Instruction::i32_lt_u_imm16_rhs),
+        (i64, "eq", Instruction::i64_ne_imm16),
+        (i64, "ne", Instruction::i64_eq_imm16),
         (i64, "lt_s", swap_ops!(Instruction::i64_le_s_imm16_lhs)),
         (u64, "lt_u", swap_ops!(Instruction::i64_le_u_imm16_lhs)),
         (i64, "le_s", swap_ops!(Instruction::i64_lt_s_imm16_lhs)),
@@ -180,6 +188,8 @@ fn binop_imm_i32_eqz_lhs() {
         (u32, "gt_u", swap_ops!(Instruction::i32_le_u_imm16_lhs)),
         (i32, "ge_s", swap_ops!(Instruction::i32_lt_s_imm16_lhs)),
         (u32, "ge_u", swap_ops!(Instruction::i32_lt_u_imm16_lhs)),
+        (i64, "eq", Instruction::i64_ne_imm16),
+        (i64, "ne", Instruction::i64_eq_imm16),
         (i64, "lt_s", Instruction::i64_le_s_imm16_rhs),
         (u64, "lt_u", Instruction::i64_le_u_imm16_rhs),
         (i64, "le_s", Instruction::i64_lt_s_imm16_rhs),

--- a/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
@@ -11,7 +11,7 @@ macro_rules! test_for {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn binop_i32_eqz_i64() {
+fn binop_i32_eqz() {
     fn test_for(
         input_ty: &str,
         op: &str,

--- a/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
@@ -198,3 +198,187 @@ fn binop_imm_i32_eqz_lhs() {
         (u64, "ge_u", swap_ops!(Instruction::i64_lt_u_imm16_lhs)),
     );
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn binop_i32_eqz_double() {
+    fn test_for(
+        input_ty: &str,
+        op: &str,
+        expect_instr: fn(result: Reg, lhs: Reg, rhs: Reg) -> Instruction,
+    ) {
+        let wasm = &format!(
+            r"
+            (module
+                (func (param {input_ty} {input_ty}) (result i32)
+                    (local.get 0)
+                    (local.get 1)
+                    ({input_ty}.{op})
+                    (i32.eqz)
+                    (i32.eqz)
+                )
+            )",
+        );
+        TranslationTest::from_wat(wasm)
+            .expect_func_instrs([
+                expect_instr(Reg::from(2), Reg::from(0), Reg::from(1)),
+                Instruction::return_reg(2),
+            ])
+            .run()
+    }
+    test_for!(
+        ("i32", "eq", Instruction::i32_eq),
+        ("i32", "ne", Instruction::i32_ne),
+        ("i32", "and", Instruction::i32_and),
+        ("i32", "or", Instruction::i32_or),
+        ("i32", "xor", Instruction::i32_xor),
+        ("i32", "lt_s", Instruction::i32_lt_s),
+        ("i32", "lt_u", Instruction::i32_lt_u),
+        ("i32", "le_s", Instruction::i32_le_s),
+        ("i32", "le_u", Instruction::i32_le_u),
+        ("i32", "gt_s", swap_ops!(Instruction::i32_lt_s)),
+        ("i32", "gt_u", swap_ops!(Instruction::i32_lt_u)),
+        ("i32", "ge_s", swap_ops!(Instruction::i32_le_s)),
+        ("i32", "ge_u", swap_ops!(Instruction::i32_le_u)),
+        ("i64", "eq", Instruction::i64_eq),
+        ("i64", "ne", Instruction::i64_ne),
+        ("i64", "lt_s", Instruction::i64_lt_s),
+        ("i64", "lt_u", Instruction::i64_lt_u),
+        ("i64", "le_s", Instruction::i64_le_s),
+        ("i64", "le_u", Instruction::i64_le_u),
+        ("i64", "gt_s", swap_ops!(Instruction::i64_lt_s)),
+        ("i64", "gt_u", swap_ops!(Instruction::i64_lt_u)),
+        ("i64", "ge_s", swap_ops!(Instruction::i64_le_s)),
+        ("i64", "ge_u", swap_ops!(Instruction::i64_le_u)),
+        ("f32", "eq", Instruction::f32_eq),
+        ("f32", "ne", Instruction::f32_ne),
+        ("f64", "eq", Instruction::f64_eq),
+        ("f64", "ne", Instruction::f64_ne),
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn binop_imm_i32_eqz_rhs_double() {
+    fn test_for<T>(
+        op: &str,
+        value: T,
+        expect_instr: fn(result: Reg, lhs: Reg, rhs: Const16<T>) -> Instruction,
+    ) where
+        T: Display + WasmTy,
+        Const16<T>: TryFrom<T>,
+        DisplayWasm<T>: Display,
+    {
+        let input_ty = T::NAME;
+        let display_value = DisplayWasm::from(value);
+        let wasm = &format!(
+            r"
+            (module
+                (func (param {input_ty} {input_ty}) (result i32)
+                    (local.get 0)
+                    ({input_ty}.const {display_value})
+                    ({input_ty}.{op})
+                    (i32.eqz)
+                    (i32.eqz)
+                )
+            )",
+        );
+        TranslationTest::from_wat(wasm)
+            .expect_func_instrs([
+                expect_instr(
+                    Reg::from(2),
+                    Reg::from(0),
+                    Const16::try_from(value).ok().unwrap(),
+                ),
+                Instruction::return_reg(2),
+            ])
+            .run()
+    }
+    test_for_imm!(
+        (i32, "eq", Instruction::i32_eq_imm16),
+        (i32, "ne", Instruction::i32_ne_imm16),
+        (i32, "and", Instruction::i32_and_imm16),
+        (i32, "or", Instruction::i32_or_imm16),
+        (i32, "xor", Instruction::i32_xor_imm16),
+        (i32, "lt_s", Instruction::i32_lt_s_imm16_rhs),
+        (u32, "lt_u", Instruction::i32_lt_u_imm16_rhs),
+        (i32, "le_s", Instruction::i32_le_s_imm16_rhs),
+        (u32, "le_u", Instruction::i32_le_u_imm16_rhs),
+        (i32, "gt_s", swap_ops!(Instruction::i32_lt_s_imm16_lhs)),
+        (u32, "gt_u", swap_ops!(Instruction::i32_lt_u_imm16_lhs)),
+        (i32, "ge_s", swap_ops!(Instruction::i32_le_s_imm16_lhs)),
+        (u32, "ge_u", swap_ops!(Instruction::i32_le_u_imm16_lhs)),
+        (i64, "eq", Instruction::i64_eq_imm16),
+        (i64, "ne", Instruction::i64_ne_imm16),
+        (i64, "lt_s", Instruction::i64_lt_s_imm16_rhs),
+        (u64, "lt_u", Instruction::i64_lt_u_imm16_rhs),
+        (i64, "le_s", Instruction::i64_le_s_imm16_rhs),
+        (u64, "le_u", Instruction::i64_le_u_imm16_rhs),
+        (i64, "gt_s", swap_ops!(Instruction::i64_lt_s_imm16_lhs)),
+        (u64, "gt_u", swap_ops!(Instruction::i64_lt_u_imm16_lhs)),
+        (i64, "ge_s", swap_ops!(Instruction::i64_le_s_imm16_lhs)),
+        (u64, "ge_u", swap_ops!(Instruction::i64_le_u_imm16_lhs)),
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn binop_imm_i32_eqz_lhs_double() {
+    fn test_for<T>(
+        op: &str,
+        value: T,
+        expect_instr: fn(result: Reg, lhs: Reg, rhs: Const16<T>) -> Instruction,
+    ) where
+        T: Display + WasmTy,
+        Const16<T>: TryFrom<T>,
+        DisplayWasm<T>: Display,
+    {
+        let input_ty = T::NAME;
+        let display_value = DisplayWasm::from(value);
+        let wasm = &format!(
+            r"
+            (module
+                (func (param {input_ty} {input_ty}) (result i32)
+                    ({input_ty}.const {display_value})
+                    (local.get 0)
+                    ({input_ty}.{op})
+                    (i32.eqz)
+                    (i32.eqz)
+                )
+            )",
+        );
+        TranslationTest::from_wat(wasm)
+            .expect_func_instrs([
+                expect_instr(
+                    Reg::from(2),
+                    Reg::from(0),
+                    Const16::try_from(value).ok().unwrap(),
+                ),
+                Instruction::return_reg(2),
+            ])
+            .run()
+    }
+    test_for_imm!(
+        (i32, "eq", Instruction::i32_eq_imm16),
+        (i32, "ne", Instruction::i32_ne_imm16),
+        (i32, "and", Instruction::i32_and_imm16),
+        (i32, "or", Instruction::i32_or_imm16),
+        (i32, "xor", Instruction::i32_xor_imm16),
+        (i32, "lt_s", swap_ops!(Instruction::i32_lt_s_imm16_lhs)),
+        (u32, "lt_u", swap_ops!(Instruction::i32_lt_u_imm16_lhs)),
+        (i32, "le_s", swap_ops!(Instruction::i32_le_s_imm16_lhs)),
+        (u32, "le_u", swap_ops!(Instruction::i32_le_u_imm16_lhs)),
+        (i32, "gt_s", Instruction::i32_lt_s_imm16_rhs),
+        (u32, "gt_u", Instruction::i32_lt_u_imm16_rhs),
+        (i32, "ge_s", Instruction::i32_le_s_imm16_rhs),
+        (u32, "ge_u", Instruction::i32_le_u_imm16_rhs),
+        (i64, "lt_s", swap_ops!(Instruction::i64_lt_s_imm16_lhs)),
+        (u64, "lt_u", swap_ops!(Instruction::i64_lt_u_imm16_lhs)),
+        (i64, "le_s", swap_ops!(Instruction::i64_le_s_imm16_lhs)),
+        (u64, "le_u", swap_ops!(Instruction::i64_le_u_imm16_lhs)),
+        (i64, "gt_s", Instruction::i64_lt_s_imm16_rhs),
+        (u64, "gt_u", Instruction::i64_lt_u_imm16_rhs),
+        (i64, "ge_s", Instruction::i64_le_s_imm16_rhs),
+        (u64, "ge_u", Instruction::i64_le_u_imm16_rhs),
+    );
+}


### PR DESCRIPTION
- This also fixes a bug in the `ComparatorAndOffset` -> `UntypedVal` impl.
- Also it adds a missing test for `cmp+br` fallback instruction translation.