### PR TITLE
Add optional `.wat` module support to `Module::new`

### DIFF
--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -31,16 +31,16 @@ spin = { version = "0.9", default-features = false, features = [
 smallvec = { version = "1.13.1", features = ["union"] }
 multi-stash = { version = "0.2.0" }
 arrayvec = { version = "0.7.4", default-features = false }
+wat = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
-wat = { version = "1", default-features = false }
 assert_matches = "1.5"
 anyhow = "1"
 wasmi_wast = { workspace = true }
 criterion = { version = "0.5", default-features = false }
 
 [features]
-default = ["std"]
+default = ["std", "wat"]
 std = [
     "wasmi_core/std",
     "wasmi_collections/std",
@@ -56,6 +56,7 @@ prefer-btree-collections = [
     "wasmi_collections/prefer-btree-collections",
     "wasmparser/prefer-btree-collections",
 ]
+wat = ["dep:wat", "std"]
 
 # Enables extra checks performed during Wasmi bytecode execution.
 #

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -18,6 +18,9 @@ use alloc::{boxed::Box, string::String};
 use core::{fmt, fmt::Display};
 use wasmparser::BinaryReaderError as WasmError;
 
+#[cfg(feature = "wat")]
+use wat::Error as WatError;
+
 /// The generic Wasmi root error type.
 #[derive(Debug)]
 pub struct Error {
@@ -192,6 +195,9 @@ pub enum ErrorKind {
     Limits(EnforcedLimitsError),
     /// Encountered for Wasmi bytecode related errors.
     Ir(IrError),
+    /// Encountered an error from the `wat` crate.
+    #[cfg(feature = "wat")]
+    Wat(WatError),
 }
 
 impl ErrorKind {
@@ -259,6 +265,8 @@ impl Display for ErrorKind {
             Self::Limits(error) => Display::fmt(error, f),
             Self::ResumableHost(error) => Display::fmt(error, f),
             Self::Ir(error) => Display::fmt(error, f),
+            #[cfg(feature = "wat")]
+            Self::Wat(error) => Display::fmt(error, f),
         }
     }
 }
@@ -291,6 +299,10 @@ impl_from! {
     impl From<EnforcedLimitsError> for Error::Limits;
     impl From<ResumableHostError> for Error::ResumableHost;
     impl From<IrError> for Error::Ir;
+}
+#[cfg(feature = "wat")]
+impl_from! {
+    impl From<WatError> for Error::Wat;
 }
 
 /// An error that can occur upon `memory.grow` or `table.grow`.

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -201,7 +201,9 @@ impl Module {
     ///
     /// # Note
     ///
-    /// This parses, validates and translates the buffered Wasm bytecode.
+    /// - This parses, validates and translates the buffered Wasm bytecode.
+    /// - The `wasm` may be encoded as WebAssembly binary (`.wasm`) or as
+    ///   WebAssembly text format (`.wat`).
     ///
     /// # Errors
     ///
@@ -211,7 +213,10 @@ impl Module {
     /// - If Wasmi cannot translate the Wasm bytecode.
     ///
     /// [`Config`]: crate::Config
-    pub fn new(engine: &Engine, wasm: &[u8]) -> Result<Self, Error> {
+    pub fn new(engine: &Engine, wasm: impl AsRef<[u8]>) -> Result<Self, Error> {
+        let wasm = wasm.as_ref();
+        #[cfg(feature = "wat")]
+        let wasm = &wat::parse_bytes(wasm)?[..];
         ModuleParser::new(engine).parse_buffered(wasm)
     }
 


### PR DESCRIPTION
A test-only `wat2wasm` function has been implemented several times in the Wasmi codebase, especially in tests which is an indicator that this functionality was crucially missing from Wasmi's module parsing.

Thus we added this feature optionally behind the new `wat` crate feature in Wasmi.
This also improves Wasmi's Wasmtime API mirroring because Wasmtime also provides `.wat` parsing support in its `Module::new` API.

We explicitly do _not_ support `.wat` parsing in `Module::new_streaming` since there is no streaming parsing support for `.wat` files via the used `wat` crate.