### PR TITLE
C API: Fix parameter type for compilation mode configuration

### DIFF
--- a/crates/c_api/include/wasmi/config.h
+++ b/crates/c_api/include/wasmi/config.h
@@ -121,7 +121,7 @@ enum wasmi_compilation_mode_enum {
  *
  * Default value: #WASMI_COMPILATION_MODE_EAGER
  */
-WASMI_CONFIG_PROP(void, compilation_mode, wasmi_compilation_mode_enum)
+WASMI_CONFIG_PROP(void, compilation_mode, enum wasmi_compilation_mode_enum)
 
 #undef WASMI_CONFIG_PROP
 


### PR DESCRIPTION
Compiling against the current header produces:

```
# github.com/onflow/wasmi-go
In file included from ./config.go:4:
In file included from ./wasmi/include/wasmi.h:5:
./wasmi/include/wasmi/config.h:124:43: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
  124 | WASMI_CONFIG_PROP(void, compilation_mode, wasmi_compilation_mode_enum)
      |                                           ^
      |                                           int
./wasmi/include/wasmi/config.h:17:66: note: expanded from macro 'WASMI_CONFIG_PROP'
   17 |   WASM_API_EXTERN ret wasmi_config_##name##_set(wasm_config_t *, ty);
      |
```

Fix the parameter type by adding the missing enum keyword. Alternatively maybe add a typedef for `wasmi_compilation_mode_enum`.