### PR TITLE
Skip fuzz run after encountering the first non-determinism

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -51,8 +51,9 @@ fuzz_target!(|seed: &[u8]| {
         let params = &params[..];
         let result_wasmi = wasmi_oracle.call(name, params);
         let result_oracle = chosen_oracle.call(name, params);
-        // Note: If either of the oracles returns a non-deterministic error we ignore it
-        //       to avoid having to deal with non-deterministic behavior between oracles.
+        // Note: If either of the oracles returns a non-deterministic error we skip the
+        //       entire fuzz run since following function executions could be affected by
+        //       this non-determinism due to shared global state, such as global variables.
         if let Err(wasmi_err) = &result_wasmi {
             if wasmi_err.is_non_deterministic() {
                 return;


### PR DESCRIPTION
The problem is that now multiple function could be run. If one function displays non-deterministic behavior between Wasmi and the other oracle, following function calls can be influenced by this via global state, for example global variable state. Thus a run needs to stop immediately after encountering non-determinism.