### PR TITLE
Update and improve fuzzing CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -211,7 +211,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           # Pin nightly so that it does not invalidate GitHub Actions cache too frequently.
-          toolchain: nightly-2024-09-24
+          toolchain: nightly-2024-10-18
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -229,9 +229,9 @@ jobs:
           cargo fuzz run ${{ matrix.fuzz_target }}
           -jobs 4              # GitHub hosted runners have 4 CPUs.
           --verbose
-          --debug-assertions
+          --debug-assertions   # We want to have debug-assertions enabled for all modes.
           --
-          -max_total_time=120 # 2 minutes of fuzzing
+          -max_total_time=120  # We run fuzz tests for 2 minutes.
 
   miri:
     name: Miri

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -227,13 +227,16 @@ jobs:
       - name: Build Fuzzing Target
         run: cargo fuzz build ${{ matrix.fuzz_target }}
       - name: Run Fuzzing Target
+        # - Use 4 jobs since GitHub hosted runners provide 4 CPUs.
+        # - Always enable debug-assertions for all modes to catch more bugs.
+        # - Run fuzzing for 120s (2 minutes) in total.
         run: >-
           cargo fuzz run ${{ matrix.fuzz_target }}
-          --jobs 4              # GitHub hosted runners have 4 CPUs.
+          --jobs 4
           --verbose
-          --debug-assertions   # We want to have debug-assertions enabled for all modes.
+          --debug-assertions
           --
-          -max_total_time=120  # We run fuzz tests for 2 minutes.
+          -max_total_time=120
 
   miri:
     name: Miri

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Run Fuzzing Target
         run: >-
           cargo fuzz run ${{ matrix.fuzz_target }}
-          -jobs 4              # GitHub hosted runners have 4 CPUs.
+          --jobs 4              # GitHub hosted runners have 4 CPUs.
           --verbose
           --debug-assertions   # We want to have debug-assertions enabled for all modes.
           --

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -222,6 +222,8 @@ jobs:
           # Note: We use `|| true` because cargo install returns an error
           #       if cargo-fuzz was already installed on the CI runner.
           cargo install cargo-fuzz || true
+      - name: Check Fuzzing Target
+        run: cargo fuzz check ${{ matrix.fuzz_target }}
       - name: Build Fuzzing Target
         run: cargo fuzz build ${{ matrix.fuzz_target }}
       - name: Run Fuzzing Target

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -227,7 +227,7 @@ jobs:
       - name: Run Fuzzing Target
         run: >-
           cargo fuzz run ${{ matrix.fuzz_target }}
-          -j 2
+          -jobs 4              # GitHub hosted runners have 4 CPUs.
           --verbose
           --debug-assertions
           --


### PR DESCRIPTION
- Using 4 threads instead of just 2.
    - GitHub hosted runners provide 4 CPU for `ubuntu-latest`.
- Update Rust nightly toolchain version.
- Add some more comments for fuzzing run command.
- Add quick type-check step for fuzzing targets.