### PR TITLE
Add missing import

### DIFF
--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -16,6 +16,7 @@
 //! ```
 //! use anyhow::Result;
 //! use wasmi::*;
+//! use wat;
 //!
 //! fn main() -> Result<()> {
 //!     // First step is to create the Wasm execution engine with some config.


### PR DESCRIPTION
The current example provided in the documentation fails to build because it uses the `wat` without a reference. This PR adds the necessary use statement.