### PR TITLE
Replace direct `wat` usage with Wasmi's new `Module::new` Wat support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,6 @@ dependencies = [
  "clap",
  "wasmi 0.40.0",
  "wasmi_wasi",
- "wat",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,6 @@ version = "0.40.0"
 dependencies = [
  "wasi-common",
  "wasmi 0.40.0",
- "wat",
  "wiggle",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -624,12 +624,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -787,9 +787,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -876,10 +876,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -891,9 +892,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.166"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1016,9 +1017,9 @@ checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "postcard"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63d01def49fc815900a83e7a4a5083d2abc81b7ddd569a3fa0477778ae9b3ec"
+checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -1185,9 +1186,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"
@@ -1334,9 +1335,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1528,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1539,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
@@ -1554,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1564,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1577,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wasm-encoder"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 wasmi = { workspace = true }
 wasmi_wasi = { workspace = true }
-wat = { version = "1", default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2.0.7"

--- a/crates/cli/src/context.rs
+++ b/crates/cli/src/context.rs
@@ -34,9 +34,9 @@ impl Context {
         }
         config.compilation_mode(compilation_mode);
         let engine = wasmi::Engine::new(&config);
-        let wasm_bytes =
+        let wasm =
             fs::read(wasm_file).map_err(|_| anyhow!("failed to read Wasm file {wasm_file:?}"))?;
-        let module = wasmi::Module::new(&engine, &wasm_bytes[..]).map_err(|error| {
+        let module = wasmi::Module::new(&engine, wasm).map_err(|error| {
             anyhow!("failed to parse and validate Wasm module {wasm_file:?}: {error}")
         })?;
         let mut store = wasmi::Store::new(&engine, wasi_ctx);

--- a/crates/cli/src/context.rs
+++ b/crates/cli/src/context.rs
@@ -1,6 +1,5 @@
-use crate::utils;
 use anyhow::{anyhow, Error};
-use std::path::Path;
+use std::{fs, path::Path};
 use wasmi::{CompilationMode, Config, ExternType, Func, FuncType, Instance, Module, Store};
 use wasmi_wasi::WasiCtx;
 
@@ -35,7 +34,8 @@ impl Context {
         }
         config.compilation_mode(compilation_mode);
         let engine = wasmi::Engine::new(&config);
-        let wasm_bytes = utils::read_wasm_or_wat(wasm_file)?;
+        let wasm_bytes =
+            fs::read(wasm_file).map_err(|_| anyhow!("failed to read Wasm file {wasm_file:?}"))?;
         let module = wasmi::Module::new(&engine, &wasm_bytes[..]).map_err(|error| {
             anyhow!("failed to parse and validate Wasm module {wasm_file:?}: {error}")
         })?;

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -1,34 +1,10 @@
 use crate::display::DisplayValueType;
 use anyhow::{anyhow, bail, Error};
-use std::{ffi::OsStr, fs, path::Path};
 use wasmi::{
     core::{ValType, F32, F64},
     FuncType,
     Val,
 };
-
-/// Converts the given `.wat` into `.wasm`.
-fn wat2wasm(wat: &str) -> Result<Vec<u8>, wat::Error> {
-    wat::parse_str(wat)
-}
-
-/// Returns the contents of the given `.wasm` or `.wat` file.
-///
-/// # Errors
-///
-/// If the Wasm file `wasm_file` does not exist.
-/// If the Wasm file `wasm_file` is not a valid `.wasm` or `.wat` format.
-pub fn read_wasm_or_wat(wasm_file: &Path) -> Result<Vec<u8>, Error> {
-    let mut wasm_bytes =
-        fs::read(wasm_file).map_err(|_| anyhow!("failed to read Wasm file {wasm_file:?}"))?;
-    if wasm_file.extension().and_then(OsStr::to_str) == Some("wat") {
-        let wat = String::from_utf8(wasm_bytes)
-            .map_err(|error| anyhow!("failed to read UTF-8 file {wasm_file:?}: {error}"))?;
-        wasm_bytes = wat2wasm(&wat)
-            .map_err(|error| anyhow!("failed to parse .wat file {wasm_file:?}: {error}"))?;
-    }
-    Ok(wasm_bytes)
-}
 
 /// Returns a [`Val`] buffer capable of holding the return values.
 ///

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -19,4 +19,4 @@ wiggle = { version = "27.0.0", default-features = false }
 wasmi = { workspace = true, features = ["std"]}
 
 [dev-dependencies]
-wat = { version = "1", default-features = false }
+wasmi = { workspace = true, features = ["std", "wat"] }

--- a/crates/wasi/tests/wasi_wat.rs
+++ b/crates/wasi/tests/wasi_wat.rs
@@ -5,7 +5,7 @@ use wasmi_wasi::{add_to_linker, WasiCtx};
 pub fn load_instance_from_wat(wasm: &[u8]) -> (Store<WasiCtx>, wasmi::Instance) {
     let config = Config::default();
     let engine = Engine::new(&config);
-    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let module = Module::new(&engine, wasm).unwrap();
     let mut linker = <Linker<WasiCtx>>::new(&engine);
     // add wasi to linker
     let wasi = WasiCtxBuilder::new()

--- a/crates/wasi/tests/wasi_wat.rs
+++ b/crates/wasi/tests/wasi_wat.rs
@@ -2,8 +2,7 @@ use wasi_common::sync::WasiCtxBuilder;
 use wasmi::{Config, Engine, Extern, Instance, Linker, Module, Store};
 use wasmi_wasi::{add_to_linker, WasiCtx};
 
-pub fn load_instance_from_wat(wat_bytes: &[u8]) -> (Store<WasiCtx>, wasmi::Instance) {
-    let wasm = wat2wasm(wat_bytes);
+pub fn load_instance_from_wat(wasm: &[u8]) -> (Store<WasiCtx>, wasmi::Instance) {
     let config = Config::default();
     let engine = Engine::new(&config);
     let module = Module::new(&engine, &wasm[..]).unwrap();
@@ -23,11 +22,6 @@ pub fn load_instance_from_wat(wat_bytes: &[u8]) -> (Store<WasiCtx>, wasmi::Insta
         .start(&mut store)
         .unwrap();
     (store, instance)
-}
-
-/// Converts the `.wat` encoded `bytes` into `.wasm` encoded bytes.
-pub fn wat2wasm(bytes: &[u8]) -> Vec<u8> {
-    wat::parse_bytes(bytes).unwrap().into_owned()
 }
 
 fn load() -> (Store<WasiCtx>, Instance) {

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -31,16 +31,16 @@ spin = { version = "0.9", default-features = false, features = [
 smallvec = { version = "1.13.1", features = ["union"] }
 multi-stash = { version = "0.2.0" }
 arrayvec = { version = "0.7.4", default-features = false }
+wat = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
-wat = { version = "1", default-features = false }
 assert_matches = "1.5"
 anyhow = "1"
 wasmi_wast = { workspace = true }
 criterion = { version = "0.5", default-features = false }
 
 [features]
-default = ["std"]
+default = ["std", "wat"]
 std = [
     "wasmi_core/std",
     "wasmi_collections/std",
@@ -56,6 +56,7 @@ prefer-btree-collections = [
     "wasmi_collections/prefer-btree-collections",
     "wasmparser/prefer-btree-collections",
 ]
+wat = ["dep:wat", "std"]
 
 # Enables extra checks performed during Wasmi bytecode execution.
 #

--- a/crates/wasmi/benches/bench/mod.rs
+++ b/crates/wasmi/benches/bench/mod.rs
@@ -41,7 +41,7 @@ pub fn bench_config() -> Config {
 pub fn load_module_from_file(file_name: &str) -> wasmi::Module {
     let wasm = load_wasm_from_file(file_name);
     let engine = wasmi::Engine::new(&bench_config());
-    wasmi::Module::new(&engine, &wasm[..]).unwrap_or_else(|error| {
+    wasmi::Module::new(&engine, wasm).unwrap_or_else(|error| {
         panic!(
             "could not parse Wasm module from file {}: {}",
             file_name, error
@@ -86,7 +86,7 @@ pub fn wat2wasm(bytes: &[u8]) -> Vec<u8> {
 /// If the benchmark Wasm file could not be opened, read or parsed.
 pub fn load_instance_from_wat(wasm: &[u8]) -> (wasmi::Store<()>, wasmi::Instance) {
     let engine = wasmi::Engine::new(&bench_config());
-    let module = wasmi::Module::new(&engine, &wasm[..]).unwrap();
+    let module = wasmi::Module::new(&engine, wasm).unwrap();
     let linker = <wasmi::Linker<()>>::new(&engine);
     let mut store = wasmi::Store::new(&engine, ());
     let instance = linker

--- a/crates/wasmi/benches/bench/mod.rs
+++ b/crates/wasmi/benches/bench/mod.rs
@@ -84,8 +84,7 @@ pub fn wat2wasm(bytes: &[u8]) -> Vec<u8> {
 /// # Panics
 ///
 /// If the benchmark Wasm file could not be opened, read or parsed.
-pub fn load_instance_from_wat(wat_bytes: &[u8]) -> (wasmi::Store<()>, wasmi::Instance) {
-    let wasm = wat2wasm(wat_bytes);
+pub fn load_instance_from_wat(wasm: &[u8]) -> (wasmi::Store<()>, wasmi::Instance) {
     let engine = wasmi::Engine::new(&bench_config());
     let module = wasmi::Module::new(&engine, &wasm[..]).unwrap();
     let linker = <wasmi::Linker<()>>::new(&engine);

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -1169,7 +1169,7 @@ fn bench_execute_host_calls(c: &mut Criterion) {
     }
 
     let mut g = c.benchmark_group("execute/call/host");
-    let wasm = wat2wasm(include_bytes!("wat/host_calls.wat"));
+    let wasm = include_bytes!("wat/host_calls.wat");
     let engine = Engine::default();
     let module = Module::new(&engine, &wasm[..]).unwrap();
     let mut store = Store::new(&engine, ());

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -349,7 +349,7 @@ fn bench_translate_case_best(c: &mut Criterion) {
         });
         b.iter_with_large_drop(|| {
             let engine = Engine::default();
-            let _ = Module::new(&engine, &wasm[..]).unwrap();
+            let _ = Module::new(&engine, wasm).unwrap();
         })
     });
 }
@@ -405,7 +405,7 @@ fn bench_translate_case_worst_stackbomb_small(c: &mut Criterion) {
         });
         b.iter_with_large_drop(|| {
             let engine = Engine::default();
-            let _ = Module::new(&engine, &wasm[..]).unwrap();
+            let _ = Module::new(&engine, wasm).unwrap();
         })
     });
 }
@@ -435,7 +435,7 @@ fn bench_translate_case_worst_stackbomb_big(c: &mut Criterion) {
         });
         b.iter_with_large_drop(|| {
             let engine = Engine::default();
-            let _ = Module::new(&engine, &wasm[..]).unwrap();
+            let _ = Module::new(&engine, wasm).unwrap();
         })
     });
 }
@@ -1171,7 +1171,7 @@ fn bench_execute_host_calls(c: &mut Criterion) {
     let mut g = c.benchmark_group("execute/call/host");
     let wasm = include_bytes!("wat/host_calls.wat");
     let engine = Engine::default();
-    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let module = Module::new(&engine, wasm).unwrap();
     let mut store = Store::new(&engine, ());
     let host0 = Func::wrap(&mut store, || ());
     let host1 = Func::wrap(&mut store, |a: i64| a);

--- a/crates/wasmi/src/engine/limits/tests.rs
+++ b/crates/wasmi/src/engine/limits/tests.rs
@@ -7,7 +7,7 @@ fn parse_with(wasm: &str, limits: EnforcedLimits) -> Result<Module, Error> {
     let mut config = Config::default();
     config.enforced_limits(limits);
     let engine = Engine::new(&config);
-    Module::new(&engine, wasm.as_bytes())
+    Module::new(&engine, wasm)
 }
 
 #[test]

--- a/crates/wasmi/src/engine/limits/tests.rs
+++ b/crates/wasmi/src/engine/limits/tests.rs
@@ -1,20 +1,13 @@
 use self::engine::AvgBytesPerFunctionLimit;
 use super::*;
 use crate::{error::ErrorKind, Config, Engine, Error, Module};
-use std::vec::Vec;
-
-/// Converts the given `.wat` into `.wasm`.
-fn wat2wasm(wat: &str) -> Vec<u8> {
-    wat::parse_str(wat).unwrap()
-}
 
 /// Parses and returns the Wasm module `wasm` with the given [`EnforcedLimits`] `limits`.
 fn parse_with(wasm: &str, limits: EnforcedLimits) -> Result<Module, Error> {
-    let wasm = wat2wasm(wasm);
     let mut config = Config::default();
     config.enforced_limits(limits);
     let engine = Engine::new(&config);
-    Module::new(&engine, &wasm[..])
+    Module::new(&engine, wasm.as_bytes())
 }
 
 #[test]

--- a/crates/wasmi/src/engine/tests/many_inout.rs
+++ b/crates/wasmi/src/engine/tests/many_inout.rs
@@ -1,18 +1,11 @@
 use crate::{Engine, Func, Linker, Module, Store, Val};
-use std::vec::Vec;
-
-/// Converts the given `.wat` into `.wasm`.
-fn wat2wasm(wat: &str) -> Vec<u8> {
-    wat::parse_str(wat).unwrap()
-}
 
 /// Common routine to setup the tests.
 fn setup_test(wat: &str) -> (Store<()>, Func) {
-    let wasm = wat2wasm(wat);
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
     let linker = <Linker<()>>::new(&engine);
-    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let module = Module::new(&engine, wat.as_bytes()).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)
         .unwrap()

--- a/crates/wasmi/src/engine/tests/many_inout.rs
+++ b/crates/wasmi/src/engine/tests/many_inout.rs
@@ -1,11 +1,11 @@
 use crate::{Engine, Func, Linker, Module, Store, Val};
 
 /// Common routine to setup the tests.
-fn setup_test(wat: &str) -> (Store<()>, Func) {
+fn setup_test(wasm: &str) -> (Store<()>, Func) {
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
     let linker = <Linker<()>>::new(&engine);
-    let module = Module::new(&engine, wat.as_bytes()).unwrap();
+    let module = Module::new(&engine, wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)
         .unwrap()

--- a/crates/wasmi/src/engine/translator/tests/driver.rs
+++ b/crates/wasmi/src/engine/translator/tests/driver.rs
@@ -186,11 +186,7 @@ impl TranslationTest {
     ///
     /// If the WebAssembly `source` is not valid WebAssembly Text Format (WAT).
     #[must_use]
-    pub fn from_wat(source: &str) -> Self {
-        let wasm = match wat::parse_str(source) {
-            Ok(wasm) => wasm,
-            Err(error) => panic!("failed to convert from `.wat` to `.wasm`: {error}"),
-        };
+    pub fn from_wat(wasm: &str) -> Self {
         Self::new(wasm)
     }
 

--- a/crates/wasmi/src/engine/translator/tests/driver.rs
+++ b/crates/wasmi/src/engine/translator/tests/driver.rs
@@ -162,11 +162,13 @@ impl ExpectedFunc {
 impl TranslationTest {
     /// Creates a new [`TranslationTest`] for the given Webassembly `bytes`.
     ///
+    /// The `bytes` can either be Wasm binary (`.wasm`) or Wasm text format (`.wat`).
+    ///
     /// # Panics
     ///
     /// If the WebAssembly `bytes` is not valid WebAssembly.
     #[must_use]
-    fn new(bytes: impl AsRef<[u8]>) -> Self {
+    pub fn new(bytes: impl AsRef<[u8]>) -> Self {
         let config = {
             let mut cfg = Config::default();
             cfg.wasm_tail_call(true);
@@ -178,16 +180,6 @@ impl TranslationTest {
             expected_funcs: Vec::new(),
             has_run: AtomicBool::from(false),
         }
-    }
-
-    /// Creates a new [`TranslationTest`] for the given Webassembly `source`.
-    ///
-    /// # Panics
-    ///
-    /// If the WebAssembly `source` is not valid WebAssembly Text Format (WAT).
-    #[must_use]
-    pub fn from_wat(wasm: &str) -> Self {
-        Self::new(wasm)
     }
 
     /// Returns the [`Config`] used for the test case.

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -260,7 +260,7 @@ fn fuzz_regression_13_execute() {
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
     let linker = Linker::new(&engine);
-    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let module = Module::new(&engine, wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)
         .unwrap()
@@ -325,7 +325,7 @@ fn fuzz_regression_15_01_execute() {
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
     let linker = Linker::new(&engine);
-    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let module = Module::new(&engine, wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)
         .unwrap()
@@ -462,7 +462,7 @@ fn audit_0_execution() {
     let wasm = wat::parse_str(wat).unwrap();
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
-    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let module = Module::new(&engine, wasm).unwrap();
     let instance = Instance::new(&mut store, &module, &[]).unwrap();
     let func = instance
         .get_func(&store, "")
@@ -498,7 +498,7 @@ fn audit_1_execution() {
     let wasm = wat::parse_str(wat).unwrap();
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
-    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let module = Module::new(&engine, wasm).unwrap();
     let instance = Instance::new(&mut store, &module, &[]).unwrap();
     let func = instance
         .get_func(&store, "")
@@ -532,7 +532,7 @@ fn audit_2_execution() {
     let wasm = wat::parse_str(wat).unwrap();
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
-    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let module = Module::new(&engine, wasm).unwrap();
     let instance = Instance::new(&mut store, &module, &[]).unwrap();
     let func = instance.get_func(&store, "").unwrap();
     let inputs = [Val::I32(1)];

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_0() {
     let wasm = include_str!("wat/fuzz_0.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(1, 0),
             Instruction::copy_imm32(Reg::from(0), 13.0_f32),
@@ -25,7 +25,7 @@ fn fuzz_regression_0() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_1() {
     let wasm = include_str!("wat/fuzz_1.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(1, 0),
             Instruction::copy_f64imm32(Reg::from(0), 13.0_f32),
@@ -38,7 +38,7 @@ fn fuzz_regression_1() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_2() {
     let wasm = include_str!("wat/fuzz_2.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(1, 0),
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(2)),
@@ -52,7 +52,7 @@ fn fuzz_regression_2() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_3() {
     let wasm = include_str!("wat/fuzz_3.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_internal_0(RegSpan::new(Reg::from(0)), EngineFunc::from_u32(0)),
             Instruction::call_internal_0(RegSpan::new(Reg::from(3)), EngineFunc::from_u32(0)),
@@ -65,7 +65,7 @@ fn fuzz_regression_3() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_4() {
     let wasm = include_str!("wat/fuzz_4.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(2, 1),
             Instruction::copy(1, 0),
@@ -80,7 +80,7 @@ fn fuzz_regression_4() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_5() {
     let wasm = include_str!("wat/fuzz_5.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(1)), EngineFunc::from_u32(0)),
             Instruction::register(Reg::from(0)),
@@ -99,7 +99,7 @@ fn fuzz_regression_5() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_6() {
     let wasm = include_str!("wat/fuzz_6.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(2, 0),
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(4)),
@@ -116,7 +116,7 @@ fn fuzz_regression_6() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_7() {
     let wasm = include_str!("wat/fuzz_7.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(1, 0),
             Instruction::copy_imm32(Reg::from(0), 1),
@@ -129,7 +129,7 @@ fn fuzz_regression_7() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_8() {
     let wasm = include_str!("wat/fuzz_8.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(4, 1),
             Instruction::copy_imm32(Reg::from(1), 10),
@@ -145,7 +145,7 @@ fn fuzz_regression_8() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_9() {
     let wasm = include_str!("wat/fuzz_9.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(6, 1),
             Instruction::copy_imm32(Reg::from(1), 10),
@@ -166,7 +166,7 @@ fn fuzz_regression_9() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_10() {
     let wasm = include_str!("wat/fuzz_10.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(3)),
             Instruction::copy_imm32(Reg::from(1), 10),
@@ -181,7 +181,7 @@ fn fuzz_regression_10() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_11() {
     let wasm = include_str!("wat/fuzz_11.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::i32_and_imm16(Reg::from(1), Reg::from(0), 2),
             Instruction::i32_eq_imm16(Reg::from(0), Reg::from(0), 0),
@@ -196,7 +196,7 @@ fn fuzz_regression_11() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_12_f32() {
     let wasm = include_str!("wat/fuzz_12_f32.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(ExpectedFunc::new([
             Instruction::copy_imm32(Reg::from(0), u32::MAX),
             Instruction::f32_le(Reg::from(1), Reg::from(0), Reg::from(0)),
@@ -216,7 +216,7 @@ fn fuzz_regression_12_f32() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_12_f64() {
     let wasm = include_str!("wat/fuzz_12_f64.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::copy(0, -1),
@@ -242,7 +242,7 @@ fn fuzz_regression_12_f64() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_13_codegen() {
     let wasm = include_str!("wat/fuzz_13.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_nez_many_ext(0, 0, 0),
             Instruction::register(0),
@@ -278,7 +278,7 @@ fn fuzz_regression_13_execute() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_14() {
     let wasm = include_str!("wat/fuzz_14.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::i32_and(Reg::from(2), Reg::from(0), Reg::from(1)),
@@ -293,7 +293,7 @@ fn fuzz_regression_14() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_15_01_codegen() {
     let wasm = include_str!("wat/fuzz_15_01.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             // Note:
             //
@@ -342,7 +342,7 @@ fn fuzz_regression_15_01_execute() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_15_02() {
     let wasm = include_str!("wat/fuzz_15_02.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             // Note: The bug is that `copy2` overwrites `i32_wrap_i64` which is the `index` of the `br_table`.
             ExpectedFunc::new([
@@ -363,7 +363,7 @@ fn fuzz_regression_15_02() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_15_03() {
     let wasm = include_str!("wat/fuzz_15_03.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             // Note: The bug is that `copy2` overwrites `i32_wrap_i64` which is the `index` of the `br_table`.
             ExpectedFunc::new([
@@ -395,7 +395,7 @@ fn fuzz_regression_16() {
     // for the preserved local value causing the `value` register
     // of the `i64_store_at` instruction to be 32676 instead of 2.
     let wasm = include_str!("wat/fuzz_16.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(2, 0),
             Instruction::global_get(Reg::from(0), Global::from(0)),
@@ -413,7 +413,7 @@ fn fuzz_regression_17() {
     // for the preserved local value causing the `value` register
     // of the `i64_store_at` instruction to be 32676 instead of 2.
     let wasm = include_str!("wat/fuzz_17.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(2, 0),
             Instruction::copy_i64imm32(Reg::from(0), 2),
@@ -428,7 +428,7 @@ fn fuzz_regression_17() {
 #[cfg_attr(miri, ignore)]
 fn audit_0_codegen() {
     let wasm = include_str!("wat/audit_0.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_many_ext(-1, -2, -1),
@@ -475,7 +475,7 @@ fn audit_0_execution() {
 #[cfg_attr(miri, ignore)]
 fn audit_1_codegen() {
     let wasm = include_str!("wat/audit_1.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_span_non_overlapping(
                 RegSpan::new(Reg::from(6)),
@@ -509,7 +509,7 @@ fn audit_1_execution() {
 #[cfg_attr(miri, ignore)]
 fn audit_2_codegen() {
     let wasm = include_str!("wat/audit_2.wat");
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(2, 0),
             Instruction::copy(0, 2),

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -255,8 +255,7 @@ fn fuzz_regression_13_codegen() {
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_13_execute() {
     use crate::{Engine, Linker, Store};
-    let wat = include_str!("wat/fuzz_13.wat");
-    let wasm = wat::parse_str(wat).unwrap();
+    let wasm = include_str!("wat/fuzz_13.wat");
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
     let linker = Linker::new(&engine);
@@ -320,8 +319,7 @@ fn fuzz_regression_15_01_execute() {
     // Note: we can remove this test case once the bug is fixed
     //       since this is a codegen bug and not an executor bug.
     use crate::{Engine, Linker, Store};
-    let wat = include_str!("wat/fuzz_15_01.wat");
-    let wasm = wat::parse_str(wat).unwrap();
+    let wasm: &str = include_str!("wat/fuzz_15_01.wat");
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
     let linker = Linker::new(&engine);
@@ -458,8 +456,7 @@ fn audit_0_codegen() {
 #[cfg_attr(miri, ignore)]
 fn audit_0_execution() {
     use crate::{Engine, Instance, Store};
-    let wat = include_str!("wat/audit_0.wat");
-    let wasm = wat::parse_str(wat).unwrap();
+    let wasm = include_str!("wat/audit_0.wat");
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
     let module = Module::new(&engine, wasm).unwrap();
@@ -494,8 +491,7 @@ fn audit_1_codegen() {
 #[cfg_attr(miri, ignore)]
 fn audit_1_execution() {
     use crate::{Engine, Instance, Store};
-    let wat = include_str!("wat/audit_1.wat");
-    let wasm = wat::parse_str(wat).unwrap();
+    let wasm = include_str!("wat/audit_1.wat");
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
     let module = Module::new(&engine, wasm).unwrap();
@@ -528,8 +524,7 @@ fn audit_2_codegen() {
 #[cfg_attr(miri, ignore)]
 fn audit_2_execution() {
     use crate::{Engine, Instance, Store};
-    let wat = include_str!("wat/audit_2.wat");
-    let wasm = wat::parse_str(wat).unwrap();
+    let wasm = include_str!("wat/audit_2.wat");
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());
     let module = Module::new(&engine, wasm).unwrap();

--- a/crates/wasmi/src/engine/translator/tests/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/mod.rs
@@ -63,7 +63,7 @@ where
     T: IntoIterator<Item = Instruction>,
     <T as IntoIterator>::IntoIter: ExactSizeIterator,
 {
-    let mut testcase = TranslationTest::from_wat(wasm);
+    let mut testcase = TranslationTest::new(wasm);
     for instrs in expected {
         testcase.expect_func_instrs(instrs);
     }
@@ -227,7 +227,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn testcase_binary_imm_reg<T>(wasm_op: WasmOp, value: T) -> TranslationTest
@@ -249,7 +249,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 /// Variant of [`test_binary_reg_imm16`] where the `rhs` operand is an immediate value.
@@ -387,7 +387,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_binary_consteval<T, E>(wasm_op: WasmOp, lhs: T, rhs: T, expected: E)

--- a/crates/wasmi/src/engine/translator/tests/op/block.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/block.rs
@@ -12,7 +12,7 @@ fn empty_block() {
         (module
             (func (block))
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .run()
 }
@@ -24,7 +24,7 @@ fn nested_empty_block() {
         (module
             (func (block (block)))
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .run()
 }
@@ -39,7 +39,7 @@ fn identity_block_1() {
                 (block (param i32) (result i32))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::copy(2, 0), Instruction::return_reg(2)])
         .run()
 }
@@ -56,7 +56,7 @@ fn identity_block_2() {
                 (drop)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(4)), 0, 1),
             Instruction::return_reg(4),
@@ -76,7 +76,7 @@ fn nested_identity_block_1() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::copy(2, 0), Instruction::return_reg(2)])
         .run()
 }
@@ -95,7 +95,7 @@ fn nested_identity_block_2() {
                 (drop)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(4)), 0, 1),
             Instruction::return_reg(4),
@@ -114,7 +114,7 @@ fn branched_block_0() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch(BranchOffset::from(1)),
             Instruction::Return,
@@ -134,7 +134,7 @@ fn branched_block_1() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(2, 0),
             Instruction::copy(1, 2),
@@ -162,7 +162,7 @@ where
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 #[test]
@@ -307,7 +307,7 @@ fn branched_block_2() {
                 (drop)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(4)), 0, 1),
             Instruction::copy2_ext(RegSpan::new(Reg::from(2)), 4, 5),
@@ -329,7 +329,7 @@ fn branch_if_block_0() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(1, 0),
             Instruction::branch_i32_ne_imm16(Reg::from(1), 0, BranchOffset16::from(1)),
@@ -351,7 +351,7 @@ fn branch_if_block_1() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(3)), 0, 1),
             Instruction::branch_i32_eq_imm16(Reg::from(4), 0, BranchOffset16::from(3)),
@@ -372,7 +372,7 @@ fn branch_to_func_block_0() {
                 (br 0)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .run()
 }
@@ -387,7 +387,7 @@ fn branch_to_func_block_1() {
                 (br 0)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg(Reg::from(0))])
         .run()
 }
@@ -403,7 +403,7 @@ fn branch_to_func_block_nested_0() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .run()
 }
@@ -420,7 +420,7 @@ fn branch_to_func_block_nested_1() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(2, 0),
             Instruction::return_reg(Reg::from(2)),

--- a/crates/wasmi/src/engine/translator/tests/op/br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br.rs
@@ -11,7 +11,7 @@ fn as_return() {
                 (br 0)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .run()
 }
@@ -26,7 +26,7 @@ fn as_return_1() {
                 (br 0)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg(Reg::from(0))])
         .run()
 }
@@ -50,7 +50,7 @@ fn as_return_1_imm() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([Instruction::return_reg(Reg::from(-1))]).consts([value]),
             )
@@ -86,7 +86,7 @@ fn as_return_1_imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([Instruction::return_imm32(value)])
             .run()
     }
@@ -110,7 +110,7 @@ fn as_return_1_i64imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([return_i64imm32_instr(value)])
             .run()
     }
@@ -137,7 +137,7 @@ fn as_return_1_f64imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([return_f64imm32_instr(value)])
             .run()
     }
@@ -168,7 +168,7 @@ fn test_br_as_return_values() {
             )
         )
         "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::copy_i64imm32(Reg::from(0), 7),

--- a/crates/wasmi/src/engine/translator/tests/op/br_if.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_if.rs
@@ -20,7 +20,7 @@ fn consteval_return() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([Instruction::Return])
             .run()
     }
@@ -49,7 +49,7 @@ fn consteval_return_1() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([Instruction::return_reg(expected)])
             .run()
     }
@@ -85,7 +85,7 @@ fn consteval_return_1_imm() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([Instruction::return_reg(Reg::from(-1))]).consts([expected]),
             )
@@ -134,7 +134,7 @@ fn consteval_return_1_imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([Instruction::return_imm32(expected)])
             .run()
     }
@@ -174,7 +174,7 @@ fn consteval_return_1_i64imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([return_i64imm32_instr(expected)])
             .run()
     }
@@ -211,7 +211,7 @@ fn consteval_return_1_f64imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([return_f64imm32_instr(expected)])
             .run()
     }
@@ -241,7 +241,7 @@ fn consteval_branch_always() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(3, 0),
             Instruction::copy(2, 3),
@@ -266,7 +266,7 @@ fn consteval_branch_never() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(3, 0),
             Instruction::return_reg(Reg::from(1)),
@@ -284,7 +284,7 @@ fn return_if_results_0() {
                 (br_if 0)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_nez(Reg::from(0)), Instruction::Return])
         .run()
 }
@@ -300,7 +300,7 @@ fn return_if_results_1() {
                 (br_if 0)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_nez_reg(Reg::from(1), Reg::from(0)),
             Instruction::return_reg(Reg::from(0)),
@@ -328,7 +328,7 @@ fn return_if_results_1_imm() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::return_nez_reg(Reg::from(0), Reg::from(-1)),
@@ -373,7 +373,7 @@ fn return_if_results_1_imm32() {
             )",
         );
         let const32: AnyConst32 = returned_value.into();
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::return_nez_imm32(Reg::from(0), const32),
                 Instruction::return_imm32(const32),
@@ -405,7 +405,7 @@ fn return_if_results_1_i64imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 return_nez_i64imm32_instr(Reg::from(0), returned_value),
                 return_i64imm32_instr(returned_value),
@@ -437,7 +437,7 @@ fn return_if_results_1_f64imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 return_nez_f64imm32_instr(Reg::from(0), returned_value),
                 return_f64imm32_instr(returned_value),
@@ -471,7 +471,7 @@ fn return_if_results_2() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_nez_reg2_ext(Reg::from(2), 0, 1),
             Instruction::return_reg2_ext(0, 1),
@@ -492,7 +492,7 @@ fn return_if_results_2_lhs() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_nez_reg2_ext(Reg::from(2), 1, 0),
             Instruction::return_reg2_ext(1, 0),
@@ -513,7 +513,7 @@ fn return_if_results_2_imm() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_nez_reg2_ext(Reg::from(0), -1, -2),
@@ -538,7 +538,7 @@ fn return_if_results_3_span() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_nez_span(Reg::from(3), bspan(0, 3)),
             Instruction::return_reg3_ext(0, 1, 2),
@@ -560,7 +560,7 @@ fn return_if_results_3() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_nez_many_ext(Reg::from(2), 0, 1),
             Instruction::register(0),
@@ -583,7 +583,7 @@ fn return_if_results_3_imm() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_nez_many_ext(Reg::from(0), -1, -2),
@@ -610,7 +610,7 @@ fn return_if_results_4_span() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_nez_span(Reg::from(4), bspan(0, 4)),
             Instruction::return_span(bspan(0, 4)),
@@ -633,7 +633,7 @@ fn return_if_results_4() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_nez_many_ext(Reg::from(2), 0, 1),
             Instruction::register2_ext(0, 1),
@@ -658,7 +658,7 @@ fn return_if_results_4_imm() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_nez_many_ext(Reg::from(0), -1, -2),
@@ -687,7 +687,7 @@ fn return_if_results_5() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_nez_many_ext(Reg::from(2), 0, 1),
             Instruction::register3_ext(0, 1, 0),
@@ -713,7 +713,7 @@ fn return_if_results_5_imm() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_nez_many_ext(Reg::from(0), -1, -2),
@@ -743,7 +743,7 @@ fn return_if_results_6() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_nez_many_ext(Reg::from(2), 0, 1),
             Instruction::register_list_ext(0, 1, 0),
@@ -771,7 +771,7 @@ fn return_if_results_6_imm() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_nez_many_ext(Reg::from(0), -1, -2),
@@ -797,7 +797,7 @@ fn branch_if_results_0() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(1, 0),
             Instruction::branch_i32_ne_imm16(Reg::from(1), 0, BranchOffset16::from(1)),
@@ -819,7 +819,7 @@ fn branch_if_results_1() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(3)), 0, 1),
             Instruction::branch_i32_eq_imm16(Reg::from(4), 0, BranchOffset16::from(3)),
@@ -851,7 +851,7 @@ fn branch_if_results_1_avoid_copy() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::i32_clz(Reg::from(2), Reg::from(0)),
             Instruction::i32_ctz(Reg::from(3), Reg::from(1)),
@@ -876,7 +876,7 @@ fn branch_if_results_2() {
                 (i32.add)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_span_non_overlapping(
                 RegSpan::new(Reg::from(5)),
@@ -914,7 +914,7 @@ fn branch_if_results_2_avoid_copy() {
                 (i32.add)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::i32_clz(Reg::from(3), Reg::from(0)),
             Instruction::i32_ctz(Reg::from(4), Reg::from(1)),
@@ -943,7 +943,7 @@ fn branch_if_results_4_mixed_1() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::branch_i32_eq_imm16(Reg::from(2), 0, BranchOffset16::from(4)),
@@ -977,7 +977,7 @@ fn branch_if_results_4_mixed_2() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(2), 0, BranchOffset16::from(4)),
             Instruction::copy_many_non_overlapping_ext(RegSpan::new(Reg::from(3)), 0, 0),
@@ -1003,7 +1003,7 @@ fn branch_if_i32_eqz() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(0, 0_i16, BranchOffset16::from(2)),
             Instruction::i32_add_imm16(1, 0, 1),
@@ -1023,7 +1023,7 @@ fn return_if_i32_eqz() {
                 (drop (i32.add (local.get 0) (i32.const 1)))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::i32_eq_imm16(1, 0, 0),
             Instruction::return_nez(1),

--- a/crates/wasmi/src/engine/translator/tests/op/br_table.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/br_table.rs
@@ -19,7 +19,7 @@ fn spec_test_failure_2() {
         )
     ";
     let result = Reg::from(1);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::branch_table_2(0, 3_u16),
@@ -54,7 +54,7 @@ fn spec_test_failure() {
                 (i32.const 3)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_table_0(0, 3_u16),
             Instruction::branch(BranchOffset::from(3)),
@@ -79,7 +79,7 @@ fn reg_len_targets_1() {
                 (return (i32.const 10))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch(BranchOffset::from(1)),
             Instruction::return_imm32(10_i32),
@@ -108,7 +108,7 @@ fn reg_params_0() {
                 (return (i32.const 40))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_table_0(Reg::from(0), 4_u16),
             Instruction::branch(BranchOffset::from(7)),
@@ -145,7 +145,7 @@ fn reg_params_0_return() {
                 (return (global.set $g (i32.const 40)))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_table_0(Reg::from(0), 5_u32),
             Instruction::Return,
@@ -190,7 +190,7 @@ fn reg_params_1_return() {
     let index = Reg::from(0);
     let value = Reg::from(1);
     let result = Reg::from(2);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_table_1(index, 5_u32),
             Instruction::register(value),
@@ -239,7 +239,7 @@ fn reg_params_1_pass() {
     let index = Reg::from(0);
     let value = Reg::from(1);
     let result = Reg::from(2);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_table_1(index, 3_u32),
             Instruction::register(value),
@@ -280,7 +280,7 @@ fn reg_params_2_ops() {
         )";
     let index = Reg::from(0);
     let result = Reg::from(3);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_table_2(index, 3_u32),
             Instruction::register2_ext(1, 2),
@@ -320,7 +320,7 @@ fn reg_params_2_return() {
     let index = Reg::from(0);
     let result = Reg::from(3);
     let result2 = result.next();
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::branch_table_2(index, 4_u32),
@@ -370,7 +370,7 @@ fn reg_params_1_diff() {
     let index = Reg::from(0);
     let input = Reg::from(1);
     let result = Reg::from(2);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::global_get(result, Global::from(0)),
             Instruction::branch_table_1(index, 7_u32),
@@ -423,7 +423,7 @@ fn reg_params_2_diff() {
         )";
     let index = Reg::from(0);
     let result = Reg::from(3);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::global_get(result, Global::from(0)),
             Instruction::branch_table_2(index, 5_u32),
@@ -467,7 +467,7 @@ fn imm_params_0() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 Instruction::branch(BranchOffset::from(1)),
                 Instruction::return_imm32(chosen),
@@ -502,7 +502,7 @@ fn all_same_targets_0() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 Instruction::branch(BranchOffset::from(1)),
                 Instruction::return_imm32(value),
@@ -536,7 +536,7 @@ fn all_same_targets_1() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 Instruction::copy(2, 1),
                 Instruction::branch(BranchOffset::from(1)),
@@ -571,7 +571,7 @@ fn reg_params_3() {
                 (return (i32.add (i32.const 30)))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_table_3(3, 4_u32),
             Instruction::register3_ext(0, 1, 2),
@@ -612,7 +612,7 @@ fn reg_params_4_span() {
                 (return (i32.add (i32.const 30)))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::i32_popcnt(Reg::from(5), Reg::from(0)),
             Instruction::branch_table_span(4, 4_u32),
@@ -663,7 +663,7 @@ fn reg_params_4_many() {
                 (return (i32.add (i32.const 30)))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::i32_popcnt(Reg::from(5), Reg::from(0)),
             Instruction::branch_table_many(4, 4_u32),
@@ -714,7 +714,7 @@ fn i64imm32_ok() {
                 )
             )"
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 Instruction::branch_table_1(0, 4_u32),
                 Instruction::i64const32(imm),
@@ -765,7 +765,7 @@ fn i64imm32_err() {
                 )
             )"
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::branch_table_1(0, 4_u32),
@@ -826,7 +826,7 @@ fn f64imm32_ok() {
                 )
             )"
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::branch_table_1(0, 4_u32),
@@ -885,7 +885,7 @@ fn f64imm32_err() {
                 )
             )"
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::branch_table_1(0, 4_u32),

--- a/crates/wasmi/src/engine/translator/tests/op/call/imported.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/call/imported.rs
@@ -12,7 +12,7 @@ fn no_params() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported_0(RegSpan::new(Reg::from(0)), Func::from(0)),
             Instruction::Return,
@@ -31,7 +31,7 @@ fn one_param_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(1)), Func::from(0)),
             Instruction::register(0),
@@ -51,7 +51,7 @@ fn one_param_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_imported(RegSpan::new(Reg::from(0)), Func::from(0)),
@@ -74,7 +74,7 @@ fn two_params_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(2)), Func::from(0)),
             Instruction::register2_ext(0, 1),
@@ -94,7 +94,7 @@ fn two_params_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(2)), Func::from(0)),
             Instruction::register2_ext(1, 0),
@@ -114,7 +114,7 @@ fn two_params_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_imported(RegSpan::new(Reg::from(0)), Func::from(0)),
@@ -137,7 +137,7 @@ fn three_params_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(3)), Func::from(0)),
             Instruction::register3_ext(0, 1, 2),
@@ -157,7 +157,7 @@ fn three_params_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(3)), Func::from(0)),
             Instruction::register3_ext(2, 1, 0),
@@ -177,7 +177,7 @@ fn three_params_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_imported(RegSpan::new(Reg::from(0)), Func::from(0)),
@@ -208,7 +208,7 @@ fn params7_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(7)), Func::from(0)),
             Instruction::register_list_ext(0, 1, 2),
@@ -238,7 +238,7 @@ fn params7_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(7)), Func::from(0)),
             Instruction::register_list_ext(6, 5, 4),
@@ -268,7 +268,7 @@ fn params7_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_imported(RegSpan::new(Reg::from(0)), Func::from(0)),
@@ -302,7 +302,7 @@ fn params8_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(8)), Func::from(0)),
             Instruction::register_list_ext(0, 1, 2),
@@ -333,7 +333,7 @@ fn params8_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(8)), Func::from(0)),
             Instruction::register_list_ext(7, 6, 5),
@@ -364,7 +364,7 @@ fn params8_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_imported(RegSpan::new(Reg::from(0)), Func::from(0)),
@@ -399,7 +399,7 @@ fn params9_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(9)), Func::from(0)),
             Instruction::register_list_ext(0, 1, 2),
@@ -431,7 +431,7 @@ fn params9_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(9)), Func::from(0)),
             Instruction::register_list_ext(8, 7, 6),
@@ -463,7 +463,7 @@ fn params9_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_imported(RegSpan::new(Reg::from(0)), Func::from(0)),

--- a/crates/wasmi/src/engine/translator/tests/op/call/indirect.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/call/indirect.rs
@@ -17,7 +17,7 @@ fn no_params_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect_0(RegSpan::new(Reg::from(1)), FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -42,7 +42,7 @@ fn no_params_imm16() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::call_indirect_0_imm16(RegSpan::new(Reg::from(1)), FuncType::from(0)),
                 Instruction::call_indirect_params_imm16(u32imm16(index), Table::from(0)),
@@ -71,7 +71,7 @@ fn one_reg_param_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect(RegSpan::new(Reg::from(2)), FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -98,7 +98,7 @@ fn one_reg_param_imm16() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::call_indirect_imm16(RegSpan::new(Reg::from(2)), FuncType::from(0)),
                 Instruction::call_indirect_params_imm16(u32imm16(index), Table::from(0)),
@@ -131,7 +131,7 @@ fn one_reg_param_imm() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::call_indirect(RegSpan::new(Reg::from(2)), FuncType::from(0)),
@@ -163,7 +163,7 @@ fn one_imm_param_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_indirect(RegSpan::new(Reg::from(1)), FuncType::from(0)),
@@ -193,7 +193,7 @@ fn one_imm_param_imm16() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::call_indirect_imm16(RegSpan::new(Reg::from(1)), FuncType::from(0)),
@@ -229,7 +229,7 @@ fn one_imm_param_imm() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::call_indirect(RegSpan::new(Reg::from(1)), FuncType::from(0)),
@@ -265,7 +265,7 @@ fn two_reg_params_reg() {
     let result_reg = Reg::from(3);
     let results = RegSpan::new(result_reg);
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect(results, FuncType::from(0)),
             Instruction::call_indirect_params(elem_index, Table::from(0)),
@@ -293,7 +293,7 @@ fn two_reg_params_reg_lhs() {
     let result_reg = Reg::from(3);
     let results = RegSpan::new(result_reg);
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect(results, FuncType::from(0)),
             Instruction::call_indirect_params(elem_index, Table::from(0)),
@@ -321,7 +321,7 @@ fn two_imm_params_reg() {
     let result_reg = Reg::from(1);
     let results = RegSpan::new(result_reg);
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_indirect(results, FuncType::from(0)),
@@ -355,7 +355,7 @@ fn two_reg_params_imm16() {
         let result_reg = Reg::from(2);
         let results = RegSpan::new(result_reg);
         let elem_index = u32imm16(index);
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::call_indirect_imm16(results, FuncType::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, Table::from(0)),
@@ -392,7 +392,7 @@ fn two_reg_params_lhs_imm16() {
         let result_reg = Reg::from(2);
         let results = RegSpan::new(result_reg);
         let elem_index = u32imm16(index);
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::call_indirect_imm16(results, FuncType::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, Table::from(0)),
@@ -429,7 +429,7 @@ fn two_imm_params_imm16() {
         let result_reg = Reg::from(0);
         let results = RegSpan::new(result_reg);
         let elem_index = u32imm16(index);
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::call_indirect_imm16(results, FuncType::from(0)),
@@ -467,7 +467,7 @@ fn three_reg_params_reg() {
     let result_reg = Reg::from(4);
     let results = RegSpan::new(result_reg);
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect(results, FuncType::from(0)),
             Instruction::call_indirect_params(elem_index, Table::from(0)),
@@ -496,7 +496,7 @@ fn three_reg_params_reg_lhs() {
     let result_reg = Reg::from(4);
     let results = RegSpan::new(result_reg);
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect(results, FuncType::from(0)),
             Instruction::call_indirect_params(elem_index, Table::from(0)),
@@ -525,7 +525,7 @@ fn three_imm_params_reg() {
     let result_reg = Reg::from(1);
     let results = RegSpan::new(result_reg);
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_indirect(results, FuncType::from(0)),
@@ -560,7 +560,7 @@ fn three_imm_params_imm16() {
         let result_reg = Reg::from(0);
         let results = RegSpan::new(result_reg);
         let elem_index = u32imm16(index);
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::call_indirect_imm16(results, FuncType::from(0)),
@@ -599,7 +599,7 @@ fn params7_reg_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect(RegSpan::new(Reg::from(8)), FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -631,7 +631,7 @@ fn params7_imm_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_indirect(RegSpan::new(Reg::from(1)), FuncType::from(0)),
@@ -667,7 +667,7 @@ fn params8_reg_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect(RegSpan::new(Reg::from(9)), FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -700,7 +700,7 @@ fn params8_imm_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_indirect(RegSpan::new(Reg::from(1)), FuncType::from(0)),
@@ -737,7 +737,7 @@ fn params9_reg_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect(RegSpan::new(Reg::from(10)), FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -771,7 +771,7 @@ fn params9_imm_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::call_indirect(RegSpan::new(Reg::from(1)), FuncType::from(0)),
@@ -807,7 +807,7 @@ fn test_imm_params_dynamic_index() {
         "#;
     let result = Reg::from(0);
     let results = RegSpan::new(result);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(0_i32)])
         .expect_func(
             ExpectedFunc::new([
@@ -844,7 +844,7 @@ fn regression_issue_768() {
         "#;
     let result = Reg::from(0);
     let results = RegSpan::new(result);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(0_i32)])
         .expect_func(
             ExpectedFunc::new([

--- a/crates/wasmi/src/engine/translator/tests/op/call/internal.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/call/internal.rs
@@ -12,7 +12,7 @@ fn no_params() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .expect_func_instrs([
             Instruction::call_internal_0(RegSpan::new(Reg::from(0)), EngineFunc::from_u32(0)),
@@ -34,7 +34,7 @@ fn one_param_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg(Reg::from(0))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(1)), EngineFunc::from_u32(0)),
@@ -57,7 +57,7 @@ fn one_param_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg(0)])
         .expect_func(
             ExpectedFunc::new([
@@ -84,7 +84,7 @@ fn two_params_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg2_ext(0, 1)])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(2)), EngineFunc::from_u32(0)),
@@ -108,7 +108,7 @@ fn two_params_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg2_ext(0, 1)])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(2)), EngineFunc::from_u32(0)),
@@ -132,7 +132,7 @@ fn two_params_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg2_ext(0, 1)])
         .expect_func(
             ExpectedFunc::new([
@@ -160,7 +160,7 @@ fn three_params_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg3_ext(0, 1, 2)])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(3)), EngineFunc::from_u32(0)),
@@ -185,7 +185,7 @@ fn three_params_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg3_ext(0, 1, 2)])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(3)), EngineFunc::from_u32(0)),
@@ -210,7 +210,7 @@ fn three_params_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg3_ext(0, 1, 2)])
         .expect_func(
             ExpectedFunc::new([
@@ -250,7 +250,7 @@ fn params7_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(7)), EngineFunc::from_u32(0)),
@@ -289,7 +289,7 @@ fn params7_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(7)), EngineFunc::from_u32(0)),
@@ -328,7 +328,7 @@ fn params7_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func(
             ExpectedFunc::new([
@@ -372,7 +372,7 @@ fn params8_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(8)), EngineFunc::from_u32(0)),
@@ -413,7 +413,7 @@ fn params8_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(8)), EngineFunc::from_u32(0)),
@@ -454,7 +454,7 @@ fn params8_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func(
             ExpectedFunc::new([
@@ -500,7 +500,7 @@ fn params9_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(9)), EngineFunc::from_u32(0)),
@@ -543,7 +543,7 @@ fn params9_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(9)), EngineFunc::from_u32(0)),
@@ -586,7 +586,7 @@ fn params9_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func(
             ExpectedFunc::new([

--- a/crates/wasmi/src/engine/translator/tests/op/cmp/i32_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp/i32_eqz.rs
@@ -2,7 +2,8 @@ use super::*;
 
 const PARAM: WasmType = WasmType::I32;
 
-#[test] #[cfg_attr(miri, ignore)]
+#[test]
+#[cfg_attr(miri, ignore)]
 fn reg() {
     let wasm = format!(
         r#"
@@ -16,11 +17,7 @@ fn reg() {
     );
     TranslationTest::from_wat(&wasm)
         .expect_func_instrs([
-            Instruction::i32_eq_imm16(
-                Reg::from(1),
-                Reg::from(0),
-                0,
-            ),
+            Instruction::i32_eq_imm16(Reg::from(1), Reg::from(0), 0),
             Instruction::return_reg(1),
         ])
         .run();
@@ -38,11 +35,12 @@ fn imm_with(value: i32) {
         "#
     );
     TranslationTest::from_wat(&wasm)
-        .expect_func_instrs([Instruction::return_imm32((value == 0) as u32)])
+        .expect_func_instrs([Instruction::return_imm32(u32::from(value == 0))])
         .run();
 }
 
-#[test] #[cfg_attr(miri, ignore)]
+#[test]
+#[cfg_attr(miri, ignore)]
 fn imm() {
     imm_with(0);
     imm_with(1);

--- a/crates/wasmi/src/engine/translator/tests/op/cmp/i32_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp/i32_eqz.rs
@@ -15,7 +15,7 @@ fn reg() {
         )
         "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::i32_eq_imm16(Reg::from(1), Reg::from(0), 0),
             Instruction::return_reg(1),
@@ -34,7 +34,7 @@ fn imm_with(value: i32) {
         )
         "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([Instruction::return_imm32(u32::from(value == 0))])
         .run();
 }

--- a/crates/wasmi/src/engine/translator/tests/op/cmp/i32_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp/i32_eqz.rs
@@ -4,7 +4,7 @@ const PARAM: WasmType = WasmType::I32;
 
 #[test] #[cfg_attr(miri, ignore)]
 fn reg() {
-    let wasm = wat2wasm(&format!(
+    let wasm = format!(
         r#"
         (module
             (func (param {PARAM}) (result i32)
@@ -13,13 +13,13 @@ fn reg() {
             )
         )
         "#
-    ));
-    TranslationTest::new(wasm)
-        .expect_func([
+    );
+    TranslationTest::from_wat(&wasm)
+        .expect_func_instrs([
             Instruction::i32_eq_imm16(
-                Reg::from_u16(1),
-                Reg::from_u16(0),
-                Const16::from_i16(0),
+                Reg::from(1),
+                Reg::from(0),
+                0,
             ),
             Instruction::return_reg(1),
         ])
@@ -27,7 +27,7 @@ fn reg() {
 }
 
 fn imm_with(value: i32) {
-    let wasm = wat2wasm(&format!(
+    let wasm = format!(
         r#"
         (module
             (func (result i32)
@@ -36,11 +36,9 @@ fn imm_with(value: i32) {
             )
         )
         "#
-    ));
-    TranslationTest::new(wasm)
-        .expect_func([Instruction::ReturnImm32 {
-            value: Const32::from(value == 0),
-        }])
+    );
+    TranslationTest::from_wat(&wasm)
+        .expect_func_instrs([Instruction::return_imm32((value == 0) as u32)])
         .run();
 }
 

--- a/crates/wasmi/src/engine/translator/tests/op/cmp/i64_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp/i64_eqz.rs
@@ -2,9 +2,10 @@ use super::*;
 
 const PARAM: WasmType = WasmType::I64;
 
-#[test] #[cfg_attr(miri, ignore)]
+#[test]
+#[cfg_attr(miri, ignore)]
 fn reg() {
-    let wasm = wat2wasm(&format!(
+    let wasm = format!(
         r#"
         (module
             (func (param {PARAM}) (result i32)
@@ -13,13 +14,13 @@ fn reg() {
             )
         )
         "#
-    ));
-    TranslationTest::new(wasm)
-        .expect_func([
+    );
+    TranslationTest::from_wat(&wasm)
+        .expect_func_instrs([
             Instruction::i64_eq_imm16(
-                Reg::from_u16(1),
-                Reg::from_u16(0),
-                Const16::from_i16(0),
+                Reg::from(1),
+                Reg::from(0),
+                0,
             ),
             Instruction::return_reg(1),
         ])
@@ -27,7 +28,7 @@ fn reg() {
 }
 
 fn imm_with(value: i64) {
-    let wasm = wat2wasm(&format!(
+    let wasm = format!(
         r#"
         (module
             (func (result i32)
@@ -36,11 +37,11 @@ fn imm_with(value: i64) {
             )
         )
         "#
-    ));
-    TranslationTest::new(wasm)
-        .expect_func([Instruction::ReturnImm32 {
-            value: Const32::from(value == 0),
-        }])
+    );
+    TranslationTest::from_wat(&wasm)
+        .expect_func_instrs([
+            Instruction::return_imm32((value == 0) as u32)
+        ])
         .run();
 }
 

--- a/crates/wasmi/src/engine/translator/tests/op/cmp/i64_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp/i64_eqz.rs
@@ -17,11 +17,7 @@ fn reg() {
     );
     TranslationTest::from_wat(&wasm)
         .expect_func_instrs([
-            Instruction::i64_eq_imm16(
-                Reg::from(1),
-                Reg::from(0),
-                0,
-            ),
+            Instruction::i64_eq_imm16(Reg::from(1), Reg::from(0), 0),
             Instruction::return_reg(1),
         ])
         .run();
@@ -39,13 +35,12 @@ fn imm_with(value: i64) {
         "#
     );
     TranslationTest::from_wat(&wasm)
-        .expect_func_instrs([
-            Instruction::return_imm32((value == 0) as u32)
-        ])
+        .expect_func_instrs([Instruction::return_imm32(u32::from(value == 0))])
         .run();
 }
 
-#[test] #[cfg_attr(miri, ignore)]
+#[test]
+#[cfg_attr(miri, ignore)]
 fn imm() {
     imm_with(0);
     imm_with(1);

--- a/crates/wasmi/src/engine/translator/tests/op/cmp/i64_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp/i64_eqz.rs
@@ -15,7 +15,7 @@ fn reg() {
         )
         "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::i64_eq_imm16(Reg::from(1), Reg::from(0), 0),
             Instruction::return_reg(1),
@@ -34,7 +34,7 @@ fn imm_with(value: i64) {
         )
         "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([Instruction::return_imm32(u32::from(value == 0))])
         .run();
 }

--- a/crates/wasmi/src/engine/translator/tests/op/cmp/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp/mod.rs
@@ -15,6 +15,9 @@
 
 use super::*;
 
+mod i32_eqz;
+mod i64_eqz;
+
 mod f32_eq;
 mod f32_ne;
 mod f64_eq;

--- a/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
@@ -27,7 +27,7 @@ fn loop_backward() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 expect_instr(Reg::from(0), Reg::from(1), BranchOffset16::from(0)),
                 Instruction::Return,
@@ -150,7 +150,7 @@ fn loop_backward_imm_rhs() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 expect_instr(
                     Reg::from(0),
@@ -247,7 +247,7 @@ fn loop_backward_imm_lhs() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 expect_instr(
                     Reg::from(0),
@@ -335,7 +335,7 @@ fn block_forward() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 expect_instr(Reg::from(0), Reg::from(1), BranchOffset16::from(1)),
                 Instruction::Return,
@@ -453,7 +453,7 @@ fn block_forward_nop_copy() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::global_get(Reg::from(2), Global::from(0)),
                 expect_instr(Reg::from(0), Reg::from(1), BranchOffset16::from(2)),
@@ -572,7 +572,7 @@ fn if_forward_multi_value() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 expect_instr(Reg::from(0), Reg::from(1), BranchOffset16::from(3)),
                 Instruction::copy(Reg::from(2), Reg::from(0)),
@@ -660,7 +660,7 @@ fn if_forward() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 expect_instr(Reg::from(0), Reg::from(1), BranchOffset16::from(1)),
                 Instruction::Return,
@@ -744,7 +744,7 @@ fn block_i32_eqz_fuse() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 expect_instr(Reg::from(0), Reg::from(1), BranchOffset16::from(1)),
                 Instruction::Return,
@@ -774,7 +774,7 @@ fn if_i32_eqz_fuse() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 expect_instr(Reg::from(0), Reg::from(1), BranchOffset16::from(1)),
                 Instruction::Return,
@@ -801,7 +801,7 @@ fn block_i64_eqz_fuse() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i64_eq_imm16(Reg::from(0), 0, BranchOffset16::from(1)),
             Instruction::Return,
@@ -821,7 +821,7 @@ fn if_i64_eqz_fuse() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i64_ne_imm16(Reg::from(0), 0, BranchOffset16::from(1)),
             Instruction::Return,
@@ -852,7 +852,7 @@ fn cmp_br_fallback() {
     let param0: ComparatorAndOffset =
         ComparatorAndOffset::new(Comparator::I32Ne, BranchOffset::from(offset));
     let param1 = ComparatorAndOffset::new(Comparator::I32Ne, BranchOffset::from(-offset));
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func(ExpectedFunc::new(expected_instrs).consts([
             UntypedVal::from(0_i64),  // reg(-1)
             UntypedVal::from(param1), // reg(-2)

--- a/crates/wasmi/src/engine/translator/tests/op/copy.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/copy.rs
@@ -11,7 +11,7 @@ fn merge_2_copy_instrs_0() {
                 (local.set 1 (local.get 4)) ;; copy 1 <- 4
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(0)), Reg::from(2), Reg::from(4)),
             Instruction::Return,
@@ -29,7 +29,7 @@ fn merge_2_copy_instrs_1() {
                 (local.set 1 (local.get 2)) ;; copy 0 <- 2
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(0)), Reg::from(4), Reg::from(2)),
             Instruction::Return,
@@ -47,7 +47,7 @@ fn merge_2_copy_instrs_2() {
                 (local.set 0 (local.get 2)) ;; copy 0 <- 2
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(0)), Reg::from(2), Reg::from(4)),
             Instruction::Return,

--- a/crates/wasmi/src/engine/translator/tests/op/global_get.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/global_get.rs
@@ -28,7 +28,7 @@ where
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::global_get(Reg::from(0), Global::from(0)),
             Instruction::return_reg(Reg::from(0)),
@@ -83,7 +83,7 @@ where
         )
     "#,
     );
-    let mut testcase = TranslationTest::from_wat(&wasm);
+    let mut testcase = TranslationTest::new(&wasm);
     let instr = <T as WasmTy>::return_imm_instr(&value);
     match instr {
         Instruction::ReturnReg { value: register } => {
@@ -143,7 +143,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::global_get(Reg::from(0), Global::from(0)),
             Instruction::return_reg(Reg::from(0)),
@@ -187,7 +187,7 @@ fn test_global_get_as_return_values_0() {
             )
         )
         "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::global_get(Reg::from(0), Global::from(0)),
@@ -212,7 +212,7 @@ fn test_global_get_as_return_values_1() {
             )
         )
         "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::global_get(Reg::from(0), Global::from(0)),

--- a/crates/wasmi/src/engine/translator/tests/op/global_set.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/global_set.rs
@@ -22,7 +22,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::global_set(Reg::from(0), Global::from(0)),
             Instruction::Return,
@@ -57,7 +57,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::global_set(Reg::from(-1), Global::from(0)),
@@ -97,7 +97,7 @@ fn test_i32imm16(value: i32) {
     );
     let imm16 = <Const16<i32>>::try_from(value)
         .unwrap_or_else(|_| panic!("cannot convert `value` to 16-bit encoding: {value}"));
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::global_set_i32imm16(imm16, Global::from(0)),
             Instruction::Return,
@@ -131,7 +131,7 @@ fn test_i64imm16(value: i64) {
     );
     let imm16 = <Const16<i64>>::try_from(value)
         .unwrap_or_else(|_| panic!("cannot convert `value` to 16-bit encoding: {value}"));
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::global_set_i64imm16(imm16, Global::from(0)),
             Instruction::Return,

--- a/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
@@ -28,7 +28,7 @@ fn binop_i32_eqz() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 expect_instr(Reg::from(2), Reg::from(0), Reg::from(1)),
                 Instruction::return_reg(2),
@@ -98,7 +98,7 @@ fn binop_imm_i32_eqz_rhs() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 expect_instr(
                     Reg::from(2),
@@ -161,7 +161,7 @@ fn binop_imm_i32_eqz_lhs() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 expect_instr(
                     Reg::from(2),
@@ -219,7 +219,7 @@ fn binop_i32_eqz_double() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 expect_instr(Reg::from(2), Reg::from(0), Reg::from(1)),
                 Instruction::return_reg(2),
@@ -280,7 +280,7 @@ fn binop_imm_i32_eqz_rhs_double() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 expect_instr(
                     Reg::from(2),
@@ -341,7 +341,7 @@ fn binop_imm_i32_eqz_lhs_double() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 expect_instr(
                     Reg::from(2),
@@ -394,7 +394,7 @@ fn binop_i32_eqz_double_invalid() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 expect_instr(Reg::from(2), Reg::from(0), Reg::from(1)),
                 Instruction::i32_eq_imm16(Reg::from(2), Reg::from(2), 0),
@@ -435,7 +435,7 @@ fn binop_imm_i32_eqz_rhs_double_invalid() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 expect_instr(
                     Reg::from(2),
@@ -480,7 +480,7 @@ fn binop_imm_i32_eqz_lhs_double_invalid() {
                 )
             )",
         );
-        TranslationTest::from_wat(wasm)
+        TranslationTest::new(wasm)
             .expect_func_instrs([
                 expect_instr(
                     Reg::from(2),

--- a/crates/wasmi/src/engine/translator/tests/op/if_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/if_.rs
@@ -16,7 +16,7 @@ fn simple_if_then() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(1)),
             Instruction::Return,
@@ -39,7 +39,7 @@ fn simple_if_then_nested() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(2)),
             Instruction::branch_i32_eq_imm16(Reg::from(1), 0, BranchOffset16::from(1)),
@@ -63,7 +63,7 @@ fn if_then_global_set() {
                 (i32.const 10)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(2_i16)),
             Instruction::global_set(Reg::from(1), Global::from(0)),
@@ -91,7 +91,7 @@ fn if_then_return() {
                 (i32.const 0)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(3)),
             Instruction::i32_add(Reg::from(3), Reg::from(1), Reg::from(2)),
@@ -118,7 +118,7 @@ fn if_then_else_return() {
                 (i32.const 30)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(2)),
             Instruction::return_imm32(AnyConst32::from(10_i32)),
@@ -144,7 +144,7 @@ fn if_then_br_else() {
                 (i32.const 20)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(2)),
             Instruction::branch(BranchOffset::from(2)),
@@ -171,7 +171,7 @@ fn if_then_else_br() {
                 (i32.const 20)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(2)),
             Instruction::return_imm32(AnyConst32::from(10_i32)),
@@ -195,7 +195,7 @@ fn simple_if_then_else() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(2)),
             Instruction::branch(BranchOffset::from(1)),
@@ -226,7 +226,7 @@ fn simple_if_then_else_nested() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(4)),
             Instruction::branch_i32_eq_imm16(Reg::from(1), 0, BranchOffset16::from(2)),
@@ -253,7 +253,7 @@ fn if_then_else_with_params() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(4)), 1, 2),
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(3)),
@@ -288,7 +288,7 @@ fn const_condition() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([Instruction::return_imm32(AnyConst32::from(expected))])
             .run()
     }
@@ -322,9 +322,7 @@ fn const_condition_trap_then() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
-            .expect_func_instrs(instrs)
-            .run()
+        TranslationTest::new(&wasm).expect_func_instrs(instrs).run()
     }
     test_for(true, [Instruction::trap(TrapCode::UnreachableCodeReached)]);
     test_for(
@@ -362,9 +360,7 @@ fn const_condition_trap_else() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
-            .expect_func_instrs(instrs)
-            .run()
+        TranslationTest::new(&wasm).expect_func_instrs(instrs).run()
     }
     test_for(
         true,
@@ -403,9 +399,7 @@ fn const_condition_br_if_then() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
-            .expect_func_instrs(instrs)
-            .run()
+        TranslationTest::new(&wasm).expect_func_instrs(instrs).run()
     }
     test_for(true, [Instruction::trap(TrapCode::UnreachableCodeReached)]);
     test_for(
@@ -445,9 +439,7 @@ fn const_condition_br_if_else() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
-            .expect_func_instrs(instrs)
-            .run()
+        TranslationTest::new(&wasm).expect_func_instrs(instrs).run()
     }
     test_for(
         true,
@@ -475,7 +467,7 @@ fn test_if_false_without_else_block_0() {
             )
         )
         "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .run()
 }
@@ -496,7 +488,7 @@ fn test_if_false_without_else_block_1() {
             )
         )
         "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(1)])
         .run()
 }
@@ -521,7 +513,7 @@ fn test_if_without_else_has_result() {
             )
         )
         "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([Instruction::return_reg2_ext(-1, -2)])
                 .consts([UntypedVal::from(1_i64), UntypedVal::from(0_i32)]),

--- a/crates/wasmi/src/engine/translator/tests/op/load.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/load.rs
@@ -24,7 +24,7 @@ fn test_load_mem0(
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             make_instr(Reg::from(1), Memory::from(0)),
             Instruction::register_and_imm32(Reg::from(0), offset),
@@ -55,7 +55,7 @@ fn test_load(
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             make_instr(Reg::from(1), Memory::from(1)),
             Instruction::register_and_imm32(Reg::from(0), offset),
@@ -81,7 +81,7 @@ fn test_load_offset16(
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             make_instr_offset16(Reg::from(1), Reg::from(0), <Const16<u32>>::from(offset)),
             Instruction::return_reg(Reg::from(1)),
@@ -110,7 +110,7 @@ fn test_load_at_mem0(
     let address = ptr
         .checked_add(offset)
         .expect("ptr+offset must be valid in this testcase");
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             make_instr_at(Reg::from(0), address),
             Instruction::return_reg(Reg::from(0)),
@@ -140,7 +140,7 @@ fn test_load_at(
     let address = ptr
         .checked_add(offset)
         .expect("ptr+offset must be valid in this testcase");
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             make_instr_at(Reg::from(0), address),
             Instruction::memory_index(1),
@@ -166,7 +166,7 @@ fn test_load_at_overflow_mem0(wasm_op: WasmOp, ptr: u32, offset: u32) {
         ptr.checked_add(offset).is_none(),
         "ptr+offset must overflow in this testcase"
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([Instruction::trap(TrapCode::MemoryOutOfBounds)])
         .run();
 }
@@ -189,7 +189,7 @@ fn test_load_at_overflow(wasm_op: WasmOp, ptr: u32, offset: u32) {
         ptr.checked_add(offset).is_none(),
         "ptr+offset must overflow in this testcase"
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([Instruction::trap(TrapCode::MemoryOutOfBounds)])
         .run();
 }

--- a/crates/wasmi/src/engine/translator/tests/op/local_preserve.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/local_preserve.rs
@@ -18,7 +18,7 @@ fn simple_block_1() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(2, 0),
             Instruction::branch_i32_ne_imm16(Reg::from(1), 0, BranchOffset16::from(2)),
@@ -44,7 +44,7 @@ fn simple_block_2() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(3)), 0, 1),
             Instruction::branch_i32_ne_imm16(Reg::from(2), 0, BranchOffset16::from(3)),
@@ -73,7 +73,7 @@ fn simple_block_3_span() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_span_non_overlapping(
                 RegSpan::new(Reg::from(4)),
@@ -107,7 +107,7 @@ fn simple_block_3_many() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_many_non_overlapping_ext(RegSpan::new(Reg::from(4)), 2, 1),
             Instruction::register(0),
@@ -140,7 +140,7 @@ fn simple_block_4_params_2() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_span_non_overlapping(
                 RegSpan::new(Reg::from(7)),
@@ -194,7 +194,7 @@ fn simple_block_30() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_many_non_overlapping_ext(RegSpan::new(Reg::from(11)), 9, 8),
             Instruction::register_list_ext(7, 6, 5),
@@ -234,7 +234,7 @@ fn simple_if_1() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(2, 0),
             Instruction::branch_i32_eq_imm16(Reg::from(1), 0, BranchOffset16::from(2)),
@@ -261,7 +261,7 @@ fn simple_if_2() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(3)), 0, 1),
             Instruction::branch_i32_eq_imm16(Reg::from(2), 0, BranchOffset16::from(3)),
@@ -291,7 +291,7 @@ fn simple_if_3_span() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_span_non_overlapping(
                 RegSpan::new(Reg::from(4)),
@@ -326,7 +326,7 @@ fn simple_if_3_many() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_many_non_overlapping_ext(RegSpan::new(Reg::from(4)), 2, 1),
             Instruction::register(0),
@@ -360,7 +360,7 @@ fn simple_if_4_params_2() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_span_non_overlapping(
                 RegSpan::new(Reg::from(7)),
@@ -400,7 +400,7 @@ fn nested_block() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(4)), 0, 1),
             Instruction::branch_i32_ne_imm16(Reg::from(2), 0, BranchOffset16::from(4)),
@@ -433,7 +433,7 @@ fn nested_if() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(4)), 0, 1),
             Instruction::branch_i32_eq_imm16(Reg::from(2), 0, BranchOffset16::from(4)),
@@ -465,7 +465,7 @@ fn expr_block() {
             )
         )
         "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(3, 1),
             Instruction::branch_i32_eq_imm16(Reg::from(0), 0, BranchOffset16::from(3)),
@@ -500,7 +500,7 @@ fn expr_if() {
             )
         )
         "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(4, 0),
             Instruction::branch_i32_eq_imm16(Reg::from(1), 0, BranchOffset16::from(4)),
@@ -529,7 +529,7 @@ fn invalid_preservation_slot_reuse_1() {
             )
           )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(3, 0),
             Instruction::i32_popcnt(Reg::from(0), Reg::from(0)),
@@ -560,7 +560,7 @@ fn invalid_preservation_slot_reuse_2() {
             )
           )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(ExpectedFunc::new([Instruction::return_imm32(20_i32)]))
         .expect_func(ExpectedFunc::new([
             Instruction::copy(3, 0),
@@ -594,7 +594,7 @@ fn concat_local_tee_pair() {
             )
         )
     ";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Reg::from(0), 10_i32),
             Instruction::copy_imm32(Reg::from(1), 20_i32),
@@ -626,7 +626,7 @@ fn loop_iter_1() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(0, 0_i32),
             Instruction::copy(2, 0),

--- a/crates/wasmi/src/engine/translator/tests/op/local_set.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/local_set.rs
@@ -17,7 +17,7 @@ fn imm() {
                 (local.get 0)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Reg::from(0), 10_i32),
             Instruction::return_reg(Reg::from(0)),
@@ -34,7 +34,7 @@ fn imm_tee() {
                 (local.tee 0 (i32.const 10))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Reg::from(0), 10_i32),
             Instruction::return_imm32(10_i32),
@@ -56,7 +56,7 @@ fn overwrite_result_1() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::i32_add(Reg::from(0), Reg::from(0), Reg::from(1)),
             Instruction::return_reg(Reg::from(0)),
@@ -78,7 +78,7 @@ fn overwrite_call_internal_result_1() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg(Reg::from(0))])
         .expect_func_instrs([
             Instruction::call_internal(RegSpan::new(Reg::from(0)), EngineFunc::from_u32(0)),
@@ -100,7 +100,7 @@ fn overwrite_call_imported_result_1() {
                 )
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_imported(RegSpan::new(Reg::from(0)), Func::from(0)),
             Instruction::register(0),
@@ -122,7 +122,7 @@ fn overwrite_call_indirect_result_1() {
                 )
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::call_indirect(RegSpan::new(Reg::from(0)), FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -144,7 +144,7 @@ fn overwrite_select_result_1() {
                 (local.tee $condition)
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::select_imm32(Reg::from(0), 10_i32),
             Instruction::register_and_imm32(Reg::from(0), 20_i32),
@@ -168,7 +168,7 @@ fn avoid_overwrite_result_1() {
                 (local.tee $lhs)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::i32_add(Reg::from(2), Reg::from(0), Reg::from(1)),
             Instruction::copy(Reg::from(0), Reg::from(2)),
@@ -188,7 +188,7 @@ fn local_set_chain() {
                 (local.get 1)
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Reg::from(0), 10_i32),
             Instruction::copy(Reg::from(1), Reg::from(0)),
@@ -207,7 +207,7 @@ fn local_tee_chain() {
                 (local.tee 1)
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Reg::from(0), 10_i32),
             Instruction::copy_imm32(Reg::from(1), 10_i32),
@@ -231,7 +231,7 @@ fn preserve_result_1() {
                 )
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(3), Reg::from(0)),
             Instruction::i32_add(Reg::from(0), Reg::from(0), Reg::from(1)),
@@ -256,7 +256,7 @@ fn preserve_result_2() {
                 )
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(3), Reg::from(0)),
             Instruction::i32_add(Reg::from(0), Reg::from(0), Reg::from(1)),
@@ -275,7 +275,7 @@ fn preserve_multiple_0() {
                 (local.set 0 (i32.const 10))
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(1), Reg::from(0)),
             Instruction::copy_imm32(Reg::from(0), 10_i32),
@@ -295,7 +295,7 @@ fn preserve_multiple_1() {
                 (local.set 0 (i32.const 10))
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(1), Reg::from(0)),
             Instruction::copy_imm32(Reg::from(0), 10_i32),
@@ -316,7 +316,7 @@ fn preserve_multiple_2() {
                 (local.set 0 (i32.const 20))
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(3), Reg::from(0)),
             Instruction::copy_imm32(Reg::from(0), 10_i32),
@@ -340,7 +340,7 @@ fn preserve_multiple_3() {
                 (local.set 0 (i32.const 20))
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(1), Reg::from(0)),
             Instruction::copy_imm32(Reg::from(0), 10_i32),
@@ -367,7 +367,7 @@ fn preserve_multiple_4() {
                 (local.set 0 (i32.const 20))
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(1), Reg::from(0)),
             Instruction::copy_imm32(Reg::from(0), 10_i32),
@@ -392,7 +392,7 @@ fn preserve_multiple_5() {
                 (local.set 0 (i32.const 33))
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(5), Reg::from(2)),
             Instruction::copy_imm32(Reg::from(2), 11_i32),
@@ -422,7 +422,7 @@ fn preserve_multiple_6() {
                 (local.set 1 (i32.const 44))
             )
         )"#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(5), Reg::from(2)),
             Instruction::copy_imm32(Reg::from(2), 11_i32),
@@ -456,7 +456,7 @@ fn merge_overwriting_local_set() {
             )
         )
     ";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Reg::from(0), 10_i32),
             Instruction::copy_imm32(Reg::from(1), 20_i32),
@@ -485,7 +485,7 @@ fn merge_overwriting_local_set_lhs() {
             )
         )
     ";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Reg::from(0), 10_i32),
             Instruction::copy_imm32(Reg::from(1), 20_i32),
@@ -513,7 +513,7 @@ fn merge_overwriting_local_set_3() {
             )
         )
     ";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Reg::from(0), 10_i32),
             Instruction::copy_imm32(Reg::from(1), 20_i32),
@@ -542,7 +542,7 @@ fn merge_overwriting_local_set_3_lhs() {
             )
         )
     ";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy_imm32(Reg::from(0), 10_i32),
             Instruction::copy_imm32(Reg::from(1), 20_i32),

--- a/crates/wasmi/src/engine/translator/tests/op/loop_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/loop_.rs
@@ -8,7 +8,7 @@ fn empty_loop() {
         (module
             (func (loop))
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .run()
 }
@@ -20,7 +20,7 @@ fn nested_empty_loop() {
         (module
             (func (loop (loop)))
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .run()
 }
@@ -35,7 +35,7 @@ fn identity_loop_1() {
                 (loop (param i32) (result i32))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(2), Reg::from(0)),
             Instruction::copy(Reg::from(1), Reg::from(2)),
@@ -56,7 +56,7 @@ fn identity_loop_1_nested() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(2), Reg::from(0)),
             Instruction::copy(Reg::from(1), Reg::from(2)),
@@ -77,7 +77,7 @@ fn identity_loop_2() {
                 (i32.add)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(4)), 0, 1),
             Instruction::copy2_ext(RegSpan::new(Reg::from(2)), 4, 5),
@@ -101,7 +101,7 @@ fn identity_loop_2_nested() {
                 (i32.add)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(4)), 0, 1),
             Instruction::copy2_ext(RegSpan::new(Reg::from(2)), 4, 5),
@@ -120,7 +120,7 @@ fn repeat_loop() {
                 (loop (br 0))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::branch(BranchOffset::from(0))])
         .run()
 }
@@ -135,7 +135,7 @@ fn repeat_loop_1() {
                 (loop (param i32) (br 0))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(2), Reg::from(0)),
             Instruction::copy(Reg::from(1), Reg::from(2)),
@@ -158,7 +158,7 @@ fn repeat_loop_1_copy() {
                 )
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy(Reg::from(3), Reg::from(0)),
             Instruction::copy(Reg::from(2), Reg::from(3)),
@@ -181,7 +181,7 @@ fn identity_loop_4_mixed_1() {
                 (loop (param i32 i32 i32 i32) (result i32 i32 i32 i32))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::copy2_ext(RegSpan::new(Reg::from(6)), 0, 1),
@@ -207,7 +207,7 @@ fn identity_loop_4_mixed_2() {
                 (loop (param i32 i32 i32 i32) (result i32 i32 i32 i32))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::copy2_ext(RegSpan::new(Reg::from(6)), 0, 1),
             Instruction::copy_many_non_overlapping_ext(RegSpan::new(Reg::from(2)), 6, 6),

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_copy.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_copy.rs
@@ -14,7 +14,7 @@ fn copy() {
                 (memory.copy $mem0 $mem1)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::memory_copy(Reg::from(0), Reg::from(1), Reg::from(2)),
             Instruction::memory_index(0),
@@ -38,7 +38,7 @@ fn testcase_copy_exact(len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_exact16(len: u32) {
@@ -96,7 +96,7 @@ fn testcase_copy_from(src: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_from16(src: u32) {
@@ -152,7 +152,7 @@ fn testcase_copy_to(dst: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_to16(dst: u32) {
@@ -208,7 +208,7 @@ fn testcase_copy_from_to(dst: u32, src: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_from_to16(dst: u32, src: u32) {
@@ -279,7 +279,7 @@ fn testcase_copy_to_exact(dst: u32, len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_to_exact16(dst: u32, len: u32) {
@@ -350,7 +350,7 @@ fn testcase_copy_from_exact(src: u32, len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_from_exact16(src: u32, len: u32) {
@@ -421,7 +421,7 @@ fn testcase_copy_from_to_exact(dst: u32, src: u32, len: u32) -> TranslationTest 
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_from_to_exact16(dst: u32, src: u32, len: u32) {

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_fill.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_fill.rs
@@ -13,7 +13,7 @@ fn fill() {
                 (memory.fill)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::memory_fill(Reg::from(0), Reg::from(1), Reg::from(2)),
             Instruction::memory_index(0),
@@ -35,7 +35,7 @@ fn testcase_fill_exact(len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_fill_exact16(len: u32) {
@@ -90,7 +90,7 @@ fn testcase_fill_imm(value: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_fill_imm(value: u32) {
@@ -127,7 +127,7 @@ fn testcase_fill_at(dst: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_fill_at16(dst: u32) {
@@ -180,7 +180,7 @@ fn testcase_fill_at_imm(dst: u32, value: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_fill_at16_imm(dst: u32, value: u32) {
@@ -258,7 +258,7 @@ fn testcase_fill_at_exact(dst: u32, len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_fill_at_exact16(dst: u32, len: u32) {
@@ -326,7 +326,7 @@ fn testcase_fill_imm_exact(value: u32, len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_fill_imm_exact16(value: u32, len: u32) {
@@ -404,7 +404,7 @@ fn testcase_fill_at_imm_exact(dst: u32, value: u32, len: u32) -> TranslationTest
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_fill_at_imm_exact16(dst: u32, value: u32, len: u32) {

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_grow.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_grow.rs
@@ -12,7 +12,7 @@ fn reg() {
                 (memory.grow $m)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::memory_grow(Reg::from(1), Reg::from(0)),
             Instruction::memory_index(0),
@@ -33,7 +33,7 @@ fn test_imm16(delta: u32) {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::memory_grow_by(Reg::from(0), delta),
             Instruction::memory_index(0),
@@ -65,7 +65,7 @@ fn imm_zero() {
                 (memory.grow $m)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::memory_size(Reg::from(0), Memory::from(0)),
             Instruction::return_reg(Reg::from(0)),

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_init.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_init.rs
@@ -14,7 +14,7 @@ fn init() {
                 (memory.init $d)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::memory_init(Reg::from(0), Reg::from(1), Reg::from(2)),
             Instruction::memory_index(0),
@@ -38,7 +38,7 @@ fn testcase_init_exact(len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_exact16(len: u32) {
@@ -96,7 +96,7 @@ fn testcase_init_from(src: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_from16(src: u32) {
@@ -152,7 +152,7 @@ fn testcase_init_to(dst: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_to16(dst: u32) {
@@ -208,7 +208,7 @@ fn testcase_init_from_to(dst: u32, src: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_from_to16(dst: u32, src: u32) {
@@ -279,7 +279,7 @@ fn testcase_init_to_exact(dst: u32, len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_to_exact16(dst: u32, len: u32) {
@@ -350,7 +350,7 @@ fn testcase_init_from_exact(src: u32, len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_from_exact16(src: u32, len: u32) {
@@ -421,7 +421,7 @@ fn testcase_init_from_to_exact(dst: u32, src: u32, len: u32) -> TranslationTest 
             )
         )",
     );
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
 }
 
 fn test_copy_from_to_exact16(dst: u32, src: u32, len: u32) {

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_size.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_size.rs
@@ -11,7 +11,7 @@ fn reg() {
                 (memory.size $m)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::memory_size(Reg::from(0), Memory::from(0)),
             Instruction::return_reg(Reg::from(0)),

--- a/crates/wasmi/src/engine/translator/tests/op/ref_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/ref_.rs
@@ -11,7 +11,7 @@ fn const_prop() {
             )
         )
     ";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(1_i32)])
         .run()
 }

--- a/crates/wasmi/src/engine/translator/tests/op/return_.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/return_.rs
@@ -11,7 +11,7 @@ fn return_0() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .run()
 }
@@ -26,7 +26,7 @@ fn return_1() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg(Reg::from(0))])
         .run()
 }
@@ -50,7 +50,7 @@ fn return_1_imm() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([Instruction::return_reg(Reg::from(-1))]).consts([value.into()]),
             )
@@ -85,7 +85,7 @@ fn return_1_imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([Instruction::return_imm32(value)])
             .run()
     }
@@ -109,7 +109,7 @@ fn return_1_i64imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([return_i64imm32_instr(value)])
             .run()
     }
@@ -134,7 +134,7 @@ fn return_1_f64imm32() {
                 )
             )",
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([return_f64imm32_instr(value)])
             .run()
     }
@@ -160,7 +160,7 @@ fn return_2() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg2_ext(0, 0)])
         .run()
 }
@@ -176,7 +176,7 @@ fn return_2_imm() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(ExpectedFunc::new([Instruction::return_reg2_ext(-1, -2)]).consts([10_i32, 20]))
         .run()
 }
@@ -192,7 +192,7 @@ fn return_2_mixed() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(ExpectedFunc::new([Instruction::return_reg2_ext(-1, 0)]).consts([10_i32]))
         .run()
 }
@@ -209,7 +209,7 @@ fn return_3() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg3_ext(0, 0, 0)])
         .run()
 }
@@ -226,7 +226,7 @@ fn return_3_imm() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([Instruction::return_reg3_ext(-1, -2, -3)]).consts([10_i32, 20, 30]),
         )
@@ -245,7 +245,7 @@ fn return_3_mixed() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(ExpectedFunc::new([Instruction::return_reg3_ext(-1, 0, -1)]).consts([10_i32]))
         .run()
 }
@@ -263,7 +263,7 @@ fn return_4_span() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 4))])
         .run()
 }
@@ -281,7 +281,7 @@ fn return_4() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_many_ext(0, 0, 0),
             Instruction::register(0),
@@ -303,7 +303,7 @@ fn return_5_span() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 5))])
         .run()
 }
@@ -322,7 +322,7 @@ fn return_5() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_many_ext(0, 1, 0),
             Instruction::register2_ext(1, 0),
@@ -345,7 +345,7 @@ fn return_6() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_many_ext(0, 1, 0),
             Instruction::register3_ext(1, 0, 1),
@@ -369,7 +369,7 @@ fn return_7() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_many_ext(0, 1, 0),
             Instruction::register_list_ext(1, 0, 1),
@@ -395,7 +395,7 @@ fn return_8() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_many_ext(0, 1, 0),
             Instruction::register_list_ext(1, 0, 1),
@@ -422,7 +422,7 @@ fn return_9() {
                 (return)
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_many_ext(0, 1, 0),
             Instruction::register_list_ext(1, 0, 1),

--- a/crates/wasmi/src/engine/translator/tests/op/return_call/imported.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/return_call/imported.rs
@@ -12,7 +12,7 @@ fn no_params() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_call_imported_0(Func::from(0))])
         .run();
 }
@@ -28,7 +28,7 @@ fn one_param_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register(0),
@@ -47,7 +47,7 @@ fn one_param_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_imported(Func::from(0)),
@@ -69,7 +69,7 @@ fn two_params_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register2_ext(0, 1),
@@ -88,7 +88,7 @@ fn two_params_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register2_ext(1, 0),
@@ -107,7 +107,7 @@ fn two_params_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_imported(Func::from(0)),
@@ -129,7 +129,7 @@ fn three_params_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register3_ext(0, 1, 2),
@@ -148,7 +148,7 @@ fn three_params_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register3_ext(2, 1, 0),
@@ -167,7 +167,7 @@ fn three_params_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_imported(Func::from(0)),
@@ -197,7 +197,7 @@ fn params7_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register_list_ext(0, 1, 2),
@@ -226,7 +226,7 @@ fn params7_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register_list_ext(6, 5, 4),
@@ -255,7 +255,7 @@ fn params7_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_imported(Func::from(0)),
@@ -288,7 +288,7 @@ fn params8_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register_list_ext(0, 1, 2),
@@ -318,7 +318,7 @@ fn params8_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register_list_ext(7, 6, 5),
@@ -348,7 +348,7 @@ fn params8_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_imported(Func::from(0)),
@@ -382,7 +382,7 @@ fn params9_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register_list_ext(0, 1, 2),
@@ -413,7 +413,7 @@ fn params9_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_imported(Func::from(0)),
             Instruction::register_list_ext(8, 7, 6),
@@ -444,7 +444,7 @@ fn params9_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_imported(Func::from(0)),

--- a/crates/wasmi/src/engine/translator/tests/op/return_call/indirect.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/return_call/indirect.rs
@@ -14,7 +14,7 @@ fn no_params_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_indirect_0(FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -38,7 +38,7 @@ fn no_params_imm16() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::return_call_indirect_0_imm16(FuncType::from(0)),
                 Instruction::call_indirect_params_imm16(u32imm16(index), Table::from(0)),
@@ -66,7 +66,7 @@ fn one_reg_param_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_indirect(FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -92,7 +92,7 @@ fn one_reg_param_imm16() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::return_call_indirect_imm16(FuncType::from(0)),
                 Instruction::call_indirect_params_imm16(u32imm16(index), Table::from(0)),
@@ -124,7 +124,7 @@ fn one_reg_param_imm() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::return_call_indirect(FuncType::from(0)),
@@ -155,7 +155,7 @@ fn one_imm_param_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_indirect(FuncType::from(0)),
@@ -184,7 +184,7 @@ fn one_imm_param_imm16() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::return_call_indirect_imm16(FuncType::from(0)),
@@ -219,7 +219,7 @@ fn one_imm_param_imm() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::return_call_indirect(FuncType::from(0)),
@@ -252,7 +252,7 @@ fn two_reg_params_reg() {
         )
     "#;
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_indirect(FuncType::from(0)),
             Instruction::call_indirect_params(elem_index, Table::from(0)),
@@ -277,7 +277,7 @@ fn two_reg_params_reg_lhs() {
         )
     "#;
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_indirect(FuncType::from(0)),
             Instruction::call_indirect_params(elem_index, Table::from(0)),
@@ -302,7 +302,7 @@ fn two_imm_params_reg() {
         )
     "#;
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_indirect(FuncType::from(0)),
@@ -333,7 +333,7 @@ fn two_reg_params_imm16() {
         "#,
         );
         let elem_index = u32imm16(index);
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::return_call_indirect_imm16(FuncType::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, Table::from(0)),
@@ -367,7 +367,7 @@ fn two_reg_params_lhs_imm16() {
         "#,
         );
         let elem_index = u32imm16(index);
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::return_call_indirect_imm16(FuncType::from(0)),
                 Instruction::call_indirect_params_imm16(elem_index, Table::from(0)),
@@ -401,7 +401,7 @@ fn two_imm_params_imm16() {
         "#,
         );
         let elem_index = u32imm16(index);
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::return_call_indirect_imm16(FuncType::from(0)),
@@ -436,7 +436,7 @@ fn three_reg_params_reg() {
         )
     "#;
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_indirect(FuncType::from(0)),
             Instruction::call_indirect_params(elem_index, Table::from(0)),
@@ -462,7 +462,7 @@ fn three_reg_params_reg_lhs() {
         )
     "#;
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_indirect(FuncType::from(0)),
             Instruction::call_indirect_params(elem_index, Table::from(0)),
@@ -488,7 +488,7 @@ fn three_imm_params_reg() {
         )
     "#;
     let elem_index = Reg::from(0);
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_indirect(FuncType::from(0)),
@@ -520,7 +520,7 @@ fn three_imm_params_imm16() {
         "#,
         );
         let elem_index = u32imm16(index);
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func(
                 ExpectedFunc::new([
                     Instruction::return_call_indirect_imm16(FuncType::from(0)),
@@ -558,7 +558,7 @@ fn params7_reg_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_indirect(FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -589,7 +589,7 @@ fn params7_imm_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_indirect(FuncType::from(0)),
@@ -624,7 +624,7 @@ fn params8_reg_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_indirect(FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -656,7 +656,7 @@ fn params8_imm_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_indirect(FuncType::from(0)),
@@ -692,7 +692,7 @@ fn params9_reg_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::return_call_indirect(FuncType::from(0)),
             Instruction::call_indirect_params(Reg::from(0), Table::from(0)),
@@ -725,7 +725,7 @@ fn params9_imm_index_local() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::return_call_indirect(FuncType::from(0)),
@@ -758,7 +758,7 @@ fn test_imm_params_dynamic_index() {
             )
         )
         "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(0_i32)])
         .expect_func(
             ExpectedFunc::new([
@@ -792,7 +792,7 @@ fn regression_issue_768() {
             )
         )
         "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_imm32(0_i32)])
         .expect_func(
             ExpectedFunc::new([

--- a/crates/wasmi/src/engine/translator/tests/op/return_call/internal.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/return_call/internal.rs
@@ -12,7 +12,7 @@ fn no_params() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::Return])
         .expect_func_instrs([Instruction::return_call_internal_0(EngineFunc::from_u32(0))])
         .run();
@@ -31,7 +31,7 @@ fn one_param_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg(Reg::from(0))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -53,7 +53,7 @@ fn one_param_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg(0)])
         .expect_func(
             ExpectedFunc::new([
@@ -79,7 +79,7 @@ fn two_params_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg2_ext(0, 1)])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -102,7 +102,7 @@ fn two_params_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg2_ext(0, 1)])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -125,7 +125,7 @@ fn two_params_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg2_ext(0, 1)])
         .expect_func(
             ExpectedFunc::new([
@@ -152,7 +152,7 @@ fn three_params_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg3_ext(0, 1, 2)])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -176,7 +176,7 @@ fn three_params_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg3_ext(0, 1, 2)])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -200,7 +200,7 @@ fn three_params_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_reg3_ext(0, 1, 2)])
         .expect_func(
             ExpectedFunc::new([
@@ -239,7 +239,7 @@ fn params7_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -277,7 +277,7 @@ fn params7_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -315,7 +315,7 @@ fn params7_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 7))])
         .expect_func(
             ExpectedFunc::new([
@@ -358,7 +358,7 @@ fn params8_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -398,7 +398,7 @@ fn params8_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -438,7 +438,7 @@ fn params8_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 8))])
         .expect_func(
             ExpectedFunc::new([
@@ -483,7 +483,7 @@ fn params9_reg() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -525,7 +525,7 @@ fn params9_reg_lhs() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func_instrs([
             Instruction::return_call_internal(EngineFunc::from_u32(0)),
@@ -567,7 +567,7 @@ fn params9_imm() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([Instruction::return_span(bspan(0, 9))])
         .expect_func(
             ExpectedFunc::new([

--- a/crates/wasmi/src/engine/translator/tests/op/select.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/select.rs
@@ -63,7 +63,7 @@ fn reg() {
         let lhs = Reg::from(1);
         let rhs = Reg::from(2);
         let result = Reg::from(3);
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([
                 Instruction::select(result, lhs),
                 Instruction::register2_ext(condition, rhs),
@@ -101,7 +101,7 @@ fn same_reg() {
             )
         "#,
         );
-        TranslationTest::from_wat(&wasm)
+        TranslationTest::new(&wasm)
             .expect_func_instrs([Instruction::return_reg(Reg::from(1))])
             .run();
     }
@@ -138,7 +138,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 #[test]
@@ -283,7 +283,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 #[test]
@@ -462,7 +462,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 #[test]
@@ -642,7 +642,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 #[test]
@@ -809,7 +809,7 @@ fn fuzz_fail_01() {
             )
         )
     "#;
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::i32_popcnt(1, 0),
             Instruction::i32_eq_imm16(2, 0, 0_i16),

--- a/crates/wasmi/src/engine/translator/tests/op/store/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/store/mod.rs
@@ -43,7 +43,7 @@ fn test_store_for(
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             make_instr(Reg::from(0), Memory::from(0)),
             Instruction::register_and_imm32(Reg::from(1), offset),
@@ -76,7 +76,7 @@ fn test_store_offset16_for(
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             make_instr(Reg::from(0), offset, Reg::from(1)),
             Instruction::Return,
@@ -116,7 +116,7 @@ fn test_store_offset16_imm_for<T>(
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func(
             ExpectedFunc::new([
                 make_instr(Reg::from(0), offset, Reg::from(-1)),
@@ -163,7 +163,7 @@ fn test_store_offset16_imm16_for<T>(
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([make_instr(Reg::from(0), offset, value), Instruction::Return])
         .run();
 }
@@ -206,7 +206,7 @@ fn test_store_wrap_offset16_imm_for<Src, Wrapped, Field>(
     "#
     );
     let value = Field::try_from(value.wrap()).ok().unwrap();
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([make_instr(Reg::from(0), offset, value), Instruction::Return])
         .run();
 }
@@ -255,7 +255,7 @@ fn test_store_wrap_imm_for<Src, Wrapped, Field>(
     "#
     );
     let value = Field::try_from(value.wrap()).ok().unwrap();
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             make_instr(Reg::from(0), Memory::from(0)),
             Instruction::imm16_and_imm32(value, offset),
@@ -306,7 +306,7 @@ fn test_store_imm_for<T>(
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func(
             ExpectedFunc::new([
                 make_instr(Reg::from(0), Memory::from(0)),
@@ -360,7 +360,7 @@ fn test_store_imm16_for<T>(
     "#
     );
     let value = value.try_into().ok().unwrap();
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             make_instr(Reg::from(0), Memory::from(0)),
             Instruction::imm16_and_imm32(value, offset),
@@ -404,7 +404,7 @@ fn test_store_at_for(
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([make_instr(Reg::from(0), address), Instruction::Return])
         .run();
 }
@@ -440,7 +440,7 @@ fn test_store_at_overflow_for(wasm_op: WasmOp, mem_idx: u32, ptr: u32, offset: u
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([Instruction::trap(TrapCode::MemoryOutOfBounds)])
         .run();
 }
@@ -480,7 +480,7 @@ fn test_store_at_imm_for<T>(
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func(
             ExpectedFunc::new([make_instr(Reg::from(-1), address), Instruction::Return])
                 .consts([value]),
@@ -543,9 +543,7 @@ fn test_store_wrap_at_imm_for<Src, Wrapped, Field>(
         instrs.push(Instruction::memory_index(mem_idx));
     }
     instrs.push(Instruction::Return);
-    TranslationTest::from_wat(&wasm)
-        .expect_func_instrs(instrs)
-        .run();
+    TranslationTest::new(&wasm).expect_func_instrs(instrs).run();
 }
 
 fn test_store_wrap_at_imm<Src, Wrapped, Field>(
@@ -602,7 +600,7 @@ where
         )
     "#
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([Instruction::trap(TrapCode::MemoryOutOfBounds)])
         .run();
 }

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_copy.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_copy.rs
@@ -16,7 +16,7 @@ fn test_copy(ty: ValType) {
             )
         )"
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_copy(Reg::from(0), Reg::from(1), Reg::from(2)),
             Instruction::table_index(0),
@@ -48,7 +48,7 @@ fn testcase_copy_exact(ty: ValType, len: u32) -> TranslationTest {
             )
         )"
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_copy_exact16(ty: ValType, len: u32) {
@@ -115,7 +115,7 @@ fn testcase_copy_from(ty: ValType, src: u32) -> TranslationTest {
             )
         )"
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_copy_from16(ty: ValType, src: u32) {
@@ -180,7 +180,7 @@ fn testcase_copy_to(ty: ValType, dst: u32) -> TranslationTest {
             )
         )"
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_copy_to16(ty: ValType, dst: u32) {
@@ -245,7 +245,7 @@ fn testcase_copy_from_to(ty: ValType, dst: u32, src: u32) -> TranslationTest {
             )
         )"
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_copy_from_to16(ty: ValType, dst: u32, src: u32) {
@@ -325,7 +325,7 @@ fn testcase_copy_to_exact(ty: ValType, dst: u32, len: u32) -> TranslationTest {
             )
         )"
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_copy_to_exact16(ty: ValType, dst: u32, len: u32) {
@@ -405,7 +405,7 @@ fn testcase_copy_from_exact(ty: ValType, src: u32, len: u32) -> TranslationTest 
             )
         )"
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_copy_from_exact16(ty: ValType, src: u32, len: u32) {
@@ -485,7 +485,7 @@ fn testcase_copy_from_to_exact(ty: ValType, dst: u32, src: u32, len: u32) -> Tra
             )
         )"
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_copy_from_to_exact16(ty: ValType, dst: u32, src: u32, len: u32) {

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_fill.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_fill.rs
@@ -15,7 +15,7 @@ fn test_fill(ty: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_fill(Reg::from(0), Reg::from(2), Reg::from(1)),
             Instruction::table_index(0),
@@ -45,7 +45,7 @@ fn testcase_fill_exact(ty: ValType, len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_fill_exact16(ty: ValType, len: u32) {
@@ -109,7 +109,7 @@ fn testcase_fill_at(ty: ValType, dst: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_fill_at16(ty: ValType, dst: u32) {
@@ -171,7 +171,7 @@ fn testcase_fill_at_exact(ty: ValType, dst: u32, len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_fill_at_exact16(ty: ValType, dst: u32, len: u32) {
@@ -253,7 +253,7 @@ fn testcase_fill_at_exact_imm(ty: ValType, dst: u32, len: u32) -> TranslationTes
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_fill_at_exact_imm(ty: ValType, dst: u32, len: u32) {

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_get.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_get.rs
@@ -13,7 +13,7 @@ fn test_reg(ty: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_get(Reg::from(1), Reg::from(0)),
             Instruction::table_index(0),
@@ -42,7 +42,7 @@ fn test_imm(ty: ValType, index: u32) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_get_imm(Reg::from(0), index),
             Instruction::table_index(0),

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_grow.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_grow.rs
@@ -14,7 +14,7 @@ fn test_reg(ty: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_grow(Reg::from(2), Reg::from(1), Reg::from(0)),
             Instruction::table_index(0),
@@ -43,7 +43,7 @@ fn test_imm16(ty: ValType, delta: u32) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_grow_imm(Reg::from(1), u32imm16(delta), Reg::from(0)),
             Instruction::table_index(0),
@@ -78,7 +78,7 @@ fn test_imm_zero(ty: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_size(Reg::from(1), 0),
             Instruction::return_reg(Reg::from(1)),
@@ -111,7 +111,7 @@ fn test_imm_value_and_zero(ty: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_size(Reg::from(1), 0),
             Instruction::return_reg(Reg::from(1)),
@@ -139,7 +139,7 @@ fn test_imm(ty: ValType, delta: u32) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::table_grow(Reg::from(1), Reg::from(-1), Reg::from(0)),

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_init.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_init.rs
@@ -16,7 +16,7 @@ fn test_init(ty: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_init(Reg::from(0), Reg::from(1), Reg::from(2)),
             Instruction::table_index(0),
@@ -48,7 +48,7 @@ fn testcase_init_exact(ty: ValType, len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_init_exact16(ty: ValType, len: u32) {
@@ -115,7 +115,7 @@ fn testcase_init_from(ty: ValType, src: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_init_from16(ty: ValType, src: u32) {
@@ -180,7 +180,7 @@ fn testcase_init_to(ty: ValType, dst: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_init_to16(ty: ValType, dst: u32) {
@@ -245,7 +245,7 @@ fn testcase_init_from_to(ty: ValType, dst: u32, src: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_init_from_to16(ty: ValType, dst: u32, src: u32) {
@@ -325,7 +325,7 @@ fn testcase_init_to_exact(ty: ValType, dst: u32, len: u32) -> TranslationTest {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_init_to_exact16(ty: ValType, dst: u32, len: u32) {
@@ -405,7 +405,7 @@ fn testcase_init_from_exact(ty: ValType, src: u32, len: u32) -> TranslationTest 
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_init_from_exact16(ty: ValType, src: u32, len: u32) {
@@ -485,7 +485,7 @@ fn testcase_init_from_to_exact(ty: ValType, dst: u32, src: u32, len: u32) -> Tra
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
 }
 
 fn test_init_from_to_exact16(ty: ValType, dst: u32, src: u32, len: u32) {

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_set.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_set.rs
@@ -14,7 +14,7 @@ fn test_reg(ty: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_set(Reg::from(0), Reg::from(1)),
             Instruction::table_index(0),
@@ -44,7 +44,7 @@ fn test_reg_at(index: u32, value_type: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_set_at(Reg::from(0), index),
             Instruction::table_index(0),
@@ -75,7 +75,7 @@ fn imm_funcref() {
                 (table.set $t (local.get $index) (ref.func $f))
             )
         )";
-    TranslationTest::from_wat(wasm)
+    TranslationTest::new(wasm)
         .expect_func_instrs([
             Instruction::ref_func(Reg::from(1), 0),
             Instruction::table_set(Reg::from(0), Reg::from(1)),
@@ -96,7 +96,7 @@ fn test_at_imm_funcref(index: u32) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::ref_func(Reg::from(0), 0),
             Instruction::table_set_at(Reg::from(0), index),
@@ -129,7 +129,7 @@ fn test_imm_null(value_type: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::table_set(Reg::from(0), Reg::from(-1)),
@@ -164,7 +164,7 @@ fn test_at_imm_null(index: u32, value_type: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func(
             ExpectedFunc::new([
                 Instruction::table_set_at(Reg::from(-1), index),

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_size.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_size.rs
@@ -12,7 +12,7 @@ fn test_reg(ty: ValType) {
             )
         )",
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([
             Instruction::table_size(Reg::from(0), 0),
             Instruction::return_reg(Reg::from(0)),

--- a/crates/wasmi/src/engine/translator/tests/op/unary/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/unary/mod.rs
@@ -27,7 +27,7 @@ where
         )
     "#,
     );
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs(expected)
         .run();
 }
@@ -75,7 +75,7 @@ where
     );
     let result = eval(input);
     let instr = <O as WasmTy>::return_imm_instr(&result);
-    let mut testcase = TranslationTest::from_wat(&wasm);
+    let mut testcase = TranslationTest::new(&wasm);
     if let Instruction::ReturnReg { value } = &instr {
         assert!(value.is_const());
         testcase.expect_func(ExpectedFunc::new([instr]).consts([result]));
@@ -115,7 +115,7 @@ where
     "#,
     );
     let trap_code = eval(input);
-    TranslationTest::from_wat(&wasm)
+    TranslationTest::new(&wasm)
         .expect_func_instrs([Instruction::trap(trap_code)])
         .run();
 }

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -18,6 +18,9 @@ use alloc::{boxed::Box, string::String};
 use core::{fmt, fmt::Display};
 use wasmparser::BinaryReaderError as WasmError;
 
+#[cfg(feature = "wat")]
+use wat::Error as WatError;
+
 /// The generic Wasmi root error type.
 #[derive(Debug)]
 pub struct Error {
@@ -192,6 +195,9 @@ pub enum ErrorKind {
     Limits(EnforcedLimitsError),
     /// Encountered for Wasmi bytecode related errors.
     Ir(IrError),
+    /// Encountered an error from the `wat` crate.
+    #[cfg(feature = "wat")]
+    Wat(WatError),
 }
 
 impl ErrorKind {
@@ -259,6 +265,8 @@ impl Display for ErrorKind {
             Self::Limits(error) => Display::fmt(error, f),
             Self::ResumableHost(error) => Display::fmt(error, f),
             Self::Ir(error) => Display::fmt(error, f),
+            #[cfg(feature = "wat")]
+            Self::Wat(error) => Display::fmt(error, f),
         }
     }
 }
@@ -291,6 +299,10 @@ impl_from! {
     impl From<EnforcedLimitsError> for Error::Limits;
     impl From<ResumableHostError> for Error::ResumableHost;
     impl From<IrError> for Error::Ir;
+}
+#[cfg(feature = "wat")]
+impl_from! {
+    impl From<WatError> for Error::Wat;
 }
 
 /// An error that can occur upon `memory.grow` or `table.grow`.

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -22,7 +22,7 @@
 //!     // First step is to create the Wasm execution engine with some config.
 //!     // In this example we are using the default configuration.
 //!     let engine = Engine::default();
-//!     let wat = r#"
+//!     let wasm = r#"
 //!         (module
 //!             (import "host" "hello" (func $host_hello (param i32)))
 //!             (func (export "hello")
@@ -30,10 +30,7 @@
 //!             )
 //!         )
 //!     "#;
-//!     // Wasmi does not yet support parsing `.wat` so we have to convert
-//!     // out `.wat` into `.wasm` before we compile and validate it.
-//!     let wasm = wat::parse_str(&wat)?;
-//!     let module = Module::new(&engine, &mut &wasm[..])?;
+//!     let module = Module::new(&engine, wasm)?;
 //!
 //!     // All Wasm objects operate within the context of a `Store`.
 //!     // Each `Store` has a type parameter to store host-specific data,

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -1071,7 +1071,7 @@ mod tests {
                 )
             "#;
         let wasm = wat::parse_str(wat).unwrap();
-        let module = Module::new(&engine, &wasm[..]).unwrap();
+        let module = Module::new(&engine, wasm).unwrap();
         let instance = linker
             .instantiate(&mut store, &module)
             .unwrap()
@@ -1149,7 +1149,7 @@ mod tests {
             .unwrap();
         let linker = builder.finish().create(&engine);
         let mut store = Store::new(&engine, ());
-        let module = Module::new(&engine, &wasm[..]).unwrap();
+        let module = Module::new(&engine, wasm).unwrap();
         linker.instantiate(&mut store, &module).unwrap();
     }
 
@@ -1178,7 +1178,7 @@ mod tests {
             .func_wrap("host", "func.1", |_caller: Caller<()>| ())
             .unwrap();
         let mut store = Store::new(&engine, ());
-        let module = Module::new(&engine, &wasm[..]).unwrap();
+        let module = Module::new(&engine, wasm).unwrap();
         linker.instantiate(&mut store, &module).unwrap();
     }
 
@@ -1220,7 +1220,7 @@ mod tests {
         let mut linker = <Linker<()>>::new(&engine);
         let mut store = Store::new(&engine, ());
         let memory = Memory::new(&mut store, MemoryType::new(1, Some(4096)).unwrap()).unwrap();
-        let module = Module::new(&engine, &wasm[..]).unwrap();
+        let module = Module::new(&engine, wasm).unwrap();
         linker.define("env", "memory", memory).unwrap();
         let func = Func::new(
             &mut store,

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -1048,7 +1048,7 @@ mod tests {
                 b: b_init,
             },
         );
-        let wat = r#"
+        let wasm = r#"
                 (module
                     (import "host" "get_a" (func $host_get_a (result i32)))
                     (import "host" "set_a" (func $host_set_a (param i32)))
@@ -1070,7 +1070,6 @@ mod tests {
                     )
                 )
             "#;
-        let wasm = wat::parse_str(wat).unwrap();
         let module = Module::new(&engine, wasm).unwrap();
         let instance = linker
             .instantiate(&mut store, &module)
@@ -1127,8 +1126,7 @@ mod tests {
     #[test]
     fn linker_builder_uses() {
         use crate::{Engine, Linker, Module, Store};
-        let wasm = wat::parse_str(
-            r#"
+        let wasm = r#"
             (module
                 (import "host" "func.0" (func $host_func.0))
                 (import "host" "func.1" (func $host_func.1))
@@ -1136,9 +1134,7 @@ mod tests {
                     (call $host_func.0)
                     (call $host_func.1)
                 )
-            )"#,
-        )
-        .unwrap();
+            )"#;
         let engine = Engine::default();
         let mut builder = <Linker<()>>::build();
         builder
@@ -1156,8 +1152,7 @@ mod tests {
     #[test]
     fn linker_builder_and_linker_uses() {
         use crate::{Engine, Linker, Module, Store};
-        let wasm = wat::parse_str(
-            r#"
+        let wasm = r#"
             (module
                 (import "host" "func.0" (func $host_func.0))
                 (import "host" "func.1" (func $host_func.1))
@@ -1165,9 +1160,7 @@ mod tests {
                     (call $host_func.0)
                     (call $host_func.1)
                 )
-            )"#,
-        )
-        .unwrap();
+            )"#;
         let engine = Engine::default();
         let mut builder = <Linker<()>>::build();
         builder
@@ -1203,8 +1196,7 @@ mod tests {
     #[test]
     fn populate_via_imports() {
         use crate::{Engine, Func, Linker, Memory, MemoryType, Module, Store};
-        let wasm = wat::parse_str(
-            r#"
+        let wasm = r#"
             (module
                 (import "host" "hello" (func $host_hello (param i32) (result i32)))
                 (import "env" "memory" (memory $mem 0 4096))
@@ -1213,9 +1205,7 @@ mod tests {
                     (i32.const 2)
                     i32.add
                 )
-            )"#,
-        )
-        .unwrap();
+            )"#;
         let engine = Engine::default();
         let mut linker = <Linker<()>>::new(&engine);
         let mut store = Store::new(&engine, ());

--- a/crates/wasmi/src/module/instantiate/tests.rs
+++ b/crates/wasmi/src/module/instantiate/tests.rs
@@ -27,7 +27,7 @@ use crate::{
 fn try_instantiate_from_wat(wat: &str) -> Result<(Store<()>, Instance), Error> {
     let wasm = wat::parse_str(wat).unwrap();
     let engine = Engine::default();
-    let module = Module::new(&engine, &wasm[..])?;
+    let module = Module::new(&engine, wasm)?;
     let mut store = Store::new(&engine, ());
     let mut linker = <Linker<()>>::new(&engine);
     // Define one memory that can be used by the tests as import.

--- a/crates/wasmi/src/module/instantiate/tests.rs
+++ b/crates/wasmi/src/module/instantiate/tests.rs
@@ -24,8 +24,7 @@ use crate::{
     Val,
 };
 
-fn try_instantiate_from_wat(wat: &str) -> Result<(Store<()>, Instance), Error> {
-    let wasm = wat::parse_str(wat).unwrap();
+fn try_instantiate_from_wat(wasm: &str) -> Result<(Store<()>, Instance), Error> {
     let engine = Engine::default();
     let module = Module::new(&engine, wasm)?;
     let mut store = Store::new(&engine, ());

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -211,7 +211,8 @@ impl Module {
     /// - If Wasmi cannot translate the Wasm bytecode.
     ///
     /// [`Config`]: crate::Config
-    pub fn new(engine: &Engine, wasm: &[u8]) -> Result<Self, Error> {
+    pub fn new(engine: &Engine, wasm: impl AsRef<[u8]>) -> Result<Self, Error> {
+        let wasm = wasm.as_ref();
         #[cfg(feature = "wat")]
         let wasm = &wat::parse_bytes(wasm)?[..];
         ModuleParser::new(engine).parse_buffered(wasm)

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -212,6 +212,8 @@ impl Module {
     ///
     /// [`Config`]: crate::Config
     pub fn new(engine: &Engine, wasm: &[u8]) -> Result<Self, Error> {
+        #[cfg(feature = "wat")]
+        let wasm = &wat::parse_bytes(wasm)?[..];
         ModuleParser::new(engine).parse_buffered(wasm)
     }
 

--- a/crates/wasmi/tests/e2e/v1/call_hook.rs
+++ b/crates/wasmi/tests/e2e/v1/call_hook.rs
@@ -38,7 +38,7 @@ fn execute_wasm_fn_a(
     mut store: &mut Store<CallHookTestState>,
     linker: &mut Linker<CallHookTestState>,
 ) -> Result<(), Error> {
-    const TEST_WAT: &str = r#"
+    let wasm = r#"
     (module
         (import "env" "host_fn_a" (func $host_fn_a))
         (import "env" "host_fn_b" (func $host_fn_b))
@@ -50,8 +50,6 @@ fn execute_wasm_fn_a(
         )
     )
     "#;
-
-    let wasm = wat::parse_str(TEST_WAT).unwrap();
     let module = Module::new(store.engine(), wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)

--- a/crates/wasmi/tests/e2e/v1/call_hook.rs
+++ b/crates/wasmi/tests/e2e/v1/call_hook.rs
@@ -52,7 +52,7 @@ fn execute_wasm_fn_a(
     "#;
 
     let wasm = wat::parse_str(TEST_WAT).unwrap();
-    let module = Module::new(store.engine(), &wasm).unwrap();
+    let module = Module::new(store.engine(), wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)
         .unwrap()

--- a/crates/wasmi/tests/e2e/v1/fuel_consumption.rs
+++ b/crates/wasmi/tests/e2e/v1/fuel_consumption.rs
@@ -12,11 +12,6 @@ fn test_setup() -> (Store<()>, Linker<()>) {
     (store, linker)
 }
 
-/// Converts the `wat` string source into `wasm` encoded byte.
-fn wat2wasm(wat: &str) -> Vec<u8> {
-    wat::parse_str(wat).unwrap()
-}
-
 /// Compiles the `wasm` encoded bytes into a [`Module`].
 ///
 /// # Panics
@@ -71,8 +66,8 @@ fn test_module() -> &'static str {
 
 fn check_fuel_consumption(given_fuel: u64, consumed_fuel: u64) {
     assert!(given_fuel >= consumed_fuel);
-    let wasm = wat2wasm(test_module());
-    let (mut store, func) = default_test_setup(&wasm);
+    let wasm = test_module();
+    let (mut store, func) = default_test_setup(wasm.as_bytes());
     let func = func.typed::<(), i32>(&store).unwrap();
     // Now add enough fuel, so execution should succeed.
     store.set_fuel(given_fuel).unwrap(); // this is just enough fuel for a successful `memory.grow`

--- a/crates/wasmi/tests/e2e/v1/fuel_metering.rs
+++ b/crates/wasmi/tests/e2e/v1/fuel_metering.rs
@@ -13,11 +13,6 @@ fn test_setup() -> (Store<()>, Linker<()>) {
     (store, linker)
 }
 
-/// Converts the `wat` string source into `wasm` encoded byte.
-fn wat2wasm(wat: &str) -> Vec<u8> {
-    wat::parse_str(wat).unwrap()
-}
-
 /// Compiles the `wasm` encoded bytes into a [`Module`].
 ///
 /// # Panics
@@ -66,8 +61,7 @@ where
 
 #[test]
 fn metered_i32_add() {
-    let wasm = wat2wasm(
-        r#"
+    let wasm = r#"
         (module
             (func (export "test") (param $a i32) (param $b i32) (result i32)
                 (i32.add
@@ -76,9 +70,8 @@ fn metered_i32_add() {
                 )
             )
         )
-    "#,
-    );
-    let (mut store, func) = default_test_setup(&wasm);
+    "#;
+    let (mut store, func) = default_test_setup(wasm.as_bytes());
     let func = func.typed::<(i32, i32), i32>(&store).unwrap();
     // No fuel -> no success.
     assert_out_of_fuel(func.call(&mut store, (1, 2)));

--- a/crates/wasmi/tests/e2e/v1/host_call_compilation.rs
+++ b/crates/wasmi/tests/e2e/v1/host_call_compilation.rs
@@ -2,14 +2,9 @@
 
 use wasmi::{AsContextMut, Caller, Engine, Linker, Module, Store};
 
-/// Converts the given `.wat` into `.wasm`.
-fn wat2wasm(wat: &str) -> Result<Vec<u8>, wat::Error> {
-    wat::parse_str(wat)
-}
-
 fn compile_module(engine: &Engine) -> wasmi::Module {
-    let wasm = wat2wasm(include_str!("../wat/host_call_compilation.wat")).unwrap();
-    Module::new(engine, &wasm[..]).unwrap()
+    let wasm = include_str!("../wat/host_call_compilation.wat");
+    Module::new(engine, wasm.as_bytes()).unwrap()
 }
 
 #[test]

--- a/crates/wasmi/tests/e2e/v1/host_call_compilation.rs
+++ b/crates/wasmi/tests/e2e/v1/host_call_compilation.rs
@@ -4,7 +4,7 @@ use wasmi::{AsContextMut, Caller, Engine, Linker, Module, Store};
 
 fn compile_module(engine: &Engine) -> wasmi::Module {
     let wasm = include_str!("../wat/host_call_compilation.wat");
-    Module::new(engine, wasm.as_bytes()).unwrap()
+    Module::new(engine, wasm).unwrap()
 }
 
 #[test]

--- a/crates/wasmi/tests/e2e/v1/host_call_instantiation.rs
+++ b/crates/wasmi/tests/e2e/v1/host_call_instantiation.rs
@@ -30,17 +30,12 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 impl wasmi::core::HostError for Error {}
 
-/// Converts the given `.wat` into `.wasm`.
-fn wat2wasm(wat: &str) -> Result<Vec<u8>, wat::Error> {
-    wat::parse_str(wat)
-}
-
 #[test]
 fn test_instantiate_in_host_call() {
     let engine = Engine::default();
     let mut store = <Store<Data>>::new(&engine, Data::Uninit);
-    let wasm = wat2wasm(include_str!("../wat/host_call_instantiation.wat")).unwrap();
-    let module = Module::new(&engine, &wasm[..]).unwrap();
+    let wasm = include_str!("../wat/host_call_instantiation.wat");
+    let module = Module::new(&engine, wasm.as_bytes()).unwrap();
     let mut linker = <Linker<Data>>::new(&engine);
     linker
         .func_wrap(

--- a/crates/wasmi/tests/e2e/v1/host_call_instantiation.rs
+++ b/crates/wasmi/tests/e2e/v1/host_call_instantiation.rs
@@ -35,7 +35,7 @@ fn test_instantiate_in_host_call() {
     let engine = Engine::default();
     let mut store = <Store<Data>>::new(&engine, Data::Uninit);
     let wasm = include_str!("../wat/host_call_instantiation.wat");
-    let module = Module::new(&engine, wasm.as_bytes()).unwrap();
+    let module = Module::new(&engine, wasm).unwrap();
     let mut linker = <Linker<Data>>::new(&engine);
     linker
         .func_wrap(

--- a/crates/wasmi/tests/e2e/v1/host_calls_wasm.rs
+++ b/crates/wasmi/tests/e2e/v1/host_calls_wasm.rs
@@ -23,8 +23,7 @@ fn host_calls_wasm() {
         wasm_fn.call(&mut caller, input + input).unwrap()
     });
     linker.define("env", "host_fn", host_fn).unwrap();
-    let wasm = wat::parse_str(
-        r#"
+    let wasm = r#"
         (module
             (import "env" "host_fn" (func $host_fn (param i32) (result i32)))
             (func (export "wasm_fn") (param i32) (result i32)
@@ -37,9 +36,7 @@ fn host_calls_wasm() {
                 )
             )
         )
-        "#,
-    )
-    .unwrap();
+        "#;
     let module = Module::new(store.engine(), wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)

--- a/crates/wasmi/tests/e2e/v1/host_calls_wasm.rs
+++ b/crates/wasmi/tests/e2e/v1/host_calls_wasm.rs
@@ -40,7 +40,7 @@ fn host_calls_wasm() {
         "#,
     )
     .unwrap();
-    let module = Module::new(store.engine(), &wasm[..]).unwrap();
+    let module = Module::new(store.engine(), wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)
         .unwrap()

--- a/crates/wasmi/tests/e2e/v1/resource_limiter.rs
+++ b/crates/wasmi/tests/e2e/v1/resource_limiter.rs
@@ -22,11 +22,6 @@ fn test_setup(limits: StoreLimits) -> (Store<StoreLimits>, Linker<StoreLimits>) 
     (store, linker)
 }
 
-/// Converts the `wat` string source into `wasm` encoded byte.
-fn wat2wasm(wat: &str) -> Vec<u8> {
-    wat::parse_str(wat).unwrap()
-}
-
 /// Compiles the `wasm` encoded bytes into a [`Module`].
 ///
 /// # Panics
@@ -46,7 +41,7 @@ struct Test {
 
 impl Test {
     fn new(mem_pages: i32, table_elts: i32, limits: StoreLimits) -> Result<Self, Error> {
-        let wasm = wat2wasm(&format!(
+        let wasm = format!(
             r#"
         (module
             (memory {})
@@ -58,9 +53,9 @@ impl Test {
         )
         "#,
             mem_pages, table_elts
-        ));
+        );
         let (mut store, linker) = test_setup(limits);
-        let module = create_module(&store, &wasm)?;
+        let module = create_module(&store, wasm.as_bytes())?;
         let instance = linker.instantiate(&mut store, &module)?.start(&mut store)?;
         let memory_grow = instance.get_func(&store, "memory_grow").unwrap();
         let memory_size = instance.get_func(&store, "memory_size").unwrap();

--- a/crates/wasmi/tests/e2e/v1/resumable_call.rs
+++ b/crates/wasmi/tests/e2e/v1/resumable_call.rs
@@ -58,7 +58,7 @@ fn resumable_call_smoldot_common(wasm: &str) -> (Store<TestData>, TypedFunc<(), 
     // host function, returns 10 if the output is 0 and
     // returns 20 otherwise.
     let wasm = wat::parse_str(wasm).unwrap();
-    let module = Module::new(store.engine(), &wasm[..]).unwrap();
+    let module = Module::new(store.engine(), wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)
         .unwrap()
@@ -230,7 +230,7 @@ fn resumable_call() {
     )
     .unwrap();
 
-    let module = Module::new(store.engine(), &wasm[..]).unwrap();
+    let module = Module::new(store.engine(), wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)
         .unwrap()

--- a/crates/wasmi/tests/e2e/v1/resumable_call.rs
+++ b/crates/wasmi/tests/e2e/v1/resumable_call.rs
@@ -57,7 +57,6 @@ fn resumable_call_smoldot_common(wasm: &str) -> (Store<TestData>, TypedFunc<(), 
     // The Wasm defines a single function that calls the
     // host function, returns 10 if the output is 0 and
     // returns 20 otherwise.
-    let wasm = wat::parse_str(wasm).unwrap();
     let module = Module::new(store.engine(), wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)
@@ -209,8 +208,7 @@ fn resumable_call() {
         }
     });
     linker.define("env", "host_fn", host_fn).unwrap();
-    let wasm = wat::parse_str(
-        r#"
+    let wasm = r#"
             (module
                 (import "env" "host_fn" (func $host_fn (param i32) (result i32)))
                 (func (export "wasm_fn") (param $wasm_trap i32) (result i32)
@@ -226,10 +224,7 @@ fn resumable_call() {
                     (local.get $i)                                ;; return i == 4
                 )
             )
-            "#,
-    )
-    .unwrap();
-
+            "#;
     let module = Module::new(store.engine(), wasm).unwrap();
     let instance = linker
         .instantiate(&mut store, &module)

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -332,7 +332,7 @@ impl WastRunner {
         let bytes = wat.encode()?;
         let engine = self.store.engine();
         let module = match self.config.parsing_mode {
-            ParsingMode::Buffered => Module::new(engine, &bytes),
+            ParsingMode::Buffered => Module::new(engine, bytes),
             ParsingMode::Streaming => Module::new_streaming(engine, &mut &bytes[..]),
         }?;
         Ok((name.map(|n| n.name()), module))


### PR DESCRIPTION
Follow-up for https://github.com/wasmi-labs/wasmi/pull/1328.

tl;dr: Cleans-up the Wasmi workspace and resolves some tech-debt.

> A test-only `wat2wasm` function has been implemented several times in the Wasmi codebase, especially in tests which is an indicator that this functionality was crucially missing from Wasmi's module parsing.
