### PR TITLE
Update `string-interner` and `hashbrown` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ name = "wasmi_collections"
 version = "0.39.1"
 dependencies = [
  "ahash",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "string-interner",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
  "foldhash",
 ]
@@ -791,7 +791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -985,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "indexmap",
  "memchr",
 ]
@@ -1318,12 +1318,11 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "string-interner"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+checksum = "1a3275464d7a9f2d4cac57c89c2ef96a8524dba2864c8d6f82e3980baf136f9b"
 dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,6 @@ dependencies = [
 name = "wasmi_collections"
 version = "0.39.1"
 dependencies = [
- "ahash",
  "hashbrown 0.15.1",
  "string-interner",
 ]

--- a/crates/collections/Cargo.toml
+++ b/crates/collections/Cargo.toml
@@ -15,7 +15,7 @@ exclude.workspace = true
 
 [dependencies]
 hashbrown = { version = "0.14", default-features = false, optional = true, features = ["ahash", "inline-more"] }
-string-interner = { version = "0.17", default-features = false, optional = true, features = ["inline-more", "backends"] }
+string-interner = { version = "0.18", default-features = false, optional = true, features = ["inline-more", "backends"] }
 ahash = { version = "0.8.11", default-features = false, optional = true }
 
 [features]

--- a/crates/collections/Cargo.toml
+++ b/crates/collections/Cargo.toml
@@ -16,7 +16,6 @@ exclude.workspace = true
 [dependencies]
 hashbrown = { version = "0.15.1", default-features = false, optional = true, features = ["default-hasher", "inline-more"] }
 string-interner = { version = "0.18", default-features = false, optional = true, features = ["inline-more", "backends"] }
-ahash = { version = "0.8.11", default-features = false, optional = true }
 
 [features]
 default = ["std"]
@@ -46,7 +45,6 @@ std = ["string-interner?/std"]
 hash-collections = [
   'dep:hashbrown',
   'dep:string-interner',
-  'dep:ahash',
 ]
 prefer-btree-collections = []
 

--- a/crates/collections/Cargo.toml
+++ b/crates/collections/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 exclude.workspace = true
 
 [dependencies]
-hashbrown = { version = "0.14", default-features = false, optional = true, features = ["ahash", "inline-more"] }
+hashbrown = { version = "0.15.1", default-features = false, optional = true, features = ["default-hasher", "inline-more"] }
 string-interner = { version = "0.18", default-features = false, optional = true, features = ["inline-more", "backends"] }
 ahash = { version = "0.8.11", default-features = false, optional = true }
 

--- a/crates/collections/src/hash.rs
+++ b/crates/collections/src/hash.rs
@@ -94,29 +94,29 @@ impl Hasher for RandomStateHasher {
 #[cfg(feature = "std")]
 use std::collections::hash_map::RandomState as RandomStateImpl;
 
-// When the `std` feature is NOT active then rely on `ahash::RandomState`
+// When the `std` feature is NOT active then rely on `hashbrown`'s `RandomState`
 // which relies on ASLR by default for randomness.
 #[derive(Clone, Debug)]
 #[cfg(not(feature = "std"))]
 struct RandomStateImpl {
-    state: ahash::RandomState,
+    state: hashbrown::DefaultHashBuilder,
 }
 
 #[cfg(not(feature = "std"))]
 impl Default for RandomStateImpl {
     fn default() -> Self {
         Self {
-            state: ahash::RandomState::new(),
+            state: hashbrown::DefaultHashBuilder::default(),
         }
     }
 }
 
 #[cfg(not(feature = "std"))]
 impl BuildHasher for RandomStateImpl {
-    type Hasher = ahash::AHasher;
+    type Hasher = <hashbrown::DefaultHashBuilder as BuildHasher>::Hasher;
 
     #[inline]
-    fn build_hasher(&self) -> ahash::AHasher {
+    fn build_hasher(&self) -> Self::Hasher {
         self.state.build_hasher()
     }
 }


### PR DESCRIPTION
This also removes the `ahash` dependency and instead uses `hashbrown`'s default hashing utilities which is implemented by `foldhash` since v0.15.0.