### PR TITLE
Update Wasm spec testsuite

### DIFF
--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -158,6 +158,7 @@ macro_rules! expand_tests {
             fn wasm_memory_redundancy("memory_redundancy");
             fn wasm_memory_size("memory_size");
             fn wasm_memory_trap("memory_trap");
+            fn wasm_obsolete_keywords("obsolete-keywords");
             fn wasm_names("names");
             fn wasm_nop("nop");
             fn wasm_ref_func("ref_func");

--- a/crates/wasmi/tests/spec/mod.rs
+++ b/crates/wasmi/tests/spec/mod.rs
@@ -224,6 +224,7 @@ macro_rules! expand_tests_mm {
         $mac! {
             $( $args )*
 
+            fn wasm_multi_memory_align("proposals/multi-memory/align");
             fn wasm_multi_memory_address0("proposals/multi-memory/address0");
             fn wasm_multi_memory_address1("proposals/multi-memory/address1");
             fn wasm_multi_memory_align0("proposals/multi-memory/align0");

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -97,8 +97,16 @@ impl WastRunner {
         )?;
         let global_i32 = Global::new(&mut *store, Val::I32(666), Mutability::Const);
         let global_i64 = Global::new(&mut *store, Val::I64(666), Mutability::Const);
-        let global_f32 = Global::new(&mut *store, Val::F32(666.0.into()), Mutability::Const);
-        let global_f64 = Global::new(&mut *store, Val::F64(666.0.into()), Mutability::Const);
+        let global_f32 = Global::new(
+            &mut *store,
+            Val::F32(F32::from_bits(0x4426_a666)),
+            Mutability::Const,
+        );
+        let global_f64 = Global::new(
+            &mut *store,
+            Val::F64(F64::from_bits(0x4084_d4cc_cccc_cccd)),
+            Mutability::Const,
+        );
 
         self.linker.define("spectest", "memory", default_memory)?;
         self.linker.define("spectest", "table", default_table)?;


### PR DESCRIPTION
This updates the Wasm spec testsuite that Wasmi's tests are using to the most recent commit.