### PR TITLE
Use `libfuzzer` for fuzzing again

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -216,16 +216,22 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-directories: |
-            ${{ github.workspace }}/hfuzz_target
-            ${{ github.workspace }}/hfuzz_workspace
-      - name: Install cargo-honggfuzz and dependencies
+            ${{ github.workspace }}/fuzz/corpus
+      - name: Install `cargo-fuzz`
         run: |
-          cargo install honggfuzz || true
-          sudo apt-get update && sudo apt-get install --yes binutils-dev libunwind-dev
-      - name: Run HFuzz
-        env:
-          HFUZZ_RUN_ARGS: "--run_time 120 --verbose --quiet" # 2 minutes of fuzzing
-        run: cargo hfuzz run ${{ matrix.fuzz_target }}
+          # Note: We use `|| true` because cargo install returns an error
+          #       if cargo-fuzz was already installed on the CI runner.
+          cargo install cargo-fuzz || true
+      - name: Build Fuzzing Target
+        run: cargo fuzz build ${{ matrix.fuzz_target }}
+      - name: Run Fuzzing Target
+        run: >-
+          cargo fuzz run ${{ matrix.fuzz_target }}
+          -j 2
+          --verbose
+          --debug-assertions
+          --
+          -max_total_time=120 # 2 minutes of fuzzing
 
   miri:
     name: Miri

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,18 +858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
-name = "honggfuzz"
-version = "0.5.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c76b6234c13c9ea73946d1379d33186151148e0da231506b964b44f3d023505"
-dependencies = [
- "arbitrary",
- "lazy_static",
- "memmap2",
- "rustc_version",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,12 +1005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1015,17 @@ name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
 
 [[package]]
 name = "libm"
@@ -1090,15 +1083,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
  "rustix",
-]
-
-[[package]]
-name = "memmap2"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1356,15 +1340,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -1960,7 +1935,7 @@ name = "wasmi_fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
- "honggfuzz",
+ "libfuzzer-sys",
  "wasm-smith",
  "wasmi 0.31.2",
  "wasmi 0.38.0",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 cargo-fuzz = true
 
 [dependencies]
-honggfuzz = "0.5"
+libfuzzer-sys = "0.4.7"
 wasmi-stack = { package = "wasmi", version = "0.31.2" }
 wasmtime = "21.0.1"
 wasmi = { workspace = true, features = ["std"] }

--- a/fuzz/fuzz_targets/execute.rs
+++ b/fuzz/fuzz_targets/execute.rs
@@ -1,69 +1,67 @@
+#![no_main]
+
 mod utils;
 
 use arbitrary::Unstructured;
-use honggfuzz::fuzz;
+use libfuzzer_sys::fuzz_target;
 use utils::{arbitrary_swarm_config_module, ty_to_arbitrary_val};
 use wasmi::{Config, Engine, Linker, Module, Store, StoreLimitsBuilder};
 
-fn main() {
-    loop {
-        fuzz!(|seed: &[u8]| {
-            let mut unstructured = Unstructured::new(seed);
-            let Ok(smith_module) = arbitrary_swarm_config_module(&mut unstructured) else {
-                return;
-            };
-            let wasm = smith_module.to_bytes();
+fuzz_target!(|seed: &[u8]| {
+    let mut unstructured = Unstructured::new(seed);
+    let Ok(smith_module) = arbitrary_swarm_config_module(&mut unstructured) else {
+        return;
+    };
+    let wasm = smith_module.to_bytes();
 
-            let mut config = Config::default();
-            config.consume_fuel(true);
-            config.compilation_mode(wasmi::CompilationMode::Eager);
+    let mut config = Config::default();
+    config.consume_fuel(true);
+    config.compilation_mode(wasmi::CompilationMode::Eager);
 
-            let engine = Engine::default();
-            let linker = Linker::new(&engine);
-            let limiter = StoreLimitsBuilder::new()
-                .memory_size(1000 * 0x10000)
-                .build();
-            let mut store = Store::new(&engine, limiter);
-            store.limiter(|lim| lim);
-            let Ok(_) = store.set_fuel(1000) else {
-                return;
-            };
-            let module = Module::new(store.engine(), wasm.as_slice()).unwrap();
-            let Ok(preinstance) = linker.instantiate(&mut store, &module) else {
-                return;
-            };
-            let Ok(instance) = preinstance.ensure_no_start(&mut store) else {
-                return;
-            };
+    let engine = Engine::default();
+    let linker = Linker::new(&engine);
+    let limiter = StoreLimitsBuilder::new()
+        .memory_size(1000 * 0x10000)
+        .build();
+    let mut store = Store::new(&engine, limiter);
+    store.limiter(|lim| lim);
+    let Ok(_) = store.set_fuel(1000) else {
+        return;
+    };
+    let module = Module::new(store.engine(), wasm.as_slice()).unwrap();
+    let Ok(preinstance) = linker.instantiate(&mut store, &module) else {
+        return;
+    };
+    let Ok(instance) = preinstance.ensure_no_start(&mut store) else {
+        return;
+    };
 
-            let mut funcs = Vec::new();
-            let mut params = Vec::new();
-            let mut results = Vec::new();
+    let mut funcs = Vec::new();
+    let mut params = Vec::new();
+    let mut results = Vec::new();
 
-            let exports = instance.exports(&store);
-            for e in exports {
-                let Some(func) = e.into_func() else {
-                    // Export is no function which we cannot execute, therefore we ignore it.
-                    continue;
-                };
-                funcs.push(func);
-            }
-            for func in &funcs {
-                params.clear();
-                results.clear();
-                let ty = func.ty(&store);
-                params.extend(
-                    ty.params()
-                        .iter()
-                        .map(|param_ty| ty_to_arbitrary_val(param_ty, &mut unstructured)),
-                );
-                results.extend(
-                    ty.results()
-                        .iter()
-                        .map(|param_ty| ty_to_arbitrary_val(param_ty, &mut unstructured)),
-                );
-                _ = func.call(&mut store, &params, &mut results);
-            }
-        });
+    let exports = instance.exports(&store);
+    for e in exports {
+        let Some(func) = e.into_func() else {
+            // Export is no function which we cannot execute, therefore we ignore it.
+            continue;
+        };
+        funcs.push(func);
     }
-}
+    for func in &funcs {
+        params.clear();
+        results.clear();
+        let ty = func.ty(&store);
+        params.extend(
+            ty.params()
+                .iter()
+                .map(|param_ty| ty_to_arbitrary_val(param_ty, &mut unstructured)),
+        );
+        results.extend(
+            ty.results()
+                .iter()
+                .map(|param_ty| ty_to_arbitrary_val(param_ty, &mut unstructured)),
+        );
+        _ = func.call(&mut store, &params, &mut results);
+    }
+});

--- a/fuzz/fuzz_targets/translate.rs
+++ b/fuzz/fuzz_targets/translate.rs
@@ -1,20 +1,17 @@
+#![no_main]
+
 mod utils;
 
 use arbitrary::Unstructured;
-use honggfuzz::fuzz;
+use libfuzzer_sys::fuzz_target;
 use utils::arbitrary_swarm_config_module;
 use wasmi::{Engine, Module};
 
-fn main() {
-    loop {
-        fuzz!(|seed: &[u8]| {
-            let Ok(smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(seed))
-            else {
-                return;
-            };
-            let wasm = smith_module.to_bytes();
-            let engine = Engine::default();
-            Module::new(&engine, &wasm[..]).unwrap();
-        });
-    }
-}
+fuzz_target!(|seed: &[u8]| {
+    let Ok(smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(seed)) else {
+        return;
+    };
+    let wasm = smith_module.to_bytes();
+    let engine = Engine::default();
+    Module::new(&engine, &wasm[..]).unwrap();
+});

--- a/fuzz/fuzz_targets/translate_metered.rs
+++ b/fuzz/fuzz_targets/translate_metered.rs
@@ -1,22 +1,19 @@
+#![no_main]
+
 mod utils;
 
 use arbitrary::Unstructured;
-use honggfuzz::fuzz;
+use libfuzzer_sys::fuzz_target;
 use utils::arbitrary_swarm_config_module;
 use wasmi::{Config, Engine, Module};
 
-fn main() {
-    loop {
-        fuzz!(|seed: &[u8]| {
-            let Ok(smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(seed))
-            else {
-                return;
-            };
-            let wasm = smith_module.to_bytes();
-            let mut config = Config::default();
-            config.consume_fuel(true);
-            let engine = Engine::new(&config);
-            Module::new(&engine, &wasm[..]).unwrap();
-        });
-    }
-}
+fuzz_target!(|seed: &[u8]| {
+    let Ok(smith_module) = arbitrary_swarm_config_module(&mut Unstructured::new(seed)) else {
+        return;
+    };
+    let wasm = smith_module.to_bytes();
+    let mut config = Config::default();
+    config.consume_fuel(true);
+    let engine = Engine::new(&config);
+    Module::new(&engine, &wasm[..]).unwrap();
+});


### PR DESCRIPTION
Unfortunately I have had problems using `honggfuzz` locally since its `Makefile` disallowed building for my MacOS version (most recent one). In all honesty, I have not dug deeply into this issue. This PR makes our fuzzing infrastructure use `libfuzzer-sys` again which seems to be the "Rust industry" standard as of today and thus it is expected that we will have the least issues using it.

cc @Scott-Guest @gtrepta 