### PR TITLE
C API: Fix function name of compilation mode setter

### DIFF
--- a/crates/c_api/src/config.rs
+++ b/crates/c_api/src/config.rs
@@ -141,7 +141,7 @@ pub enum wasmi_compilation_mode_t {
 ///
 /// Wraps [`wasmi::Config::compilation_mode`]
 #[no_mangle]
-pub extern "C" fn wasmi_config_set_compilation_mode(
+pub extern "C" fn wasmi_config_compilation_mode_set(
     config: &mut wasm_config_t,
     mode: wasmi_compilation_mode_t,
 ) {


### PR DESCRIPTION
`config.h` defines `WASMI_CONFIG_PROP` to define setters for configuration options as `wasmi_config_##name##_set`. Just like for all other configuration options, this macro is used for `compilation_mode`.  However, the function is exported from the `c_api` crate with a different name.

Fix the exported name and make it consistent with the other configuration options.