### PR TITLE
Add `prefix-symbols` feature

### DIFF
--- a/crates/c_api/Cargo.toml
+++ b/crates/c_api/Cargo.toml
@@ -26,3 +26,4 @@ doctest = false
 [features]
 default = ["std"]
 std = []
+prefix-symbols = []

--- a/crates/c_api/macro/lib.rs
+++ b/crates/c_api/macro/lib.rs
@@ -22,7 +22,7 @@ pub fn declare_own(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ty = extract_ident(input);
     let name = ty.to_string();
     let delete = quote::format_ident!("{}_delete", &name[..name.len() - 2]);
-    let prefixed_delete = format!("wasmi_{}_delete", &name[..name.len() - 2]);
+    let prefixed_delete = format!("wasmi_{delete}");
     let docs = format!("Deletes the [`{name}`].");
 
     (quote! {
@@ -40,7 +40,7 @@ pub fn declare_ty(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let name = ty.to_string();
     let prefix = &name[..name.len() - 2];
     let copy = quote::format_ident!("{}_copy", &prefix);
-    let prefixed_copy = format!("wasmi_{}_copy", &prefix);
+    let prefixed_copy = format!("wasmi_{copy}");
     let docs = format!(
         "Creates a new [`{name}`] which matches the provided one.\n\n\
         The caller is responsible for deleting the returned value via [`{prefix}_delete`].\n\n\
@@ -66,37 +66,37 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let name = ty.to_string();
     let prefix = &name[..name.len() - 2];
     let same = quote::format_ident!("{}_same", prefix);
-    let same_prefixed = format!("wasmi_{}_same", prefix);
+    let same_prefixed = format!("wasmi_{same}");
     let same_docs = format!(
         "Returns `true` if the given references are pointing to the same [`{name}`].\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let get_host_info = quote::format_ident!("{}_get_host_info", prefix);
-    let get_host_info_prefixed = format!("wasmi_{}_get_host_info", prefix);
+    let get_host_info_prefixed = format!("wasmi_{get_host_info}");
     let get_host_info_docs = format!(
         "Returns the host information of the [`{name}`].\n\n\
         This is not yet supported and always returns `NULL`."
     );
     let set_host_info = quote::format_ident!("{}_set_host_info", prefix);
-    let set_host_info_prefixed = format!("wasmi_{}_set_host_info", prefix);
+    let set_host_info_prefixed = format!("wasmi_{set_host_info}");
     let set_host_info_docs = format!(
         "Sets the host information of the [`{name}`].\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let set_host_info_final = quote::format_ident!("{}_set_host_info_with_finalizer", prefix);
-    let set_host_info_final_prefixed = format!("wasmi_{}_set_host_info_with_finalizer", prefix);
+    let set_host_info_final_prefixed = format!("wasmi_{set_host_info_final}");
     let set_host_info_final_docs = format!(
         "Sets the host information finalizer of the [`{name}`].\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let as_ref = quote::format_ident!("{}_as_ref", prefix);
-    let as_ref_prefixed = format!("wasmi_{}_as_ref", prefix);
+    let as_ref_prefixed = format!("wasmi_{as_ref}");
     let as_ref_docs = format!(
         "Returns the [`{name}`] as mutable reference.\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let as_ref_const = quote::format_ident!("{}_as_ref_const", prefix);
-    let as_ref_const_prefixed = format!("wasmi_{}_as_ref_const", prefix);
+    let as_ref_const_prefixed = format!("wasmi_{as_ref_const}");
     let as_ref_const_docs = format!(
         "Returns the [`{name}`] as immutable reference.\n\n\
         This is not yet supported and aborts the process upon use."

--- a/crates/c_api/macro/lib.rs
+++ b/crates/c_api/macro/lib.rs
@@ -22,13 +22,12 @@ pub fn declare_own(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ty = extract_ident(input);
     let name = ty.to_string();
     let delete = quote::format_ident!("{}_delete", &name[..name.len() - 2]);
-    let prefixed_delete = format!("wasmi_{delete}");
     let docs = format!("Deletes the [`{name}`].");
 
     (quote! {
         #[doc = #docs]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = #prefixed_delete)]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #delete(_: ::alloc::boxed::Box<#ty>) {}
     })
     .into()
@@ -40,7 +39,6 @@ pub fn declare_ty(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let name = ty.to_string();
     let prefix = &name[..name.len() - 2];
     let copy = quote::format_ident!("{}_copy", &prefix);
-    let prefixed_copy = format!("wasmi_{copy}");
     let docs = format!(
         "Creates a new [`{name}`] which matches the provided one.\n\n\
         The caller is responsible for deleting the returned value via [`{prefix}_delete`].\n\n\
@@ -52,7 +50,7 @@ pub fn declare_ty(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #docs]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = #prefixed_copy)]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #copy(src: &#ty) -> ::alloc::boxed::Box<#ty> {
             ::alloc::boxed::Box::new(src.clone())
         }
@@ -66,37 +64,31 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let name = ty.to_string();
     let prefix = &name[..name.len() - 2];
     let same = quote::format_ident!("{}_same", prefix);
-    let same_prefixed = format!("wasmi_{same}");
     let same_docs = format!(
         "Returns `true` if the given references are pointing to the same [`{name}`].\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let get_host_info = quote::format_ident!("{}_get_host_info", prefix);
-    let get_host_info_prefixed = format!("wasmi_{get_host_info}");
     let get_host_info_docs = format!(
         "Returns the host information of the [`{name}`].\n\n\
         This is not yet supported and always returns `NULL`."
     );
     let set_host_info = quote::format_ident!("{}_set_host_info", prefix);
-    let set_host_info_prefixed = format!("wasmi_{set_host_info}");
     let set_host_info_docs = format!(
         "Sets the host information of the [`{name}`].\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let set_host_info_final = quote::format_ident!("{}_set_host_info_with_finalizer", prefix);
-    let set_host_info_final_prefixed = format!("wasmi_{set_host_info_final}");
     let set_host_info_final_docs = format!(
         "Sets the host information finalizer of the [`{name}`].\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let as_ref = quote::format_ident!("{}_as_ref", prefix);
-    let as_ref_prefixed = format!("wasmi_{as_ref}");
     let as_ref_docs = format!(
         "Returns the [`{name}`] as mutable reference.\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let as_ref_const = quote::format_ident!("{}_as_ref_const", prefix);
-    let as_ref_const_prefixed = format!("wasmi_{as_ref_const}");
     let as_ref_const_docs = format!(
         "Returns the [`{name}`] as immutable reference.\n\n\
         This is not yet supported and aborts the process upon use."
@@ -107,7 +99,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #same_docs]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = #same_prefixed)]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #same(_a: &#ty, _b: &#ty) -> ::core::primitive::bool {
             #[cfg(feature = "std")]
             ::std::eprintln!("`{}` is not implemented", ::core::stringify!(#same));
@@ -116,14 +108,14 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #get_host_info_docs]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = #get_host_info_prefixed)]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #get_host_info(a: &#ty) -> *mut ::core::ffi::c_void {
             ::core::ptr::null_mut()
         }
 
         #[doc = #set_host_info_docs]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = #set_host_info_prefixed)]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #set_host_info(a: &#ty, info: *mut ::core::ffi::c_void) {
             #[cfg(feature = "std")]
             ::std::eprintln!("`{}` is not implemented", ::core::stringify!(#set_host_info));
@@ -132,7 +124,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #set_host_info_final_docs]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = #set_host_info_final_prefixed)]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #set_host_info_final(
             a: &#ty,
             info: *mut ::core::ffi::c_void,
@@ -145,7 +137,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #as_ref_docs]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = #as_ref_prefixed)]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #as_ref(a: &#ty) -> ::alloc::boxed::Box<crate::wasm_ref_t> {
             #[cfg(feature = "std")]
             ::std::eprintln!("`{}` is not implemented", ::core::stringify!(#as_ref));
@@ -154,7 +146,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #as_ref_const_docs]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = #as_ref_const_prefixed)]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #as_ref_const(a: &#ty) -> ::alloc::boxed::Box<crate::wasm_ref_t> {
             #[cfg(feature = "std")]
             ::std::eprintln!("`{}` is not implemented", ::core::stringify!(#as_ref_const));
@@ -165,4 +157,40 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         // TODO: implement `wasm_ref_as_#name#_const`
     })
     .into()
+}
+
+#[proc_macro_attribute]
+pub fn prefix_symbol(
+    _attributes: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let mut stream = TokenStream::from(input.clone()).into_iter();
+
+    let mut fn_name = None;
+
+    while let Some(token) = stream.next() {
+        match token {
+            TokenTree::Ident(ref ident) if *ident == "fn" => {
+                if let Some(TokenTree::Ident(ident_name)) = stream.next() {
+                    fn_name = Some(ident_name.to_string());
+                    break;
+                }
+            }
+            _ => continue,
+        }
+    }
+
+    if fn_name.is_none() {
+        panic!("expected a valid Rust function definition, but it does not appear in: {input:?}");
+    }
+
+    let prefixed_fn_name = format!("wasmi_{}", fn_name.unwrap());
+
+    let mut attr: proc_macro::TokenStream = quote! {
+        #[cfg_attr(feature = "prefix-symbols", export_name = #prefixed_fn_name)]
+    }
+    .into();
+    attr.extend(input);
+
+    attr
 }

--- a/crates/c_api/macro/lib.rs
+++ b/crates/c_api/macro/lib.rs
@@ -22,11 +22,13 @@ pub fn declare_own(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ty = extract_ident(input);
     let name = ty.to_string();
     let delete = quote::format_ident!("{}_delete", &name[..name.len() - 2]);
+    let prefixed_delete = format!("wasmi_{}_delete", &name[..name.len() - 2]);
     let docs = format!("Deletes the [`{name}`].");
 
     (quote! {
         #[doc = #docs]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = #prefixed_delete)]
         pub extern "C" fn #delete(_: ::alloc::boxed::Box<#ty>) {}
     })
     .into()
@@ -38,6 +40,7 @@ pub fn declare_ty(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let name = ty.to_string();
     let prefix = &name[..name.len() - 2];
     let copy = quote::format_ident!("{}_copy", &prefix);
+    let prefixed_copy = format!("wasmi_{}_copy", &prefix);
     let docs = format!(
         "Creates a new [`{name}`] which matches the provided one.\n\n\
         The caller is responsible for deleting the returned value via [`{prefix}_delete`].\n\n\
@@ -49,6 +52,7 @@ pub fn declare_ty(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #docs]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = #prefixed_copy)]
         pub extern "C" fn #copy(src: &#ty) -> ::alloc::boxed::Box<#ty> {
             ::alloc::boxed::Box::new(src.clone())
         }
@@ -62,31 +66,37 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let name = ty.to_string();
     let prefix = &name[..name.len() - 2];
     let same = quote::format_ident!("{}_same", prefix);
+    let same_prefixed = format!("wasmi_{}_same", prefix);
     let same_docs = format!(
         "Returns `true` if the given references are pointing to the same [`{name}`].\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let get_host_info = quote::format_ident!("{}_get_host_info", prefix);
+    let get_host_info_prefixed = format!("wasmi_{}_get_host_info", prefix);
     let get_host_info_docs = format!(
         "Returns the host information of the [`{name}`].\n\n\
         This is not yet supported and always returns `NULL`."
     );
     let set_host_info = quote::format_ident!("{}_set_host_info", prefix);
+    let set_host_info_prefixed = format!("wasmi_{}_set_host_info", prefix);
     let set_host_info_docs = format!(
         "Sets the host information of the [`{name}`].\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let set_host_info_final = quote::format_ident!("{}_set_host_info_with_finalizer", prefix);
+    let set_host_info_final_prefixed = format!("wasmi_{}_set_host_info_with_finalizer", prefix);
     let set_host_info_final_docs = format!(
         "Sets the host information finalizer of the [`{name}`].\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let as_ref = quote::format_ident!("{}_as_ref", prefix);
+    let as_ref_prefixed = format!("wasmi_{}_as_ref", prefix);
     let as_ref_docs = format!(
         "Returns the [`{name}`] as mutable reference.\n\n\
         This is not yet supported and aborts the process upon use."
     );
     let as_ref_const = quote::format_ident!("{}_as_ref_const", prefix);
+    let as_ref_const_prefixed = format!("wasmi_{}_as_ref_const", prefix);
     let as_ref_const_docs = format!(
         "Returns the [`{name}`] as immutable reference.\n\n\
         This is not yet supported and aborts the process upon use."
@@ -97,6 +107,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #same_docs]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = #same_prefixed)]
         pub extern "C" fn #same(_a: &#ty, _b: &#ty) -> ::core::primitive::bool {
             #[cfg(feature = "std")]
             ::std::eprintln!("`{}` is not implemented", ::core::stringify!(#same));
@@ -105,12 +116,14 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #get_host_info_docs]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = #get_host_info_prefixed)]
         pub extern "C" fn #get_host_info(a: &#ty) -> *mut ::core::ffi::c_void {
             ::core::ptr::null_mut()
         }
 
         #[doc = #set_host_info_docs]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = #set_host_info_prefixed)]
         pub extern "C" fn #set_host_info(a: &#ty, info: *mut ::core::ffi::c_void) {
             #[cfg(feature = "std")]
             ::std::eprintln!("`{}` is not implemented", ::core::stringify!(#set_host_info));
@@ -119,6 +132,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #set_host_info_final_docs]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = #set_host_info_final_prefixed)]
         pub extern "C" fn #set_host_info_final(
             a: &#ty,
             info: *mut ::core::ffi::c_void,
@@ -131,6 +145,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #as_ref_docs]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = #as_ref_prefixed)]
         pub extern "C" fn #as_ref(a: &#ty) -> ::alloc::boxed::Box<crate::wasm_ref_t> {
             #[cfg(feature = "std")]
             ::std::eprintln!("`{}` is not implemented", ::core::stringify!(#as_ref));
@@ -139,6 +154,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         #[doc = #as_ref_const_docs]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = #as_ref_const_prefixed)]
         pub extern "C" fn #as_ref_const(a: &#ty) -> ::alloc::boxed::Box<crate::wasm_ref_t> {
             #[cfg(feature = "std")]
             ::std::eprintln!("`{}` is not implemented", ::core::stringify!(#as_ref_const));

--- a/crates/c_api/macro/lib.rs
+++ b/crates/c_api/macro/lib.rs
@@ -187,7 +187,7 @@ pub fn prefix_symbol(
     let prefixed_fn_name = format!("wasmi_{}", fn_name.unwrap());
 
     let mut attr: proc_macro::TokenStream = quote! {
-        #[cfg_attr(feature = "prefix-symbols", export_name = #prefixed_fn_name)]
+        #[export_name = #prefixed_fn_name]
     }
     .into();
     attr.extend(input);

--- a/crates/c_api/src/config.rs
+++ b/crates/c_api/src/config.rs
@@ -21,6 +21,7 @@ wasmi_c_api_macros::declare_own!(wasm_config_t);
 ///
 /// [`wasm_engine_new_with_config`]: crate::wasm_engine_new_with_config
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_config_new() -> Box<wasm_config_t> {
     Box::new(wasm_config_t {
         inner: Config::default(),

--- a/crates/c_api/src/engine.rs
+++ b/crates/c_api/src/engine.rs
@@ -19,6 +19,7 @@ wasmi_c_api_macros::declare_own!(wasm_engine_t);
 ///
 /// Wraps [`wasmi::Engine::default`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_engine_new")]
 pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
     Box::new(wasm_engine_t {
         inner: Engine::default(),
@@ -31,6 +32,10 @@ pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
 ///
 /// Wraps [`wasmi::Engine::new`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_engine_new_with_config"
+)]
 pub extern "C" fn wasm_engine_new_with_config(config: Box<wasm_config_t>) -> Box<wasm_engine_t> {
     Box::new(wasm_engine_t {
         inner: Engine::new(&config.inner),

--- a/crates/c_api/src/engine.rs
+++ b/crates/c_api/src/engine.rs
@@ -19,7 +19,7 @@ wasmi_c_api_macros::declare_own!(wasm_engine_t);
 ///
 /// Wraps [`wasmi::Engine::default`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_engine_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
     Box::new(wasm_engine_t {
         inner: Engine::default(),
@@ -32,10 +32,7 @@ pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
 ///
 /// Wraps [`wasmi::Engine::new`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_engine_new_with_config"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_engine_new_with_config(config: Box<wasm_config_t>) -> Box<wasm_engine_t> {
     Box::new(wasm_engine_t {
         inner: Engine::new(&config.inner),

--- a/crates/c_api/src/extern.rs
+++ b/crates/c_api/src/extern.rs
@@ -60,10 +60,7 @@ pub extern "C" fn wasm_extern_as_func(e: &mut wasm_extern_t) -> Option<&mut wasm
 ///
 /// Returns `None` if `e` is not a [`wasm_func_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_extern_as_func_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_func_const(e: &wasm_extern_t) -> Option<&wasm_func_t> {
     wasm_func_t::try_from(e)
 }
@@ -99,10 +96,7 @@ pub extern "C" fn wasm_extern_as_table(e: &mut wasm_extern_t) -> Option<&mut was
 ///
 /// Returns `None` if `e` is not a [`wasm_table_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_extern_as_table_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_table_const(e: &wasm_extern_t) -> Option<&wasm_table_t> {
     wasm_table_t::try_from(e)
 }

--- a/crates/c_api/src/extern.rs
+++ b/crates/c_api/src/extern.rs
@@ -23,7 +23,7 @@ wasmi_c_api_macros::declare_ref!(wasm_extern_t);
 
 /// Returns the [`wasm_extern_kind`] of the [`wasm_extern_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_extern_kind")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
     match e.which {
         Extern::Func(_) => wasm_externkind_t::WASM_EXTERN_FUNC,
@@ -40,7 +40,7 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
 /// It is the caller's responsibility not to alias the [`wasm_extern_t`]
 /// with its underlying, internal [`WasmStoreRef`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_extern_type")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externtype_t> {
     Box::new(wasm_externtype_t::from_extern_type(
         e.which.ty(e.store.context()),
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externt
 ///
 /// Returns `None` if `e` is not a [`wasm_func_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_extern_as_func")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_func(e: &mut wasm_extern_t) -> Option<&mut wasm_func_t> {
     wasm_func_t::try_from_mut(e)
 }
@@ -72,10 +72,7 @@ pub extern "C" fn wasm_extern_as_func_const(e: &wasm_extern_t) -> Option<&wasm_f
 ///
 /// Returns `None` if `e` is not a [`wasm_global_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_extern_as_global"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_global(e: &mut wasm_extern_t) -> Option<&mut wasm_global_t> {
     wasm_global_t::try_from_mut(e)
 }
@@ -84,10 +81,7 @@ pub extern "C" fn wasm_extern_as_global(e: &mut wasm_extern_t) -> Option<&mut wa
 ///
 /// Returns `None` if `e` is not a [`wasm_global_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_extern_as_global_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_global_const(e: &wasm_extern_t) -> Option<&wasm_global_t> {
     wasm_global_t::try_from(e)
 }
@@ -96,7 +90,7 @@ pub extern "C" fn wasm_extern_as_global_const(e: &wasm_extern_t) -> Option<&wasm
 ///
 /// Returns `None` if `e` is not a [`wasm_table_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_extern_as_table")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_table(e: &mut wasm_extern_t) -> Option<&mut wasm_table_t> {
     wasm_table_t::try_from_mut(e)
 }
@@ -117,10 +111,7 @@ pub extern "C" fn wasm_extern_as_table_const(e: &wasm_extern_t) -> Option<&wasm_
 ///
 /// Returns `None` if `e` is not a [`wasm_memory_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_extern_as_memory"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_memory(e: &mut wasm_extern_t) -> Option<&mut wasm_memory_t> {
     wasm_memory_t::try_from_mut(e)
 }
@@ -129,10 +120,7 @@ pub extern "C" fn wasm_extern_as_memory(e: &mut wasm_extern_t) -> Option<&mut wa
 ///
 /// Returns `None` if `e` is not a [`wasm_memory_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_extern_as_memory_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_memory_const(e: &wasm_extern_t) -> Option<&wasm_memory_t> {
     wasm_memory_t::try_from(e)
 }

--- a/crates/c_api/src/extern.rs
+++ b/crates/c_api/src/extern.rs
@@ -23,6 +23,7 @@ wasmi_c_api_macros::declare_ref!(wasm_extern_t);
 
 /// Returns the [`wasm_extern_kind`] of the [`wasm_extern_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_extern_kind")]
 pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
     match e.which {
         Extern::Func(_) => wasm_externkind_t::WASM_EXTERN_FUNC,
@@ -39,6 +40,7 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
 /// It is the caller's responsibility not to alias the [`wasm_extern_t`]
 /// with its underlying, internal [`WasmStoreRef`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_extern_type")]
 pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externtype_t> {
     Box::new(wasm_externtype_t::from_extern_type(
         e.which.ty(e.store.context()),
@@ -49,6 +51,7 @@ pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externt
 ///
 /// Returns `None` if `e` is not a [`wasm_func_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_extern_as_func")]
 pub extern "C" fn wasm_extern_as_func(e: &mut wasm_extern_t) -> Option<&mut wasm_func_t> {
     wasm_func_t::try_from_mut(e)
 }
@@ -57,6 +60,10 @@ pub extern "C" fn wasm_extern_as_func(e: &mut wasm_extern_t) -> Option<&mut wasm
 ///
 /// Returns `None` if `e` is not a [`wasm_func_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_extern_as_func_const"
+)]
 pub extern "C" fn wasm_extern_as_func_const(e: &wasm_extern_t) -> Option<&wasm_func_t> {
     wasm_func_t::try_from(e)
 }
@@ -65,6 +72,10 @@ pub extern "C" fn wasm_extern_as_func_const(e: &wasm_extern_t) -> Option<&wasm_f
 ///
 /// Returns `None` if `e` is not a [`wasm_global_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_extern_as_global"
+)]
 pub extern "C" fn wasm_extern_as_global(e: &mut wasm_extern_t) -> Option<&mut wasm_global_t> {
     wasm_global_t::try_from_mut(e)
 }
@@ -73,6 +84,10 @@ pub extern "C" fn wasm_extern_as_global(e: &mut wasm_extern_t) -> Option<&mut wa
 ///
 /// Returns `None` if `e` is not a [`wasm_global_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_extern_as_global_const"
+)]
 pub extern "C" fn wasm_extern_as_global_const(e: &wasm_extern_t) -> Option<&wasm_global_t> {
     wasm_global_t::try_from(e)
 }
@@ -81,6 +96,7 @@ pub extern "C" fn wasm_extern_as_global_const(e: &wasm_extern_t) -> Option<&wasm
 ///
 /// Returns `None` if `e` is not a [`wasm_table_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_extern_as_table")]
 pub extern "C" fn wasm_extern_as_table(e: &mut wasm_extern_t) -> Option<&mut wasm_table_t> {
     wasm_table_t::try_from_mut(e)
 }
@@ -89,6 +105,10 @@ pub extern "C" fn wasm_extern_as_table(e: &mut wasm_extern_t) -> Option<&mut was
 ///
 /// Returns `None` if `e` is not a [`wasm_table_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_extern_as_table_const"
+)]
 pub extern "C" fn wasm_extern_as_table_const(e: &wasm_extern_t) -> Option<&wasm_table_t> {
     wasm_table_t::try_from(e)
 }
@@ -97,6 +117,10 @@ pub extern "C" fn wasm_extern_as_table_const(e: &wasm_extern_t) -> Option<&wasm_
 ///
 /// Returns `None` if `e` is not a [`wasm_memory_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_extern_as_memory"
+)]
 pub extern "C" fn wasm_extern_as_memory(e: &mut wasm_extern_t) -> Option<&mut wasm_memory_t> {
     wasm_memory_t::try_from_mut(e)
 }
@@ -105,6 +129,10 @@ pub extern "C" fn wasm_extern_as_memory(e: &mut wasm_extern_t) -> Option<&mut wa
 ///
 /// Returns `None` if `e` is not a [`wasm_memory_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_extern_as_memory_const"
+)]
 pub extern "C" fn wasm_extern_as_memory_const(e: &wasm_extern_t) -> Option<&wasm_memory_t> {
     wasm_memory_t::try_from(e)
 }

--- a/crates/c_api/src/foreign.rs
+++ b/crates/c_api/src/foreign.rs
@@ -13,6 +13,7 @@ wasmi_c_api_macros::declare_ref!(wasm_foreign_t);
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_foreign_new")]
 pub extern "C" fn wasm_foreign_new(_store: &crate::wasm_store_t) -> Box<wasm_foreign_t> {
     unimplemented!("wasm_foreign_new")
 }

--- a/crates/c_api/src/foreign.rs
+++ b/crates/c_api/src/foreign.rs
@@ -13,7 +13,7 @@ wasmi_c_api_macros::declare_ref!(wasm_foreign_t);
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_foreign_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_foreign_new(_store: &crate::wasm_store_t) -> Box<wasm_foreign_t> {
     unimplemented!("wasm_foreign_new")
 }

--- a/crates/c_api/src/frame.rs
+++ b/crates/c_api/src/frame.rs
@@ -70,7 +70,7 @@ pub extern "C" fn wasm_frame_module_offset(_frame: &wasm_frame_t<'_>) -> usize {
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_frame_copy<'a>")]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_frame_copy")]
 pub extern "C" fn wasm_frame_copy<'a>(_frame: &wasm_frame_t<'a>) -> Box<wasm_frame_t<'a>> {
     unimplemented!("wasm_frame_copy")
 }

--- a/crates/c_api/src/frame.rs
+++ b/crates/c_api/src/frame.rs
@@ -17,10 +17,7 @@ wasmi_c_api_macros::declare_own!(wasm_frame_t);
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_frame_func_index"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_frame_func_index(_frame: &wasm_frame_t<'_>) -> u32 {
     unimplemented!("wasm_frame_func_index")
 }
@@ -45,7 +42,7 @@ pub extern "C" fn wasm_frame_func_offset(_frame: &wasm_frame_t<'_>) -> usize {
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_frame_instance")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_frame_instance(_arg1: *const wasm_frame_t<'_>) -> *mut wasm_instance_t {
     unimplemented!("wasm_frame_instance")
 }
@@ -56,10 +53,7 @@ pub extern "C" fn wasm_frame_instance(_arg1: *const wasm_frame_t<'_>) -> *mut wa
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_frame_module_offset"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_frame_module_offset(_frame: &wasm_frame_t<'_>) -> usize {
     unimplemented!("wasm_frame_module_offset")
 }
@@ -70,7 +64,7 @@ pub extern "C" fn wasm_frame_module_offset(_frame: &wasm_frame_t<'_>) -> usize {
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_frame_copy")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_frame_copy<'a>(_frame: &wasm_frame_t<'a>) -> Box<wasm_frame_t<'a>> {
     unimplemented!("wasm_frame_copy")
 }

--- a/crates/c_api/src/frame.rs
+++ b/crates/c_api/src/frame.rs
@@ -17,6 +17,10 @@ wasmi_c_api_macros::declare_own!(wasm_frame_t);
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_frame_func_index"
+)]
 pub extern "C" fn wasm_frame_func_index(_frame: &wasm_frame_t<'_>) -> u32 {
     unimplemented!("wasm_frame_func_index")
 }
@@ -27,6 +31,10 @@ pub extern "C" fn wasm_frame_func_index(_frame: &wasm_frame_t<'_>) -> u32 {
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_frame_func_offset"
+)]
 pub extern "C" fn wasm_frame_func_offset(_frame: &wasm_frame_t<'_>) -> usize {
     unimplemented!("wasm_frame_func_offset")
 }
@@ -37,6 +45,7 @@ pub extern "C" fn wasm_frame_func_offset(_frame: &wasm_frame_t<'_>) -> usize {
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_frame_instance")]
 pub extern "C" fn wasm_frame_instance(_arg1: *const wasm_frame_t<'_>) -> *mut wasm_instance_t {
     unimplemented!("wasm_frame_instance")
 }
@@ -47,6 +56,10 @@ pub extern "C" fn wasm_frame_instance(_arg1: *const wasm_frame_t<'_>) -> *mut wa
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_frame_module_offset"
+)]
 pub extern "C" fn wasm_frame_module_offset(_frame: &wasm_frame_t<'_>) -> usize {
     unimplemented!("wasm_frame_module_offset")
 }
@@ -57,6 +70,7 @@ pub extern "C" fn wasm_frame_module_offset(_frame: &wasm_frame_t<'_>) -> usize {
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_frame_copy<'a>")]
 pub extern "C" fn wasm_frame_copy<'a>(_frame: &wasm_frame_t<'a>) -> Box<wasm_frame_t<'a>> {
     unimplemented!("wasm_frame_copy")
 }

--- a/crates/c_api/src/frame.rs
+++ b/crates/c_api/src/frame.rs
@@ -28,10 +28,7 @@ pub extern "C" fn wasm_frame_func_index(_frame: &wasm_frame_t<'_>) -> u32 {
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_frame_func_offset"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_frame_func_offset(_frame: &wasm_frame_t<'_>) -> usize {
     unimplemented!("wasm_frame_func_offset")
 }

--- a/crates/c_api/src/func.rs
+++ b/crates/c_api/src/func.rs
@@ -120,6 +120,7 @@ unsafe fn create_function(
 /// It is the caller's responsibility not to alias the [`wasm_functype_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_func_new")]
 pub unsafe extern "C" fn wasm_func_new(
     store: &mut wasm_store_t,
     ty: &wasm_functype_t,
@@ -141,6 +142,10 @@ pub unsafe extern "C" fn wasm_func_new(
 /// It is the caller's responsibility not to alias the [`wasm_functype_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_func_new_with_env"
+)]
 pub unsafe extern "C" fn wasm_func_new_with_env(
     store: &mut wasm_store_t,
     ty: &wasm_functype_t,
@@ -184,6 +189,7 @@ fn prepare_params_and_results(
 /// It is the caller's responsibility not to alias the [`wasm_func_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_func_call")]
 pub unsafe extern "C" fn wasm_func_call(
     func: &mut wasm_func_t,
     params: *const wasm_val_vec_t,
@@ -248,6 +254,7 @@ fn error_from_panic(panic: Box<dyn Any + Send>) -> Error {
 /// It is the caller's responsibility not to alias the [`wasm_func_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_func_type")]
 pub unsafe extern "C" fn wasm_func_type(f: &wasm_func_t) -> Box<wasm_functype_t> {
     Box::new(wasm_functype_t::new(f.func().ty(f.inner.store.context())))
 }
@@ -263,6 +270,10 @@ pub unsafe extern "C" fn wasm_func_type(f: &wasm_func_t) -> Box<wasm_functype_t>
 ///
 /// [`FuncType::params`]: wasmi::FuncType::params
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_func_param_arity"
+)]
 pub unsafe extern "C" fn wasm_func_param_arity(f: &wasm_func_t) -> usize {
     f.func().ty(f.inner.store.context()).params().len()
 }
@@ -278,18 +289,27 @@ pub unsafe extern "C" fn wasm_func_param_arity(f: &wasm_func_t) -> usize {
 ///
 /// [`FuncType::results`]: wasmi::FuncType::results
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_func_result_arity"
+)]
 pub unsafe extern "C" fn wasm_func_result_arity(f: &wasm_func_t) -> usize {
     f.func().ty(f.inner.store.context()).results().len()
 }
 
 /// Returns the [`wasm_func_t`] as mutable reference to [`wasm_extern_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_func_as_extern")]
 pub extern "C" fn wasm_func_as_extern(f: &mut wasm_func_t) -> &mut wasm_extern_t {
     &mut f.inner
 }
 
 /// Returns the [`wasm_func_t`] as shared reference to [`wasm_extern_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_func_as_extern_const"
+)]
 pub extern "C" fn wasm_func_as_extern_const(f: &wasm_func_t) -> &wasm_extern_t {
     &f.inner
 }

--- a/crates/c_api/src/func.rs
+++ b/crates/c_api/src/func.rs
@@ -142,10 +142,7 @@ pub unsafe extern "C" fn wasm_func_new(
 /// It is the caller's responsibility not to alias the [`wasm_functype_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_func_new_with_env"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_new_with_env(
     store: &mut wasm_store_t,
     ty: &wasm_functype_t,

--- a/crates/c_api/src/func.rs
+++ b/crates/c_api/src/func.rs
@@ -120,7 +120,7 @@ unsafe fn create_function(
 /// It is the caller's responsibility not to alias the [`wasm_functype_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_func_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_new(
     store: &mut wasm_store_t,
     ty: &wasm_functype_t,
@@ -189,7 +189,7 @@ fn prepare_params_and_results(
 /// It is the caller's responsibility not to alias the [`wasm_func_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_func_call")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_call(
     func: &mut wasm_func_t,
     params: *const wasm_val_vec_t,
@@ -254,7 +254,7 @@ fn error_from_panic(panic: Box<dyn Any + Send>) -> Error {
 /// It is the caller's responsibility not to alias the [`wasm_func_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_func_type")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_type(f: &wasm_func_t) -> Box<wasm_functype_t> {
     Box::new(wasm_functype_t::new(f.func().ty(f.inner.store.context())))
 }
@@ -270,10 +270,7 @@ pub unsafe extern "C" fn wasm_func_type(f: &wasm_func_t) -> Box<wasm_functype_t>
 ///
 /// [`FuncType::params`]: wasmi::FuncType::params
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_func_param_arity"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_param_arity(f: &wasm_func_t) -> usize {
     f.func().ty(f.inner.store.context()).params().len()
 }
@@ -289,27 +286,21 @@ pub unsafe extern "C" fn wasm_func_param_arity(f: &wasm_func_t) -> usize {
 ///
 /// [`FuncType::results`]: wasmi::FuncType::results
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_func_result_arity"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_result_arity(f: &wasm_func_t) -> usize {
     f.func().ty(f.inner.store.context()).results().len()
 }
 
 /// Returns the [`wasm_func_t`] as mutable reference to [`wasm_extern_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_func_as_extern")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_func_as_extern(f: &mut wasm_func_t) -> &mut wasm_extern_t {
     &mut f.inner
 }
 
 /// Returns the [`wasm_func_t`] as shared reference to [`wasm_extern_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_func_as_extern_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_func_as_extern_const(f: &wasm_func_t) -> &wasm_extern_t {
     &f.inner
 }

--- a/crates/c_api/src/global.rs
+++ b/crates/c_api/src/global.rs
@@ -49,6 +49,7 @@ impl wasm_global_t {
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_global_new")]
 pub unsafe extern "C" fn wasm_global_new(
     store: &mut wasm_store_t,
     ty: &wasm_globaltype_t,
@@ -89,6 +90,7 @@ pub extern "C" fn wasm_global_as_extern_const(g: &wasm_global_t) -> &wasm_extern
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_global_type")]
 pub unsafe extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globaltype_t> {
     let globaltype = g.global().ty(g.inner.store.context());
     Box::new(wasm_globaltype_t::new(globaltype))
@@ -103,6 +105,7 @@ pub unsafe extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globalt
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_global_get")]
 pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeUninit<wasm_val_t>) {
     let global = g.global();
     crate::initialize(
@@ -121,6 +124,7 @@ pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeU
 /// - It is the caller's responsibility not to alias the [`wasm_global_t`]
 ///   with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_global_set")]
 pub unsafe extern "C" fn wasm_global_set(g: &mut wasm_global_t, val: &wasm_val_t) {
     let global = g.global();
     drop(global.set(g.inner.store.context_mut(), val.to_val()));

--- a/crates/c_api/src/global.rs
+++ b/crates/c_api/src/global.rs
@@ -49,7 +49,7 @@ impl wasm_global_t {
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_global_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_global_new(
     store: &mut wasm_store_t,
     ty: &wasm_globaltype_t,
@@ -71,12 +71,14 @@ pub unsafe extern "C" fn wasm_global_new(
 
 /// Returns the [`wasm_global_t`] as mutable reference to [`wasm_extern_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_global_as_extern(g: &mut wasm_global_t) -> &mut wasm_extern_t {
     &mut g.inner
 }
 
 /// Returns the [`wasm_global_t`] as shared reference to [`wasm_extern_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_global_as_extern_const(g: &wasm_global_t) -> &wasm_extern_t {
     &g.inner
 }
@@ -90,7 +92,7 @@ pub extern "C" fn wasm_global_as_extern_const(g: &wasm_global_t) -> &wasm_extern
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_global_type")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globaltype_t> {
     let globaltype = g.global().ty(g.inner.store.context());
     Box::new(wasm_globaltype_t::new(globaltype))
@@ -105,7 +107,7 @@ pub unsafe extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globalt
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_global_get")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeUninit<wasm_val_t>) {
     let global = g.global();
     crate::initialize(
@@ -124,7 +126,7 @@ pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeU
 /// - It is the caller's responsibility not to alias the [`wasm_global_t`]
 ///   with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_global_set")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_global_set(g: &mut wasm_global_t, val: &wasm_val_t) {
     let global = g.global();
     drop(global.set(g.inner.store.context_mut(), val.to_val()));

--- a/crates/c_api/src/instance.rs
+++ b/crates/c_api/src/instance.rs
@@ -44,7 +44,7 @@ impl wasm_instance_t {
 ///
 /// [Wasm core specification]: https://webassembly.github.io/spec/core/exec/modules.html#exec-instantiation
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_instance_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_instance_new(
     store: &mut wasm_store_t,
     wasm_module: &wasm_module_t,
@@ -81,10 +81,7 @@ pub unsafe extern "C" fn wasm_instance_new(
 /// It is the caller's responsibility not to alias the [`wasm_instance_t`]
 /// with its underlying, internal [`WasmStoreRef`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_instance_exports"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_instance_exports(
     instance: &mut wasm_instance_t,
     out: &mut wasm_extern_vec_t,

--- a/crates/c_api/src/instance.rs
+++ b/crates/c_api/src/instance.rs
@@ -44,6 +44,7 @@ impl wasm_instance_t {
 ///
 /// [Wasm core specification]: https://webassembly.github.io/spec/core/exec/modules.html#exec-instantiation
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_instance_new")]
 pub unsafe extern "C" fn wasm_instance_new(
     store: &mut wasm_store_t,
     wasm_module: &wasm_module_t,
@@ -80,6 +81,10 @@ pub unsafe extern "C" fn wasm_instance_new(
 /// It is the caller's responsibility not to alias the [`wasm_instance_t`]
 /// with its underlying, internal [`WasmStoreRef`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_instance_exports"
+)]
 pub unsafe extern "C" fn wasm_instance_exports(
     instance: &mut wasm_instance_t,
     out: &mut wasm_extern_vec_t,

--- a/crates/c_api/src/lib.rs
+++ b/crates/c_api/src/lib.rs
@@ -1,6 +1,60 @@
 //! Implements C-API support for the Wasmi WebAssembly interpreter.
 //!
 //! Namely implements the Wasm C-API proposal found here: <https://github.com/WebAssembly/wasm-c-api/>
+//!
+//! # Crate features
+//!
+//! ## The `prefix-symbols` feature
+//! Adds a `wasmi_` prefix to all the public symbols. This means that, for example, the function `wasm_store_delete`
+//! will be given the public (not mangled) symbol `wasmi_wasm_store_delete`.
+//!
+//! ### Rationale
+//! This feature allows users that need to separate multiple C-API implementers to segregate wasmi's C-API symbols,
+//! avoiding symbol clashes.
+//!
+//! ### Note
+//! It's important to notice that when the `prefix-symbols` feature is enabled, the symbols declared in the C-API header
+//! are not given the prefix, introducing - by design, in order to keep the C-API header same as the actual
+//! specification - an asymmetry. For example, Rust users that want to enable this feature, can use `bindgen` to
+//! generate correct C-to-Rust interop code:
+//!
+//! ```ignore
+//!    #[derive(Debug)]
+//!    struct WasmiRenamer {}
+//!
+//!    impl ParseCallbacks for WasmiRenamer {
+//!        /// This function will run for every extern variable and function. The returned value determines
+//!        /// the link name in the bindings.
+//!        fn generated_link_name_override(
+//!            &self,
+//!            item_info: bindgen::callbacks::ItemInfo<'_>,
+//!        ) -> Option<String> {
+//!            if item_info.name.starts_with("wasm") {
+//!                let new_name = if cfg!(any(target_os = "macos", target_os = "ios")) {
+//!                    format!("_wasmi_{}", item_info.name)
+//!                } else {
+//!                    format!("wasmi_{}", item_info.name)
+//!                };
+//!
+//!                Some(new_name)
+//!            } else {
+//!                None
+//!            }
+//!        }
+//!    }
+//!
+//!    let bindings = bindgen::Builder::default()
+//!        .header(
+//!            PathBuf::from(std::env::var("DEP_WASMI_C_API_INCLUDE").unwrap())
+//!                .join("wasm.h")
+//!                .to_string_lossy(),
+//!        )
+//!        .derive_default(true)
+//!        .derive_debug(true)
+//!        .parse_callbacks(Box::new(WasmiRenamer {}))
+//!        .generate()
+//!        .expect("Unable to generate bindings for `wasmi`!");
+//! ```
 
 #![no_std]
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]

--- a/crates/c_api/src/memory.rs
+++ b/crates/c_api/src/memory.rs
@@ -50,6 +50,7 @@ impl wasm_memory_t {
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memory_new")]
 pub unsafe extern "C" fn wasm_memory_new(
     store: &mut wasm_store_t,
     mt: &wasm_memorytype_t,
@@ -65,12 +66,20 @@ pub unsafe extern "C" fn wasm_memory_new(
 
 /// Returns the [`wasm_memory_t`] as mutable reference to [`wasm_extern_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_memory_as_extern"
+)]
 pub extern "C" fn wasm_memory_as_extern(m: &mut wasm_memory_t) -> &mut wasm_extern_t {
     &mut m.inner
 }
 
 /// Returns the [`wasm_memory_t`] as shared reference to [`wasm_extern_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_memory_as_extern_const"
+)]
 pub extern "C" fn wasm_memory_as_extern_const(m: &wasm_memory_t) -> &wasm_extern_t {
     &m.inner
 }
@@ -84,6 +93,7 @@ pub extern "C" fn wasm_memory_as_extern_const(m: &wasm_memory_t) -> &wasm_extern
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memory_type")]
 pub unsafe extern "C" fn wasm_memory_type(m: &wasm_memory_t) -> Box<wasm_memorytype_t> {
     let ty = m.memory().ty(m.inner.store.context());
     Box::new(wasm_memorytype_t::new(ty))
@@ -98,6 +108,7 @@ pub unsafe extern "C" fn wasm_memory_type(m: &wasm_memory_t) -> Box<wasm_memoryt
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memory_data")]
 pub unsafe extern "C" fn wasm_memory_data(m: &wasm_memory_t) -> *mut u8 {
     m.memory().data_ptr(m.inner.store.context())
 }
@@ -111,6 +122,10 @@ pub unsafe extern "C" fn wasm_memory_data(m: &wasm_memory_t) -> *mut u8 {
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_memory_data_size"
+)]
 pub unsafe extern "C" fn wasm_memory_data_size(m: &wasm_memory_t) -> usize {
     m.memory().data_size(m.inner.store.context())
 }
@@ -124,6 +139,7 @@ pub unsafe extern "C" fn wasm_memory_data_size(m: &wasm_memory_t) -> usize {
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memory_size")]
 pub unsafe extern "C" fn wasm_memory_size(m: &wasm_memory_t) -> wasm_memory_pages_t {
     m.memory().size(m.inner.store.context())
 }
@@ -139,6 +155,7 @@ pub unsafe extern "C" fn wasm_memory_size(m: &wasm_memory_t) -> wasm_memory_page
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memory_grow")]
 pub unsafe extern "C" fn wasm_memory_grow(
     m: &mut wasm_memory_t,
     delta: wasm_memory_pages_t,

--- a/crates/c_api/src/memory.rs
+++ b/crates/c_api/src/memory.rs
@@ -50,7 +50,7 @@ impl wasm_memory_t {
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memory_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_new(
     store: &mut wasm_store_t,
     mt: &wasm_memorytype_t,
@@ -66,20 +66,14 @@ pub unsafe extern "C" fn wasm_memory_new(
 
 /// Returns the [`wasm_memory_t`] as mutable reference to [`wasm_extern_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_memory_as_extern"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memory_as_extern(m: &mut wasm_memory_t) -> &mut wasm_extern_t {
     &mut m.inner
 }
 
 /// Returns the [`wasm_memory_t`] as shared reference to [`wasm_extern_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_memory_as_extern_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memory_as_extern_const(m: &wasm_memory_t) -> &wasm_extern_t {
     &m.inner
 }
@@ -93,7 +87,7 @@ pub extern "C" fn wasm_memory_as_extern_const(m: &wasm_memory_t) -> &wasm_extern
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memory_type")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_type(m: &wasm_memory_t) -> Box<wasm_memorytype_t> {
     let ty = m.memory().ty(m.inner.store.context());
     Box::new(wasm_memorytype_t::new(ty))
@@ -108,7 +102,7 @@ pub unsafe extern "C" fn wasm_memory_type(m: &wasm_memory_t) -> Box<wasm_memoryt
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memory_data")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_data(m: &wasm_memory_t) -> *mut u8 {
     m.memory().data_ptr(m.inner.store.context())
 }
@@ -122,10 +116,7 @@ pub unsafe extern "C" fn wasm_memory_data(m: &wasm_memory_t) -> *mut u8 {
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_memory_data_size"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_data_size(m: &wasm_memory_t) -> usize {
     m.memory().data_size(m.inner.store.context())
 }
@@ -139,7 +130,7 @@ pub unsafe extern "C" fn wasm_memory_data_size(m: &wasm_memory_t) -> usize {
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memory_size")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_size(m: &wasm_memory_t) -> wasm_memory_pages_t {
     m.memory().size(m.inner.store.context())
 }
@@ -155,7 +146,7 @@ pub unsafe extern "C" fn wasm_memory_size(m: &wasm_memory_t) -> wasm_memory_page
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memory_grow")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_grow(
     m: &mut wasm_memory_t,
     delta: wasm_memory_pages_t,

--- a/crates/c_api/src/module.rs
+++ b/crates/c_api/src/module.rs
@@ -50,7 +50,7 @@ wasmi_c_api_macros::declare_own!(wasm_shared_module_t);
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_module_new(
     store: &mut wasm_store_t,
     binary: &wasm_byte_vec_t,
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn wasm_module_new(
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_validate")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_module_validate(
     store: &mut wasm_store_t,
     binary: &wasm_byte_vec_t,
@@ -98,7 +98,7 @@ fn fill_exports(module: &Module, out: &mut wasm_exporttype_vec_t) {
 ///
 /// Wraps [`Module::exports`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_exports")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_module_exports(module: &wasm_module_t, out: &mut wasm_exporttype_vec_t) {
     fill_exports(&module.inner, out);
 }
@@ -124,7 +124,7 @@ fn fill_imports(module: &Module, out: &mut wasm_importtype_vec_t) {
 ///
 /// Wraps [`Module::imports`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_imports")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_importtype_vec_t) {
     fill_imports(&module.inner, out);
 }
@@ -136,7 +136,7 @@ pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_imp
 ///
 /// Wraps [`Module::clone`] (kinda).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_share")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_module_share(module: &wasm_module_t) -> Box<wasm_shared_module_t> {
     Box::new(wasm_shared_module_t {
         inner: module.inner.clone(),
@@ -154,7 +154,7 @@ pub extern "C" fn wasm_module_share(module: &wasm_module_t) -> Box<wasm_shared_m
 ///
 /// Wraps [`Module::clone`] (kinda).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_obtain")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_module_obtain(
     store: &mut wasm_store_t,
     shared_module: &wasm_shared_module_t,
@@ -175,10 +175,7 @@ pub unsafe extern "C" fn wasm_module_obtain(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_module_serialize"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_module_serialize(_module: &wasm_module_t, _ret: &mut wasm_byte_vec_t) {
     unimplemented!("wasm_module_serialize")
 }
@@ -198,10 +195,7 @@ pub extern "C" fn wasm_module_serialize(_module: &wasm_module_t, _ret: &mut wasm
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_module_deserialize"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_module_deserialize(
     _store: &mut wasm_store_t,
     _binary: &wasm_byte_vec_t,

--- a/crates/c_api/src/module.rs
+++ b/crates/c_api/src/module.rs
@@ -50,6 +50,7 @@ wasmi_c_api_macros::declare_own!(wasm_shared_module_t);
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_new")]
 pub unsafe extern "C" fn wasm_module_new(
     store: &mut wasm_store_t,
     binary: &wasm_byte_vec_t,
@@ -69,6 +70,7 @@ pub unsafe extern "C" fn wasm_module_new(
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_validate")]
 pub unsafe extern "C" fn wasm_module_validate(
     store: &mut wasm_store_t,
     binary: &wasm_byte_vec_t,
@@ -96,6 +98,7 @@ fn fill_exports(module: &Module, out: &mut wasm_exporttype_vec_t) {
 ///
 /// Wraps [`Module::exports`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_exports")]
 pub extern "C" fn wasm_module_exports(module: &wasm_module_t, out: &mut wasm_exporttype_vec_t) {
     fill_exports(&module.inner, out);
 }
@@ -121,6 +124,7 @@ fn fill_imports(module: &Module, out: &mut wasm_importtype_vec_t) {
 ///
 /// Wraps [`Module::imports`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_imports")]
 pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_importtype_vec_t) {
     fill_imports(&module.inner, out);
 }
@@ -132,6 +136,7 @@ pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_imp
 ///
 /// Wraps [`Module::clone`] (kinda).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_share")]
 pub extern "C" fn wasm_module_share(module: &wasm_module_t) -> Box<wasm_shared_module_t> {
     Box::new(wasm_shared_module_t {
         inner: module.inner.clone(),
@@ -149,6 +154,7 @@ pub extern "C" fn wasm_module_share(module: &wasm_module_t) -> Box<wasm_shared_m
 ///
 /// Wraps [`Module::clone`] (kinda).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_module_obtain")]
 pub unsafe extern "C" fn wasm_module_obtain(
     store: &mut wasm_store_t,
     shared_module: &wasm_shared_module_t,
@@ -169,6 +175,10 @@ pub unsafe extern "C" fn wasm_module_obtain(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_module_serialize"
+)]
 pub extern "C" fn wasm_module_serialize(_module: &wasm_module_t, _ret: &mut wasm_byte_vec_t) {
     unimplemented!("wasm_module_serialize")
 }
@@ -188,6 +198,10 @@ pub extern "C" fn wasm_module_serialize(_module: &wasm_module_t, _ret: &mut wasm
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_module_deserialize"
+)]
 pub unsafe extern "C" fn wasm_module_deserialize(
     _store: &mut wasm_store_t,
     _binary: &wasm_byte_vec_t,

--- a/crates/c_api/src/ref.rs
+++ b/crates/c_api/src/ref.rs
@@ -89,6 +89,7 @@ pub(crate) fn ref_to_val(r: &wasm_ref_t) -> Val {
 ///
 /// Returns `None` if `r` was `None`.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_copy")]
 pub extern "C" fn wasm_ref_copy(r: Option<&wasm_ref_t>) -> Option<Box<wasm_ref_t>> {
     r.map(|r| Box::new(r.clone()))
 }
@@ -99,6 +100,7 @@ pub extern "C" fn wasm_ref_copy(r: Option<&wasm_ref_t>) -> Option<Box<wasm_ref_t
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_same")]
 pub extern "C" fn wasm_ref_same(_a: Option<&wasm_ref_t>, _b: Option<&wasm_ref_t>) -> bool {
     // In Wasmi we require a store to determine whether these are the same
     // reference or not and therefore we cannot support this Wasm C API.
@@ -111,6 +113,10 @@ pub extern "C" fn wasm_ref_same(_a: Option<&wasm_ref_t>, _b: Option<&wasm_ref_t>
 ///
 /// This API is unsupported and always returns a `null` pointer.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_get_host_info"
+)]
 pub extern "C" fn wasm_ref_get_host_info(_ref: Option<&wasm_ref_t>) -> *mut c_void {
     ptr::null_mut()
 }
@@ -121,6 +127,10 @@ pub extern "C" fn wasm_ref_get_host_info(_ref: Option<&wasm_ref_t>) -> *mut c_vo
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_set_host_info"
+)]
 pub extern "C" fn wasm_ref_set_host_info(_ref: Option<&wasm_ref_t>, _info: *mut c_void) {
     unimplemented!("wasm_ref_set_host_info")
 }
@@ -133,6 +143,10 @@ pub extern "C" fn wasm_ref_set_host_info(_ref: Option<&wasm_ref_t>, _info: *mut 
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_set_host_info_with_finalizer"
+)]
 pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
     _ref: Option<&wasm_ref_t>,
     _info: *mut c_void,
@@ -147,6 +161,7 @@ pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_extern")]
 pub extern "C" fn wasm_ref_as_extern(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_extern_t> {
     unimplemented!("wasm_ref_as_extern")
 }
@@ -157,6 +172,10 @@ pub extern "C" fn wasm_ref_as_extern(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_as_extern_const"
+)]
 pub extern "C" fn wasm_ref_as_extern_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_extern_t> {
     unimplemented!("wasm_ref_as_extern_const")
 }
@@ -167,6 +186,7 @@ pub extern "C" fn wasm_ref_as_extern_const(_ref: Option<&wasm_ref_t>) -> Option<
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_foreign")]
 pub extern "C" fn wasm_ref_as_foreign(
     _ref: Option<&mut wasm_ref_t>,
 ) -> Option<&mut wasm_foreign_t> {
@@ -179,6 +199,10 @@ pub extern "C" fn wasm_ref_as_foreign(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_as_foreign_const"
+)]
 pub extern "C" fn wasm_ref_as_foreign_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_foreign_t> {
@@ -191,6 +215,7 @@ pub extern "C" fn wasm_ref_as_foreign_const(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_func")]
 pub extern "C" fn wasm_ref_as_func(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_func_t> {
     unimplemented!("wasm_ref_as_func")
 }
@@ -201,6 +226,10 @@ pub extern "C" fn wasm_ref_as_func(_ref: Option<&mut wasm_ref_t>) -> Option<&mut
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_as_func_const"
+)]
 pub extern "C" fn wasm_ref_as_func_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_func_t> {
     unimplemented!("wasm_ref_as_func_const")
 }
@@ -211,6 +240,7 @@ pub extern "C" fn wasm_ref_as_func_const(_ref: Option<&wasm_ref_t>) -> Option<&w
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_global")]
 pub extern "C" fn wasm_ref_as_global(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_global_t> {
     unimplemented!("wasm_ref_as_global")
 }
@@ -221,6 +251,10 @@ pub extern "C" fn wasm_ref_as_global(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_as_global_const"
+)]
 pub extern "C" fn wasm_ref_as_global_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_global_t> {
     unimplemented!("wasm_ref_as_global_const")
 }
@@ -231,6 +265,7 @@ pub extern "C" fn wasm_ref_as_global_const(_ref: Option<&wasm_ref_t>) -> Option<
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_instance")]
 pub extern "C" fn wasm_ref_as_instance(
     _ref: Option<&mut wasm_ref_t>,
 ) -> Option<&mut wasm_instance_t> {
@@ -243,6 +278,10 @@ pub extern "C" fn wasm_ref_as_instance(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_as_instance_const"
+)]
 pub extern "C" fn wasm_ref_as_instance_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&wasm_instance_t> {
@@ -255,6 +294,7 @@ pub extern "C" fn wasm_ref_as_instance_const(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_memory")]
 pub extern "C" fn wasm_ref_as_memory(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_memory_t> {
     unimplemented!("wasm_ref_as_memory")
 }
@@ -265,6 +305,10 @@ pub extern "C" fn wasm_ref_as_memory(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_as_memory_const"
+)]
 pub extern "C" fn wasm_ref_as_memory_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_memory_t> {
     unimplemented!("wasm_ref_as_memory_const")
 }
@@ -275,6 +319,7 @@ pub extern "C" fn wasm_ref_as_memory_const(_ref: Option<&wasm_ref_t>) -> Option<
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_module")]
 pub extern "C" fn wasm_ref_as_module(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_module_t> {
     unimplemented!("wasm_ref_as_module")
 }
@@ -285,6 +330,10 @@ pub extern "C" fn wasm_ref_as_module(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_as_module_const"
+)]
 pub extern "C" fn wasm_ref_as_module_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_module_t> {
     unimplemented!("wasm_ref_as_module_const")
 }
@@ -295,6 +344,7 @@ pub extern "C" fn wasm_ref_as_module_const(_ref: Option<&wasm_ref_t>) -> Option<
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_table")]
 pub extern "C" fn wasm_ref_as_table(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_table_t> {
     unimplemented!("wasm_ref_as_table")
 }
@@ -305,6 +355,10 @@ pub extern "C" fn wasm_ref_as_table(_ref: Option<&mut wasm_ref_t>) -> Option<&mu
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_as_table_const"
+)]
 pub extern "C" fn wasm_ref_as_table_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_table_t> {
     unimplemented!("wasm_ref_as_table_const")
 }
@@ -315,6 +369,7 @@ pub extern "C" fn wasm_ref_as_table_const(_ref: Option<&wasm_ref_t>) -> Option<&
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_trap")]
 pub extern "C" fn wasm_ref_as_trap(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_trap_t> {
     unimplemented!("wasm_ref_as_trap")
 }
@@ -325,6 +380,10 @@ pub extern "C" fn wasm_ref_as_trap(_ref: Option<&mut wasm_ref_t>) -> Option<&mut
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_ref_as_trap_const"
+)]
 pub extern "C" fn wasm_ref_as_trap_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_trap_t> {
     unimplemented!("wasm_ref_as_trap_const")
 }

--- a/crates/c_api/src/ref.rs
+++ b/crates/c_api/src/ref.rs
@@ -89,7 +89,7 @@ pub(crate) fn ref_to_val(r: &wasm_ref_t) -> Val {
 ///
 /// Returns `None` if `r` was `None`.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_copy")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_copy(r: Option<&wasm_ref_t>) -> Option<Box<wasm_ref_t>> {
     r.map(|r| Box::new(r.clone()))
 }
@@ -100,7 +100,7 @@ pub extern "C" fn wasm_ref_copy(r: Option<&wasm_ref_t>) -> Option<Box<wasm_ref_t
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_same")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_same(_a: Option<&wasm_ref_t>, _b: Option<&wasm_ref_t>) -> bool {
     // In Wasmi we require a store to determine whether these are the same
     // reference or not and therefore we cannot support this Wasm C API.
@@ -113,10 +113,7 @@ pub extern "C" fn wasm_ref_same(_a: Option<&wasm_ref_t>, _b: Option<&wasm_ref_t>
 ///
 /// This API is unsupported and always returns a `null` pointer.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_get_host_info"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_get_host_info(_ref: Option<&wasm_ref_t>) -> *mut c_void {
     ptr::null_mut()
 }
@@ -127,10 +124,7 @@ pub extern "C" fn wasm_ref_get_host_info(_ref: Option<&wasm_ref_t>) -> *mut c_vo
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_set_host_info"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_set_host_info(_ref: Option<&wasm_ref_t>, _info: *mut c_void) {
     unimplemented!("wasm_ref_set_host_info")
 }
@@ -143,10 +137,7 @@ pub extern "C" fn wasm_ref_set_host_info(_ref: Option<&wasm_ref_t>, _info: *mut 
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_set_host_info_with_finalizer"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
     _ref: Option<&wasm_ref_t>,
     _info: *mut c_void,
@@ -161,7 +152,7 @@ pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_extern")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_extern(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_extern_t> {
     unimplemented!("wasm_ref_as_extern")
 }
@@ -172,10 +163,7 @@ pub extern "C" fn wasm_ref_as_extern(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_as_extern_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_extern_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_extern_t> {
     unimplemented!("wasm_ref_as_extern_const")
 }
@@ -186,7 +174,7 @@ pub extern "C" fn wasm_ref_as_extern_const(_ref: Option<&wasm_ref_t>) -> Option<
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_foreign")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_foreign(
     _ref: Option<&mut wasm_ref_t>,
 ) -> Option<&mut wasm_foreign_t> {
@@ -199,10 +187,7 @@ pub extern "C" fn wasm_ref_as_foreign(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_as_foreign_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_foreign_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_foreign_t> {
@@ -215,7 +200,7 @@ pub extern "C" fn wasm_ref_as_foreign_const(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_func")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_func(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_func_t> {
     unimplemented!("wasm_ref_as_func")
 }
@@ -226,10 +211,7 @@ pub extern "C" fn wasm_ref_as_func(_ref: Option<&mut wasm_ref_t>) -> Option<&mut
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_as_func_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_func_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_func_t> {
     unimplemented!("wasm_ref_as_func_const")
 }
@@ -240,7 +222,7 @@ pub extern "C" fn wasm_ref_as_func_const(_ref: Option<&wasm_ref_t>) -> Option<&w
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_global")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_global(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_global_t> {
     unimplemented!("wasm_ref_as_global")
 }
@@ -251,10 +233,7 @@ pub extern "C" fn wasm_ref_as_global(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_as_global_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_global_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_global_t> {
     unimplemented!("wasm_ref_as_global_const")
 }
@@ -265,7 +244,7 @@ pub extern "C" fn wasm_ref_as_global_const(_ref: Option<&wasm_ref_t>) -> Option<
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_instance")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_instance(
     _ref: Option<&mut wasm_ref_t>,
 ) -> Option<&mut wasm_instance_t> {
@@ -278,10 +257,7 @@ pub extern "C" fn wasm_ref_as_instance(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_as_instance_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_instance_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&wasm_instance_t> {
@@ -294,7 +270,7 @@ pub extern "C" fn wasm_ref_as_instance_const(
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_memory")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_memory(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_memory_t> {
     unimplemented!("wasm_ref_as_memory")
 }
@@ -305,10 +281,7 @@ pub extern "C" fn wasm_ref_as_memory(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_as_memory_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_memory_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_memory_t> {
     unimplemented!("wasm_ref_as_memory_const")
 }
@@ -319,7 +292,7 @@ pub extern "C" fn wasm_ref_as_memory_const(_ref: Option<&wasm_ref_t>) -> Option<
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_module")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_module(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_module_t> {
     unimplemented!("wasm_ref_as_module")
 }
@@ -330,10 +303,7 @@ pub extern "C" fn wasm_ref_as_module(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_as_module_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_module_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_module_t> {
     unimplemented!("wasm_ref_as_module_const")
 }
@@ -344,7 +314,7 @@ pub extern "C" fn wasm_ref_as_module_const(_ref: Option<&wasm_ref_t>) -> Option<
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_table")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_table(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_table_t> {
     unimplemented!("wasm_ref_as_table")
 }
@@ -355,10 +325,7 @@ pub extern "C" fn wasm_ref_as_table(_ref: Option<&mut wasm_ref_t>) -> Option<&mu
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_as_table_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_table_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_table_t> {
     unimplemented!("wasm_ref_as_table_const")
 }
@@ -369,7 +336,7 @@ pub extern "C" fn wasm_ref_as_table_const(_ref: Option<&wasm_ref_t>) -> Option<&
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_ref_as_trap")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_trap(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_trap_t> {
     unimplemented!("wasm_ref_as_trap")
 }
@@ -380,10 +347,7 @@ pub extern "C" fn wasm_ref_as_trap(_ref: Option<&mut wasm_ref_t>) -> Option<&mut
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_ref_as_trap_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_trap_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_trap_t> {
     unimplemented!("wasm_ref_as_trap_const")
 }

--- a/crates/c_api/src/store.rs
+++ b/crates/c_api/src/store.rs
@@ -63,7 +63,7 @@ wasmi_c_api_macros::declare_own!(wasm_store_t);
 /// Wraps [`<wasmi::Store<()>>::new`](wasmi::Store::new).
 #[no_mangle]
 #[allow(clippy::arc_with_non_send_sync)]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_store_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_store_new(engine: &wasm_engine_t) -> Box<wasm_store_t> {
     let engine = &engine.inner;
     let store = Store::new(engine, ());
@@ -98,7 +98,7 @@ pub struct WasmiStoreData {
 ///
 /// Wraps [`<wasmi::Store<()>>::new`](wasmi::Store::new).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasmi_store_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_store_new(
     engine: &wasm_engine_t,
     data: *mut ffi::c_void,
@@ -122,7 +122,7 @@ pub extern "C" fn wasmi_store_new(
 ///
 /// It is the callers responsibility to provide a valid `self`.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasmi_store_context")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_store_context(
     store: &mut wasmi_store_t,
 ) -> StoreContextMut<'_, WasmiStoreData> {
@@ -131,10 +131,7 @@ pub extern "C" fn wasmi_store_context(
 
 /// Returns a pointer to the foreign data of the Wasmi store context.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasmi_context_get_data"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_context_get_data(
     store: StoreContext<'_, WasmiStoreData>,
 ) -> *mut ffi::c_void {
@@ -143,10 +140,7 @@ pub extern "C" fn wasmi_context_get_data(
 
 /// Sets the foreign data of the Wasmi store context.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasmi_context_set_data"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_context_set_data(
     mut store: StoreContextMut<'_, WasmiStoreData>,
     data: *mut ffi::c_void,
@@ -162,10 +156,7 @@ pub extern "C" fn wasmi_context_set_data(
 ///
 /// If [`Store::get_fuel`] errors.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasmi_context_get_fuel"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_context_get_fuel(
     store: StoreContext<'_, WasmiStoreData>,
     fuel: &mut u64,
@@ -183,10 +174,7 @@ pub extern "C" fn wasmi_context_get_fuel(
 ///
 /// If [`Store::set_fuel`] errors.
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasmi_context_set_fuel"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_context_set_fuel(
     mut store: StoreContextMut<'_, WasmiStoreData>,
     fuel: u64,

--- a/crates/c_api/src/store.rs
+++ b/crates/c_api/src/store.rs
@@ -63,6 +63,7 @@ wasmi_c_api_macros::declare_own!(wasm_store_t);
 /// Wraps [`<wasmi::Store<()>>::new`](wasmi::Store::new).
 #[no_mangle]
 #[allow(clippy::arc_with_non_send_sync)]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_store_new")]
 pub extern "C" fn wasm_store_new(engine: &wasm_engine_t) -> Box<wasm_store_t> {
     let engine = &engine.inner;
     let store = Store::new(engine, ());
@@ -97,6 +98,7 @@ pub struct WasmiStoreData {
 ///
 /// Wraps [`<wasmi::Store<()>>::new`](wasmi::Store::new).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasmi_store_new")]
 pub extern "C" fn wasmi_store_new(
     engine: &wasm_engine_t,
     data: *mut ffi::c_void,
@@ -120,6 +122,7 @@ pub extern "C" fn wasmi_store_new(
 ///
 /// It is the callers responsibility to provide a valid `self`.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasmi_store_context")]
 pub extern "C" fn wasmi_store_context(
     store: &mut wasmi_store_t,
 ) -> StoreContextMut<'_, WasmiStoreData> {
@@ -128,6 +131,10 @@ pub extern "C" fn wasmi_store_context(
 
 /// Returns a pointer to the foreign data of the Wasmi store context.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasmi_context_get_data"
+)]
 pub extern "C" fn wasmi_context_get_data(
     store: StoreContext<'_, WasmiStoreData>,
 ) -> *mut ffi::c_void {
@@ -136,6 +143,10 @@ pub extern "C" fn wasmi_context_get_data(
 
 /// Sets the foreign data of the Wasmi store context.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasmi_context_set_data"
+)]
 pub extern "C" fn wasmi_context_set_data(
     mut store: StoreContextMut<'_, WasmiStoreData>,
     data: *mut ffi::c_void,
@@ -151,6 +162,10 @@ pub extern "C" fn wasmi_context_set_data(
 ///
 /// If [`Store::get_fuel`] errors.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasmi_context_get_fuel"
+)]
 pub extern "C" fn wasmi_context_get_fuel(
     store: StoreContext<'_, WasmiStoreData>,
     fuel: &mut u64,
@@ -168,6 +183,10 @@ pub extern "C" fn wasmi_context_get_fuel(
 ///
 /// If [`Store::set_fuel`] errors.
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasmi_context_set_fuel"
+)]
 pub extern "C" fn wasmi_context_set_fuel(
     mut store: StoreContextMut<'_, WasmiStoreData>,
     fuel: u64,

--- a/crates/c_api/src/table.rs
+++ b/crates/c_api/src/table.rs
@@ -62,7 +62,7 @@ fn option_wasm_ref_t_to_ref(r: Option<&wasm_ref_t>, table_ty: &TableType) -> Was
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_new(
     store: &mut wasm_store_t,
     tt: &wasm_tabletype_t,
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn wasm_table_new(
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_type")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_type(t: &wasm_table_t) -> Box<wasm_tabletype_t> {
     let table = t.table();
     let store = t.inner.store.context();
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn wasm_table_type(t: &wasm_table_t) -> Box<wasm_tabletype
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_get")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_get(
     t: &mut wasm_table_t,
     index: wasm_table_size_t,
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn wasm_table_get(
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_set")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_set(
     t: &mut wasm_table_t,
     index: wasm_table_size_t,
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn wasm_table_set(
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_size")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_size(t: &wasm_table_t) -> wasm_table_size_t {
     let table = t.table();
     let store = t.inner.store.context();
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn wasm_table_size(t: &wasm_table_t) -> wasm_table_size_t 
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_grow")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_grow(
     t: &mut wasm_table_t,
     delta: wasm_table_size_t,
@@ -182,17 +182,14 @@ pub unsafe extern "C" fn wasm_table_grow(
 
 /// Returns the [`wasm_table_t`] as mutable reference to [`wasm_extern_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_as_extern")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_table_as_extern(t: &mut wasm_table_t) -> &mut wasm_extern_t {
     &mut t.inner
 }
 
 /// Returns the [`wasm_table_t`] as shared reference to [`wasm_extern_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_table_as_extern_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_table_as_extern_const(t: &wasm_table_t) -> &wasm_extern_t {
     &t.inner
 }

--- a/crates/c_api/src/table.rs
+++ b/crates/c_api/src/table.rs
@@ -62,6 +62,7 @@ fn option_wasm_ref_t_to_ref(r: Option<&wasm_ref_t>, table_ty: &TableType) -> Was
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_new")]
 pub unsafe extern "C" fn wasm_table_new(
     store: &mut wasm_store_t,
     tt: &wasm_tabletype_t,
@@ -87,6 +88,7 @@ pub unsafe extern "C" fn wasm_table_new(
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_type")]
 pub unsafe extern "C" fn wasm_table_type(t: &wasm_table_t) -> Box<wasm_tabletype_t> {
     let table = t.table();
     let store = t.inner.store.context();
@@ -102,6 +104,7 @@ pub unsafe extern "C" fn wasm_table_type(t: &wasm_table_t) -> Box<wasm_tabletype
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_get")]
 pub unsafe extern "C" fn wasm_table_get(
     t: &mut wasm_table_t,
     index: wasm_table_size_t,
@@ -125,6 +128,7 @@ pub unsafe extern "C" fn wasm_table_get(
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_set")]
 pub unsafe extern "C" fn wasm_table_set(
     t: &mut wasm_table_t,
     index: wasm_table_size_t,
@@ -146,6 +150,7 @@ pub unsafe extern "C" fn wasm_table_set(
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_size")]
 pub unsafe extern "C" fn wasm_table_size(t: &wasm_table_t) -> wasm_table_size_t {
     let table = t.table();
     let store = t.inner.store.context();
@@ -162,6 +167,7 @@ pub unsafe extern "C" fn wasm_table_size(t: &wasm_table_t) -> wasm_table_size_t 
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_grow")]
 pub unsafe extern "C" fn wasm_table_grow(
     t: &mut wasm_table_t,
     delta: wasm_table_size_t,
@@ -176,12 +182,17 @@ pub unsafe extern "C" fn wasm_table_grow(
 
 /// Returns the [`wasm_table_t`] as mutable reference to [`wasm_extern_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_table_as_extern")]
 pub extern "C" fn wasm_table_as_extern(t: &mut wasm_table_t) -> &mut wasm_extern_t {
     &mut t.inner
 }
 
 /// Returns the [`wasm_table_t`] as shared reference to [`wasm_extern_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_table_as_extern_const"
+)]
 pub extern "C" fn wasm_table_as_extern_const(t: &wasm_table_t) -> &wasm_extern_t {
     &t.inner
 }

--- a/crates/c_api/src/trap.rs
+++ b/crates/c_api/src/trap.rs
@@ -42,6 +42,7 @@ pub type wasm_message_t = wasm_name_t;
 ///
 /// The `message` is expected to contain a valid null-terminated C string.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_trap_new")]
 pub extern "C" fn wasm_trap_new(
     _store: &wasm_store_t,
     message: &wasm_message_t,
@@ -74,6 +75,7 @@ pub unsafe extern "C" fn wasmi_trap_new(message: *const u8, len: usize) -> Box<w
 ///
 /// Stores the returned error message in `out`.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_trap_message")]
 pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t) {
     let mut buffer = Vec::new();
     buffer.extend_from_slice(format!("{:?}", trap.error).as_bytes());
@@ -88,6 +90,7 @@ pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_trap_origin")]
 pub extern "C" fn wasm_trap_origin(_raw: &wasm_trap_t) -> Option<Box<wasm_frame_t<'_>>> {
     unimplemented!("wasm_trap_origin")
 }
@@ -100,6 +103,7 @@ pub extern "C" fn wasm_trap_origin(_raw: &wasm_trap_t) -> Option<Box<wasm_frame_
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_trap_trace<'a>")]
 pub extern "C" fn wasm_trap_trace<'a>(_raw: &'a wasm_trap_t, _out: &mut wasm_frame_vec_t<'a>) {
     unimplemented!("wasm_trap_trace")
 }

--- a/crates/c_api/src/trap.rs
+++ b/crates/c_api/src/trap.rs
@@ -103,7 +103,7 @@ pub extern "C" fn wasm_trap_origin(_raw: &wasm_trap_t) -> Option<Box<wasm_frame_
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_trap_trace<'a>")]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_trap_trace")]
 pub extern "C" fn wasm_trap_trace<'a>(_raw: &'a wasm_trap_t, _out: &mut wasm_frame_vec_t<'a>) {
     unimplemented!("wasm_trap_trace")
 }

--- a/crates/c_api/src/trap.rs
+++ b/crates/c_api/src/trap.rs
@@ -42,7 +42,7 @@ pub type wasm_message_t = wasm_name_t;
 ///
 /// The `message` is expected to contain a valid null-terminated C string.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_trap_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_trap_new(
     _store: &wasm_store_t,
     message: &wasm_message_t,
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn wasmi_trap_new(message: *const u8, len: usize) -> Box<w
 ///
 /// Stores the returned error message in `out`.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_trap_message")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t) {
     let mut buffer = Vec::new();
     buffer.extend_from_slice(format!("{:?}", trap.error).as_bytes());
@@ -90,7 +90,7 @@ pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_trap_origin")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_trap_origin(_raw: &wasm_trap_t) -> Option<Box<wasm_frame_t<'_>>> {
     unimplemented!("wasm_trap_origin")
 }
@@ -103,7 +103,7 @@ pub extern "C" fn wasm_trap_origin(_raw: &wasm_trap_t) -> Option<Box<wasm_frame_
 ///
 /// This API is unsupported and will panic upon use.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_trap_trace")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_trap_trace<'a>(_raw: &'a wasm_trap_t, _out: &mut wasm_frame_vec_t<'a>) {
     unimplemented!("wasm_trap_trace")
 }

--- a/crates/c_api/src/types/export.rs
+++ b/crates/c_api/src/types/export.rs
@@ -31,7 +31,7 @@ impl wasm_exporttype_t {
 
 /// Creates a new [`wasm_exporttype_t`] with the given `name` and extern type `ty`
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_exporttype_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_exporttype_new(
     name: &mut wasm_name_t,
     ty: Box<wasm_externtype_t>,
@@ -43,14 +43,14 @@ pub extern "C" fn wasm_exporttype_new(
 
 /// Returns a shared reference to the name of the [`wasm_exporttype_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_exporttype_name")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_exporttype_name(et: &wasm_exporttype_t) -> &wasm_name_t {
     &et.c_name
 }
 
 /// Returns a shared reference to the extern type of the [`wasm_exporttype_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_exporttype_type")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_exporttype_type(et: &wasm_exporttype_t) -> &wasm_externtype_t {
     &et.c_ty
 }

--- a/crates/c_api/src/types/export.rs
+++ b/crates/c_api/src/types/export.rs
@@ -31,6 +31,7 @@ impl wasm_exporttype_t {
 
 /// Creates a new [`wasm_exporttype_t`] with the given `name` and extern type `ty`
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_exporttype_new")]
 pub extern "C" fn wasm_exporttype_new(
     name: &mut wasm_name_t,
     ty: Box<wasm_externtype_t>,
@@ -42,12 +43,14 @@ pub extern "C" fn wasm_exporttype_new(
 
 /// Returns a shared reference to the name of the [`wasm_exporttype_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_exporttype_name")]
 pub extern "C" fn wasm_exporttype_name(et: &wasm_exporttype_t) -> &wasm_name_t {
     &et.c_name
 }
 
 /// Returns a shared reference to the extern type of the [`wasm_exporttype_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_exporttype_type")]
 pub extern "C" fn wasm_exporttype_type(et: &wasm_exporttype_t) -> &wasm_externtype_t {
     &et.c_ty
 }

--- a/crates/c_api/src/types/extern.rs
+++ b/crates/c_api/src/types/extern.rs
@@ -64,6 +64,7 @@ impl wasm_externtype_t {
 
 /// Returns the [`wasm_externkind_t`] of the [`wasm_externtype_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_externtype_kind")]
 pub extern "C" fn wasm_externtype_kind(et: &wasm_externtype_t) -> wasm_externkind_t {
     match &et.which {
         CExternType::Func(_) => wasm_externkind_t::WASM_EXTERN_FUNC,
@@ -75,6 +76,10 @@ pub extern "C" fn wasm_externtype_kind(et: &wasm_externtype_t) -> wasm_externkin
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_functype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_externtype_as_functype"
+)]
 pub extern "C" fn wasm_externtype_as_functype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_functype_t> {
@@ -83,6 +88,10 @@ pub extern "C" fn wasm_externtype_as_functype(
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_functype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_externtype_as_functype_const"
+)]
 pub extern "C" fn wasm_externtype_as_functype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_functype_t> {
@@ -91,6 +100,10 @@ pub extern "C" fn wasm_externtype_as_functype_const(
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_globaltype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_externtype_as_globaltype"
+)]
 pub extern "C" fn wasm_externtype_as_globaltype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_globaltype_t> {
@@ -99,6 +112,10 @@ pub extern "C" fn wasm_externtype_as_globaltype(
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_globaltype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_externtype_as_globaltype_const"
+)]
 pub extern "C" fn wasm_externtype_as_globaltype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_globaltype_t> {
@@ -107,6 +124,10 @@ pub extern "C" fn wasm_externtype_as_globaltype_const(
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_tabletype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_externtype_as_tabletype"
+)]
 pub extern "C" fn wasm_externtype_as_tabletype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_tabletype_t> {
@@ -115,6 +136,10 @@ pub extern "C" fn wasm_externtype_as_tabletype(
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_tabletype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_externtype_as_tabletype_const"
+)]
 pub extern "C" fn wasm_externtype_as_tabletype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_tabletype_t> {
@@ -123,6 +148,10 @@ pub extern "C" fn wasm_externtype_as_tabletype_const(
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_memorytype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_externtype_as_memorytype"
+)]
 pub extern "C" fn wasm_externtype_as_memorytype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_memorytype_t> {
@@ -131,6 +160,10 @@ pub extern "C" fn wasm_externtype_as_memorytype(
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_memorytype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_externtype_as_memorytype_const"
+)]
 pub extern "C" fn wasm_externtype_as_memorytype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_memorytype_t> {

--- a/crates/c_api/src/types/extern.rs
+++ b/crates/c_api/src/types/extern.rs
@@ -64,7 +64,7 @@ impl wasm_externtype_t {
 
 /// Returns the [`wasm_externkind_t`] of the [`wasm_externtype_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_externtype_kind")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_kind(et: &wasm_externtype_t) -> wasm_externkind_t {
     match &et.which {
         CExternType::Func(_) => wasm_externkind_t::WASM_EXTERN_FUNC,

--- a/crates/c_api/src/types/extern.rs
+++ b/crates/c_api/src/types/extern.rs
@@ -76,10 +76,7 @@ pub extern "C" fn wasm_externtype_kind(et: &wasm_externtype_t) -> wasm_externkin
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_functype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_externtype_as_functype"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_functype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_functype_t> {
@@ -88,10 +85,7 @@ pub extern "C" fn wasm_externtype_as_functype(
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_functype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_externtype_as_functype_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_functype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_functype_t> {
@@ -100,10 +94,7 @@ pub extern "C" fn wasm_externtype_as_functype_const(
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_globaltype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_externtype_as_globaltype"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_globaltype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_globaltype_t> {
@@ -112,10 +103,7 @@ pub extern "C" fn wasm_externtype_as_globaltype(
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_globaltype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_externtype_as_globaltype_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_globaltype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_globaltype_t> {
@@ -124,10 +112,7 @@ pub extern "C" fn wasm_externtype_as_globaltype_const(
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_tabletype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_externtype_as_tabletype"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_tabletype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_tabletype_t> {
@@ -136,10 +121,7 @@ pub extern "C" fn wasm_externtype_as_tabletype(
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_tabletype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_externtype_as_tabletype_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_tabletype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_tabletype_t> {
@@ -148,10 +130,7 @@ pub extern "C" fn wasm_externtype_as_tabletype_const(
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_memorytype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_externtype_as_memorytype"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_memorytype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_memorytype_t> {
@@ -160,10 +139,7 @@ pub extern "C" fn wasm_externtype_as_memorytype(
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_memorytype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_externtype_as_memorytype_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_memorytype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_memorytype_t> {

--- a/crates/c_api/src/types/func.rs
+++ b/crates/c_api/src/types/func.rs
@@ -77,6 +77,7 @@ impl CFuncType {
 ///
 /// Wraps [`FuncType::new`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_functype_new")]
 pub extern "C" fn wasm_functype_new(
     params: &mut wasm_valtype_vec_t,
     results: &mut wasm_valtype_vec_t,
@@ -99,6 +100,7 @@ pub extern "C" fn wasm_functype_new(
 ///
 /// Wraps [`FuncType::params`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_functype_params")]
 pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     &ft.ty().params
 }
@@ -107,18 +109,30 @@ pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_ve
 ///
 /// Wraps [`FuncType::results`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_functype_results"
+)]
 pub extern "C" fn wasm_functype_results(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     &ft.ty().results
 }
 
 /// Returns a mutable reference to the element type of [`wasm_functype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_functype_as_externtype"
+)]
 pub extern "C" fn wasm_functype_as_externtype(ty: &mut wasm_functype_t) -> &mut wasm_externtype_t {
     &mut ty.ext
 }
 
 /// Returns a shared reference to the element type of [`wasm_functype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_functype_as_externtype_const"
+)]
 pub extern "C" fn wasm_functype_as_externtype_const(ty: &wasm_functype_t) -> &wasm_externtype_t {
     &ty.ext
 }

--- a/crates/c_api/src/types/func.rs
+++ b/crates/c_api/src/types/func.rs
@@ -77,7 +77,7 @@ impl CFuncType {
 ///
 /// Wraps [`FuncType::new`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_functype_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_functype_new(
     params: &mut wasm_valtype_vec_t,
     results: &mut wasm_valtype_vec_t,
@@ -100,7 +100,7 @@ pub extern "C" fn wasm_functype_new(
 ///
 /// Wraps [`FuncType::params`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_functype_params")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     &ft.ty().params
 }
@@ -109,30 +109,21 @@ pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_ve
 ///
 /// Wraps [`FuncType::results`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_functype_results"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_functype_results(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     &ft.ty().results
 }
 
 /// Returns a mutable reference to the element type of [`wasm_functype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_functype_as_externtype"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_functype_as_externtype(ty: &mut wasm_functype_t) -> &mut wasm_externtype_t {
     &mut ty.ext
 }
 
 /// Returns a shared reference to the element type of [`wasm_functype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_functype_as_externtype_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_functype_as_externtype_const(ty: &wasm_functype_t) -> &wasm_externtype_t {
     &ty.ext
 }

--- a/crates/c_api/src/types/global.rs
+++ b/crates/c_api/src/types/global.rs
@@ -71,7 +71,7 @@ impl CGlobalType {
 ///
 /// Wraps [`GlobalType::new`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_globaltype_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_globaltype_new(
     ty: Box<wasm_valtype_t>,
     mutability: wasm_mutability_t,
@@ -86,20 +86,14 @@ pub extern "C" fn wasm_globaltype_new(
 
 /// Returns a shared reference to the content type of the [`wasm_globaltype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_globaltype_content"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_globaltype_content(gt: &wasm_globaltype_t) -> &wasm_valtype_t {
     &gt.ty().content
 }
 
 /// Returns the mutability of the [`wasm_globaltype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_globaltype_mutability"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_globaltype_mutability(gt: &wasm_globaltype_t) -> wasm_mutability_t {
     match gt.ty().ty.mutability() {
         wasmi::Mutability::Const => wasm_mutability_t::WASM_CONST,
@@ -109,10 +103,7 @@ pub extern "C" fn wasm_globaltype_mutability(gt: &wasm_globaltype_t) -> wasm_mut
 
 /// Returns a mutable reference to the element type of [`wasm_globaltype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_globaltype_as_externtype"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_globaltype_as_externtype(
     ty: &mut wasm_globaltype_t,
 ) -> &mut wasm_externtype_t {
@@ -121,10 +112,7 @@ pub extern "C" fn wasm_globaltype_as_externtype(
 
 /// Returns a shared reference to the element type of [`wasm_globaltype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_globaltype_as_externtype_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_globaltype_as_externtype_const(
     ty: &wasm_globaltype_t,
 ) -> &wasm_externtype_t {

--- a/crates/c_api/src/types/global.rs
+++ b/crates/c_api/src/types/global.rs
@@ -71,6 +71,7 @@ impl CGlobalType {
 ///
 /// Wraps [`GlobalType::new`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_globaltype_new")]
 pub extern "C" fn wasm_globaltype_new(
     ty: Box<wasm_valtype_t>,
     mutability: wasm_mutability_t,
@@ -85,12 +86,20 @@ pub extern "C" fn wasm_globaltype_new(
 
 /// Returns a shared reference to the content type of the [`wasm_globaltype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_globaltype_content"
+)]
 pub extern "C" fn wasm_globaltype_content(gt: &wasm_globaltype_t) -> &wasm_valtype_t {
     &gt.ty().content
 }
 
 /// Returns the mutability of the [`wasm_globaltype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_globaltype_mutability"
+)]
 pub extern "C" fn wasm_globaltype_mutability(gt: &wasm_globaltype_t) -> wasm_mutability_t {
     match gt.ty().ty.mutability() {
         wasmi::Mutability::Const => wasm_mutability_t::WASM_CONST,
@@ -100,6 +109,10 @@ pub extern "C" fn wasm_globaltype_mutability(gt: &wasm_globaltype_t) -> wasm_mut
 
 /// Returns a mutable reference to the element type of [`wasm_globaltype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_globaltype_as_externtype"
+)]
 pub extern "C" fn wasm_globaltype_as_externtype(
     ty: &mut wasm_globaltype_t,
 ) -> &mut wasm_externtype_t {
@@ -108,6 +121,10 @@ pub extern "C" fn wasm_globaltype_as_externtype(
 
 /// Returns a shared reference to the element type of [`wasm_globaltype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_globaltype_as_externtype_const"
+)]
 pub extern "C" fn wasm_globaltype_as_externtype_const(
     ty: &wasm_globaltype_t,
 ) -> &wasm_externtype_t {

--- a/crates/c_api/src/types/import.rs
+++ b/crates/c_api/src/types/import.rs
@@ -35,7 +35,7 @@ impl wasm_importtype_t {
 
 /// Creates a new [`wasm_importtype_t`] from the given `module` and `name` namespace and extern type `ty`.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_importtype_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_importtype_new(
     module: &mut wasm_name_t,
     name: &mut wasm_name_t,
@@ -64,14 +64,14 @@ pub extern "C" fn wasm_importtype_module(it: &wasm_importtype_t) -> &wasm_name_t
 
 /// Returns a shared reference to the name namespace of the [`wasm_importtype_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_importtype_name")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_importtype_name(it: &wasm_importtype_t) -> &wasm_name_t {
     &it.c_name
 }
 
 /// Returns a shared reference to the extern type of the [`wasm_importtype_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_importtype_type")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_importtype_type(it: &wasm_importtype_t) -> &wasm_externtype_t {
     &it.c_ty
 }

--- a/crates/c_api/src/types/import.rs
+++ b/crates/c_api/src/types/import.rs
@@ -35,6 +35,7 @@ impl wasm_importtype_t {
 
 /// Creates a new [`wasm_importtype_t`] from the given `module` and `name` namespace and extern type `ty`.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_importtype_new")]
 pub extern "C" fn wasm_importtype_new(
     module: &mut wasm_name_t,
     name: &mut wasm_name_t,
@@ -53,18 +54,24 @@ pub extern "C" fn wasm_importtype_new(
 
 /// Returns a shared reference to the module namespace of the [`wasm_importtype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_importtype_module"
+)]
 pub extern "C" fn wasm_importtype_module(it: &wasm_importtype_t) -> &wasm_name_t {
     &it.c_module
 }
 
 /// Returns a shared reference to the name namespace of the [`wasm_importtype_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_importtype_name")]
 pub extern "C" fn wasm_importtype_name(it: &wasm_importtype_t) -> &wasm_name_t {
     &it.c_name
 }
 
 /// Returns a shared reference to the extern type of the [`wasm_importtype_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_importtype_type")]
 pub extern "C" fn wasm_importtype_type(it: &wasm_importtype_t) -> &wasm_externtype_t {
     &it.c_ty
 }

--- a/crates/c_api/src/types/import.rs
+++ b/crates/c_api/src/types/import.rs
@@ -54,10 +54,7 @@ pub extern "C" fn wasm_importtype_new(
 
 /// Returns a shared reference to the module namespace of the [`wasm_importtype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_importtype_module"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_importtype_module(it: &wasm_importtype_t) -> &wasm_name_t {
     &it.c_module
 }

--- a/crates/c_api/src/types/memory.rs
+++ b/crates/c_api/src/types/memory.rs
@@ -63,7 +63,7 @@ impl CMemoryType {
 ///
 /// Wraps [`MemoryType::new`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memorytype_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm_memorytype_t> {
     let memory_type = MemoryType::new(limits.min, limits.max()).unwrap();
     Box::new(wasm_memorytype_t::new(memory_type))

--- a/crates/c_api/src/types/memory.rs
+++ b/crates/c_api/src/types/memory.rs
@@ -71,20 +71,14 @@ pub extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm_memory
 
 /// Returns a shared reference to the table limits of the [`wasm_memorytype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_memorytype_limits"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memorytype_limits(mt: &wasm_memorytype_t) -> &wasm_limits_t {
     &mt.ty().limits
 }
 
 /// Returns a mutable reference to the element type of [`wasm_memorytype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_memorytype_as_externtype"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memorytype_as_externtype(
     ty: &mut wasm_memorytype_t,
 ) -> &mut wasm_externtype_t {
@@ -93,10 +87,7 @@ pub extern "C" fn wasm_memorytype_as_externtype(
 
 /// Returns a shared reference to the element type of [`wasm_memorytype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_memorytype_as_externtype_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memorytype_as_externtype_const(
     ty: &wasm_memorytype_t,
 ) -> &wasm_externtype_t {

--- a/crates/c_api/src/types/memory.rs
+++ b/crates/c_api/src/types/memory.rs
@@ -63,6 +63,7 @@ impl CMemoryType {
 ///
 /// Wraps [`MemoryType::new`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_memorytype_new")]
 pub extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm_memorytype_t> {
     let memory_type = MemoryType::new(limits.min, limits.max()).unwrap();
     Box::new(wasm_memorytype_t::new(memory_type))
@@ -70,12 +71,20 @@ pub extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm_memory
 
 /// Returns a shared reference to the table limits of the [`wasm_memorytype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_memorytype_limits"
+)]
 pub extern "C" fn wasm_memorytype_limits(mt: &wasm_memorytype_t) -> &wasm_limits_t {
     &mt.ty().limits
 }
 
 /// Returns a mutable reference to the element type of [`wasm_memorytype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_memorytype_as_externtype"
+)]
 pub extern "C" fn wasm_memorytype_as_externtype(
     ty: &mut wasm_memorytype_t,
 ) -> &mut wasm_externtype_t {
@@ -84,6 +93,10 @@ pub extern "C" fn wasm_memorytype_as_externtype(
 
 /// Returns a shared reference to the element type of [`wasm_memorytype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_memorytype_as_externtype_const"
+)]
 pub extern "C" fn wasm_memorytype_as_externtype_const(
     ty: &wasm_memorytype_t,
 ) -> &wasm_externtype_t {

--- a/crates/c_api/src/types/table.rs
+++ b/crates/c_api/src/types/table.rs
@@ -66,7 +66,7 @@ impl CTableType {
 ///
 /// Wraps [`TableType::new`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_tabletype_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_tabletype_new(
     ty: Box<wasm_valtype_t>,
     limits: &wasm_limits_t,

--- a/crates/c_api/src/types/table.rs
+++ b/crates/c_api/src/types/table.rs
@@ -80,30 +80,21 @@ pub extern "C" fn wasm_tabletype_new(
 
 /// Returns a shared reference to the element type of the [`wasm_tabletype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_tabletype_element"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_tabletype_element(tt: &wasm_tabletype_t) -> &wasm_valtype_t {
     &tt.ty().element
 }
 
 /// Returns a shared reference to the table limits of the [`wasm_tabletype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_tabletype_limits"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_tabletype_limits(tt: &wasm_tabletype_t) -> &wasm_limits_t {
     &tt.ty().limits
 }
 
 /// Returns a mutable reference to the element type of [`wasm_tabletype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_tabletype_as_externtype"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_tabletype_as_externtype(
     ty: &mut wasm_tabletype_t,
 ) -> &mut wasm_externtype_t {
@@ -112,10 +103,7 @@ pub extern "C" fn wasm_tabletype_as_externtype(
 
 /// Returns a shared reference to the element type of [`wasm_tabletype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
-#[cfg_attr(
-    feature = "prefix-symbols",
-    export_name = "wasmi_wasm_tabletype_as_externtype_const"
-)]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_tabletype_as_externtype_const(ty: &wasm_tabletype_t) -> &wasm_externtype_t {
     &ty.ext
 }

--- a/crates/c_api/src/types/table.rs
+++ b/crates/c_api/src/types/table.rs
@@ -66,6 +66,7 @@ impl CTableType {
 ///
 /// Wraps [`TableType::new`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_tabletype_new")]
 pub extern "C" fn wasm_tabletype_new(
     ty: Box<wasm_valtype_t>,
     limits: &wasm_limits_t,
@@ -79,18 +80,30 @@ pub extern "C" fn wasm_tabletype_new(
 
 /// Returns a shared reference to the element type of the [`wasm_tabletype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_tabletype_element"
+)]
 pub extern "C" fn wasm_tabletype_element(tt: &wasm_tabletype_t) -> &wasm_valtype_t {
     &tt.ty().element
 }
 
 /// Returns a shared reference to the table limits of the [`wasm_tabletype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_tabletype_limits"
+)]
 pub extern "C" fn wasm_tabletype_limits(tt: &wasm_tabletype_t) -> &wasm_limits_t {
     &tt.ty().limits
 }
 
 /// Returns a mutable reference to the element type of [`wasm_tabletype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_tabletype_as_externtype"
+)]
 pub extern "C" fn wasm_tabletype_as_externtype(
     ty: &mut wasm_tabletype_t,
 ) -> &mut wasm_externtype_t {
@@ -99,6 +112,10 @@ pub extern "C" fn wasm_tabletype_as_externtype(
 
 /// Returns a shared reference to the element type of [`wasm_tabletype_t`] as [`wasm_externtype_t`].
 #[no_mangle]
+#[cfg_attr(
+    feature = "prefix-symbols",
+    export_name = "wasmi_wasm_tabletype_as_externtype_const"
+)]
 pub extern "C" fn wasm_tabletype_as_externtype_const(ty: &wasm_tabletype_t) -> &wasm_externtype_t {
     &ty.ext
 }

--- a/crates/c_api/src/types/val.rs
+++ b/crates/c_api/src/types/val.rs
@@ -46,7 +46,7 @@ pub enum wasm_valkind_t {
 
 /// Creates a new owned [`wasm_valtype_t`] from the [`wasm_valkind_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_valtype_new")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> {
     Box::new(wasm_valtype_t {
         ty: into_valtype(kind),
@@ -55,7 +55,7 @@ pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> 
 
 /// Returns the [`wasm_valkind_t`] of the [`wasm_valtype_t`].
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_valtype_kind")]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_valtype_kind(vt: &wasm_valtype_t) -> wasm_valkind_t {
     from_valtype(&vt.ty)
 }

--- a/crates/c_api/src/types/val.rs
+++ b/crates/c_api/src/types/val.rs
@@ -46,6 +46,7 @@ pub enum wasm_valkind_t {
 
 /// Creates a new owned [`wasm_valtype_t`] from the [`wasm_valkind_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_valtype_new")]
 pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> {
     Box::new(wasm_valtype_t {
         ty: into_valtype(kind),
@@ -54,6 +55,7 @@ pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> 
 
 /// Returns the [`wasm_valkind_t`] of the [`wasm_valtype_t`].
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", export_name = "wasmi_wasm_valtype_kind")]
 pub extern "C" fn wasm_valtype_kind(vt: &wasm_valtype_t) -> wasm_valkind_t {
     from_valtype(&vt.ty)
 }

--- a/crates/c_api/src/val.rs
+++ b/crates/c_api/src/val.rs
@@ -146,6 +146,7 @@ impl wasm_val_t {
 ///
 /// The caller is responsible to provide a valid [`wasm_val_t`] that can safely be copied.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_val_copy(out: &mut MaybeUninit<wasm_val_t>, source: &wasm_val_t) {
     utils::initialize(out, source.clone());
 }
@@ -157,6 +158,7 @@ pub unsafe extern "C" fn wasm_val_copy(out: &mut MaybeUninit<wasm_val_t>, source
 /// The caller is responsible to provide a valid [`wasm_val_t`] that can safely be deleted.
 /// The same [`wasm_val_t`] must not be deleted more than once.
 #[no_mangle]
+#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_val_delete(val: *mut wasm_val_t) {
     ptr::drop_in_place(val);
 }

--- a/crates/c_api/src/vec.rs
+++ b/crates/c_api/src/vec.rs
@@ -135,6 +135,7 @@ macro_rules! declare_vecs {
         #[doc = ""]
         #[doc = concat!("Returns the resulting [`", stringify!($name), "`] in `out`.")]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = concat!("wasmi_", stringify!($empty)))]
         pub extern "C" fn $empty(out: &mut $name) {
             out.size = 0;
             out.data = ptr::null_mut();
@@ -146,6 +147,7 @@ macro_rules! declare_vecs {
         #[doc = ""]
         #[doc = concat!("Returns the resulting [`", stringify!($name), "`] in `out`.")]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = concat!("wasmi_", stringify!($uninit)))]
         pub extern "C" fn $uninit(out: &mut $name, size: usize) {
             out.set_buffer(vec![Default::default(); size].into());
         }
@@ -161,6 +163,7 @@ macro_rules! declare_vecs {
         #[doc = ""]
         #[doc = "It is the callers responsibility to provide a valid pair of `ptr` and `size`."]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = concat!("wasmi_", stringify!($new)))]
         pub unsafe extern "C" fn $new $(<$lt>)? (
             out: &mut $name $(<$lt>)?,
             size: usize,
@@ -176,6 +179,7 @@ macro_rules! declare_vecs {
         #[doc = ""]
         #[doc = concat!("- Returns the resulting [`", stringify!($name), "`] in `out`.")]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = concat!("wasmi_", stringify!($copy)))]
         pub extern "C" fn $copy $(<$lt>)? (
             out: &mut $name $(<$lt>)?,
             src: &$name $(<$lt>)?,
@@ -185,6 +189,7 @@ macro_rules! declare_vecs {
 
         #[doc = concat!("Frees memory associated to the [`", stringify!($name),"`].")]
         #[no_mangle]
+        #[cfg_attr(feature = "prefix-symbols", export_name = concat!("wasmi_", stringify!($delete)))]
         pub extern "C" fn $delete $(<$lt>)? (out: &mut $name $(<$lt>)?) {
             out.take();
         }

--- a/crates/c_api/src/vec.rs
+++ b/crates/c_api/src/vec.rs
@@ -135,7 +135,7 @@ macro_rules! declare_vecs {
         #[doc = ""]
         #[doc = concat!("Returns the resulting [`", stringify!($name), "`] in `out`.")]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = concat!("wasmi_", stringify!($empty)))]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn $empty(out: &mut $name) {
             out.size = 0;
             out.data = ptr::null_mut();
@@ -147,7 +147,7 @@ macro_rules! declare_vecs {
         #[doc = ""]
         #[doc = concat!("Returns the resulting [`", stringify!($name), "`] in `out`.")]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = concat!("wasmi_", stringify!($uninit)))]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn $uninit(out: &mut $name, size: usize) {
             out.set_buffer(vec![Default::default(); size].into());
         }
@@ -163,7 +163,7 @@ macro_rules! declare_vecs {
         #[doc = ""]
         #[doc = "It is the callers responsibility to provide a valid pair of `ptr` and `size`."]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = concat!("wasmi_", stringify!($new)))]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub unsafe extern "C" fn $new $(<$lt>)? (
             out: &mut $name $(<$lt>)?,
             size: usize,
@@ -179,7 +179,7 @@ macro_rules! declare_vecs {
         #[doc = ""]
         #[doc = concat!("- Returns the resulting [`", stringify!($name), "`] in `out`.")]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = concat!("wasmi_", stringify!($copy)))]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn $copy $(<$lt>)? (
             out: &mut $name $(<$lt>)?,
             src: &$name $(<$lt>)?,
@@ -189,7 +189,7 @@ macro_rules! declare_vecs {
 
         #[doc = concat!("Frees memory associated to the [`", stringify!($name),"`].")]
         #[no_mangle]
-        #[cfg_attr(feature = "prefix-symbols", export_name = concat!("wasmi_", stringify!($delete)))]
+        #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn $delete $(<$lt>)? (out: &mut $name $(<$lt>)?) {
             out.take();
         }


### PR DESCRIPTION
Hello again! 

This small patch adds a `prefix-symbols` feature that adds a `wasmi_` prefix to all the public symbols that did not have it before, keeping the symbols not mangled. This way, users (that need to use `wasmi`'s c_api implementation with other backends) need not worry about `Option<Box<_>>`es but can simply use `bindgen` to take care of it. 

I think that this method makes more sense than the other one we ended up merging.

Again, thank you in advance for taking the time to review the PR.