### PR TITLE
Fix or silence `wasmi_wast` warnings

### DIFF
--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -363,10 +363,11 @@ impl WastRunner {
 
     /// Asserts that `result` match the `expected` value.
     fn assert_result(&self, result: &Val, expected: &WastRet) -> Result<()> {
+        #[allow(unreachable_patterns)] // TODO: remove once `wast v220` is used
         let expected = match expected {
             WastRet::Core(arg) => arg,
-            WastRet::Component(arg) => {
-                bail!("encountered unsupported component-model result: {arg:?}")
+            _ => {
+                bail!("encountered unsupported Wast result: {expected:?}")
             }
         };
         let is_equal = match (result, expected) {
@@ -529,10 +530,11 @@ impl WastRunner {
     fn fill_params(&mut self, args: &[WastArg]) -> Result<()> {
         self.params.clear();
         for arg in args {
+            #[allow(unreachable_patterns)] // TODO: remove once `wast v220` is used
             let arg = match arg {
                 WastArg::Core(arg) => arg,
-                WastArg::Component(arg) => {
-                    bail!("encountered unsupported component-model argument: {arg:?}")
+                _ => {
+                    bail!("encountered unsupported Wast argument: {arg:?}")
                 }
             };
             let Some(val) = self.value(arg) else {


### PR DESCRIPTION
These warning fixes can be removed once `wasmi_wast` uses the next version of the `wast` crate (v220) which includes fixes for these issues: https://github.com/bytecodealliance/wasm-tools/pull/1891