### PR TITLE
Introduce Wast directives processor for `WastRunner`

### DIFF
--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -87,7 +87,10 @@ fn test_config(consume_fuel: bool, parsing_mode: ParsingMode) -> RunnerConfig {
         .wasm_tail_call(true)
         .wasm_extended_const(true)
         .consume_fuel(consume_fuel);
-    RunnerConfig { config, parsing_mode }
+    RunnerConfig {
+        config,
+        parsing_mode,
+    }
 }
 
 macro_rules! expand_tests {
@@ -293,7 +296,10 @@ mod multi_memory {
     fn test_config() -> RunnerConfig {
         let config = Config::default();
         let parsing_mode = ParsingMode::Buffered;
-        RunnerConfig { config, parsing_mode }
+        RunnerConfig {
+            config,
+            parsing_mode,
+        }
     }
 
     expand_tests_mm! {

--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -71,7 +71,7 @@ fn mvp_config() -> Config {
 /// # Note
 ///
 /// The Wasm MVP has no Wasm proposals enabled.
-fn test_config(consume_fuel: bool, mode: ParsingMode) -> RunnerConfig {
+fn test_config(consume_fuel: bool, parsing_mode: ParsingMode) -> RunnerConfig {
     let mut config = mvp_config();
     // We have to enable the `mutable-global` Wasm proposal because
     // it seems that the entire Wasm spec test suite is already built
@@ -87,7 +87,7 @@ fn test_config(consume_fuel: bool, mode: ParsingMode) -> RunnerConfig {
         .wasm_tail_call(true)
         .wasm_extended_const(true)
         .consume_fuel(consume_fuel);
-    RunnerConfig { config, mode }
+    RunnerConfig { config, parsing_mode }
 }
 
 macro_rules! expand_tests {
@@ -292,8 +292,8 @@ mod multi_memory {
 
     fn test_config() -> RunnerConfig {
         let config = Config::default();
-        let mode = ParsingMode::Buffered;
-        RunnerConfig { config, mode }
+        let parsing_mode = ParsingMode::Buffered;
+        RunnerConfig { config, parsing_mode }
     }
 
     expand_tests_mm! {

--- a/crates/wasmi/tests/spec/runner.rs
+++ b/crates/wasmi/tests/spec/runner.rs
@@ -89,7 +89,7 @@ pub struct RunnerConfig {
     /// The Wasmi configuration used for all tests.
     pub config: Config,
     /// The parsing mode that is used.
-    pub mode: ParsingMode,
+    pub parsing_mode: ParsingMode,
 }
 
 /// The mode in which Wasm is parsed.
@@ -379,7 +379,7 @@ impl WastRunner {
     ) -> Result<Instance> {
         let module_name = id.map(|id| id.name());
         let engine = self.store.engine();
-        let module = match self.config.mode {
+        let module = match self.config.parsing_mode {
             ParsingMode::Buffered => Module::new(engine, wasm)?,
             ParsingMode::Streaming => Module::new_streaming(engine, wasm)?,
         };

--- a/crates/wasmi/tests/spec/runner.rs
+++ b/crates/wasmi/tests/spec/runner.rs
@@ -227,7 +227,10 @@ impl<'runner, 'wast> DirectivesProcessor<'runner, 'wast> {
                 let wasm = module.encode().unwrap();
                 self.module_compilation_fails(span, id, &wasm, message);
             }
-            WastDirective::AssertMalformed { .. } => {}
+            WastDirective::AssertMalformed {
+                module: QuoteWat::QuoteModule { .. },
+                ..
+            } => {}
             #[rustfmt::skip]
             WastDirective::AssertInvalid {
                 span,
@@ -321,16 +324,6 @@ impl<'runner, 'wast> DirectivesProcessor<'runner, 'wast> {
                 let id = module.id;
                 let wasm = module.encode().unwrap();
                 self.module_compilation_fails(span, id, &wasm, message);
-            }
-            WastDirective::AssertUnlinkable { .. } => {}
-            WastDirective::AssertException { span, exec } => {
-                if self.execute_wast_execute(exec).is_ok() {
-                    bail!(
-                        "{}: expected to fail due to exception but succeeded with: {:?}",
-                        self.source.pos(span),
-                        &self.results[..]
-                    )
-                }
             }
             unsupported => bail!(
                 "{}: encountered unsupported Wast directive: {unsupported:?}",

--- a/crates/wasmi/tests/spec/runner.rs
+++ b/crates/wasmi/tests/spec/runner.rs
@@ -275,11 +275,11 @@ impl<'runner, 'wast> DirectivesProcessor<'runner, 'wast> {
                 .runner
                 .execute_wast_execute(self.source, exec, &mut self.results)
             {
-                Ok(results) => bail!(
+                Ok(_) => bail!(
                     "{}: expected to trap with message '{}' but succeeded with: {:?}",
                     self.source.pos(span),
                     message,
-                    results
+                    &self.results[..],
                 ),
                 Err(error) => {
                     WastRunner::assert_trap(self.source, span, error, message)?;
@@ -307,12 +307,12 @@ impl<'runner, 'wast> DirectivesProcessor<'runner, 'wast> {
                 call,
                 message,
             } => match self.runner.invoke(self.source, call, &mut self.results) {
-                Ok(results) => {
+                Ok(_) => {
                     bail!(
                         "{}: expected to fail due to resource exhaustion '{}' but succeeded with: {:?}",
                         self.source.pos(span),
                         message,
-                        results
+                        &self.results[..],
                     )
                 }
                 Err(error) => {
@@ -330,14 +330,15 @@ impl<'runner, 'wast> DirectivesProcessor<'runner, 'wast> {
             }
             WastDirective::AssertUnlinkable { .. } => {}
             WastDirective::AssertException { span, exec } => {
-                if let Ok(results) =
-                    self.runner
-                        .execute_wast_execute(self.source, exec, &mut self.results)
+                if self
+                    .runner
+                    .execute_wast_execute(self.source, exec, &mut self.results)
+                    .is_ok()
                 {
                     bail!(
                         "{}: expected to fail due to exception but succeeded with: {:?}",
                         self.source.pos(span),
-                        results
+                        &self.results[..]
                     )
                 }
             }

--- a/crates/wasmi/tests/spec/runner.rs
+++ b/crates/wasmi/tests/spec/runner.rs
@@ -36,7 +36,7 @@ use std::fmt::{self, Display};
 
 /// The desciptor of a Wasm spec test suite run.
 #[derive(Debug)]
-pub struct TestDescriptor<'a> {
+struct TestDescriptor<'a> {
     /// The contents of the Wasm spec test `.wast` file.
     wast: &'a str,
 }
@@ -47,19 +47,19 @@ impl<'a> TestDescriptor<'a> {
     /// # Errors
     ///
     /// If the corresponding Wasm test spec file cannot properly be read.
-    pub fn new(wast: &'a str) -> Self {
+    fn new(wast: &'a str) -> Self {
         Self { wast }
     }
 
     /// Creates a [`ErrorPos`] which can be used to print the location within the `.wast` test file.
-    pub fn spanned(&self, span: Span) -> ErrorPos<'a> {
+    fn spanned(&self, span: Span) -> ErrorPos<'a> {
         ErrorPos::new(self.wast, span)
     }
 }
 
 /// Useful for printing the location where the `.wast` parse is located.
 #[derive(Debug)]
-pub struct ErrorPos<'a> {
+struct ErrorPos<'a> {
     /// The file contents of the `.wast` test.
     wast: &'a str,
     /// The line and column within the `.wast` test file.
@@ -68,7 +68,7 @@ pub struct ErrorPos<'a> {
 
 impl<'a> ErrorPos<'a> {
     /// Creates a new [`ErrorPos`].
-    pub fn new(wast: &'a str, span: Span) -> Self {
+    fn new(wast: &'a str, span: Span) -> Self {
         Self { wast, span }
     }
 }


### PR DESCRIPTION
This encapsulates data and code of directives processing from data and code required for Wasmi operations.