### PR TITLE
Lower `load` and `store` instructions by pruning types where possible

### DIFF
--- a/crates/core/src/untyped.rs
+++ b/crates/core/src/untyped.rs
@@ -178,44 +178,24 @@ impl UntypedVal {
         Self::load_extend::<T, T>(memory, address, offset)
     }
 
-    /// Executes the `i32.load` Wasm operation.
+    /// Executes a Wasmi `load32` instruction.
     ///
     /// # Errors
     ///
     /// - If `address + offset` overflows.
     /// - If `address + offset` loads out of bounds from `memory`.
-    pub fn i32_load(memory: &[u8], address: Self, offset: u32) -> Result<Self, TrapCode> {
-        Self::load::<i32>(memory, address, offset)
+    pub fn load32(memory: &[u8], address: Self, offset: u32) -> Result<Self, TrapCode> {
+        Self::load::<u32>(memory, address, offset)
     }
 
-    /// Executes the `i64.load` Wasm operation.
+    /// Executes a Wasmi `load64` instruction.
     ///
     /// # Errors
     ///
     /// - If `address + offset` overflows.
     /// - If `address + offset` loads out of bounds from `memory`.
-    pub fn i64_load(memory: &[u8], address: Self, offset: u32) -> Result<Self, TrapCode> {
-        Self::load::<i64>(memory, address, offset)
-    }
-
-    /// Executes the `f32.load` Wasm operation.
-    ///
-    /// # Errors
-    ///
-    /// - If `address + offset` overflows.
-    /// - If `address + offset` loads out of bounds from `memory`.
-    pub fn f32_load(memory: &[u8], address: Self, offset: u32) -> Result<Self, TrapCode> {
-        Self::load::<F32>(memory, address, offset)
-    }
-
-    /// Executes the `f64.load` Wasm operation.
-    ///
-    /// # Errors
-    ///
-    /// - If `address + offset` overflows.
-    /// - If `address + offset` loads out of bounds from `memory`.
-    pub fn f64_load(memory: &[u8], address: Self, offset: u32) -> Result<Self, TrapCode> {
-        Self::load::<F64>(memory, address, offset)
+    pub fn load64(memory: &[u8], address: Self, offset: u32) -> Result<Self, TrapCode> {
+        Self::load::<u64>(memory, address, offset)
     }
 
     /// Executes the `i32.load8_s` Wasm operation.

--- a/crates/core/src/untyped.rs
+++ b/crates/core/src/untyped.rs
@@ -335,64 +335,34 @@ impl UntypedVal {
         Self::store_wrap::<T, T>(memory, address, offset, value)
     }
 
-    /// Executes the `i32.store` Wasm operation.
+    /// Executes a Wasmi `store32` instruction.
     ///
     /// # Errors
     ///
     /// - If `address + offset` overflows.
     /// - If `address + offset` stores out of bounds from `memory`.
-    pub fn i32_store(
+    pub fn store32(
         memory: &mut [u8],
         address: Self,
         offset: u32,
         value: Self,
     ) -> Result<(), TrapCode> {
-        Self::store::<i32>(memory, address, offset, value)
+        Self::store::<u32>(memory, address, offset, value)
     }
 
-    /// Executes the `i64.store` Wasm operation.
+    /// Executes a Wasmi `store64` instruction.
     ///
     /// # Errors
     ///
     /// - If `address + offset` overflows.
     /// - If `address + offset` stores out of bounds from `memory`.
-    pub fn i64_store(
+    pub fn store64(
         memory: &mut [u8],
         address: Self,
         offset: u32,
         value: Self,
     ) -> Result<(), TrapCode> {
-        Self::store::<i64>(memory, address, offset, value)
-    }
-
-    /// Executes the `f32.store` Wasm operation.
-    ///
-    /// # Errors
-    ///
-    /// - If `address + offset` overflows.
-    /// - If `address + offset` stores out of bounds from `memory`.
-    pub fn f32_store(
-        memory: &mut [u8],
-        address: Self,
-        offset: u32,
-        value: Self,
-    ) -> Result<(), TrapCode> {
-        Self::store::<F32>(memory, address, offset, value)
-    }
-
-    /// Executes the `f64.store` Wasm operation.
-    ///
-    /// # Errors
-    ///
-    /// - If `address + offset` overflows.
-    /// - If `address + offset` stores out of bounds from `memory`.
-    pub fn f64_store(
-        memory: &mut [u8],
-        address: Self,
-        offset: u32,
-        value: Self,
-    ) -> Result<(), TrapCode> {
-        Self::store::<F64>(memory, address, offset, value)
+        Self::store::<u64>(memory, address, offset, value)
     }
 
     /// Executes the `i32.store8` Wasm operation.

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -394,6 +394,9 @@ impl_extend_into!(i32, i64);
 impl_extend_into!(u32, i64);
 impl_extend_into!(u32, u64);
 
+impl_extend_into!(u32, u32);
+impl_extend_into!(u64, u64);
+
 impl_extend_into!(i32, f32, F32);
 impl_extend_into!(i32, f64, F64);
 impl_extend_into!(u32, f32, F32);

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -391,9 +391,6 @@ impl_extend_into!(i32, i64);
 impl_extend_into!(u32, i64);
 impl_extend_into!(u32, u64);
 
-impl_extend_into!(u32, u32);
-impl_extend_into!(u64, u64);
-
 impl_extend_into!(i32, f32, F32);
 impl_extend_into!(i32, f64, F64);
 impl_extend_into!(u32, f32, F32);
@@ -403,6 +400,8 @@ impl_extend_into!(u64, f64, F64);
 impl_extend_into!(f32, f64, F64);
 
 // Casting to self
+impl_extend_into!(u32, u32);
+impl_extend_into!(u64, u64);
 
 impl ExtendInto<F64> for F32 {
     #[inline]

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -289,6 +289,9 @@ impl_wrap_into!(i64, i64);
 impl_wrap_into!(F32, F32);
 impl_wrap_into!(F64, F64);
 
+impl_wrap_into!(u32, u32);
+impl_wrap_into!(u64, u64);
+
 impl WrapInto<F32> for F64 {
     #[inline]
     fn wrap_into(self) -> F32 {

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -283,12 +283,6 @@ impl_wrap_into!(i64, i32);
 impl_wrap_into!(i64, f32, F32);
 impl_wrap_into!(u64, f32, F32);
 
-// Casting to self
-impl_wrap_into!(i32, i32);
-impl_wrap_into!(i64, i64);
-impl_wrap_into!(F32, F32);
-impl_wrap_into!(F64, F64);
-
 impl_wrap_into!(u32, u32);
 impl_wrap_into!(u64, u64);
 
@@ -409,10 +403,6 @@ impl_extend_into!(u64, f64, F64);
 impl_extend_into!(f32, f64, F64);
 
 // Casting to self
-impl_extend_into!(i32, i32);
-impl_extend_into!(i64, i64);
-impl_extend_into!(F32, F32);
-impl_extend_into!(F64, F64);
 
 impl ExtendInto<F64> for F32 {
     #[inline]

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -2093,7 +2093,7 @@ macro_rules! for_each_op {
             ///
             /// # Note
             ///
-            /// Variant of [`Instruction::I32Store`] with 16-bit immediate `value`.
+            /// Variant of [`Instruction::Store32`] with 16-bit immediate `value`.
             ///
             /// # Encoding
             ///
@@ -2109,7 +2109,7 @@ macro_rules! for_each_op {
             ///
             /// # Note
             ///
-            /// - Variant of [`Instruction::I32StoreOffset16`] with 16-bit immediate `value`.
+            /// - Variant of [`Instruction::Store32Offset16`] with 16-bit immediate `value`.
             /// - Operates on the default Wasm memory instance.
             #[snake_name(i32_store_offset16_imm16)]
             I32StoreOffset16Imm16 {
@@ -2124,7 +2124,7 @@ macro_rules! for_each_op {
             ///
             /// # Note
             ///
-            /// Variant of [`Instruction::I32StoreAt`] with 16-bit immediate `value`.
+            /// Variant of [`Instruction::Store32At`] with 16-bit immediate `value`.
             ///
             /// # Encoding
             ///
@@ -2333,7 +2333,7 @@ macro_rules! for_each_op {
             ///
             /// # Note
             ///
-            /// Variant of [`Instruction::I64Store`] with 16-bit immediate `value`.
+            /// Variant of [`Instruction::Store64`] with 16-bit immediate `value`.
             ///
             /// # Encoding
             ///
@@ -2349,7 +2349,7 @@ macro_rules! for_each_op {
             ///
             /// # Note
             ///
-            /// - Variant of [`Instruction::I64StoreOffset16`] with 16-bit immediate `value`.
+            /// - Variant of [`Instruction::Store64Offset16`] with 16-bit immediate `value`.
             /// - Operates on the default Wasm memory instance.
             #[snake_name(i64_store_offset16_imm16)]
             I64StoreOffset16Imm16 {
@@ -2364,7 +2364,7 @@ macro_rules! for_each_op {
             ///
             /// # Note
             ///
-            /// Variant of [`Instruction::I64StoreAt`] with 16-bit immediate `value`.
+            /// Variant of [`Instruction::Store64At`] with 16-bit immediate `value`.
             ///
             /// # Encoding
             ///

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -1465,6 +1465,100 @@ macro_rules! for_each_op {
                 global: Global,
             },
 
+            /// Load instruction for 32-bit values.
+            ///
+            /// # Note
+            /// 
+            /// Equivalent to Wasm `{i32,f32}.load` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset`.
+            #[snake_name(load32)]
+            Load32 {
+                @result: Reg,
+                /// The linear memory index for which the load instruction is executed.
+                memory: Memory,
+            },
+            /// Load instruction for 32-bit values.
+            ///
+            /// # Note
+            ///
+            /// Variant of [`Instruction::Load32`] with a constant load address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
+            ///
+            /// - Operates on the default Wasm memory instance if missing.
+            #[snake_name(load32_at)]
+            Load32At {
+                @result: Reg,
+                /// The `ptr+offset` address of the `load` instruction.
+                address: u32,
+            },
+            /// Load instruction for 32-bit values.
+            ///
+            /// # Note
+            ///
+            /// - Variant of [`Instruction::Load32`] with a 16-bit `offset`.
+            /// - Operates on the default Wasm memory instance.
+            #[snake_name(load32_offset16)]
+            Load32Offset16 {
+                @result: Reg,
+                /// The register storing the pointer of the `load` instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Const16<u32>,
+            },
+
+            /// Load instruction for 64-bit values.
+            ///
+            /// # Note
+            /// 
+            /// Equivalent to Wasm `{i64,f64}.load` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset`.
+            #[snake_name(load64)]
+            Load64 {
+                @result: Reg,
+                /// The linear memory index for which the load instruction is executed.
+                memory: Memory,
+            },
+            /// Load instruction for 64-bit values.
+            ///
+            /// # Note
+            ///
+            /// Variant of [`Instruction::Load32`] with a constant load address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
+            ///
+            /// - Operates on the default Wasm memory instance if missing.
+            #[snake_name(load64_at)]
+            Load64At {
+                @result: Reg,
+                /// The `ptr+offset` address of the `load` instruction.
+                address: u32,
+            },
+            /// Load instruction for 64-bit values.
+            ///
+            /// # Note
+            ///
+            /// - Variant of [`Instruction::Load64`] with a 16-bit `offset`.
+            /// - Operates on the default Wasm memory instance.
+            #[snake_name(load64_offset16)]
+            Load64Offset16 {
+                @result: Reg,
+                /// The register storing the pointer of the `load` instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Const16<u32>,
+            },
+
             /// Wasm `i32.load` equivalent Wasmi instruction.
             ///
             /// # Encoding
@@ -2065,6 +2159,106 @@ macro_rules! for_each_op {
                 ptr: Reg,
                 /// The 16-bit encoded offset of the `load` instruction.
                 offset: Const16<u32>,
+            },
+
+            /// Store instruction for 32-bit values.
+            ///
+            /// # Note
+            /// 
+            /// Equivalent to Wasm `{i32,f32}.store` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `value` and `offset`.
+            #[snake_name(store32)]
+            Store32 {
+                /// The register storing the pointer of the `store` instruction.
+                ptr: Reg,
+                /// The linear memory index for which the store instruction is executed.
+                memory: Memory,
+            },
+            /// Store instruction for 32-bit values.
+            ///
+            /// # Note
+            ///
+            /// - Variant of [`Instruction::Store32`] with a 16-bit `offset`.
+            /// - Operates on the default Wasm memory instance.
+            #[snake_name(store32_offset16)]
+            Store32Offset16 {
+                /// The register storing the pointer of the `store` instruction.
+                ptr: Reg,
+                /// The register storing the pointer offset of the `store` instruction.
+                offset: Const16<u32>,
+                /// The value to be stored.
+                value: Reg,
+            },
+            /// Store instruction for 32-bit values.
+            ///
+            /// # Note
+            ///
+            /// Variant of [`Instruction::Store32`] with an immediate `ptr+offset` address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
+            ///
+            /// - Operates on the default Wasm memory instance if missing.
+            #[snake_name(store32_at)]
+            Store32At {
+                /// The value to be stored.
+                value: Reg,
+                /// The constant address to store the value.
+                address: u32,
+            },
+
+            /// Store instruction for 64-bit values.
+            ///
+            /// # Note
+            /// 
+            /// Equivalent to Wasm `{i64,f64}.store` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `value` and `offset`.
+            #[snake_name(store64)]
+            Store64 {
+                /// The register storing the pointer of the `store` instruction.
+                ptr: Reg,
+                /// The linear memory index for which the store instruction is executed.
+                memory: Memory,
+            },
+            /// Store instruction for 64-bit values.
+            ///
+            /// # Note
+            ///
+            /// - Variant of [`Instruction::Store64`] with a 16-bit `offset`.
+            /// - Operates on the default Wasm memory instance.
+            #[snake_name(store64_offset16)]
+            Store64Offset16 {
+                /// The register storing the pointer of the `store` instruction.
+                ptr: Reg,
+                /// The register storing the pointer offset of the `store` instruction.
+                offset: Const16<u32>,
+                /// The value to be stored.
+                value: Reg,
+            },
+            /// Store instruction for 64-bit values.
+            ///
+            /// # Note
+            ///
+            /// Variant of [`Instruction::Store64`] with an immediate `ptr+offset` address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
+            ///
+            /// - Operates on the default Wasm memory instance if missing.
+            #[snake_name(store64_at)]
+            Store64At {
+                /// The value to be stored.
+                value: Reg,
+                /// The constant address to store the value.
+                address: u32,
             },
 
             /// Wasm `i32.store` equivalent Wasmi instruction.

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -1559,178 +1559,6 @@ macro_rules! for_each_op {
                 offset: Const16<u32>,
             },
 
-            /// Wasm `i32.load` equivalent Wasmi instruction.
-            ///
-            /// # Encoding
-            ///
-            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset`.
-            #[snake_name(i32_load)]
-            I32Load {
-                @result: Reg,
-                /// The linear memory index for which the load instruction is executed.
-                memory: Memory,
-            },
-            /// Wasm `i32.load` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// Variant of [`Instruction::I32Load`] with a constant load address.
-            ///
-            /// # Encoding
-            ///
-            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
-            ///
-            /// - Operates on the default Wasm memory instance if missing.
-            #[snake_name(i32_load_at)]
-            I32LoadAt {
-                @result: Reg,
-                /// The `ptr+offset` address of the `load` instruction.
-                address: u32,
-            },
-            /// Wasm `i32.load` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// - Variant of [`Instruction::I32Load`] with a 16-bit `offset`.
-            /// - Operates on the default Wasm memory instance.
-            #[snake_name(i32_load_offset16)]
-            I32LoadOffset16 {
-                @result: Reg,
-                /// The register storing the pointer of the `load` instruction.
-                ptr: Reg,
-                /// The 16-bit encoded offset of the `load` instruction.
-                offset: Const16<u32>,
-            },
-
-            /// Wasm `i64.load` equivalent Wasmi instruction.
-            ///
-            /// # Encoding
-            ///
-            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset`.
-            #[snake_name(i64_load)]
-            I64Load {
-                @result: Reg,
-                /// The linear memory index for which the load instruction is executed.
-                memory: Memory,
-            },
-            /// Wasm `i64.load` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// Variant of [`Instruction::I64Load`] with a constant load address.
-            ///
-            /// # Encoding
-            ///
-            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
-            ///
-            /// - Operates on the default Wasm memory instance if missing.
-            #[snake_name(i64_load_at)]
-            I64LoadAt {
-                @result: Reg,
-                /// The `ptr+offset` address of the `load` instruction.
-                address: u32,
-            },
-            /// Wasm `i64.load` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// - Variant of [`Instruction::I64Load`] with a 16-bit `offset`.
-            /// - Operates on the default Wasm memory instance.
-            #[snake_name(i64_load_offset16)]
-            I64LoadOffset16 {
-                @result: Reg,
-                /// The register storing the pointer of the `load` instruction.
-                ptr: Reg,
-                /// The 16-bit encoded offset of the `load` instruction.
-                offset: Const16<u32>,
-            },
-
-            /// Wasm `f32.load` equivalent Wasmi instruction.
-            ///
-            /// # Encoding
-            ///
-            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset`.
-            #[snake_name(f32_load)]
-            F32Load {
-                @result: Reg,
-                /// The linear memory index for which the load instruction is executed.
-                memory: Memory,
-            },
-            /// Wasm `f32.load` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// Variant of [`Instruction::F32Load`] with a constant load address.
-            ///
-            /// # Encoding
-            ///
-            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
-            ///
-            /// - Operates on the default Wasm memory instance if missing.
-            #[snake_name(f32_load_at)]
-            F32LoadAt {
-                @result: Reg,
-                /// The `ptr+offset` address of the `load` instruction.
-                address: u32,
-            },
-            /// Wasm `f32.load` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// - Variant of [`Instruction::F32Load`] with a 16-bit `offset`.
-            /// - Operates on the default Wasm memory instance.
-            #[snake_name(f32_load_offset16)]
-            F32LoadOffset16 {
-                @result: Reg,
-                /// The register storing the pointer of the `load` instruction.
-                ptr: Reg,
-                /// The 16-bit encoded offset of the `load` instruction.
-                offset: Const16<u32>,
-            },
-
-            /// Wasm `f64.load` equivalent Wasmi instruction.
-            ///
-            /// # Encoding
-            ///
-            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset`.
-            #[snake_name(f64_load)]
-            F64Load {
-                @result: Reg,
-                /// The linear memory index for which the load instruction is executed.
-                memory: Memory,
-            },
-            /// Wasm `f64.load` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// Variant of [`Instruction::F64Load`] with a constant load address.
-            ///
-            /// # Encoding
-            ///
-            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
-            ///
-            /// - Operates on the default Wasm memory instance if missing.
-            #[snake_name(f64_load_at)]
-            F64LoadAt {
-                @result: Reg,
-                /// The `ptr+offset` address of the `load` instruction.
-                address: u32,
-            },
-            /// Wasm `f64.load` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// - Variant of [`Instruction::F64Load`] with a 16-bit `offset`.
-            /// - Operates on the default Wasm memory instance.
-            #[snake_name(f64_load_offset16)]
-            F64LoadOffset16 {
-                @result: Reg,
-                /// The register storing the pointer of the `load` instruction.
-                ptr: Reg,
-                /// The 16-bit encoded offset of the `load` instruction.
-                offset: Const16<u32>,
-            },
-
             /// Wasm `i32.load8_s` equivalent Wasmi instruction.
             ///
             /// # Encoding
@@ -2263,18 +2091,6 @@ macro_rules! for_each_op {
 
             /// Wasm `i32.store` equivalent Wasmi instruction.
             ///
-            /// # Encoding
-            ///
-            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `value` and `offset`.
-            #[snake_name(i32_store)]
-            I32Store {
-                /// The register storing the pointer of the `store` instruction.
-                ptr: Reg,
-                /// The linear memory index for which the store instruction is executed.
-                memory: Memory,
-            },
-            /// Wasm `i32.store` equivalent Wasmi instruction.
-            ///
             /// # Note
             ///
             /// Variant of [`Instruction::I32Store`] with 16-bit immediate `value`.
@@ -2293,21 +2109,6 @@ macro_rules! for_each_op {
             ///
             /// # Note
             ///
-            /// - Variant of [`Instruction::I32Store`] with a 16-bit `offset`.
-            /// - Operates on the default Wasm memory instance.
-            #[snake_name(i32_store_offset16)]
-            I32StoreOffset16 {
-                /// The register storing the pointer of the `store` instruction.
-                ptr: Reg,
-                /// The register storing the pointer offset of the `store` instruction.
-                offset: Const16<u32>,
-                /// The value to be stored.
-                value: Reg,
-            },
-            /// Wasm `i32.store` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
             /// - Variant of [`Instruction::I32StoreOffset16`] with 16-bit immediate `value`.
             /// - Operates on the default Wasm memory instance.
             #[snake_name(i32_store_offset16_imm16)]
@@ -2318,24 +2119,6 @@ macro_rules! for_each_op {
                 offset: Const16<u32>,
                 /// The value to be stored.
                 value: Const16<i32>,
-            },
-            /// Wasm `i32.store` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// Variant of [`Instruction::I32Store`] with an immediate `ptr+offset` address.
-            ///
-            /// # Encoding
-            ///
-            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
-            ///
-            /// - Operates on the default Wasm memory instance if missing.
-            #[snake_name(i32_store_at)]
-            I32StoreAt {
-                /// The value to be stored.
-                value: Reg,
-                /// The constant address to store the value.
-                address: u32,
             },
             /// Wasm `i32.store` equivalent Wasmi instruction.
             ///
@@ -2548,18 +2331,6 @@ macro_rules! for_each_op {
 
             /// Wasm `i64.store` equivalent Wasmi instruction.
             ///
-            /// # Encoding
-            ///
-            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `value` and `offset`.
-            #[snake_name(i64_store)]
-            I64Store {
-                /// The register storing the pointer of the `store` instruction.
-                ptr: Reg,
-                /// The linear memory index for which the store instruction is executed.
-                memory: Memory,
-            },
-            /// Wasm `i64.store` equivalent Wasmi instruction.
-            ///
             /// # Note
             ///
             /// Variant of [`Instruction::I64Store`] with 16-bit immediate `value`.
@@ -2578,21 +2349,6 @@ macro_rules! for_each_op {
             ///
             /// # Note
             ///
-            /// - Variant of [`Instruction::I64Store`] with a 16-bit `offset`.
-            /// - Operates on the default Wasm memory instance.
-            #[snake_name(i64_store_offset16)]
-            I64StoreOffset16 {
-                /// The register storing the pointer of the `store` instruction.
-                ptr: Reg,
-                /// The register storing the pointer offset of the `store` instruction.
-                offset: Const16<u32>,
-                /// The value to be stored.
-                value: Reg,
-            },
-            /// Wasm `i64.store` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
             /// - Variant of [`Instruction::I64StoreOffset16`] with 16-bit immediate `value`.
             /// - Operates on the default Wasm memory instance.
             #[snake_name(i64_store_offset16_imm16)]
@@ -2603,24 +2359,6 @@ macro_rules! for_each_op {
                 offset: Const16<u32>,
                 /// The value to be stored.
                 value: Const16<i64>,
-            },
-            /// Wasm `i64.store` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// Variant of [`Instruction::I64Store`] with an immediate `ptr+offset` address.
-            ///
-            /// # Encoding
-            ///
-            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
-            ///
-            /// - Operates on the default Wasm memory instance if missing.
-            #[snake_name(i64_store_at)]
-            I64StoreAt {
-                /// The value to be stored.
-                value: Reg,
-                /// The constant address to store the value.
-                address: u32,
             },
             /// Wasm `i64.store` equivalent Wasmi instruction.
             ///
@@ -2922,98 +2660,6 @@ macro_rules! for_each_op {
             I64Store32AtImm16 {
                 /// The value to be stored.
                 value: Const16<i32>,
-                /// The constant address to store the value.
-                address: u32,
-            },
-
-            /// Wasm `f32.store` equivalent Wasmi instruction.
-            ///
-            /// # Encoding
-            ///
-            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `value` and `offset`.
-            #[snake_name(f32_store)]
-            F32Store {
-                /// The register storing the pointer of the `store` instruction.
-                ptr: Reg,
-                /// The linear memory index for which the store instruction is executed.
-                memory: Memory,
-            },
-            /// Wasm `f32.store` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// - Variant of [`Instruction::F32Store`] with a 16-bit `offset`.
-            /// - Operates on the default Wasm memory instance.
-            #[snake_name(f32_store_offset16)]
-            F32StoreOffset16 {
-                /// The register storing the pointer of the `store` instruction.
-                ptr: Reg,
-                /// The register storing the pointer offset of the `store` instruction.
-                offset: Const16<u32>,
-                /// The value to be stored.
-                value: Reg,
-            },
-            /// Wasm `f32.store` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// Variant of [`Instruction::F32Store`] with an immediate `ptr+offset` address.
-            ///
-            /// # Encoding
-            ///
-            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
-            ///
-            /// - Operates on the default Wasm memory instance if missing.
-            #[snake_name(f32_store_at)]
-            F32StoreAt {
-                /// The value to be stored.
-                value: Reg,
-                /// The constant address to store the value.
-                address: u32,
-            },
-
-            /// Wasm `f32.store` equivalent Wasmi instruction.
-            ///
-            /// # Encoding
-            ///
-            /// Followed by an [`Instruction::RegisterAndImm32`] encoding `value` and `offset`.
-            #[snake_name(f64_store)]
-            F64Store {
-                /// The register storing the pointer of the `store` instruction.
-                ptr: Reg,
-                /// The linear memory index for which the store instruction is executed.
-                memory: Memory,
-            },
-            /// Wasm `f64.store` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// - Variant of [`Instruction::F64Store`] with a 16-bit `offset`.
-            /// - Operates on the default Wasm memory instance.
-            #[snake_name(f64_store_offset16)]
-            F64StoreOffset16 {
-                /// The register storing the pointer of the `store` instruction.
-                ptr: Reg,
-                /// The register storing the pointer offset of the `store` instruction.
-                offset: Const16<u32>,
-                /// The value to be stored.
-                value: Reg,
-            },
-            /// Wasm `f64.store` equivalent Wasmi instruction.
-            ///
-            /// # Note
-            ///
-            /// Variant of [`Instruction::F64Store`] with an immediate `ptr+offset` address.
-            ///
-            /// # Encoding
-            ///
-            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
-            ///
-            /// - Operates on the default Wasm memory instance if missing.
-            #[snake_name(f64_store_at)]
-            F64StoreAt {
-                /// The value to be stored.
-                value: Reg,
                 /// The constant address to store the value.
                 address: u32,
             },

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -1468,7 +1468,7 @@ macro_rules! for_each_op {
             /// Load instruction for 32-bit values.
             ///
             /// # Note
-            /// 
+            ///
             /// Equivalent to Wasm `{i32,f32}.load` instruction.
             ///
             /// # Encoding
@@ -1515,7 +1515,7 @@ macro_rules! for_each_op {
             /// Load instruction for 64-bit values.
             ///
             /// # Note
-            /// 
+            ///
             /// Equivalent to Wasm `{i64,f64}.load` instruction.
             ///
             /// # Encoding
@@ -1992,7 +1992,7 @@ macro_rules! for_each_op {
             /// Store instruction for 32-bit values.
             ///
             /// # Note
-            /// 
+            ///
             /// Equivalent to Wasm `{i32,f32}.store` instruction.
             ///
             /// # Encoding
@@ -2042,7 +2042,7 @@ macro_rules! for_each_op {
             /// Store instruction for 64-bit values.
             ///
             /// # Note
-            /// 
+            ///
             /// Equivalent to Wasm `{i64,f64}.store` instruction.
             ///
             /// # Encoding

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -600,20 +600,29 @@ impl<'engine> Executor<'engine> {
                     ptr,
                     offset,
                 } => self.execute_i64_load32_u_offset16(result, ptr, offset)?,
-                Instr::I32Store { ptr, memory } => {
-                    self.execute_i32_store(&mut store.inner, ptr, memory)?
+                Instr::Store32 { ptr, memory } => {
+                    self.execute_store32(&mut store.inner, ptr, memory)?
+                }
+                Instr::Store32Offset16 { ptr, offset, value } => {
+                    self.execute_store32_offset16(ptr, offset, value)?
+                }
+                Instr::Store32At { address, value } => {
+                    self.execute_store32_at(&mut store.inner, address, value)?
+                }
+                Instr::Store64 { ptr, memory } => {
+                    self.execute_store64(&mut store.inner, ptr, memory)?
+                }
+                Instr::Store64Offset16 { ptr, offset, value } => {
+                    self.execute_store64_offset16(ptr, offset, value)?
+                }
+                Instr::Store64At { address, value } => {
+                    self.execute_store64_at(&mut store.inner, address, value)?
                 }
                 Instr::I32StoreImm16 { ptr, memory } => {
                     self.execute_i32_store_imm16(&mut store.inner, ptr, memory)?
                 }
-                Instr::I32StoreOffset16 { ptr, offset, value } => {
-                    self.execute_i32_store_offset16(ptr, offset, value)?
-                }
                 Instr::I32StoreOffset16Imm16 { ptr, offset, value } => {
                     self.execute_i32_store_offset16_imm16(ptr, offset, value)?
-                }
-                Instr::I32StoreAt { address, value } => {
-                    self.execute_i32_store_at(&mut store.inner, address, value)?
                 }
                 Instr::I32StoreAtImm16 { address, value } => {
                     self.execute_i32_store_at_imm16(&mut store.inner, address, value)?
@@ -654,20 +663,11 @@ impl<'engine> Executor<'engine> {
                 Instr::I32Store16AtImm { address, value } => {
                     self.execute_i32_store16_at_imm(&mut store.inner, address, value)?
                 }
-                Instr::I64Store { ptr, memory } => {
-                    self.execute_i64_store(&mut store.inner, ptr, memory)?
-                }
                 Instr::I64StoreImm16 { ptr, memory } => {
                     self.execute_i64_store_imm16(&mut store.inner, ptr, memory)?
                 }
-                Instr::I64StoreOffset16 { ptr, offset, value } => {
-                    self.execute_i64_store_offset16(ptr, offset, value)?
-                }
                 Instr::I64StoreOffset16Imm16 { ptr, offset, value } => {
                     self.execute_i64_store_offset16_imm16(ptr, offset, value)?
-                }
-                Instr::I64StoreAt { address, value } => {
-                    self.execute_i64_store_at(&mut store.inner, address, value)?
                 }
                 Instr::I64StoreAtImm16 { address, value } => {
                     self.execute_i64_store_at_imm16(&mut store.inner, address, value)?
@@ -725,24 +725,6 @@ impl<'engine> Executor<'engine> {
                 }
                 Instr::I64Store32AtImm16 { address, value } => {
                     self.execute_i64_store32_at_imm16(&mut store.inner, address, value)?
-                }
-                Instr::F32Store { ptr, memory } => {
-                    self.execute_f32_store(&mut store.inner, ptr, memory)?
-                }
-                Instr::F32StoreOffset16 { ptr, offset, value } => {
-                    self.execute_f32_store_offset16(ptr, offset, value)?
-                }
-                Instr::F32StoreAt { address, value } => {
-                    self.execute_f32_store_at(&mut store.inner, address, value)?
-                }
-                Instr::F64Store { ptr, memory } => {
-                    self.execute_f64_store(&mut store.inner, ptr, memory)?
-                }
-                Instr::F64StoreOffset16 { ptr, offset, value } => {
-                    self.execute_f64_store_offset16(ptr, offset, value)?
-                }
-                Instr::F64StoreAt { address, value } => {
-                    self.execute_f64_store_at(&mut store.inner, address, value)?
                 }
                 Instr::I32Eq { result, lhs, rhs } => self.execute_i32_eq(result, lhs, rhs),
                 Instr::I32EqImm16 { result, lhs, rhs } => {

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -468,50 +468,28 @@ impl<'engine> Executor<'engine> {
                 Instr::GlobalSetI64Imm16 { global, input } => {
                     self.execute_global_set_i64imm16(&mut store.inner, global, input)
                 }
-                Instr::I32Load { result, memory } => {
-                    self.execute_i32_load(&store.inner, result, memory)?
+                Instr::Load32 { result, memory } => {
+                    self.execute_load32(&store.inner, result, memory)?
                 }
-                Instr::I32LoadAt { result, address } => {
-                    self.execute_i32_load_at(&store.inner, result, address)?
+                Instr::Load32At { result, address } => {
+                    self.execute_load32_at(&store.inner, result, address)?
                 }
-                Instr::I32LoadOffset16 {
+                Instr::Load32Offset16 {
                     result,
                     ptr,
                     offset,
-                } => self.execute_i32_load_offset16(result, ptr, offset)?,
-                Instr::I64Load { result, memory } => {
-                    self.execute_i64_load(&store.inner, result, memory)?
+                } => self.execute_load32_offset16(result, ptr, offset)?,
+                Instr::Load64 { result, memory } => {
+                    self.execute_load64(&store.inner, result, memory)?
                 }
-                Instr::I64LoadAt { result, address } => {
-                    self.execute_i64_load_at(&store.inner, result, address)?
+                Instr::Load64At { result, address } => {
+                    self.execute_load64_at(&store.inner, result, address)?
                 }
-                Instr::I64LoadOffset16 {
+                Instr::Load64Offset16 {
                     result,
                     ptr,
                     offset,
-                } => self.execute_i64_load_offset16(result, ptr, offset)?,
-                Instr::F32Load { result, memory } => {
-                    self.execute_f32_load(&store.inner, result, memory)?
-                }
-                Instr::F32LoadAt { result, address } => {
-                    self.execute_f32_load_at(&store.inner, result, address)?
-                }
-                Instr::F32LoadOffset16 {
-                    result,
-                    ptr,
-                    offset,
-                } => self.execute_f32_load_offset16(result, ptr, offset)?,
-                Instr::F64Load { result, memory } => {
-                    self.execute_f64_load(&store.inner, result, memory)?
-                }
-                Instr::F64LoadAt { result, address } => {
-                    self.execute_f64_load_at(&store.inner, result, address)?
-                }
-                Instr::F64LoadOffset16 {
-                    result,
-                    ptr,
-                    offset,
-                } => self.execute_f64_load_offset16(result, ptr, offset)?,
+                } => self.execute_load64_offset16(result, ptr, offset)?,
                 Instr::I32Load8s { result, memory } => {
                     self.execute_i32_load8_s(&store.inner, result, memory)?
                 }

--- a/crates/wasmi/src/engine/executor/instrs/load.rs
+++ b/crates/wasmi/src/engine/executor/instrs/load.rs
@@ -202,27 +202,15 @@ macro_rules! impl_execute_load {
 impl Executor<'_> {
     impl_execute_load! {
         (
-            (Instruction::I32Load, execute_i32_load),
-            (Instruction::I32LoadAt, execute_i32_load_at),
-            (Instruction::I32LoadOffset16, execute_i32_load_offset16),
+            (Instruction::Load32, execute_load32),
+            (Instruction::Load32At, execute_load32_at),
+            (Instruction::Load32Offset16, execute_load32_offset16),
             UntypedVal::load32,
         ),
         (
-            (Instruction::I64Load, execute_i64_load),
-            (Instruction::I64LoadAt, execute_i64_load_at),
-            (Instruction::I64LoadOffset16, execute_i64_load_offset16),
-            UntypedVal::load64,
-        ),
-        (
-            (Instruction::F32Load, execute_f32_load),
-            (Instruction::F32LoadAt, execute_f32_load_at),
-            (Instruction::F32LoadOffset16, execute_f32_load_offset16),
-            UntypedVal::load32,
-        ),
-        (
-            (Instruction::F64Load, execute_f64_load),
-            (Instruction::F64LoadAt, execute_f64_load_at),
-            (Instruction::F64LoadOffset16, execute_f64_load_offset16),
+            (Instruction::Load64, execute_load64),
+            (Instruction::Load64At, execute_load64_at),
+            (Instruction::Load64Offset16, execute_load64_offset16),
             UntypedVal::load64,
         ),
 

--- a/crates/wasmi/src/engine/executor/instrs/load.rs
+++ b/crates/wasmi/src/engine/executor/instrs/load.rs
@@ -205,25 +205,25 @@ impl Executor<'_> {
             (Instruction::I32Load, execute_i32_load),
             (Instruction::I32LoadAt, execute_i32_load_at),
             (Instruction::I32LoadOffset16, execute_i32_load_offset16),
-            UntypedVal::i32_load,
+            UntypedVal::load32,
         ),
         (
             (Instruction::I64Load, execute_i64_load),
             (Instruction::I64LoadAt, execute_i64_load_at),
             (Instruction::I64LoadOffset16, execute_i64_load_offset16),
-            UntypedVal::i64_load,
+            UntypedVal::load64,
         ),
         (
             (Instruction::F32Load, execute_f32_load),
             (Instruction::F32LoadAt, execute_f32_load_at),
             (Instruction::F32LoadOffset16, execute_f32_load_offset16),
-            UntypedVal::f32_load,
+            UntypedVal::load32,
         ),
         (
             (Instruction::F64Load, execute_f64_load),
             (Instruction::F64LoadAt, execute_f64_load_at),
             (Instruction::F64LoadOffset16, execute_f64_load_offset16),
-            UntypedVal::f64_load,
+            UntypedVal::load64,
         ),
 
         (

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -351,8 +351,8 @@ impl InstrEncoder {
     /// # Note
     ///
     /// This is used primarily for [`Instruction`] words that are just carrying
-    /// parameters for the [`Instruction`]. An example of this is [`Instruction::Const32`]
-    /// carrying the `offset` parameter for [`Instruction::I32Load`].
+    /// parameters for the [`Instruction`]. An example of this is [`Instruction::RegisterAndImm32`]
+    /// carrying the `ptr` and `offset` parameters for [`Instruction::Load32`].
     pub fn append_instr(&mut self, instr: Instruction) -> Result<Instr, Error> {
         self.instrs.push(instr)
     }

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -402,7 +402,7 @@ fn fuzz_regression_16() {
             Instruction::copy(2, 0),
             Instruction::global_get(Reg::from(0), Global::from(0)),
             Instruction::global_set(Reg::from(0), Global::from(0)),
-            Instruction::i64_store_at(Reg::from(2), 2147483647_u32),
+            Instruction::store64_at(Reg::from(2), 2147483647_u32),
             Instruction::trap(TrapCode::UnreachableCodeReached),
         ])
         .run()
@@ -420,7 +420,7 @@ fn fuzz_regression_17() {
             Instruction::copy(2, 0),
             Instruction::copy_i64imm32(Reg::from(0), 2),
             Instruction::copy_imm32(Reg::from(1), -1.0_f32),
-            Instruction::i64_store_at(Reg::from(2), 4294967295_u32),
+            Instruction::store64_at(Reg::from(2), 4294967295_u32),
             Instruction::trap(TrapCode::UnreachableCodeReached),
         ])
         .run()

--- a/crates/wasmi/src/engine/translator/tests/op/load.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/load.rs
@@ -260,9 +260,9 @@ mod i32_load {
 
     generate_tests!(
         WASM_OP,
-        Instruction::i32_load,
-        Instruction::i32_load_offset16,
-        Instruction::i32_load_at
+        Instruction::load32,
+        Instruction::load32_offset16,
+        Instruction::load32_at
     );
 }
 
@@ -325,9 +325,9 @@ mod i64_load {
 
     generate_tests!(
         WASM_OP,
-        Instruction::i64_load,
-        Instruction::i64_load_offset16,
-        Instruction::i64_load_at
+        Instruction::load64,
+        Instruction::load64_offset16,
+        Instruction::load64_at
     );
 }
 
@@ -416,9 +416,9 @@ mod f32_load {
 
     generate_tests!(
         WASM_OP,
-        Instruction::f32_load,
-        Instruction::f32_load_offset16,
-        Instruction::f32_load_at
+        Instruction::load32,
+        Instruction::load32_offset16,
+        Instruction::load32_at
     );
 }
 
@@ -429,8 +429,8 @@ mod f64_load {
 
     generate_tests!(
         WASM_OP,
-        Instruction::f64_load,
-        Instruction::f64_load_offset16,
-        Instruction::f64_load_at
+        Instruction::load64,
+        Instruction::load64_offset16,
+        Instruction::load64_at
     );
 }

--- a/crates/wasmi/src/engine/translator/tests/op/store/f32_store.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/store/f32_store.rs
@@ -5,42 +5,42 @@ const WASM_OP: WasmOp = WasmOp::store(WasmType::F32, "store");
 #[test]
 #[cfg_attr(miri, ignore)]
 fn reg() {
-    test_store(WASM_OP, Instruction::f32_store);
+    test_store(WASM_OP, Instruction::store32);
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
 fn imm() {
-    test_store_imm::<f32>(WASM_OP, 0.0, Instruction::f32_store);
-    test_store_imm::<f32>(WASM_OP, 1.0, Instruction::f32_store);
-    test_store_imm::<f32>(WASM_OP, -1.0, Instruction::f32_store);
-    test_store_imm::<f32>(WASM_OP, 42.25, Instruction::f32_store);
-    test_store_imm::<f32>(WASM_OP, f32::INFINITY, Instruction::f32_store);
-    test_store_imm::<f32>(WASM_OP, f32::NEG_INFINITY, Instruction::f32_store);
-    test_store_imm::<f32>(WASM_OP, f32::NAN, Instruction::f32_store);
+    test_store_imm::<f32>(WASM_OP, 0.0, Instruction::store32);
+    test_store_imm::<f32>(WASM_OP, 1.0, Instruction::store32);
+    test_store_imm::<f32>(WASM_OP, -1.0, Instruction::store32);
+    test_store_imm::<f32>(WASM_OP, 42.25, Instruction::store32);
+    test_store_imm::<f32>(WASM_OP, f32::INFINITY, Instruction::store32);
+    test_store_imm::<f32>(WASM_OP, f32::NEG_INFINITY, Instruction::store32);
+    test_store_imm::<f32>(WASM_OP, f32::NAN, Instruction::store32);
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
 fn offset16() {
-    test_store_offset16(WASM_OP, Instruction::f32_store_offset16);
+    test_store_offset16(WASM_OP, Instruction::store32_offset16);
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
 fn offset16_imm() {
-    test_store_offset16_imm::<f32>(WASM_OP, 0.0, Instruction::f32_store_offset16);
-    test_store_offset16_imm::<f32>(WASM_OP, 1.0, Instruction::f32_store_offset16);
-    test_store_offset16_imm::<f32>(WASM_OP, -1.0, Instruction::f32_store_offset16);
-    test_store_offset16_imm::<f32>(WASM_OP, f32::INFINITY, Instruction::f32_store_offset16);
-    test_store_offset16_imm::<f32>(WASM_OP, f32::NEG_INFINITY, Instruction::f32_store_offset16);
-    test_store_offset16_imm::<f32>(WASM_OP, f32::NAN, Instruction::f32_store_offset16);
+    test_store_offset16_imm::<f32>(WASM_OP, 0.0, Instruction::store32_offset16);
+    test_store_offset16_imm::<f32>(WASM_OP, 1.0, Instruction::store32_offset16);
+    test_store_offset16_imm::<f32>(WASM_OP, -1.0, Instruction::store32_offset16);
+    test_store_offset16_imm::<f32>(WASM_OP, f32::INFINITY, Instruction::store32_offset16);
+    test_store_offset16_imm::<f32>(WASM_OP, f32::NEG_INFINITY, Instruction::store32_offset16);
+    test_store_offset16_imm::<f32>(WASM_OP, f32::NAN, Instruction::store32_offset16);
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
 fn at() {
-    test_store_at(WASM_OP, Instruction::f32_store_at);
+    test_store_at(WASM_OP, Instruction::store32_at);
 }
 
 #[test]
@@ -52,12 +52,12 @@ fn at_overflow() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn at_imm() {
-    test_store_at_imm::<f32>(WASM_OP, 0.0, Instruction::f32_store_at);
-    test_store_at_imm::<f32>(WASM_OP, 1.0, Instruction::f32_store_at);
-    test_store_at_imm::<f32>(WASM_OP, -1.0, Instruction::f32_store_at);
-    test_store_at_imm::<f32>(WASM_OP, f32::NEG_INFINITY, Instruction::f32_store_at);
-    test_store_at_imm::<f32>(WASM_OP, f32::INFINITY, Instruction::f32_store_at);
-    test_store_at_imm::<f32>(WASM_OP, f32::NAN, Instruction::f32_store_at);
+    test_store_at_imm::<f32>(WASM_OP, 0.0, Instruction::store32_at);
+    test_store_at_imm::<f32>(WASM_OP, 1.0, Instruction::store32_at);
+    test_store_at_imm::<f32>(WASM_OP, -1.0, Instruction::store32_at);
+    test_store_at_imm::<f32>(WASM_OP, f32::NEG_INFINITY, Instruction::store32_at);
+    test_store_at_imm::<f32>(WASM_OP, f32::INFINITY, Instruction::store32_at);
+    test_store_at_imm::<f32>(WASM_OP, f32::NAN, Instruction::store32_at);
 }
 
 #[test]

--- a/crates/wasmi/src/engine/translator/tests/op/store/f64_store.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/store/f64_store.rs
@@ -5,42 +5,42 @@ const WASM_OP: WasmOp = WasmOp::store(WasmType::F64, "store");
 #[test]
 #[cfg_attr(miri, ignore)]
 fn reg() {
-    test_store(WASM_OP, Instruction::f64_store);
+    test_store(WASM_OP, Instruction::store64);
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
 fn imm() {
-    test_store_imm::<f64>(WASM_OP, 0.0, Instruction::f64_store);
-    test_store_imm::<f64>(WASM_OP, 1.0, Instruction::f64_store);
-    test_store_imm::<f64>(WASM_OP, -1.0, Instruction::f64_store);
-    test_store_imm::<f64>(WASM_OP, 42.25, Instruction::f64_store);
-    test_store_imm::<f64>(WASM_OP, f64::INFINITY, Instruction::f64_store);
-    test_store_imm::<f64>(WASM_OP, f64::NEG_INFINITY, Instruction::f64_store);
-    test_store_imm::<f64>(WASM_OP, f64::NAN, Instruction::f64_store);
+    test_store_imm::<f64>(WASM_OP, 0.0, Instruction::store64);
+    test_store_imm::<f64>(WASM_OP, 1.0, Instruction::store64);
+    test_store_imm::<f64>(WASM_OP, -1.0, Instruction::store64);
+    test_store_imm::<f64>(WASM_OP, 42.25, Instruction::store64);
+    test_store_imm::<f64>(WASM_OP, f64::INFINITY, Instruction::store64);
+    test_store_imm::<f64>(WASM_OP, f64::NEG_INFINITY, Instruction::store64);
+    test_store_imm::<f64>(WASM_OP, f64::NAN, Instruction::store64);
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
 fn offset16() {
-    test_store_offset16(WASM_OP, Instruction::f64_store_offset16);
+    test_store_offset16(WASM_OP, Instruction::store64_offset16);
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
 fn offset16_imm() {
-    test_store_offset16_imm::<f64>(WASM_OP, 0.0, Instruction::f64_store_offset16);
-    test_store_offset16_imm::<f64>(WASM_OP, 1.0, Instruction::f64_store_offset16);
-    test_store_offset16_imm::<f64>(WASM_OP, -1.0, Instruction::f64_store_offset16);
-    test_store_offset16_imm::<f64>(WASM_OP, f64::INFINITY, Instruction::f64_store_offset16);
-    test_store_offset16_imm::<f64>(WASM_OP, f64::NEG_INFINITY, Instruction::f64_store_offset16);
-    test_store_offset16_imm::<f64>(WASM_OP, f64::NAN, Instruction::f64_store_offset16);
+    test_store_offset16_imm::<f64>(WASM_OP, 0.0, Instruction::store64_offset16);
+    test_store_offset16_imm::<f64>(WASM_OP, 1.0, Instruction::store64_offset16);
+    test_store_offset16_imm::<f64>(WASM_OP, -1.0, Instruction::store64_offset16);
+    test_store_offset16_imm::<f64>(WASM_OP, f64::INFINITY, Instruction::store64_offset16);
+    test_store_offset16_imm::<f64>(WASM_OP, f64::NEG_INFINITY, Instruction::store64_offset16);
+    test_store_offset16_imm::<f64>(WASM_OP, f64::NAN, Instruction::store64_offset16);
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
 fn at() {
-    test_store_at(WASM_OP, Instruction::f64_store_at);
+    test_store_at(WASM_OP, Instruction::store64_at);
 }
 
 #[test]
@@ -52,12 +52,12 @@ fn at_overflow() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn at_imm() {
-    test_store_at_imm::<f64>(WASM_OP, 0.0, Instruction::f64_store_at);
-    test_store_at_imm::<f64>(WASM_OP, 1.0, Instruction::f64_store_at);
-    test_store_at_imm::<f64>(WASM_OP, -1.0, Instruction::f64_store_at);
-    test_store_at_imm::<f64>(WASM_OP, f64::NEG_INFINITY, Instruction::f64_store_at);
-    test_store_at_imm::<f64>(WASM_OP, f64::INFINITY, Instruction::f64_store_at);
-    test_store_at_imm::<f64>(WASM_OP, f64::NAN, Instruction::f64_store_at);
+    test_store_at_imm::<f64>(WASM_OP, 0.0, Instruction::store64_at);
+    test_store_at_imm::<f64>(WASM_OP, 1.0, Instruction::store64_at);
+    test_store_at_imm::<f64>(WASM_OP, -1.0, Instruction::store64_at);
+    test_store_at_imm::<f64>(WASM_OP, f64::NEG_INFINITY, Instruction::store64_at);
+    test_store_at_imm::<f64>(WASM_OP, f64::INFINITY, Instruction::store64_at);
+    test_store_at_imm::<f64>(WASM_OP, f64::NAN, Instruction::store64_at);
 }
 
 #[test]

--- a/crates/wasmi/src/engine/translator/tests/op/store/i32_store.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/store/i32_store.rs
@@ -5,7 +5,7 @@ const WASM_OP: WasmOp = WasmOp::store(WasmType::I32, "store");
 #[test]
 #[cfg_attr(miri, ignore)]
 fn reg() {
-    test_store(WASM_OP, Instruction::i32_store);
+    test_store(WASM_OP, Instruction::store32);
 }
 
 #[test]
@@ -20,7 +20,7 @@ fn imm() {
         i32::MAX - 1,
     ];
     for value in values {
-        test_store_imm::<i32>(WASM_OP, value, Instruction::i32_store);
+        test_store_imm::<i32>(WASM_OP, value, Instruction::store32);
     }
 }
 
@@ -45,7 +45,7 @@ fn imm16() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn offset16() {
-    test_store_offset16(WASM_OP, Instruction::i32_store_offset16);
+    test_store_offset16(WASM_OP, Instruction::store32_offset16);
 }
 
 #[test]
@@ -54,17 +54,17 @@ fn offset16_imm() {
     test_store_offset16_imm::<i32>(
         WASM_OP,
         i32::from(i16::MIN) - 1,
-        Instruction::i32_store_offset16,
+        Instruction::store32_offset16,
     );
     test_store_offset16_imm::<i32>(
         WASM_OP,
         i32::from(i16::MAX) + 1,
-        Instruction::i32_store_offset16,
+        Instruction::store32_offset16,
     );
-    test_store_offset16_imm::<i32>(WASM_OP, i32::MIN + 1, Instruction::i32_store_offset16);
-    test_store_offset16_imm::<i32>(WASM_OP, i32::MAX - 1, Instruction::i32_store_offset16);
-    test_store_offset16_imm::<i32>(WASM_OP, i32::MIN, Instruction::i32_store_offset16);
-    test_store_offset16_imm::<i32>(WASM_OP, i32::MAX, Instruction::i32_store_offset16);
+    test_store_offset16_imm::<i32>(WASM_OP, i32::MIN + 1, Instruction::store32_offset16);
+    test_store_offset16_imm::<i32>(WASM_OP, i32::MAX - 1, Instruction::store32_offset16);
+    test_store_offset16_imm::<i32>(WASM_OP, i32::MIN, Instruction::store32_offset16);
+    test_store_offset16_imm::<i32>(WASM_OP, i32::MAX, Instruction::store32_offset16);
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn offset16_imm16() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn at() {
-    test_store_at(WASM_OP, Instruction::i32_store_at);
+    test_store_at(WASM_OP, Instruction::store32_at);
 }
 
 #[test]
@@ -94,9 +94,9 @@ fn at_overflow() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn at_imm() {
-    test_store_at_imm::<i32>(WASM_OP, i32::from(i16::MAX) + 1, Instruction::i32_store_at);
-    test_store_at_imm::<i32>(WASM_OP, i32::MAX - 1, Instruction::i32_store_at);
-    test_store_at_imm::<i32>(WASM_OP, i32::MAX, Instruction::i32_store_at);
+    test_store_at_imm::<i32>(WASM_OP, i32::from(i16::MAX) + 1, Instruction::store32_at);
+    test_store_at_imm::<i32>(WASM_OP, i32::MAX - 1, Instruction::store32_at);
+    test_store_at_imm::<i32>(WASM_OP, i32::MAX, Instruction::store32_at);
 }
 
 #[test]

--- a/crates/wasmi/src/engine/translator/tests/op/store/i64_store.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/store/i64_store.rs
@@ -5,7 +5,7 @@ const WASM_OP: WasmOp = WasmOp::store(WasmType::I64, "store");
 #[test]
 #[cfg_attr(miri, ignore)]
 fn reg() {
-    test_store(WASM_OP, Instruction::i64_store);
+    test_store(WASM_OP, Instruction::store64);
 }
 
 #[test]
@@ -20,7 +20,7 @@ fn imm() {
         i64::MAX - 1,
     ];
     for value in values {
-        test_store_imm::<i64>(WASM_OP, value, Instruction::i64_store);
+        test_store_imm::<i64>(WASM_OP, value, Instruction::store64);
     }
 }
 
@@ -45,7 +45,7 @@ fn imm16() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn offset16() {
-    test_store_offset16(WASM_OP, Instruction::i64_store_offset16);
+    test_store_offset16(WASM_OP, Instruction::store64_offset16);
 }
 
 #[test]
@@ -54,17 +54,17 @@ fn offset16_imm() {
     test_store_offset16_imm::<i64>(
         WASM_OP,
         i64::from(i16::MIN) - 1,
-        Instruction::i64_store_offset16,
+        Instruction::store64_offset16,
     );
     test_store_offset16_imm::<i64>(
         WASM_OP,
         i64::from(i16::MAX) + 1,
-        Instruction::i64_store_offset16,
+        Instruction::store64_offset16,
     );
-    test_store_offset16_imm::<i64>(WASM_OP, i64::MAX - 1, Instruction::i64_store_offset16);
-    test_store_offset16_imm::<i64>(WASM_OP, i64::MIN + 1, Instruction::i64_store_offset16);
-    test_store_offset16_imm::<i64>(WASM_OP, i64::MIN, Instruction::i64_store_offset16);
-    test_store_offset16_imm::<i64>(WASM_OP, i64::MAX, Instruction::i64_store_offset16);
+    test_store_offset16_imm::<i64>(WASM_OP, i64::MAX - 1, Instruction::store64_offset16);
+    test_store_offset16_imm::<i64>(WASM_OP, i64::MIN + 1, Instruction::store64_offset16);
+    test_store_offset16_imm::<i64>(WASM_OP, i64::MIN, Instruction::store64_offset16);
+    test_store_offset16_imm::<i64>(WASM_OP, i64::MAX, Instruction::store64_offset16);
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn offset16_imm16() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn at() {
-    test_store_at(WASM_OP, Instruction::i64_store_at);
+    test_store_at(WASM_OP, Instruction::store64_at);
 }
 
 #[test]
@@ -94,9 +94,9 @@ fn at_overflow() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn at_imm() {
-    test_store_at_imm::<i64>(WASM_OP, i64::from(i16::MAX) + 1, Instruction::i64_store_at);
-    test_store_at_imm::<i64>(WASM_OP, i64::MAX - 1, Instruction::i64_store_at);
-    test_store_at_imm::<i64>(WASM_OP, i64::MAX, Instruction::i64_store_at);
+    test_store_at_imm::<i64>(WASM_OP, i64::from(i16::MAX) + 1, Instruction::store64_at);
+    test_store_at_imm::<i64>(WASM_OP, i64::MAX - 1, Instruction::store64_at);
+    test_store_at_imm::<i64>(WASM_OP, i64::MAX, Instruction::store64_at);
 }
 
 #[test]

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -754,36 +754,36 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
     fn visit_i32_load(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
         self.translate_load(
             memarg,
-            Instruction::i32_load,
-            Instruction::i32_load_offset16,
-            Instruction::i32_load_at,
+            Instruction::load32,
+            Instruction::load32_offset16,
+            Instruction::load32_at,
         )
     }
 
     fn visit_i64_load(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
         self.translate_load(
             memarg,
-            Instruction::i64_load,
-            Instruction::i64_load_offset16,
-            Instruction::i64_load_at,
+            Instruction::load64,
+            Instruction::load64_offset16,
+            Instruction::load64_at,
         )
     }
 
     fn visit_f32_load(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
         self.translate_load(
             memarg,
-            Instruction::f32_load,
-            Instruction::f32_load_offset16,
-            Instruction::f32_load_at,
+            Instruction::load32,
+            Instruction::load32_offset16,
+            Instruction::load32_at,
         )
     }
 
     fn visit_f64_load(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
         self.translate_load(
             memarg,
-            Instruction::f64_load,
-            Instruction::f64_load_offset16,
-            Instruction::f64_load_at,
+            Instruction::load64,
+            Instruction::load64_offset16,
+            Instruction::load64_at,
         )
     }
 
@@ -880,11 +880,11 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
     fn visit_i32_store(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
         self.translate_istore::<i32, i16>(
             memarg,
-            Instruction::i32_store,
+            Instruction::store32,
             Instruction::i32_store_imm16,
-            Instruction::i32_store_offset16,
+            Instruction::store32_offset16,
             Instruction::i32_store_offset16_imm16,
-            Instruction::i32_store_at,
+            Instruction::store32_at,
             Instruction::i32_store_at_imm16,
         )
     }
@@ -892,11 +892,11 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
     fn visit_i64_store(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
         self.translate_istore::<i64, i16>(
             memarg,
-            Instruction::i64_store,
+            Instruction::store64,
             Instruction::i64_store_imm16,
-            Instruction::i64_store_offset16,
+            Instruction::store64_offset16,
             Instruction::i64_store_offset16_imm16,
-            Instruction::i64_store_at,
+            Instruction::store64_at,
             Instruction::i64_store_at_imm16,
         )
     }
@@ -904,18 +904,18 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
     fn visit_f32_store(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
         self.translate_fstore(
             memarg,
-            Instruction::f32_store,
-            Instruction::f32_store_offset16,
-            Instruction::f32_store_at,
+            Instruction::store32,
+            Instruction::store32_offset16,
+            Instruction::store32_at,
         )
     }
 
     fn visit_f64_store(&mut self, memarg: wasmparser::MemArg) -> Self::Output {
         self.translate_fstore(
             memarg,
-            Instruction::f64_store,
-            Instruction::f64_store_offset16,
-            Instruction::f64_store_at,
+            Instruction::store64,
+            Instruction::store64_offset16,
+            Instruction::store64_at,
         )
     }
 


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1302.