### PR TITLE
Add new `Linker` APIs

### DIFF
--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -534,6 +534,10 @@ impl<T> Linker<T> {
         module_name: &str,
         instance: Instance,
     ) -> Result<&mut Self, Error> {
+        assert!(Engine::same(
+            store.as_context().store.engine(),
+            self.engine()
+        ));
         let mut store = store.as_context_mut();
         for export in instance.exports(&mut store) {
             let key = self.inner.new_import_key(module_name, export.name());

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -28,7 +28,6 @@ use core::{
     marker::PhantomData,
 };
 use std::{
-    boxed::Box,
     collections::{btree_map::Entry, BTreeMap},
     sync::Arc,
     vec::Vec,
@@ -912,7 +911,7 @@ impl<T> LinkerInner<T> {
             .iter()
             .filter(|(key, _def)| key.module() == module)
             .map(|(key, def)| (key.name(), def.clone()))
-            .collect::<Box<[_]>>();
+            .collect::<Vec<_>>();
         for (name, item) in items {
             self.insert(ImportKey::new(as_module, name), item)?;
         }

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -256,7 +256,7 @@ impl ImportKey {
 /// A [`Linker`] definition.
 #[derive(Debug)]
 enum Definition<T> {
-    /// An external item from an [`Instance`](crate::Instance).
+    /// An external item from an [`Instance`].
     Extern(Extern),
     /// A [`Linker`] internal host function.
     HostFunc(HostFuncTrampolineEntity<T>),
@@ -531,7 +531,8 @@ impl<T> Linker<T> {
     /// # Errors
     ///
     /// - If any item is re-defined in `self` (for example the same `module_name` was already defined).
-    /// - If `instance` comes from a different [`Store`] than this [`Linker`] originally was created with.
+    /// - If `instance` comes from a different [`Store`](crate::Store) than this [`Linker`] originally
+    ///   was created with.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Adds the following `Linker` APIs:

- `Linker::allow_shadowing`: configures the `Linker` to allow to shadow previous definitions without errors.
- `Linker::instance`: convenience method to define all exports of an `Instance`.
- `Linker::alias_module`: convenience method to add a module aliasing name.