### PR TITLE
Conditionally foward the `std` crate feature for `string-interner`

### DIFF
--- a/crates/collections/Cargo.toml
+++ b/crates/collections/Cargo.toml
@@ -20,7 +20,7 @@ ahash = { version = "0.8.11", default-features = false, optional = true }
 
 [features]
 default = ["std"]
-std = ["string-interner/std"]
+std = ["string-interner?/std"]
 
 # Hash collections usage:
 #


### PR DESCRIPTION
This no longer enables `string-interner` usage when enabling `std` crate feature without also enabling `hash-collections`.