### PR TITLE
Bump `nextest` timeout to 360s from 300s

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
 [profile.default-miri]
-slow-timeout = { period = "150s", terminate-after = 2 }
+slow-timeout = { period = "180s", terminate-after = 2 }
 test-threads = "num-cpus"
 fail-fast = false


### PR DESCRIPTION
This should make it less likely that the `Miri (spec)` CI job will time out.