### PR TITLE
chore: remove unnecessary type conversions

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -109,9 +109,7 @@ impl Executor<'_> {
         }
         let memory = self.get_memory(memory);
         let (memory, fuel) = store.resolve_memory_and_fuel_mut(&memory);
-        let return_value = memory
-            .grow(delta, Some(fuel), resource_limiter)
-            .map(u32::from);
+        let return_value = memory.grow(delta, Some(fuel), resource_limiter);
         let return_value = match return_value {
             Ok(return_value) => {
                 // The `memory.grow` operation might have invalidated the cached

--- a/crates/wasmi/src/engine/resumable.rs
+++ b/crates/wasmi/src/engine/resumable.rs
@@ -226,7 +226,6 @@ impl ResumableInvocation {
         self.engine
             .clone()
             .resume_func(ctx.as_context_mut(), self, inputs, outputs)
-            .map_err(Into::into)
             .map(ResumableCall::new)
     }
 }
@@ -305,7 +304,6 @@ impl<Results> TypedResumableInvocation<Results> {
                 inputs,
                 <CallResultsTuple<Results>>::default(),
             )
-            .map_err(Into::into)
             .map(TypedResumableCall::new)
     }
 }

--- a/crates/wasmi/src/engine/translator/driver.rs
+++ b/crates/wasmi/src/engine/translator/driver.rs
@@ -57,7 +57,7 @@ where
         finalize: impl FnOnce(CompiledFuncEntity),
     ) -> Result<T::Allocations, Error> {
         self.translator.update_pos(offset);
-        self.translator.finish(finalize).map_err(Into::into)
+        self.translator.finish(finalize)
     }
 
     /// Translates local variables of the Wasm function.

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -461,7 +461,6 @@ impl Func {
             .engine()
             .clone()
             .execute_func_resumable(ctx.as_context_mut(), self, inputs, outputs)
-            .map_err(Into::into)
             .map(ResumableCall::new)
     }
 


### PR DESCRIPTION
Detected during an extension of the `useless_conversion` Clippy lint.