### PR TITLE
Remove `paste` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,7 +1946,6 @@ dependencies = [
  "downcast-rs",
  "libm",
  "num-traits",
- "paste",
  "rand",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,7 +17,6 @@ exclude.workspace = true
 libm = "0.2.8"
 num-traits = { workspace = true }
 downcast-rs = { version = "1.2", default-features = false }
-paste = "1"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/crates/core/src/untyped.rs
+++ b/crates/core/src/untyped.rs
@@ -1484,17 +1484,17 @@ macro_rules! impl_encode_untyped_slice {
                 $tuple: Into<UntypedVal>
             ),*
         {
-            #[allow(non_snake_case, unused_variables, unused_mut, unused_assignments)]
+            #[allow(non_snake_case)]
             #[inline]
             fn encode_untyped_slice<'a>(self, results: &'a mut [UntypedVal]) -> Result<(), UntypedError> {
-                let Ok(mut results) = <&'a mut [UntypedVal; $n]>::try_from(results) else {
+                let Ok(_results) = <&'a mut [UntypedVal; $n]>::try_from(results) else {
                     return Err(UntypedError::invalid_len())
                 };
                 let ( $( $tuple ,)* ) = self;
-                let mut i = 0;
+                let mut _i = 0;
                 $(
-                    results[i] = <$tuple as Into<UntypedVal>>::into($tuple);
-                    i += 1;
+                    _results[_i] = <$tuple as Into<UntypedVal>>::into($tuple);
+                    _i += 1;
                 )*
                 Ok(())
             }

--- a/crates/core/src/untyped.rs
+++ b/crates/core/src/untyped.rs
@@ -17,7 +17,6 @@ use core::{
     fmt::{self, Display},
     ops::{Neg, Shl, Shr},
 };
-use paste::paste;
 
 /// An untyped value.
 ///
@@ -1479,27 +1478,25 @@ where
 
 macro_rules! impl_encode_untyped_slice {
     ( $n:literal $( $tuple:ident )* ) => {
-        paste! {
-            impl<$($tuple),*> EncodeUntypedSlice for ($($tuple,)*)
-            where
+        impl<$($tuple),*> EncodeUntypedSlice for ($($tuple,)*)
+        where
+            $(
+                $tuple: Into<UntypedVal>
+            ),*
+        {
+            #[allow(non_snake_case, unused_variables, unused_mut, unused_assignments)]
+            #[inline]
+            fn encode_untyped_slice<'a>(self, results: &'a mut [UntypedVal]) -> Result<(), UntypedError> {
+                let Ok(mut results) = <&'a mut [UntypedVal; $n]>::try_from(results) else {
+                    return Err(UntypedError::invalid_len())
+                };
+                let ( $( $tuple ,)* ) = self;
+                let mut i = 0;
                 $(
-                    $tuple: Into<UntypedVal>
-                ),*
-            {
-                #[allow(non_snake_case)]
-                #[inline]
-                fn encode_untyped_slice(self, results: &mut [UntypedVal]) -> Result<(), UntypedError> {
-                    match results {
-                        [ $( [< _results_ $tuple >] ,)* ] => {
-                            let ( $( [< _self_ $tuple >] ,)* ) = self;
-                            $(
-                                *[< _results_ $tuple >] = <$tuple as Into<UntypedVal>>::into([< _self_ $tuple >]);
-                            )*
-                            Ok(())
-                        }
-                        _ => Err(UntypedError::invalid_len())
-                    }
-                }
+                    results[i] = <$tuple as Into<UntypedVal>>::into($tuple);
+                    i += 1;
+                )*
+                Ok(())
             }
         }
     };


### PR DESCRIPTION
The `paste` proc. macro dependency only has a single use in the `wasmi_core` crate which can be easily removed.