### PR TITLE
Improve C-API `prefix_symbol` attribute macro

### DIFF
--- a/crates/c_api/macro/lib.rs
+++ b/crates/c_api/macro/lib.rs
@@ -196,10 +196,7 @@ fn prefix_symbol_impl(attributes: TokenStream, input: TokenStream) -> Result<Tok
         bail!("err(prefix_symbol): attributes must be empty")
     }
     let mut stream = input.clone().into_iter();
-    let fn_token = stream.find(|tt| match tt {
-        TokenTree::Ident(ref ident) if *ident == "fn" => true,
-        _ => false,
-    });
+    let fn_token = stream.find(|tt| matches!(tt, TokenTree::Ident(ref ident) if *ident == "fn"));
     if fn_token.is_none() {
         bail!("can only apply on `fn` items")
     }
@@ -215,6 +212,5 @@ fn prefix_symbol_impl(attributes: TokenStream, input: TokenStream) -> Result<Tok
     Ok(quote! {
         #[export_name = #prefixed_fn_name]
         #input
-    }
-    .into())
+    })
 }

--- a/crates/c_api/macro/lib.rs
+++ b/crates/c_api/macro/lib.rs
@@ -195,6 +195,10 @@ fn prefix_symbol_impl(attributes: TokenStream, input: TokenStream) -> Result<Tok
         bail!("function name must follow `fn` keyword")
     };
     let fn_name = fn_ident.to_string();
+    if !fn_name.starts_with("wasm_") {
+        // No prefix needed since the function is not a part of the Wasm spec.
+        return Ok(input)
+    }
     let prefixed_fn_name = format!("wasmi_{}", fn_name);
     Ok(quote! {
         #[export_name = #prefixed_fn_name]

--- a/crates/c_api/macro/lib.rs
+++ b/crates/c_api/macro/lib.rs
@@ -180,6 +180,9 @@ pub fn prefix_symbol(
 }
 
 fn prefix_symbol_impl(attributes: TokenStream, input: TokenStream) -> Result<TokenStream, String> {
+    if !attributes.is_empty() {
+        bail!("err(prefix_symbol): attributes must be empty")
+    }
     let mut stream = input.clone().into_iter();
     let fn_token = stream.find(|tt| match tt {
         TokenTree::Ident(ref ident) if *ident == "fn" => true,

--- a/crates/c_api/src/store.rs
+++ b/crates/c_api/src/store.rs
@@ -98,7 +98,6 @@ pub struct WasmiStoreData {
 ///
 /// Wraps [`<wasmi::Store<()>>::new`](wasmi::Store::new).
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_store_new(
     engine: &wasm_engine_t,
     data: *mut ffi::c_void,
@@ -122,7 +121,6 @@ pub extern "C" fn wasmi_store_new(
 ///
 /// It is the callers responsibility to provide a valid `self`.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_store_context(
     store: &mut wasmi_store_t,
 ) -> StoreContextMut<'_, WasmiStoreData> {
@@ -131,7 +129,6 @@ pub extern "C" fn wasmi_store_context(
 
 /// Returns a pointer to the foreign data of the Wasmi store context.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_context_get_data(
     store: StoreContext<'_, WasmiStoreData>,
 ) -> *mut ffi::c_void {
@@ -140,7 +137,6 @@ pub extern "C" fn wasmi_context_get_data(
 
 /// Sets the foreign data of the Wasmi store context.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_context_set_data(
     mut store: StoreContextMut<'_, WasmiStoreData>,
     data: *mut ffi::c_void,
@@ -156,7 +152,6 @@ pub extern "C" fn wasmi_context_set_data(
 ///
 /// If [`Store::get_fuel`] errors.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_context_get_fuel(
     store: StoreContext<'_, WasmiStoreData>,
     fuel: &mut u64,
@@ -174,7 +169,6 @@ pub extern "C" fn wasmi_context_get_fuel(
 ///
 /// If [`Store::set_fuel`] errors.
 #[no_mangle]
-#[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasmi_context_set_fuel(
     mut store: StoreContextMut<'_, WasmiStoreData>,
     fuel: u64,


### PR DESCRIPTION
Follow-up for https://github.com/wasmi-labs/wasmi/pull/1315.

cc @xdoardo

- Improves error handling and error reporting.
- Makes macro code more readable.
- Adds new checks to guard against misuse.
- Remove misuses for non-Wasm spec API functions.