### PR TITLE
Fix execution of tail calling host functions from Wasm

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -399,22 +399,24 @@ impl<'engine> Executor<'engine> {
                     self.execute_return_call_internal(&mut store.inner, EngineFunc::from(func))?
                 }
                 Instr::ReturnCallImported0 { func } => {
-                    self.execute_return_call_imported_0::<T>(store, func)?
+                    forward_return!(self.execute_return_call_imported_0::<T>(store, func)?)
                 }
                 Instr::ReturnCallImported { func } => {
-                    self.execute_return_call_imported::<T>(store, func)?
+                    forward_return!(self.execute_return_call_imported::<T>(store, func)?)
                 }
                 Instr::ReturnCallIndirect0 { func_type } => {
-                    self.execute_return_call_indirect_0::<T>(store, func_type)?
+                    forward_return!(self.execute_return_call_indirect_0::<T>(store, func_type)?)
                 }
                 Instr::ReturnCallIndirect0Imm16 { func_type } => {
-                    self.execute_return_call_indirect_0_imm16::<T>(store, func_type)?
+                    forward_return!(
+                        self.execute_return_call_indirect_0_imm16::<T>(store, func_type)?
+                    )
                 }
                 Instr::ReturnCallIndirect { func_type } => {
-                    self.execute_return_call_indirect::<T>(store, func_type)?
+                    forward_return!(self.execute_return_call_indirect::<T>(store, func_type)?)
                 }
                 Instr::ReturnCallIndirectImm16 { func_type } => {
-                    self.execute_return_call_indirect_imm16::<T>(store, func_type)?
+                    forward_return!(self.execute_return_call_indirect_imm16::<T>(store, func_type)?)
                 }
                 Instr::CallInternal0 { results, func } => {
                     self.execute_call_internal_0(&mut store.inner, results, EngineFunc::from(func))?

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -48,6 +48,9 @@ macro_rules! forward_return {
     }};
 }
 
+/// Tells if execution loop shall continue or break (return) to the execution's caller.
+type ControlFlow = ::core::ops::ControlFlow<(), ()>;
+
 /// Executes compiled function instructions until execution returns from the root function.
 ///
 /// # Errors

--- a/crates/wasmi/src/engine/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/executor/instrs/return_.rs
@@ -1,4 +1,4 @@
-use super::{Executor, InstructionPtr};
+use super::{Executor, InstructionPtr, ControlFlow};
 use crate::{
     core::UntypedVal,
     engine::{executor::stack::FrameRegisters, utils::unreachable_unchecked},
@@ -6,9 +6,6 @@ use crate::{
     store::StoreInner,
 };
 use core::slice;
-
-/// Tells if execution loop shall continue or break (return) to the execution's caller.
-type ControlFlow = ::core::ops::ControlFlow<(), ()>;
 
 impl Executor<'_> {
     /// Returns the execution to the caller.

--- a/crates/wasmi/src/engine/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/executor/instrs/return_.rs
@@ -1,4 +1,4 @@
-use super::{Executor, InstructionPtr, ControlFlow};
+use super::{ControlFlow, Executor, InstructionPtr};
 use crate::{
     core::UntypedVal,
     engine::{executor::stack::FrameRegisters, utils::unreachable_unchecked},

--- a/crates/wasmi/src/engine/tests/host_calls.rs
+++ b/crates/wasmi/src/engine/tests/host_calls.rs
@@ -1,6 +1,6 @@
 //! This submodule tests the unusual use case of calling host functions through the engine from the host side.
 
-use crate::{Caller, Config, Engine, Error, Func, Store};
+use crate::{Caller, Config, Engine, Error, Func, Linker, Module, Store};
 
 /// Setup a new `Store` for testing with initial value of 5.
 fn setup_store() -> Store<i32> {
@@ -82,4 +82,37 @@ fn host_call_from_host_params_4_results_4() {
         reverse_and_add.call(&mut store, (40, 30, 20, 10)).unwrap(),
         (20, 30, 40, 50)
     );
+}
+
+fn wat2wasm(wat: &str) -> alloc::vec::Vec<u8> {
+    wat::parse_str(wat).unwrap()
+}
+
+#[test]
+fn host_tail_calls() {
+    let wat = r#"
+        (module
+            (import "host" "sum_with_data" (func $sum_with_data (param i32) (result i32)))
+            (func (export "test") (param i32) (result i32)
+                (local.get 0)
+                (return_call $sum_with_data)
+            )
+        )
+    "#;
+    let wasm = wat2wasm(wat);
+    let engine = Engine::default();
+    let module = Module::new(&engine, &wasm).unwrap();
+    let mut store = Store::new(&engine, 5_i32);
+    let mut linker = Linker::new(&engine);
+    linker.func_wrap("host", "sum_with_data", |caller: Caller<i32>, a: i32| {
+        caller.data() + a
+    }).unwrap();
+    let instance = linker.instantiate(&mut store, &module).unwrap().start(&mut store).unwrap();
+    let test = instance.get_typed_func::<i32, i32>(&mut store, "test").unwrap();
+
+    assert_eq!(*store.data(), 5);
+    assert_eq!(test.call(&mut store, 1).unwrap(), 1 + 5);
+    *store.data_mut() = 10;
+    assert_eq!(*store.data(), 10);
+    assert_eq!(test.call(&mut store, 5).unwrap(), 5 + 10);
 }

--- a/crates/wasmi/src/engine/tests/host_calls.rs
+++ b/crates/wasmi/src/engine/tests/host_calls.rs
@@ -125,13 +125,13 @@ fn host_tail_calls_1() {
     let wasm = r#"
         (module
             (import "host" "sum_with_data" (func $sum_with_data (param i32) (result i32)))
-            (func $wasm0 (param i32) (result i32)
+            (func $f (param i32) (result i32)
                 (local.get 0)
                 (return_call $sum_with_data)
             )
             (func (export "test") (param i32) (result i32)
                 (local.get 0)
-                (call $0)
+                (call $f)
             )
         )
     "#;

--- a/crates/wasmi/src/engine/tests/host_calls.rs
+++ b/crates/wasmi/src/engine/tests/host_calls.rs
@@ -99,11 +99,19 @@ fn host_tail_calls() {
     let module = Module::new(&engine, wasm).unwrap();
     let mut store = Store::new(&engine, 5_i32);
     let mut linker = Linker::new(&engine);
-    linker.func_wrap("host", "sum_with_data", |caller: Caller<i32>, a: i32| {
-        caller.data() + a
-    }).unwrap();
-    let instance = linker.instantiate(&mut store, &module).unwrap().start(&mut store).unwrap();
-    let test = instance.get_typed_func::<i32, i32>(&mut store, "test").unwrap();
+    linker
+        .func_wrap("host", "sum_with_data", |caller: Caller<i32>, a: i32| {
+            caller.data() + a
+        })
+        .unwrap();
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .unwrap()
+        .start(&mut store)
+        .unwrap();
+    let test = instance
+        .get_typed_func::<i32, i32>(&mut store, "test")
+        .unwrap();
 
     assert_eq!(*store.data(), 5);
     assert_eq!(test.call(&mut store, 1).unwrap(), 1 + 5);

--- a/crates/wasmi/src/engine/tests/host_calls.rs
+++ b/crates/wasmi/src/engine/tests/host_calls.rs
@@ -84,13 +84,9 @@ fn host_call_from_host_params_4_results_4() {
     );
 }
 
-fn wat2wasm(wat: &str) -> alloc::vec::Vec<u8> {
-    wat::parse_str(wat).unwrap()
-}
-
 #[test]
 fn host_tail_calls() {
-    let wat = r#"
+    let wasm = r#"
         (module
             (import "host" "sum_with_data" (func $sum_with_data (param i32) (result i32)))
             (func (export "test") (param i32) (result i32)
@@ -99,9 +95,8 @@ fn host_tail_calls() {
             )
         )
     "#;
-    let wasm = wat2wasm(wat);
     let engine = Engine::default();
-    let module = Module::new(&engine, &wasm).unwrap();
+    let module = Module::new(&engine, wasm).unwrap();
     let mut store = Store::new(&engine, 5_i32);
     let mut linker = Linker::new(&engine);
     linker.func_wrap("host", "sum_with_data", |caller: Caller<i32>, a: i32| {


### PR DESCRIPTION
Tail calling host functions did not properly manipulate the value- and call stack which resulted in crashes.
Fortunately tail calls that invoke host functions are rather rare which is probably the reason why this has been undetected.

Our fuzzing infrastructure could use some improvement by making it possible to fuzz host function calls which currently is not possible. A simple solution could be to allow function imports and generate host functions on the fly depending on the imported functions when setting up a Wasm instance. The difficulty is that each Wasm oracle needs to allow for this.

Another downside is that the code surrounding function calls in the Wasmi executor is probably the messiest part of the entire Wasmi codebase. We really should investigate some resources to clean-up this part of the codebase.

Benchmarks indicate no or insignificant changes in execution performance.