### PR TITLE
Improve fuzzer compile times

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -242,12 +242,12 @@ jobs:
         # - Always enable debug-assertions for all modes to catch more bugs.
         # - Run fuzzing for 120s (2 minutes) in total.
         run: >-
-          cargo fuzz run ${{ matrix.fuzz_target }} \\
-            --jobs 4 \\
-            --verbose \\
-            --debug-assertions \\
-            $FEATURES \\
-            -- \\
+          cargo fuzz run ${{ matrix.fuzz_target }}
+            --jobs 4
+            --verbose
+            --debug-assertions
+            $FEATURES
+            --
             -max_total_time=120
 
   miri:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -239,12 +239,12 @@ jobs:
           if [ "${{ matrix.fuzz_target }}" == "differential" ]; then
             FEATURES="--features differential"
           fi
-          cargo fuzz run ${{ matrix.fuzz_target }} \
-            --jobs 4 \
-            --verbose \
-            --debug-assertions \
-            $FEATURES \
-            -- \
+          cargo fuzz run ${{ matrix.fuzz_target }} \\
+            --jobs 4 \\
+            --verbose \\
+            --debug-assertions \\
+            $FEATURES \\
+            -- \\
             -max_total_time=120
 
   miri:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -226,10 +226,6 @@ jobs:
           # Note: We use `|| true` because cargo install returns an error
           #       if cargo-fuzz was already installed on the CI runner.
           cargo install cargo-fuzz || true
-      - name: Check Fuzzing Target
-        run: cargo fuzz check ${{ matrix.fuzz_target }}
-      - name: Build Fuzzing Target
-        run: cargo fuzz build ${{ matrix.fuzz_target }}
       - name: Set Fuzzing Features
         run: |
           FEATURES=""
@@ -237,6 +233,10 @@ jobs:
             FEATURES="--features differential"
           fi
           echo "FEATURES=$FEATURES" >> $GITHUB_ENV
+      - name: Check Fuzzing Target
+        run: cargo fuzz check ${{ matrix.fuzz_target }} $FEATURES
+      - name: Build Fuzzing Target
+        run: cargo fuzz build ${{ matrix.fuzz_target }} $FEATURES
       - name: Run Fuzzing Target
         # - Use 4 jobs since GitHub hosted runners provide 4 CPUs.
         # - Always enable debug-assertions for all modes to catch more bugs.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -243,12 +243,12 @@ jobs:
         # - Run fuzzing for 120s (2 minutes) in total.
         run: >-
           cargo fuzz run ${{ matrix.fuzz_target }}
-            --jobs 4
-            --verbose
-            --debug-assertions
-            $FEATURES
-            --
-            -max_total_time=120
+          --jobs 4
+          --verbose
+          --debug-assertions
+          $FEATURES
+          --
+          -max_total_time=120
 
   miri:
     name: Miri

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -234,13 +234,18 @@ jobs:
         # - Use 4 jobs since GitHub hosted runners provide 4 CPUs.
         # - Always enable debug-assertions for all modes to catch more bugs.
         # - Run fuzzing for 120s (2 minutes) in total.
-        run: >-
-          cargo fuzz run ${{ matrix.fuzz_target }}
-          --jobs 4
-          --verbose
-          --debug-assertions
-          --
-          -max_total_time=120
+        run: |
+          FEATURES=""
+          if [ "${{ matrix.fuzz_target }}" == "differential" ]; then
+            FEATURES="--features differential"
+          fi
+          cargo fuzz run ${{ matrix.fuzz_target }} \
+            --jobs 4 \
+            --verbose \
+            --debug-assertions \
+            $FEATURES \
+            -- \
+            -max_total_time=120
 
   miri:
     name: Miri

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -230,15 +230,18 @@ jobs:
         run: cargo fuzz check ${{ matrix.fuzz_target }}
       - name: Build Fuzzing Target
         run: cargo fuzz build ${{ matrix.fuzz_target }}
-      - name: Run Fuzzing Target
-        # - Use 4 jobs since GitHub hosted runners provide 4 CPUs.
-        # - Always enable debug-assertions for all modes to catch more bugs.
-        # - Run fuzzing for 120s (2 minutes) in total.
+      - name: Set Fuzzing Features
         run: |
           FEATURES=""
           if [ "${{ matrix.fuzz_target }}" == "differential" ]; then
             FEATURES="--features differential"
           fi
+          echo "FEATURES=$FEATURES" >> $GITHUB_ENV
+      - name: Run Fuzzing Target
+        # - Use 4 jobs since GitHub hosted runners provide 4 CPUs.
+        # - Always enable debug-assertions for all modes to catch more bugs.
+        # - Run fuzzing for 120s (2 minutes) in total.
+        run: >-
           cargo fuzz run ${{ matrix.fuzz_target }} \\
             --jobs 4 \\
             --verbose \\

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,11 +13,15 @@ cargo-fuzz = true
 [dependencies]
 wasmi_fuzz = { workspace = true }
 libfuzzer-sys = "0.4.7"
-wasmi-stack = { package = "wasmi", version = "0.31.2" }
-wasmtime = "26.0.0"
+wasmi-stack = { package = "wasmi", version = "0.31.2", optional = true }
+wasmtime = { version = "26.0.0", optional = true }
 wasmi = { workspace = true, features = ["std"] }
 wasm-smith = "0.219.1"
 arbitrary = "1.3.2"
+
+[features]
+default = []
+differential = ["dep:wasmtime", "dep:wasmi-stack"]
 
 [[bin]]
 name = "translate"
@@ -34,5 +38,6 @@ doc = false
 [[bin]]
 name = "differential"
 path = "fuzz_targets/differential.rs"
+required-features = ["differential"]
 test = false
 doc = false


### PR DESCRIPTION
We reduce compile time for `translate` and `execute` fuzzers by not making them have to compile Wasmtime and Wasmi (stack) since they don't need it. Instead those heavy dependencies are only compiled in for the `differential` fuzzer which requires them.