### PR TITLE
Use the config in the wasmtime oracle

### DIFF
--- a/crates/fuzz/src/oracle/wasmtime.rs
+++ b/crates/fuzz/src/oracle/wasmtime.rs
@@ -26,7 +26,10 @@ impl DifferentialOracleMeta for WasmtimeOracle {
         // more interested what kind of error occurred and now how an error
         // occurred.
         config.wasm_backtrace(false);
-        let engine = Engine::default();
+        // We're disabling POSIX signals on errors in the engine because
+        // some fuzzers will catch them and report them as false positives.
+        config.signals_based_traps(false);
+        let engine = Engine::new(&config).unwrap();
         let linker = Linker::new(&engine);
         let limiter = StoreLimitsBuilder::new()
             .memory_size(1000 * 0x10000)


### PR DESCRIPTION
The config in the wasmtime oracle for differential fuzzing wasn't being used, this fixes that.

It also disables POSIX signals in the config because some fuzzers (ie. honggfuzz) will catch them and report false positives. A couple examples of these signals are SIGILL for bad instructions, and SIGSEGV when there's an out of bounds load in the webassembly. [More info.](https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.signals_based_traps)