### PR TITLE
fix: Revert `mangle-symbols` feature

### DIFF
--- a/crates/c_api/Cargo.toml
+++ b/crates/c_api/Cargo.toml
@@ -26,4 +26,3 @@ doctest = false
 [features]
 default = ["std"]
 std = []
-mangle-symbols = []

--- a/crates/c_api/src/config.rs
+++ b/crates/c_api/src/config.rs
@@ -20,7 +20,7 @@ wasmi_c_api_macros::declare_own!(wasm_config_t);
 /// Wraps [`wasmi::Config::default`].
 ///
 /// [`wasm_engine_new_with_config`]: crate::wasm_engine_new_with_config
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_config_new() -> Box<wasm_config_t> {
     Box::new(wasm_config_t {
         inner: Config::default(),
@@ -32,7 +32,7 @@ pub extern "C" fn wasm_config_new() -> Box<wasm_config_t> {
 /// Wraps [`wasmi::Config::wasm_multi_value`]
 ///
 /// [`mutable-global`]: <https://github.com/WebAssembly/mutable-global>
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_wasm_mutable_globals_set(c: &mut wasm_config_t, enable: bool) {
     c.inner.wasm_mutable_global(enable);
 }
@@ -42,7 +42,7 @@ pub extern "C" fn wasmi_config_wasm_mutable_globals_set(c: &mut wasm_config_t, e
 /// Wraps [`wasmi::Config::wasm_multi_value`]
 ///
 /// [`multi-value`]: <https://github.com/WebAssembly/multi-value>
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_wasm_multi_value_set(c: &mut wasm_config_t, enable: bool) {
     c.inner.wasm_multi_value(enable);
 }
@@ -52,7 +52,7 @@ pub extern "C" fn wasmi_config_wasm_multi_value_set(c: &mut wasm_config_t, enabl
 /// Wraps [`wasmi::Config::wasm_sign_extension`]
 ///
 /// [`sign-extension-ops`]: <https://github.com/WebAssembly/sign-extension-ops>
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_wasm_sign_extension_set(c: &mut wasm_config_t, enable: bool) {
     c.inner.wasm_sign_extension(enable);
 }
@@ -62,7 +62,7 @@ pub extern "C" fn wasmi_config_wasm_sign_extension_set(c: &mut wasm_config_t, en
 /// Wraps [`wasmi::Config::wasm_saturating_float_to_int`]
 ///
 /// [`nontrapping-float-to-int-conversions`]: <https://github.com/WebAssembly/nontrapping-float-to-int-conversions>
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_wasm_saturating_float_to_int_set(
     c: &mut wasm_config_t,
     enable: bool,
@@ -75,7 +75,7 @@ pub extern "C" fn wasmi_config_wasm_saturating_float_to_int_set(
 /// Wraps [`wasmi::Config::wasm_bulk_memory`]
 ///
 /// [`bulk-memory-operations`]: <https://github.com/WebAssembly/bulk-memory-operations>
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_wasm_bulk_memory_set(c: &mut wasm_config_t, enable: bool) {
     c.inner.wasm_bulk_memory(enable);
 }
@@ -85,7 +85,7 @@ pub extern "C" fn wasmi_config_wasm_bulk_memory_set(c: &mut wasm_config_t, enabl
 /// Wraps [`wasmi::Config::wasm_reference_types`]
 ///
 /// [`reference-types`]: <https://github.com/WebAssembly/reference-types>
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_wasm_reference_types_set(c: &mut wasm_config_t, enable: bool) {
     c.inner.wasm_reference_types(enable);
 }
@@ -95,7 +95,7 @@ pub extern "C" fn wasmi_config_wasm_reference_types_set(c: &mut wasm_config_t, e
 /// Wraps [`wasmi::Config::wasm_tail_call`]
 ///
 /// [`tail-call`]: <https://github.com/WebAssembly/tail-call>
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_wasm_tail_call_set(c: &mut wasm_config_t, enable: bool) {
     c.inner.wasm_tail_call(enable);
 }
@@ -105,7 +105,7 @@ pub extern "C" fn wasmi_config_wasm_tail_call_set(c: &mut wasm_config_t, enable:
 /// Wraps [`wasmi::Config::wasm_extended_const`]
 ///
 /// [`extended-const`]: <https://github.com/WebAssembly/extended-const>
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_wasm_extended_const_set(c: &mut wasm_config_t, enable: bool) {
     c.inner.wasm_extended_const(enable);
 }
@@ -113,7 +113,7 @@ pub extern "C" fn wasmi_config_wasm_extended_const_set(c: &mut wasm_config_t, en
 /// Enables or disables support for floating point numbers for the config.
 ///
 /// Wraps [`wasmi::Config::floats`]
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_floats_set(config: &mut wasm_config_t, enable: bool) {
     config.inner.floats(enable);
 }
@@ -121,7 +121,7 @@ pub extern "C" fn wasmi_config_floats_set(config: &mut wasm_config_t, enable: bo
 /// Enables or disables fuel consumption for the config.
 ///
 /// Wraps [`wasmi::Config::consume_fuel`]
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_consume_fuel_set(config: &mut wasm_config_t, enable: bool) {
     config.inner.consume_fuel(enable);
 }
@@ -140,7 +140,7 @@ pub enum wasmi_compilation_mode_t {
 /// Sets the compilation mode for the config.
 ///
 /// Wraps [`wasmi::Config::compilation_mode`]
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_compilation_mode_set(
     config: &mut wasm_config_t,
     mode: wasmi_compilation_mode_t,
@@ -156,7 +156,7 @@ pub extern "C" fn wasmi_config_compilation_mode_set(
 /// Enables or disables processing of Wasm custom sections.
 ///
 /// Wraps [`wasmi::Config::ignore_custom_sections`]
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_config_ignore_custom_sections_set(
     config: &mut wasm_config_t,
     enable: bool,

--- a/crates/c_api/src/engine.rs
+++ b/crates/c_api/src/engine.rs
@@ -18,7 +18,7 @@ wasmi_c_api_macros::declare_own!(wasm_engine_t);
 /// The returned [`wasm_engine_t`] must be freed using [`wasm_engine_delete`].
 ///
 /// Wraps [`wasmi::Engine::default`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
     Box::new(wasm_engine_t {
         inner: Engine::default(),
@@ -30,7 +30,7 @@ pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
 /// The returned [`wasm_engine_t`] must be freed using [`wasm_engine_delete`].
 ///
 /// Wraps [`wasmi::Engine::new`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_engine_new_with_config(config: Box<wasm_config_t>) -> Box<wasm_engine_t> {
     Box::new(wasm_engine_t {
         inner: Engine::new(&config.inner),
@@ -42,7 +42,7 @@ pub extern "C" fn wasm_engine_new_with_config(config: Box<wasm_config_t>) -> Box
 /// The cloned [`wasm_engine_t`] has to be freed with [`wasm_engine_delete`] after use.
 ///
 /// Wraps [`wasmi::Engine::clone`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_engine_clone(engine: &wasm_engine_t) -> Box<wasm_engine_t> {
     Box::new(engine.clone())
 }

--- a/crates/c_api/src/extern.rs
+++ b/crates/c_api/src/extern.rs
@@ -22,7 +22,7 @@ pub struct wasm_extern_t {
 wasmi_c_api_macros::declare_ref!(wasm_extern_t);
 
 /// Returns the [`wasm_extern_kind`] of the [`wasm_extern_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
     match e.which {
         Extern::Func(_) => wasm_externkind_t::WASM_EXTERN_FUNC,
@@ -38,7 +38,7 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_extern_t`]
 /// with its underlying, internal [`WasmStoreRef`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externtype_t> {
     Box::new(wasm_externtype_t::from_extern_type(
         e.which.ty(e.store.context()),
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externt
 /// Returns the [`wasm_extern_t`] as reference to mutable [`wasm_func_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_func_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_extern_as_func(e: &mut wasm_extern_t) -> Option<&mut wasm_func_t> {
     wasm_func_t::try_from_mut(e)
 }
@@ -56,7 +56,7 @@ pub extern "C" fn wasm_extern_as_func(e: &mut wasm_extern_t) -> Option<&mut wasm
 /// Returns the [`wasm_extern_t`] as reference to shared [`wasm_func_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_func_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_extern_as_func_const(e: &wasm_extern_t) -> Option<&wasm_func_t> {
     wasm_func_t::try_from(e)
 }
@@ -64,7 +64,7 @@ pub extern "C" fn wasm_extern_as_func_const(e: &wasm_extern_t) -> Option<&wasm_f
 /// Returns the [`wasm_extern_t`] as reference to mutable [`wasm_global_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_global_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_extern_as_global(e: &mut wasm_extern_t) -> Option<&mut wasm_global_t> {
     wasm_global_t::try_from_mut(e)
 }
@@ -72,7 +72,7 @@ pub extern "C" fn wasm_extern_as_global(e: &mut wasm_extern_t) -> Option<&mut wa
 /// Returns the [`wasm_extern_t`] as reference to shared [`wasm_global_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_global_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_extern_as_global_const(e: &wasm_extern_t) -> Option<&wasm_global_t> {
     wasm_global_t::try_from(e)
 }
@@ -80,7 +80,7 @@ pub extern "C" fn wasm_extern_as_global_const(e: &wasm_extern_t) -> Option<&wasm
 /// Returns the [`wasm_extern_t`] as reference to mutable [`wasm_table_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_table_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_extern_as_table(e: &mut wasm_extern_t) -> Option<&mut wasm_table_t> {
     wasm_table_t::try_from_mut(e)
 }
@@ -88,7 +88,7 @@ pub extern "C" fn wasm_extern_as_table(e: &mut wasm_extern_t) -> Option<&mut was
 /// Returns the [`wasm_extern_t`] as reference to shared [`wasm_table_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_table_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_extern_as_table_const(e: &wasm_extern_t) -> Option<&wasm_table_t> {
     wasm_table_t::try_from(e)
 }
@@ -96,7 +96,7 @@ pub extern "C" fn wasm_extern_as_table_const(e: &wasm_extern_t) -> Option<&wasm_
 /// Returns the [`wasm_extern_t`] as reference to mutable [`wasm_memory_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_memory_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_extern_as_memory(e: &mut wasm_extern_t) -> Option<&mut wasm_memory_t> {
     wasm_memory_t::try_from_mut(e)
 }
@@ -104,7 +104,7 @@ pub extern "C" fn wasm_extern_as_memory(e: &mut wasm_extern_t) -> Option<&mut wa
 /// Returns the [`wasm_extern_t`] as reference to shared [`wasm_memory_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_memory_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_extern_as_memory_const(e: &wasm_extern_t) -> Option<&wasm_memory_t> {
     wasm_memory_t::try_from(e)
 }

--- a/crates/c_api/src/foreign.rs
+++ b/crates/c_api/src/foreign.rs
@@ -12,7 +12,7 @@ wasmi_c_api_macros::declare_ref!(wasm_foreign_t);
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_foreign_new(_store: &crate::wasm_store_t) -> Box<wasm_foreign_t> {
     unimplemented!("wasm_foreign_new")
 }

--- a/crates/c_api/src/frame.rs
+++ b/crates/c_api/src/frame.rs
@@ -16,7 +16,7 @@ wasmi_c_api_macros::declare_own!(wasm_frame_t);
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_frame_func_index(_frame: &wasm_frame_t<'_>) -> u32 {
     unimplemented!("wasm_frame_func_index")
 }
@@ -26,7 +26,7 @@ pub extern "C" fn wasm_frame_func_index(_frame: &wasm_frame_t<'_>) -> u32 {
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_frame_func_offset(_frame: &wasm_frame_t<'_>) -> usize {
     unimplemented!("wasm_frame_func_offset")
 }
@@ -36,7 +36,7 @@ pub extern "C" fn wasm_frame_func_offset(_frame: &wasm_frame_t<'_>) -> usize {
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_frame_instance(_arg1: *const wasm_frame_t<'_>) -> *mut wasm_instance_t {
     unimplemented!("wasm_frame_instance")
 }
@@ -46,7 +46,7 @@ pub extern "C" fn wasm_frame_instance(_arg1: *const wasm_frame_t<'_>) -> *mut wa
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_frame_module_offset(_frame: &wasm_frame_t<'_>) -> usize {
     unimplemented!("wasm_frame_module_offset")
 }
@@ -56,7 +56,7 @@ pub extern "C" fn wasm_frame_module_offset(_frame: &wasm_frame_t<'_>) -> usize {
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_frame_copy<'a>(_frame: &wasm_frame_t<'a>) -> Box<wasm_frame_t<'a>> {
     unimplemented!("wasm_frame_copy")
 }

--- a/crates/c_api/src/func.rs
+++ b/crates/c_api/src/func.rs
@@ -119,7 +119,7 @@ unsafe fn create_function(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_functype_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_func_new(
     store: &mut wasm_store_t,
     ty: &wasm_functype_t,
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn wasm_func_new(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_functype_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_func_new_with_env(
     store: &mut wasm_store_t,
     ty: &wasm_functype_t,
@@ -183,7 +183,7 @@ fn prepare_params_and_results(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_func_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_func_call(
     func: &mut wasm_func_t,
     params: *const wasm_val_vec_t,
@@ -247,7 +247,7 @@ fn error_from_panic(panic: Box<dyn Any + Send>) -> Error {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_func_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_func_type(f: &wasm_func_t) -> Box<wasm_functype_t> {
     Box::new(wasm_functype_t::new(f.func().ty(f.inner.store.context())))
 }
@@ -262,7 +262,7 @@ pub unsafe extern "C" fn wasm_func_type(f: &wasm_func_t) -> Box<wasm_functype_t>
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 ///
 /// [`FuncType::params`]: wasmi::FuncType::params
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_func_param_arity(f: &wasm_func_t) -> usize {
     f.func().ty(f.inner.store.context()).params().len()
 }
@@ -277,19 +277,19 @@ pub unsafe extern "C" fn wasm_func_param_arity(f: &wasm_func_t) -> usize {
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 ///
 /// [`FuncType::results`]: wasmi::FuncType::results
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_func_result_arity(f: &wasm_func_t) -> usize {
     f.func().ty(f.inner.store.context()).results().len()
 }
 
 /// Returns the [`wasm_func_t`] as mutable reference to [`wasm_extern_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_func_as_extern(f: &mut wasm_func_t) -> &mut wasm_extern_t {
     &mut f.inner
 }
 
 /// Returns the [`wasm_func_t`] as shared reference to [`wasm_extern_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_func_as_extern_const(f: &wasm_func_t) -> &wasm_extern_t {
     &f.inner
 }

--- a/crates/c_api/src/global.rs
+++ b/crates/c_api/src/global.rs
@@ -48,7 +48,7 @@ impl wasm_global_t {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_global_new(
     store: &mut wasm_store_t,
     ty: &wasm_globaltype_t,
@@ -69,13 +69,13 @@ pub unsafe extern "C" fn wasm_global_new(
 }
 
 /// Returns the [`wasm_global_t`] as mutable reference to [`wasm_extern_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_global_as_extern(g: &mut wasm_global_t) -> &mut wasm_extern_t {
     &mut g.inner
 }
 
 /// Returns the [`wasm_global_t`] as shared reference to [`wasm_extern_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_global_as_extern_const(g: &wasm_global_t) -> &wasm_extern_t {
     &g.inner
 }
@@ -88,7 +88,7 @@ pub extern "C" fn wasm_global_as_extern_const(g: &wasm_global_t) -> &wasm_extern
 ///
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globaltype_t> {
     let globaltype = g.global().ty(g.inner.store.context());
     Box::new(wasm_globaltype_t::new(globaltype))
@@ -102,7 +102,7 @@ pub unsafe extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globalt
 ///
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeUninit<wasm_val_t>) {
     let global = g.global();
     crate::initialize(
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeU
 /// - It is the caller's responsibility that `val` matches the type of `g`.
 /// - It is the caller's responsibility not to alias the [`wasm_global_t`]
 ///   with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_global_set(g: &mut wasm_global_t, val: &wasm_val_t) {
     let global = g.global();
     drop(global.set(g.inner.store.context_mut(), val.to_val()));

--- a/crates/c_api/src/instance.rs
+++ b/crates/c_api/src/instance.rs
@@ -43,7 +43,7 @@ impl wasm_instance_t {
 /// with its underlying, internal [`WasmStoreRef`].
 ///
 /// [Wasm core specification]: https://webassembly.github.io/spec/core/exec/modules.html#exec-instantiation
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_instance_new(
     store: &mut wasm_store_t,
     wasm_module: &wasm_module_t,
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn wasm_instance_new(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_instance_t`]
 /// with its underlying, internal [`WasmStoreRef`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_instance_exports(
     instance: &mut wasm_instance_t,
     out: &mut wasm_extern_vec_t,

--- a/crates/c_api/src/lib.rs
+++ b/crates/c_api/src/lib.rs
@@ -1,21 +1,6 @@
 //! Implements C-API support for the Wasmi WebAssembly interpreter.
 //!
 //! Namely implements the Wasm C-API proposal found here: <https://github.com/WebAssembly/wasm-c-api/>
-//!
-//! # Crate features
-//!
-//! ## The `mangle-symbols` feature
-//! The `mangle-symbols` feature, when enabled, disables the `#[no_mangle]` attributes on exported symbols. This means that,
-//! when the feature is enabled, the public symbols (such as `wasm_func_new`) in this library are not visible with the
-//! plain "C" name, and the usual Rust mangling is operated instead.
-//!
-//! The rationale behind this feature is to allow (or facilitate) users that want to use multiple implementers of the
-//! C-API proposal together to avoid duplicate symbols error. This feature is disabled by default, thus public symbols
-//! are not mangled.
-//!
-//! ### Note
-//! When enabeld, the public symbols prefixed with `wasmi_` are mangled as well, even if they should not, in principle,
-//! cause any duplicate symbol error when working with other implementers.
 
 #![no_std]
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]

--- a/crates/c_api/src/memory.rs
+++ b/crates/c_api/src/memory.rs
@@ -49,7 +49,7 @@ impl wasm_memory_t {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_memory_new(
     store: &mut wasm_store_t,
     mt: &wasm_memorytype_t,
@@ -64,13 +64,13 @@ pub unsafe extern "C" fn wasm_memory_new(
 }
 
 /// Returns the [`wasm_memory_t`] as mutable reference to [`wasm_extern_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_memory_as_extern(m: &mut wasm_memory_t) -> &mut wasm_extern_t {
     &mut m.inner
 }
 
 /// Returns the [`wasm_memory_t`] as shared reference to [`wasm_extern_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_memory_as_extern_const(m: &wasm_memory_t) -> &wasm_extern_t {
     &m.inner
 }
@@ -83,7 +83,7 @@ pub extern "C" fn wasm_memory_as_extern_const(m: &wasm_memory_t) -> &wasm_extern
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_memory_type(m: &wasm_memory_t) -> Box<wasm_memorytype_t> {
     let ty = m.memory().ty(m.inner.store.context());
     Box::new(wasm_memorytype_t::new(ty))
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn wasm_memory_type(m: &wasm_memory_t) -> Box<wasm_memoryt
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_memory_data(m: &wasm_memory_t) -> *mut u8 {
     m.memory().data_ptr(m.inner.store.context())
 }
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn wasm_memory_data(m: &wasm_memory_t) -> *mut u8 {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_memory_data_size(m: &wasm_memory_t) -> usize {
     m.memory().data_size(m.inner.store.context())
 }
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn wasm_memory_data_size(m: &wasm_memory_t) -> usize {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_memory_size(m: &wasm_memory_t) -> wasm_memory_pages_t {
     m.memory().size(m.inner.store.context())
 }
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn wasm_memory_size(m: &wasm_memory_t) -> wasm_memory_page
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_memory_grow(
     m: &mut wasm_memory_t,
     delta: wasm_memory_pages_t,

--- a/crates/c_api/src/module.rs
+++ b/crates/c_api/src/module.rs
@@ -49,7 +49,7 @@ wasmi_c_api_macros::declare_own!(wasm_shared_module_t);
 ///
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_module_new(
     store: &mut wasm_store_t,
     binary: &wasm_byte_vec_t,
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn wasm_module_new(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_module_validate(
     store: &mut wasm_store_t,
     binary: &wasm_byte_vec_t,
@@ -95,7 +95,7 @@ fn fill_exports(module: &Module, out: &mut wasm_exporttype_vec_t) {
 /// Stores the queried module exports in `out`.
 ///
 /// Wraps [`Module::exports`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_module_exports(module: &wasm_module_t, out: &mut wasm_exporttype_vec_t) {
     fill_exports(&module.inner, out);
 }
@@ -120,7 +120,7 @@ fn fill_imports(module: &Module, out: &mut wasm_importtype_vec_t) {
 /// Stores the queried module imports in `out`.
 ///
 /// Wraps [`Module::imports`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_importtype_vec_t) {
     fill_imports(&module.inner, out);
 }
@@ -131,7 +131,7 @@ pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_imp
 /// - Obtain the original [`wasm_module_t`] via a call to [`wasm_module_obtain`].
 ///
 /// Wraps [`Module::clone`] (kinda).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_module_share(module: &wasm_module_t) -> Box<wasm_shared_module_t> {
     Box::new(wasm_shared_module_t {
         inner: module.inner.clone(),
@@ -148,7 +148,7 @@ pub extern "C" fn wasm_module_share(module: &wasm_module_t) -> Box<wasm_shared_m
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 ///
 /// Wraps [`Module::clone`] (kinda).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_module_obtain(
     store: &mut wasm_store_t,
     shared_module: &wasm_shared_module_t,
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn wasm_module_obtain(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_module_serialize(_module: &wasm_module_t, _ret: &mut wasm_byte_vec_t) {
     unimplemented!("wasm_module_serialize")
 }
@@ -187,7 +187,7 @@ pub extern "C" fn wasm_module_serialize(_module: &wasm_module_t, _ret: &mut wasm
 ///
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_module_deserialize(
     _store: &mut wasm_store_t,
     _binary: &wasm_byte_vec_t,

--- a/crates/c_api/src/ref.rs
+++ b/crates/c_api/src/ref.rs
@@ -88,7 +88,7 @@ pub(crate) fn ref_to_val(r: &wasm_ref_t) -> Val {
 /// Copies the [`wasm_ref_t`] and returns the copied reference.
 ///
 /// Returns `None` if `r` was `None`.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_copy(r: Option<&wasm_ref_t>) -> Option<Box<wasm_ref_t>> {
     r.map(|r| Box::new(r.clone()))
 }
@@ -98,7 +98,7 @@ pub extern "C" fn wasm_ref_copy(r: Option<&wasm_ref_t>) -> Option<Box<wasm_ref_t
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_same(_a: Option<&wasm_ref_t>, _b: Option<&wasm_ref_t>) -> bool {
     // In Wasmi we require a store to determine whether these are the same
     // reference or not and therefore we cannot support this Wasm C API.
@@ -110,7 +110,7 @@ pub extern "C" fn wasm_ref_same(_a: Option<&wasm_ref_t>, _b: Option<&wasm_ref_t>
 /// # Note
 ///
 /// This API is unsupported and always returns a `null` pointer.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_get_host_info(_ref: Option<&wasm_ref_t>) -> *mut c_void {
     ptr::null_mut()
 }
@@ -120,7 +120,7 @@ pub extern "C" fn wasm_ref_get_host_info(_ref: Option<&wasm_ref_t>) -> *mut c_vo
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_set_host_info(_ref: Option<&wasm_ref_t>, _info: *mut c_void) {
     unimplemented!("wasm_ref_set_host_info")
 }
@@ -132,7 +132,7 @@ pub extern "C" fn wasm_ref_set_host_info(_ref: Option<&wasm_ref_t>, _info: *mut 
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
     _ref: Option<&wasm_ref_t>,
     _info: *mut c_void,
@@ -146,7 +146,7 @@ pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_extern(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_extern_t> {
     unimplemented!("wasm_ref_as_extern")
 }
@@ -156,7 +156,7 @@ pub extern "C" fn wasm_ref_as_extern(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_extern_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_extern_t> {
     unimplemented!("wasm_ref_as_extern_const")
 }
@@ -166,7 +166,7 @@ pub extern "C" fn wasm_ref_as_extern_const(_ref: Option<&wasm_ref_t>) -> Option<
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_foreign(
     _ref: Option<&mut wasm_ref_t>,
 ) -> Option<&mut wasm_foreign_t> {
@@ -178,7 +178,7 @@ pub extern "C" fn wasm_ref_as_foreign(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_foreign_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&crate::wasm_foreign_t> {
@@ -190,7 +190,7 @@ pub extern "C" fn wasm_ref_as_foreign_const(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_func(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_func_t> {
     unimplemented!("wasm_ref_as_func")
 }
@@ -200,7 +200,7 @@ pub extern "C" fn wasm_ref_as_func(_ref: Option<&mut wasm_ref_t>) -> Option<&mut
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_func_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_func_t> {
     unimplemented!("wasm_ref_as_func_const")
 }
@@ -210,7 +210,7 @@ pub extern "C" fn wasm_ref_as_func_const(_ref: Option<&wasm_ref_t>) -> Option<&w
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_global(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_global_t> {
     unimplemented!("wasm_ref_as_global")
 }
@@ -220,7 +220,7 @@ pub extern "C" fn wasm_ref_as_global(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_global_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_global_t> {
     unimplemented!("wasm_ref_as_global_const")
 }
@@ -230,7 +230,7 @@ pub extern "C" fn wasm_ref_as_global_const(_ref: Option<&wasm_ref_t>) -> Option<
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_instance(
     _ref: Option<&mut wasm_ref_t>,
 ) -> Option<&mut wasm_instance_t> {
@@ -242,7 +242,7 @@ pub extern "C" fn wasm_ref_as_instance(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_instance_const(
     _ref: Option<&wasm_ref_t>,
 ) -> Option<&wasm_instance_t> {
@@ -254,7 +254,7 @@ pub extern "C" fn wasm_ref_as_instance_const(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_memory(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_memory_t> {
     unimplemented!("wasm_ref_as_memory")
 }
@@ -264,7 +264,7 @@ pub extern "C" fn wasm_ref_as_memory(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_memory_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_memory_t> {
     unimplemented!("wasm_ref_as_memory_const")
 }
@@ -274,7 +274,7 @@ pub extern "C" fn wasm_ref_as_memory_const(_ref: Option<&wasm_ref_t>) -> Option<
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_module(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_module_t> {
     unimplemented!("wasm_ref_as_module")
 }
@@ -284,7 +284,7 @@ pub extern "C" fn wasm_ref_as_module(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_module_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_module_t> {
     unimplemented!("wasm_ref_as_module_const")
 }
@@ -294,7 +294,7 @@ pub extern "C" fn wasm_ref_as_module_const(_ref: Option<&wasm_ref_t>) -> Option<
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_table(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_table_t> {
     unimplemented!("wasm_ref_as_table")
 }
@@ -304,7 +304,7 @@ pub extern "C" fn wasm_ref_as_table(_ref: Option<&mut wasm_ref_t>) -> Option<&mu
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_table_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_table_t> {
     unimplemented!("wasm_ref_as_table_const")
 }
@@ -314,7 +314,7 @@ pub extern "C" fn wasm_ref_as_table_const(_ref: Option<&wasm_ref_t>) -> Option<&
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_trap(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_trap_t> {
     unimplemented!("wasm_ref_as_trap")
 }
@@ -324,7 +324,7 @@ pub extern "C" fn wasm_ref_as_trap(_ref: Option<&mut wasm_ref_t>) -> Option<&mut
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_ref_as_trap_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_trap_t> {
     unimplemented!("wasm_ref_as_trap_const")
 }

--- a/crates/c_api/src/store.rs
+++ b/crates/c_api/src/store.rs
@@ -61,7 +61,7 @@ wasmi_c_api_macros::declare_own!(wasm_store_t);
 /// The returned [`wasm_store_t`] must be freed using [`wasm_store_delete`].
 ///
 /// Wraps [`<wasmi::Store<()>>::new`](wasmi::Store::new).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 #[allow(clippy::arc_with_non_send_sync)]
 pub extern "C" fn wasm_store_new(engine: &wasm_engine_t) -> Box<wasm_store_t> {
     let engine = &engine.inner;
@@ -96,7 +96,7 @@ pub struct WasmiStoreData {
 /// - The returned [`wasm_store_t`] must be freed using [`wasm_store_delete`].
 ///
 /// Wraps [`<wasmi::Store<()>>::new`](wasmi::Store::new).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_store_new(
     engine: &wasm_engine_t,
     data: *mut ffi::c_void,
@@ -119,7 +119,7 @@ pub extern "C" fn wasmi_store_new(
 /// # Safety
 ///
 /// It is the callers responsibility to provide a valid `self`.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_store_context(
     store: &mut wasmi_store_t,
 ) -> StoreContextMut<'_, WasmiStoreData> {
@@ -127,7 +127,7 @@ pub extern "C" fn wasmi_store_context(
 }
 
 /// Returns a pointer to the foreign data of the Wasmi store context.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_context_get_data(
     store: StoreContext<'_, WasmiStoreData>,
 ) -> *mut ffi::c_void {
@@ -135,7 +135,7 @@ pub extern "C" fn wasmi_context_get_data(
 }
 
 /// Sets the foreign data of the Wasmi store context.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_context_set_data(
     mut store: StoreContextMut<'_, WasmiStoreData>,
     data: *mut ffi::c_void,
@@ -150,7 +150,7 @@ pub extern "C" fn wasmi_context_set_data(
 /// # Errors
 ///
 /// If [`Store::get_fuel`] errors.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_context_get_fuel(
     store: StoreContext<'_, WasmiStoreData>,
     fuel: &mut u64,
@@ -167,7 +167,7 @@ pub extern "C" fn wasmi_context_get_fuel(
 /// # Errors
 ///
 /// If [`Store::set_fuel`] errors.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasmi_context_set_fuel(
     mut store: StoreContextMut<'_, WasmiStoreData>,
     fuel: u64,

--- a/crates/c_api/src/table.rs
+++ b/crates/c_api/src/table.rs
@@ -61,7 +61,7 @@ fn option_wasm_ref_t_to_ref(r: Option<&wasm_ref_t>, table_ty: &TableType) -> Was
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_table_new(
     store: &mut wasm_store_t,
     tt: &wasm_tabletype_t,
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn wasm_table_new(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_table_type(t: &wasm_table_t) -> Box<wasm_tabletype_t> {
     let table = t.table();
     let store = t.inner.store.context();
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn wasm_table_type(t: &wasm_table_t) -> Box<wasm_tabletype
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_table_get(
     t: &mut wasm_table_t,
     index: wasm_table_size_t,
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn wasm_table_get(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_table_set(
     t: &mut wasm_table_t,
     index: wasm_table_size_t,
@@ -145,7 +145,7 @@ pub unsafe extern "C" fn wasm_table_set(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_table_size(t: &wasm_table_t) -> wasm_table_size_t {
     let table = t.table();
     let store = t.inner.store.context();
@@ -161,7 +161,7 @@ pub unsafe extern "C" fn wasm_table_size(t: &wasm_table_t) -> wasm_table_size_t 
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_table_grow(
     t: &mut wasm_table_t,
     delta: wasm_table_size_t,
@@ -175,13 +175,13 @@ pub unsafe extern "C" fn wasm_table_grow(
 }
 
 /// Returns the [`wasm_table_t`] as mutable reference to [`wasm_extern_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_table_as_extern(t: &mut wasm_table_t) -> &mut wasm_extern_t {
     &mut t.inner
 }
 
 /// Returns the [`wasm_table_t`] as shared reference to [`wasm_extern_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_table_as_extern_const(t: &wasm_table_t) -> &wasm_extern_t {
     &t.inner
 }

--- a/crates/c_api/src/trap.rs
+++ b/crates/c_api/src/trap.rs
@@ -41,7 +41,7 @@ pub type wasm_message_t = wasm_name_t;
 /// # Note
 ///
 /// The `message` is expected to contain a valid null-terminated C string.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_trap_new(
     _store: &wasm_store_t,
     message: &wasm_message_t,
@@ -61,7 +61,7 @@ pub extern "C" fn wasm_trap_new(
 /// # Safety
 ///
 /// The caller is responsible to provide a valid `message` and `len` pair.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasmi_trap_new(message: *const u8, len: usize) -> Box<wasm_trap_t> {
     let bytes = crate::slice_from_raw_parts(message, len);
     let message = String::from_utf8_lossy(bytes);
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn wasmi_trap_new(message: *const u8, len: usize) -> Box<w
 /// Returns the error message of the [`wasm_trap_t`].
 ///
 /// Stores the returned error message in `out`.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t) {
     let mut buffer = Vec::new();
     buffer.extend_from_slice(format!("{:?}", trap.error).as_bytes());
@@ -87,7 +87,7 @@ pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_trap_origin(_raw: &wasm_trap_t) -> Option<Box<wasm_frame_t<'_>>> {
     unimplemented!("wasm_trap_origin")
 }
@@ -99,7 +99,7 @@ pub extern "C" fn wasm_trap_origin(_raw: &wasm_trap_t) -> Option<Box<wasm_frame_
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_trap_trace<'a>(_raw: &'a wasm_trap_t, _out: &mut wasm_frame_vec_t<'a>) {
     unimplemented!("wasm_trap_trace")
 }

--- a/crates/c_api/src/types/export.rs
+++ b/crates/c_api/src/types/export.rs
@@ -30,7 +30,7 @@ impl wasm_exporttype_t {
 }
 
 /// Creates a new [`wasm_exporttype_t`] with the given `name` and extern type `ty`
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_exporttype_new(
     name: &mut wasm_name_t,
     ty: Box<wasm_externtype_t>,
@@ -41,13 +41,13 @@ pub extern "C" fn wasm_exporttype_new(
 }
 
 /// Returns a shared reference to the name of the [`wasm_exporttype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_exporttype_name(et: &wasm_exporttype_t) -> &wasm_name_t {
     &et.c_name
 }
 
 /// Returns a shared reference to the extern type of the [`wasm_exporttype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_exporttype_type(et: &wasm_exporttype_t) -> &wasm_externtype_t {
     &et.c_ty
 }

--- a/crates/c_api/src/types/extern.rs
+++ b/crates/c_api/src/types/extern.rs
@@ -63,7 +63,7 @@ impl wasm_externtype_t {
 }
 
 /// Returns the [`wasm_externkind_t`] of the [`wasm_externtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_externtype_kind(et: &wasm_externtype_t) -> wasm_externkind_t {
     match &et.which {
         CExternType::Func(_) => wasm_externkind_t::WASM_EXTERN_FUNC,
@@ -74,7 +74,7 @@ pub extern "C" fn wasm_externtype_kind(et: &wasm_externtype_t) -> wasm_externkin
 }
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_functype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_externtype_as_functype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_functype_t> {
@@ -82,7 +82,7 @@ pub extern "C" fn wasm_externtype_as_functype(
 }
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_functype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_externtype_as_functype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_functype_t> {
@@ -90,7 +90,7 @@ pub extern "C" fn wasm_externtype_as_functype_const(
 }
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_globaltype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_externtype_as_globaltype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_globaltype_t> {
@@ -98,7 +98,7 @@ pub extern "C" fn wasm_externtype_as_globaltype(
 }
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_globaltype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_externtype_as_globaltype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_globaltype_t> {
@@ -106,7 +106,7 @@ pub extern "C" fn wasm_externtype_as_globaltype_const(
 }
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_tabletype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_externtype_as_tabletype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_tabletype_t> {
@@ -114,7 +114,7 @@ pub extern "C" fn wasm_externtype_as_tabletype(
 }
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_tabletype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_externtype_as_tabletype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_tabletype_t> {
@@ -122,7 +122,7 @@ pub extern "C" fn wasm_externtype_as_tabletype_const(
 }
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_memorytype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_externtype_as_memorytype(
     et: &mut wasm_externtype_t,
 ) -> Option<&mut wasm_memorytype_t> {
@@ -130,7 +130,7 @@ pub extern "C" fn wasm_externtype_as_memorytype(
 }
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_memorytype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_externtype_as_memorytype_const(
     et: &wasm_externtype_t,
 ) -> Option<&wasm_memorytype_t> {

--- a/crates/c_api/src/types/func.rs
+++ b/crates/c_api/src/types/func.rs
@@ -76,7 +76,7 @@ impl CFuncType {
 /// Creates a new [`wasm_functype_t`] from the given parameter and result types.
 ///
 /// Wraps [`FuncType::new`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_functype_new(
     params: &mut wasm_valtype_vec_t,
     results: &mut wasm_valtype_vec_t,
@@ -98,7 +98,7 @@ pub extern "C" fn wasm_functype_new(
 /// Returns a shared reference to the parameter types of the [`wasm_functype_t`].
 ///
 /// Wraps [`FuncType::params`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     &ft.ty().params
 }
@@ -106,19 +106,19 @@ pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_ve
 /// Returns a shared reference to the result types of the [`wasm_functype_t`].
 ///
 /// Wraps [`FuncType::results`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_functype_results(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     &ft.ty().results
 }
 
 /// Returns a mutable reference to the element type of [`wasm_functype_t`] as [`wasm_externtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_functype_as_externtype(ty: &mut wasm_functype_t) -> &mut wasm_externtype_t {
     &mut ty.ext
 }
 
 /// Returns a shared reference to the element type of [`wasm_functype_t`] as [`wasm_externtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_functype_as_externtype_const(ty: &wasm_functype_t) -> &wasm_externtype_t {
     &ty.ext
 }

--- a/crates/c_api/src/types/global.rs
+++ b/crates/c_api/src/types/global.rs
@@ -70,7 +70,7 @@ impl CGlobalType {
 /// Creates a new [`wasm_globaltype_t`] with the given content type and mutability.
 ///
 /// Wraps [`GlobalType::new`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_globaltype_new(
     ty: Box<wasm_valtype_t>,
     mutability: wasm_mutability_t,
@@ -84,13 +84,13 @@ pub extern "C" fn wasm_globaltype_new(
 }
 
 /// Returns a shared reference to the content type of the [`wasm_globaltype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_globaltype_content(gt: &wasm_globaltype_t) -> &wasm_valtype_t {
     &gt.ty().content
 }
 
 /// Returns the mutability of the [`wasm_globaltype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_globaltype_mutability(gt: &wasm_globaltype_t) -> wasm_mutability_t {
     match gt.ty().ty.mutability() {
         wasmi::Mutability::Const => wasm_mutability_t::WASM_CONST,
@@ -99,7 +99,7 @@ pub extern "C" fn wasm_globaltype_mutability(gt: &wasm_globaltype_t) -> wasm_mut
 }
 
 /// Returns a mutable reference to the element type of [`wasm_globaltype_t`] as [`wasm_externtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_globaltype_as_externtype(
     ty: &mut wasm_globaltype_t,
 ) -> &mut wasm_externtype_t {
@@ -107,7 +107,7 @@ pub extern "C" fn wasm_globaltype_as_externtype(
 }
 
 /// Returns a shared reference to the element type of [`wasm_globaltype_t`] as [`wasm_externtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_globaltype_as_externtype_const(
     ty: &wasm_globaltype_t,
 ) -> &wasm_externtype_t {

--- a/crates/c_api/src/types/import.rs
+++ b/crates/c_api/src/types/import.rs
@@ -34,7 +34,7 @@ impl wasm_importtype_t {
 }
 
 /// Creates a new [`wasm_importtype_t`] from the given `module` and `name` namespace and extern type `ty`.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_importtype_new(
     module: &mut wasm_name_t,
     name: &mut wasm_name_t,
@@ -52,19 +52,19 @@ pub extern "C" fn wasm_importtype_new(
 }
 
 /// Returns a shared reference to the module namespace of the [`wasm_importtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_importtype_module(it: &wasm_importtype_t) -> &wasm_name_t {
     &it.c_module
 }
 
 /// Returns a shared reference to the name namespace of the [`wasm_importtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_importtype_name(it: &wasm_importtype_t) -> &wasm_name_t {
     &it.c_name
 }
 
 /// Returns a shared reference to the extern type of the [`wasm_importtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_importtype_type(it: &wasm_importtype_t) -> &wasm_externtype_t {
     &it.c_ty
 }

--- a/crates/c_api/src/types/memory.rs
+++ b/crates/c_api/src/types/memory.rs
@@ -62,20 +62,20 @@ impl CMemoryType {
 /// Creates a new [`wasm_memorytype_t`] with the given `limits`.
 ///
 /// Wraps [`MemoryType::new`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm_memorytype_t> {
     let memory_type = MemoryType::new(limits.min, limits.max()).unwrap();
     Box::new(wasm_memorytype_t::new(memory_type))
 }
 
 /// Returns a shared reference to the table limits of the [`wasm_memorytype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_memorytype_limits(mt: &wasm_memorytype_t) -> &wasm_limits_t {
     &mt.ty().limits
 }
 
 /// Returns a mutable reference to the element type of [`wasm_memorytype_t`] as [`wasm_externtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_memorytype_as_externtype(
     ty: &mut wasm_memorytype_t,
 ) -> &mut wasm_externtype_t {
@@ -83,7 +83,7 @@ pub extern "C" fn wasm_memorytype_as_externtype(
 }
 
 /// Returns a shared reference to the element type of [`wasm_memorytype_t`] as [`wasm_externtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_memorytype_as_externtype_const(
     ty: &wasm_memorytype_t,
 ) -> &wasm_externtype_t {

--- a/crates/c_api/src/types/table.rs
+++ b/crates/c_api/src/types/table.rs
@@ -65,7 +65,7 @@ impl CTableType {
 /// Creates a new [`wasm_tabletype_t`] with the element `ty` and `limits`.
 ///
 /// Wraps [`TableType::new`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_tabletype_new(
     ty: Box<wasm_valtype_t>,
     limits: &wasm_limits_t,
@@ -78,19 +78,19 @@ pub extern "C" fn wasm_tabletype_new(
 }
 
 /// Returns a shared reference to the element type of the [`wasm_tabletype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_tabletype_element(tt: &wasm_tabletype_t) -> &wasm_valtype_t {
     &tt.ty().element
 }
 
 /// Returns a shared reference to the table limits of the [`wasm_tabletype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_tabletype_limits(tt: &wasm_tabletype_t) -> &wasm_limits_t {
     &tt.ty().limits
 }
 
 /// Returns a mutable reference to the element type of [`wasm_tabletype_t`] as [`wasm_externtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_tabletype_as_externtype(
     ty: &mut wasm_tabletype_t,
 ) -> &mut wasm_externtype_t {
@@ -98,7 +98,7 @@ pub extern "C" fn wasm_tabletype_as_externtype(
 }
 
 /// Returns a shared reference to the element type of [`wasm_tabletype_t`] as [`wasm_externtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_tabletype_as_externtype_const(ty: &wasm_tabletype_t) -> &wasm_externtype_t {
     &ty.ext
 }

--- a/crates/c_api/src/types/val.rs
+++ b/crates/c_api/src/types/val.rs
@@ -45,7 +45,7 @@ pub enum wasm_valkind_t {
 }
 
 /// Creates a new owned [`wasm_valtype_t`] from the [`wasm_valkind_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> {
     Box::new(wasm_valtype_t {
         ty: into_valtype(kind),
@@ -53,7 +53,7 @@ pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> 
 }
 
 /// Returns the [`wasm_valkind_t`] of the [`wasm_valtype_t`].
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub extern "C" fn wasm_valtype_kind(vt: &wasm_valtype_t) -> wasm_valkind_t {
     from_valtype(&vt.ty)
 }

--- a/crates/c_api/src/val.rs
+++ b/crates/c_api/src/val.rs
@@ -145,7 +145,7 @@ impl wasm_val_t {
 /// # Safety
 ///
 /// The caller is responsible to provide a valid [`wasm_val_t`] that can safely be copied.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_val_copy(out: &mut MaybeUninit<wasm_val_t>, source: &wasm_val_t) {
     utils::initialize(out, source.clone());
 }
@@ -156,7 +156,7 @@ pub unsafe extern "C" fn wasm_val_copy(out: &mut MaybeUninit<wasm_val_t>, source
 ///
 /// The caller is responsible to provide a valid [`wasm_val_t`] that can safely be deleted.
 /// The same [`wasm_val_t`] must not be deleted more than once.
-#[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+#[no_mangle]
 pub unsafe extern "C" fn wasm_val_delete(val: *mut wasm_val_t) {
     ptr::drop_in_place(val);
 }

--- a/crates/c_api/src/vec.rs
+++ b/crates/c_api/src/vec.rs
@@ -134,7 +134,7 @@ macro_rules! declare_vecs {
         #[doc = "# Note"]
         #[doc = ""]
         #[doc = concat!("Returns the resulting [`", stringify!($name), "`] in `out`.")]
-        #[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+        #[no_mangle]
         pub extern "C" fn $empty(out: &mut $name) {
             out.size = 0;
             out.data = ptr::null_mut();
@@ -145,7 +145,7 @@ macro_rules! declare_vecs {
         #[doc = "# Note"]
         #[doc = ""]
         #[doc = concat!("Returns the resulting [`", stringify!($name), "`] in `out`.")]
-        #[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+        #[no_mangle]
         pub extern "C" fn $uninit(out: &mut $name, size: usize) {
             out.set_buffer(vec![Default::default(); size].into());
         }
@@ -160,7 +160,7 @@ macro_rules! declare_vecs {
         #[doc = "# Safety"]
         #[doc = ""]
         #[doc = "It is the callers responsibility to provide a valid pair of `ptr` and `size`."]
-        #[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+        #[no_mangle]
         pub unsafe extern "C" fn $new $(<$lt>)? (
             out: &mut $name $(<$lt>)?,
             size: usize,
@@ -175,7 +175,7 @@ macro_rules! declare_vecs {
         #[doc = "# Note"]
         #[doc = ""]
         #[doc = concat!("- Returns the resulting [`", stringify!($name), "`] in `out`.")]
-        #[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+        #[no_mangle]
         pub extern "C" fn $copy $(<$lt>)? (
             out: &mut $name $(<$lt>)?,
             src: &$name $(<$lt>)?,
@@ -184,7 +184,7 @@ macro_rules! declare_vecs {
         }
 
         #[doc = concat!("Frees memory associated to the [`", stringify!($name),"`].")]
-        #[cfg_attr(not(feature = "mangle-symbols"), no_mangle)]
+        #[no_mangle]
         pub extern "C" fn $delete $(<$lt>)? (out: &mut $name $(<$lt>)?) {
             out.take();
         }


### PR DESCRIPTION
As discussed in #1315. 