### PR TITLE
`clippy`: fix `no_mangle` and `export_name` usage

### DIFF
--- a/crates/c_api/macro/lib.rs
+++ b/crates/c_api/macro/lib.rs
@@ -26,7 +26,7 @@ pub fn declare_own(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     (quote! {
         #[doc = #docs]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #delete(_: ::alloc::boxed::Box<#ty>) {}
     })
@@ -49,7 +49,7 @@ pub fn declare_ty(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         ::wasmi_c_api_macros::declare_own!(#ty);
 
         #[doc = #docs]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #copy(src: &#ty) -> ::alloc::boxed::Box<#ty> {
             ::alloc::boxed::Box::new(src.clone())
@@ -98,7 +98,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         ::wasmi_c_api_macros::declare_ty!(#ty);
 
         #[doc = #same_docs]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #same(_a: &#ty, _b: &#ty) -> ::core::primitive::bool {
             #[cfg(feature = "std")]
@@ -107,14 +107,14 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
 
         #[doc = #get_host_info_docs]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #get_host_info(a: &#ty) -> *mut ::core::ffi::c_void {
             ::core::ptr::null_mut()
         }
 
         #[doc = #set_host_info_docs]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #set_host_info(a: &#ty, info: *mut ::core::ffi::c_void) {
             #[cfg(feature = "std")]
@@ -123,7 +123,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
 
         #[doc = #set_host_info_final_docs]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #set_host_info_final(
             a: &#ty,
@@ -136,7 +136,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
 
         #[doc = #as_ref_docs]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #as_ref(a: &#ty) -> ::alloc::boxed::Box<crate::wasm_ref_t> {
             #[cfg(feature = "std")]
@@ -145,7 +145,7 @@ pub fn declare_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
 
         #[doc = #as_ref_const_docs]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn #as_ref_const(a: &#ty) -> ::alloc::boxed::Box<crate::wasm_ref_t> {
             #[cfg(feature = "std")]

--- a/crates/c_api/src/config.rs
+++ b/crates/c_api/src/config.rs
@@ -20,7 +20,7 @@ wasmi_c_api_macros::declare_own!(wasm_config_t);
 /// Wraps [`wasmi::Config::default`].
 ///
 /// [`wasm_engine_new_with_config`]: crate::wasm_engine_new_with_config
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_config_new() -> Box<wasm_config_t> {
     Box::new(wasm_config_t {

--- a/crates/c_api/src/engine.rs
+++ b/crates/c_api/src/engine.rs
@@ -18,7 +18,7 @@ wasmi_c_api_macros::declare_own!(wasm_engine_t);
 /// The returned [`wasm_engine_t`] must be freed using [`wasm_engine_delete`].
 ///
 /// Wraps [`wasmi::Engine::default`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
     Box::new(wasm_engine_t {
@@ -31,7 +31,7 @@ pub extern "C" fn wasm_engine_new() -> Box<wasm_engine_t> {
 /// The returned [`wasm_engine_t`] must be freed using [`wasm_engine_delete`].
 ///
 /// Wraps [`wasmi::Engine::new`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_engine_new_with_config(config: Box<wasm_config_t>) -> Box<wasm_engine_t> {
     Box::new(wasm_engine_t {

--- a/crates/c_api/src/error.rs
+++ b/crates/c_api/src/error.rs
@@ -29,7 +29,7 @@ impl From<wasmi_error_t> for Error {
 /// Creates a new [`wasmi_error_t`] with the given error message.
 ///
 /// Wraps [`wasmi::Error::new`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)] // clippy 0.1.79 (129f3b99 2024-06-10): incorrectly reports a bug here
 pub extern "C" fn wasmi_error_new(msg: *const ffi::c_char) -> Option<Box<wasmi_error_t>> {
     let msg_bytes = unsafe { ffi::CStr::from_ptr(msg) };

--- a/crates/c_api/src/extern.rs
+++ b/crates/c_api/src/extern.rs
@@ -22,7 +22,7 @@ pub struct wasm_extern_t {
 wasmi_c_api_macros::declare_ref!(wasm_extern_t);
 
 /// Returns the [`wasm_extern_kind`] of the [`wasm_extern_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
     match e.which {
@@ -39,7 +39,7 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_extern_t`]
 /// with its underlying, internal [`WasmStoreRef`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externtype_t> {
     Box::new(wasm_externtype_t::from_extern_type(
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externt
 /// Returns the [`wasm_extern_t`] as reference to mutable [`wasm_func_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_func_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_func(e: &mut wasm_extern_t) -> Option<&mut wasm_func_t> {
     wasm_func_t::try_from_mut(e)
@@ -59,7 +59,7 @@ pub extern "C" fn wasm_extern_as_func(e: &mut wasm_extern_t) -> Option<&mut wasm
 /// Returns the [`wasm_extern_t`] as reference to shared [`wasm_func_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_func_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_func_const(e: &wasm_extern_t) -> Option<&wasm_func_t> {
     wasm_func_t::try_from(e)
@@ -68,7 +68,7 @@ pub extern "C" fn wasm_extern_as_func_const(e: &wasm_extern_t) -> Option<&wasm_f
 /// Returns the [`wasm_extern_t`] as reference to mutable [`wasm_global_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_global_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_global(e: &mut wasm_extern_t) -> Option<&mut wasm_global_t> {
     wasm_global_t::try_from_mut(e)
@@ -77,7 +77,7 @@ pub extern "C" fn wasm_extern_as_global(e: &mut wasm_extern_t) -> Option<&mut wa
 /// Returns the [`wasm_extern_t`] as reference to shared [`wasm_global_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_global_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_global_const(e: &wasm_extern_t) -> Option<&wasm_global_t> {
     wasm_global_t::try_from(e)
@@ -86,7 +86,7 @@ pub extern "C" fn wasm_extern_as_global_const(e: &wasm_extern_t) -> Option<&wasm
 /// Returns the [`wasm_extern_t`] as reference to mutable [`wasm_table_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_table_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_table(e: &mut wasm_extern_t) -> Option<&mut wasm_table_t> {
     wasm_table_t::try_from_mut(e)
@@ -95,7 +95,7 @@ pub extern "C" fn wasm_extern_as_table(e: &mut wasm_extern_t) -> Option<&mut was
 /// Returns the [`wasm_extern_t`] as reference to shared [`wasm_table_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_table_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_table_const(e: &wasm_extern_t) -> Option<&wasm_table_t> {
     wasm_table_t::try_from(e)
@@ -104,7 +104,7 @@ pub extern "C" fn wasm_extern_as_table_const(e: &wasm_extern_t) -> Option<&wasm_
 /// Returns the [`wasm_extern_t`] as reference to mutable [`wasm_memory_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_memory_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_memory(e: &mut wasm_extern_t) -> Option<&mut wasm_memory_t> {
     wasm_memory_t::try_from_mut(e)
@@ -113,7 +113,7 @@ pub extern "C" fn wasm_extern_as_memory(e: &mut wasm_extern_t) -> Option<&mut wa
 /// Returns the [`wasm_extern_t`] as reference to shared [`wasm_memory_t`] if possible.
 ///
 /// Returns `None` if `e` is not a [`wasm_memory_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_extern_as_memory_const(e: &wasm_extern_t) -> Option<&wasm_memory_t> {
     wasm_memory_t::try_from(e)

--- a/crates/c_api/src/foreign.rs
+++ b/crates/c_api/src/foreign.rs
@@ -12,7 +12,7 @@ wasmi_c_api_macros::declare_ref!(wasm_foreign_t);
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_foreign_new(_store: &crate::wasm_store_t) -> Box<wasm_foreign_t> {
     unimplemented!("wasm_foreign_new")

--- a/crates/c_api/src/frame.rs
+++ b/crates/c_api/src/frame.rs
@@ -16,7 +16,7 @@ wasmi_c_api_macros::declare_own!(wasm_frame_t);
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_frame_func_index(_frame: &wasm_frame_t<'_>) -> u32 {
     unimplemented!("wasm_frame_func_index")
@@ -27,7 +27,7 @@ pub extern "C" fn wasm_frame_func_index(_frame: &wasm_frame_t<'_>) -> u32 {
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_frame_func_offset(_frame: &wasm_frame_t<'_>) -> usize {
     unimplemented!("wasm_frame_func_offset")
@@ -38,7 +38,7 @@ pub extern "C" fn wasm_frame_func_offset(_frame: &wasm_frame_t<'_>) -> usize {
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_frame_instance(_arg1: *const wasm_frame_t<'_>) -> *mut wasm_instance_t {
     unimplemented!("wasm_frame_instance")
@@ -49,7 +49,7 @@ pub extern "C" fn wasm_frame_instance(_arg1: *const wasm_frame_t<'_>) -> *mut wa
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_frame_module_offset(_frame: &wasm_frame_t<'_>) -> usize {
     unimplemented!("wasm_frame_module_offset")
@@ -60,7 +60,7 @@ pub extern "C" fn wasm_frame_module_offset(_frame: &wasm_frame_t<'_>) -> usize {
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_frame_copy<'a>(_frame: &wasm_frame_t<'a>) -> Box<wasm_frame_t<'a>> {
     unimplemented!("wasm_frame_copy")

--- a/crates/c_api/src/func.rs
+++ b/crates/c_api/src/func.rs
@@ -119,7 +119,7 @@ unsafe fn create_function(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_functype_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_new(
     store: &mut wasm_store_t,
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn wasm_func_new(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_functype_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_new_with_env(
     store: &mut wasm_store_t,
@@ -185,7 +185,7 @@ fn prepare_params_and_results(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_func_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_call(
     func: &mut wasm_func_t,
@@ -250,7 +250,7 @@ fn error_from_panic(panic: Box<dyn Any + Send>) -> Error {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_func_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_type(f: &wasm_func_t) -> Box<wasm_functype_t> {
     Box::new(wasm_functype_t::new(f.func().ty(f.inner.store.context())))
@@ -266,7 +266,7 @@ pub unsafe extern "C" fn wasm_func_type(f: &wasm_func_t) -> Box<wasm_functype_t>
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 ///
 /// [`FuncType::params`]: wasmi::FuncType::params
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_param_arity(f: &wasm_func_t) -> usize {
     f.func().ty(f.inner.store.context()).params().len()
@@ -282,21 +282,21 @@ pub unsafe extern "C" fn wasm_func_param_arity(f: &wasm_func_t) -> usize {
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 ///
 /// [`FuncType::results`]: wasmi::FuncType::results
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_func_result_arity(f: &wasm_func_t) -> usize {
     f.func().ty(f.inner.store.context()).results().len()
 }
 
 /// Returns the [`wasm_func_t`] as mutable reference to [`wasm_extern_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_func_as_extern(f: &mut wasm_func_t) -> &mut wasm_extern_t {
     &mut f.inner
 }
 
 /// Returns the [`wasm_func_t`] as shared reference to [`wasm_extern_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_func_as_extern_const(f: &wasm_func_t) -> &wasm_extern_t {
     &f.inner

--- a/crates/c_api/src/global.rs
+++ b/crates/c_api/src/global.rs
@@ -48,7 +48,7 @@ impl wasm_global_t {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_global_new(
     store: &mut wasm_store_t,
@@ -70,14 +70,14 @@ pub unsafe extern "C" fn wasm_global_new(
 }
 
 /// Returns the [`wasm_global_t`] as mutable reference to [`wasm_extern_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_global_as_extern(g: &mut wasm_global_t) -> &mut wasm_extern_t {
     &mut g.inner
 }
 
 /// Returns the [`wasm_global_t`] as shared reference to [`wasm_extern_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_global_as_extern_const(g: &wasm_global_t) -> &wasm_extern_t {
     &g.inner
@@ -91,7 +91,7 @@ pub extern "C" fn wasm_global_as_extern_const(g: &wasm_global_t) -> &wasm_extern
 ///
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globaltype_t> {
     let globaltype = g.global().ty(g.inner.store.context());
@@ -106,7 +106,7 @@ pub unsafe extern "C" fn wasm_global_type(g: &wasm_global_t) -> Box<wasm_globalt
 ///
 /// It is the caller's responsibility not to alias the [`wasm_global_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeUninit<wasm_val_t>) {
     let global = g.global();
@@ -125,7 +125,7 @@ pub unsafe extern "C" fn wasm_global_get(g: &mut wasm_global_t, out: &mut MaybeU
 /// - It is the caller's responsibility that `val` matches the type of `g`.
 /// - It is the caller's responsibility not to alias the [`wasm_global_t`]
 ///   with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_global_set(g: &mut wasm_global_t, val: &wasm_val_t) {
     let global = g.global();

--- a/crates/c_api/src/instance.rs
+++ b/crates/c_api/src/instance.rs
@@ -43,7 +43,7 @@ impl wasm_instance_t {
 /// with its underlying, internal [`WasmStoreRef`].
 ///
 /// [Wasm core specification]: https://webassembly.github.io/spec/core/exec/modules.html#exec-instantiation
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_instance_new(
     store: &mut wasm_store_t,
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn wasm_instance_new(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_instance_t`]
 /// with its underlying, internal [`WasmStoreRef`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_instance_exports(
     instance: &mut wasm_instance_t,

--- a/crates/c_api/src/memory.rs
+++ b/crates/c_api/src/memory.rs
@@ -49,7 +49,7 @@ impl wasm_memory_t {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_new(
     store: &mut wasm_store_t,
@@ -65,14 +65,14 @@ pub unsafe extern "C" fn wasm_memory_new(
 }
 
 /// Returns the [`wasm_memory_t`] as mutable reference to [`wasm_extern_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memory_as_extern(m: &mut wasm_memory_t) -> &mut wasm_extern_t {
     &mut m.inner
 }
 
 /// Returns the [`wasm_memory_t`] as shared reference to [`wasm_extern_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memory_as_extern_const(m: &wasm_memory_t) -> &wasm_extern_t {
     &m.inner
@@ -86,7 +86,7 @@ pub extern "C" fn wasm_memory_as_extern_const(m: &wasm_memory_t) -> &wasm_extern
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_type(m: &wasm_memory_t) -> Box<wasm_memorytype_t> {
     let ty = m.memory().ty(m.inner.store.context());
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn wasm_memory_type(m: &wasm_memory_t) -> Box<wasm_memoryt
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_data(m: &wasm_memory_t) -> *mut u8 {
     m.memory().data_ptr(m.inner.store.context())
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn wasm_memory_data(m: &wasm_memory_t) -> *mut u8 {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_data_size(m: &wasm_memory_t) -> usize {
     m.memory().data_size(m.inner.store.context())
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn wasm_memory_data_size(m: &wasm_memory_t) -> usize {
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_size(m: &wasm_memory_t) -> wasm_memory_pages_t {
     m.memory().size(m.inner.store.context())
@@ -145,7 +145,7 @@ pub unsafe extern "C" fn wasm_memory_size(m: &wasm_memory_t) -> wasm_memory_page
 ///
 /// It is the caller's responsibility not to alias the [`wasm_memory_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_memory_grow(
     m: &mut wasm_memory_t,

--- a/crates/c_api/src/module.rs
+++ b/crates/c_api/src/module.rs
@@ -49,7 +49,7 @@ wasmi_c_api_macros::declare_own!(wasm_shared_module_t);
 ///
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_module_new(
     store: &mut wasm_store_t,
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn wasm_module_new(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_module_validate(
     store: &mut wasm_store_t,
@@ -97,7 +97,7 @@ fn fill_exports(module: &Module, out: &mut wasm_exporttype_vec_t) {
 /// Stores the queried module exports in `out`.
 ///
 /// Wraps [`Module::exports`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_module_exports(module: &wasm_module_t, out: &mut wasm_exporttype_vec_t) {
     fill_exports(&module.inner, out);
@@ -123,7 +123,7 @@ fn fill_imports(module: &Module, out: &mut wasm_importtype_vec_t) {
 /// Stores the queried module imports in `out`.
 ///
 /// Wraps [`Module::imports`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_importtype_vec_t) {
     fill_imports(&module.inner, out);
@@ -135,7 +135,7 @@ pub extern "C" fn wasm_module_imports(module: &wasm_module_t, out: &mut wasm_imp
 /// - Obtain the original [`wasm_module_t`] via a call to [`wasm_module_obtain`].
 ///
 /// Wraps [`Module::clone`] (kinda).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_module_share(module: &wasm_module_t) -> Box<wasm_shared_module_t> {
     Box::new(wasm_shared_module_t {
@@ -153,7 +153,7 @@ pub extern "C" fn wasm_module_share(module: &wasm_module_t) -> Box<wasm_shared_m
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
 ///
 /// Wraps [`Module::clone`] (kinda).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_module_obtain(
     store: &mut wasm_store_t,
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn wasm_module_obtain(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_module_serialize(_module: &wasm_module_t, _ret: &mut wasm_byte_vec_t) {
     unimplemented!("wasm_module_serialize")
@@ -194,7 +194,7 @@ pub extern "C" fn wasm_module_serialize(_module: &wasm_module_t, _ret: &mut wasm
 ///
 /// It is the caller's responsibility not to alias the [`wasm_module_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_module_deserialize(
     _store: &mut wasm_store_t,

--- a/crates/c_api/src/ref.rs
+++ b/crates/c_api/src/ref.rs
@@ -88,7 +88,7 @@ pub(crate) fn ref_to_val(r: &wasm_ref_t) -> Val {
 /// Copies the [`wasm_ref_t`] and returns the copied reference.
 ///
 /// Returns `None` if `r` was `None`.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_copy(r: Option<&wasm_ref_t>) -> Option<Box<wasm_ref_t>> {
     r.map(|r| Box::new(r.clone()))
@@ -99,7 +99,7 @@ pub extern "C" fn wasm_ref_copy(r: Option<&wasm_ref_t>) -> Option<Box<wasm_ref_t
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_same(_a: Option<&wasm_ref_t>, _b: Option<&wasm_ref_t>) -> bool {
     // In Wasmi we require a store to determine whether these are the same
@@ -112,7 +112,7 @@ pub extern "C" fn wasm_ref_same(_a: Option<&wasm_ref_t>, _b: Option<&wasm_ref_t>
 /// # Note
 ///
 /// This API is unsupported and always returns a `null` pointer.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_get_host_info(_ref: Option<&wasm_ref_t>) -> *mut c_void {
     ptr::null_mut()
@@ -123,7 +123,7 @@ pub extern "C" fn wasm_ref_get_host_info(_ref: Option<&wasm_ref_t>) -> *mut c_vo
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_set_host_info(_ref: Option<&wasm_ref_t>, _info: *mut c_void) {
     unimplemented!("wasm_ref_set_host_info")
@@ -136,7 +136,7 @@ pub extern "C" fn wasm_ref_set_host_info(_ref: Option<&wasm_ref_t>, _info: *mut 
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
     _ref: Option<&wasm_ref_t>,
@@ -151,7 +151,7 @@ pub extern "C" fn wasm_ref_set_host_info_with_finalizer(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_extern(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_extern_t> {
     unimplemented!("wasm_ref_as_extern")
@@ -162,7 +162,7 @@ pub extern "C" fn wasm_ref_as_extern(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_extern_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_extern_t> {
     unimplemented!("wasm_ref_as_extern_const")
@@ -173,7 +173,7 @@ pub extern "C" fn wasm_ref_as_extern_const(_ref: Option<&wasm_ref_t>) -> Option<
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_foreign(
     _ref: Option<&mut wasm_ref_t>,
@@ -186,7 +186,7 @@ pub extern "C" fn wasm_ref_as_foreign(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_foreign_const(
     _ref: Option<&wasm_ref_t>,
@@ -199,7 +199,7 @@ pub extern "C" fn wasm_ref_as_foreign_const(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_func(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_func_t> {
     unimplemented!("wasm_ref_as_func")
@@ -210,7 +210,7 @@ pub extern "C" fn wasm_ref_as_func(_ref: Option<&mut wasm_ref_t>) -> Option<&mut
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_func_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_func_t> {
     unimplemented!("wasm_ref_as_func_const")
@@ -221,7 +221,7 @@ pub extern "C" fn wasm_ref_as_func_const(_ref: Option<&wasm_ref_t>) -> Option<&w
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_global(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_global_t> {
     unimplemented!("wasm_ref_as_global")
@@ -232,7 +232,7 @@ pub extern "C" fn wasm_ref_as_global(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_global_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_global_t> {
     unimplemented!("wasm_ref_as_global_const")
@@ -243,7 +243,7 @@ pub extern "C" fn wasm_ref_as_global_const(_ref: Option<&wasm_ref_t>) -> Option<
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_instance(
     _ref: Option<&mut wasm_ref_t>,
@@ -256,7 +256,7 @@ pub extern "C" fn wasm_ref_as_instance(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_instance_const(
     _ref: Option<&wasm_ref_t>,
@@ -269,7 +269,7 @@ pub extern "C" fn wasm_ref_as_instance_const(
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_memory(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_memory_t> {
     unimplemented!("wasm_ref_as_memory")
@@ -280,7 +280,7 @@ pub extern "C" fn wasm_ref_as_memory(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_memory_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_memory_t> {
     unimplemented!("wasm_ref_as_memory_const")
@@ -291,7 +291,7 @@ pub extern "C" fn wasm_ref_as_memory_const(_ref: Option<&wasm_ref_t>) -> Option<
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_module(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_module_t> {
     unimplemented!("wasm_ref_as_module")
@@ -302,7 +302,7 @@ pub extern "C" fn wasm_ref_as_module(_ref: Option<&mut wasm_ref_t>) -> Option<&m
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_module_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_module_t> {
     unimplemented!("wasm_ref_as_module_const")
@@ -313,7 +313,7 @@ pub extern "C" fn wasm_ref_as_module_const(_ref: Option<&wasm_ref_t>) -> Option<
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_table(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_table_t> {
     unimplemented!("wasm_ref_as_table")
@@ -324,7 +324,7 @@ pub extern "C" fn wasm_ref_as_table(_ref: Option<&mut wasm_ref_t>) -> Option<&mu
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_table_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_table_t> {
     unimplemented!("wasm_ref_as_table_const")
@@ -335,7 +335,7 @@ pub extern "C" fn wasm_ref_as_table_const(_ref: Option<&wasm_ref_t>) -> Option<&
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_trap(_ref: Option<&mut wasm_ref_t>) -> Option<&mut wasm_trap_t> {
     unimplemented!("wasm_ref_as_trap")
@@ -346,7 +346,7 @@ pub extern "C" fn wasm_ref_as_trap(_ref: Option<&mut wasm_ref_t>) -> Option<&mut
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_ref_as_trap_const(_ref: Option<&wasm_ref_t>) -> Option<&wasm_trap_t> {
     unimplemented!("wasm_ref_as_trap_const")

--- a/crates/c_api/src/store.rs
+++ b/crates/c_api/src/store.rs
@@ -61,7 +61,7 @@ wasmi_c_api_macros::declare_own!(wasm_store_t);
 /// The returned [`wasm_store_t`] must be freed using [`wasm_store_delete`].
 ///
 /// Wraps [`<wasmi::Store<()>>::new`](wasmi::Store::new).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[allow(clippy::arc_with_non_send_sync)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_store_new(engine: &wasm_engine_t) -> Box<wasm_store_t> {

--- a/crates/c_api/src/table.rs
+++ b/crates/c_api/src/table.rs
@@ -61,7 +61,7 @@ fn option_wasm_ref_t_to_ref(r: Option<&wasm_ref_t>, table_ty: &TableType) -> Was
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_new(
     store: &mut wasm_store_t,
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn wasm_table_new(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_type(t: &wasm_table_t) -> Box<wasm_tabletype_t> {
     let table = t.table();
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn wasm_table_type(t: &wasm_table_t) -> Box<wasm_tabletype
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_get(
     t: &mut wasm_table_t,
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn wasm_table_get(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_set(
     t: &mut wasm_table_t,
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn wasm_table_set(
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_size(t: &wasm_table_t) -> wasm_table_size_t {
     let table = t.table();
@@ -166,7 +166,7 @@ pub unsafe extern "C" fn wasm_table_size(t: &wasm_table_t) -> wasm_table_size_t 
 ///
 /// It is the caller's responsibility not to alias the [`wasm_table_t`]
 /// with its underlying, internal [`WasmStoreRef`](crate::WasmStoreRef).
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_table_grow(
     t: &mut wasm_table_t,
@@ -181,14 +181,14 @@ pub unsafe extern "C" fn wasm_table_grow(
 }
 
 /// Returns the [`wasm_table_t`] as mutable reference to [`wasm_extern_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_table_as_extern(t: &mut wasm_table_t) -> &mut wasm_extern_t {
     &mut t.inner
 }
 
 /// Returns the [`wasm_table_t`] as shared reference to [`wasm_extern_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_table_as_extern_const(t: &wasm_table_t) -> &wasm_extern_t {
     &t.inner

--- a/crates/c_api/src/trap.rs
+++ b/crates/c_api/src/trap.rs
@@ -41,7 +41,7 @@ pub type wasm_message_t = wasm_name_t;
 /// # Note
 ///
 /// The `message` is expected to contain a valid null-terminated C string.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_trap_new(
     _store: &wasm_store_t,
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn wasmi_trap_new(message: *const u8, len: usize) -> Box<w
 /// Returns the error message of the [`wasm_trap_t`].
 ///
 /// Stores the returned error message in `out`.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t) {
     let mut buffer = Vec::new();
@@ -89,7 +89,7 @@ pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_trap_origin(_raw: &wasm_trap_t) -> Option<Box<wasm_frame_t<'_>>> {
     unimplemented!("wasm_trap_origin")
@@ -102,7 +102,7 @@ pub extern "C" fn wasm_trap_origin(_raw: &wasm_trap_t) -> Option<Box<wasm_frame_
 /// # Note
 ///
 /// This API is unsupported and will panic upon use.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_trap_trace<'a>(_raw: &'a wasm_trap_t, _out: &mut wasm_frame_vec_t<'a>) {
     unimplemented!("wasm_trap_trace")

--- a/crates/c_api/src/types/export.rs
+++ b/crates/c_api/src/types/export.rs
@@ -30,7 +30,7 @@ impl wasm_exporttype_t {
 }
 
 /// Creates a new [`wasm_exporttype_t`] with the given `name` and extern type `ty`
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_exporttype_new(
     name: &mut wasm_name_t,
@@ -42,14 +42,14 @@ pub extern "C" fn wasm_exporttype_new(
 }
 
 /// Returns a shared reference to the name of the [`wasm_exporttype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_exporttype_name(et: &wasm_exporttype_t) -> &wasm_name_t {
     &et.c_name
 }
 
 /// Returns a shared reference to the extern type of the [`wasm_exporttype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_exporttype_type(et: &wasm_exporttype_t) -> &wasm_externtype_t {
     &et.c_ty

--- a/crates/c_api/src/types/extern.rs
+++ b/crates/c_api/src/types/extern.rs
@@ -63,7 +63,7 @@ impl wasm_externtype_t {
 }
 
 /// Returns the [`wasm_externkind_t`] of the [`wasm_externtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_kind(et: &wasm_externtype_t) -> wasm_externkind_t {
     match &et.which {
@@ -75,7 +75,7 @@ pub extern "C" fn wasm_externtype_kind(et: &wasm_externtype_t) -> wasm_externkin
 }
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_functype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_functype(
     et: &mut wasm_externtype_t,
@@ -84,7 +84,7 @@ pub extern "C" fn wasm_externtype_as_functype(
 }
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_functype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_functype_const(
     et: &wasm_externtype_t,
@@ -93,7 +93,7 @@ pub extern "C" fn wasm_externtype_as_functype_const(
 }
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_globaltype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_globaltype(
     et: &mut wasm_externtype_t,
@@ -102,7 +102,7 @@ pub extern "C" fn wasm_externtype_as_globaltype(
 }
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_globaltype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_globaltype_const(
     et: &wasm_externtype_t,
@@ -111,7 +111,7 @@ pub extern "C" fn wasm_externtype_as_globaltype_const(
 }
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_tabletype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_tabletype(
     et: &mut wasm_externtype_t,
@@ -120,7 +120,7 @@ pub extern "C" fn wasm_externtype_as_tabletype(
 }
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_tabletype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_tabletype_const(
     et: &wasm_externtype_t,
@@ -129,7 +129,7 @@ pub extern "C" fn wasm_externtype_as_tabletype_const(
 }
 
 /// Returns a mutable reference to the [`wasm_externtype_t`] as [`wasm_memorytype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_memorytype(
     et: &mut wasm_externtype_t,
@@ -138,7 +138,7 @@ pub extern "C" fn wasm_externtype_as_memorytype(
 }
 
 /// Returns a shared reference to the [`wasm_externtype_t`] as [`wasm_memorytype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_externtype_as_memorytype_const(
     et: &wasm_externtype_t,

--- a/crates/c_api/src/types/func.rs
+++ b/crates/c_api/src/types/func.rs
@@ -76,7 +76,7 @@ impl CFuncType {
 /// Creates a new [`wasm_functype_t`] from the given parameter and result types.
 ///
 /// Wraps [`FuncType::new`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_functype_new(
     params: &mut wasm_valtype_vec_t,
@@ -99,7 +99,7 @@ pub extern "C" fn wasm_functype_new(
 /// Returns a shared reference to the parameter types of the [`wasm_functype_t`].
 ///
 /// Wraps [`FuncType::params`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     &ft.ty().params
@@ -108,21 +108,21 @@ pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_ve
 /// Returns a shared reference to the result types of the [`wasm_functype_t`].
 ///
 /// Wraps [`FuncType::results`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_functype_results(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     &ft.ty().results
 }
 
 /// Returns a mutable reference to the element type of [`wasm_functype_t`] as [`wasm_externtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_functype_as_externtype(ty: &mut wasm_functype_t) -> &mut wasm_externtype_t {
     &mut ty.ext
 }
 
 /// Returns a shared reference to the element type of [`wasm_functype_t`] as [`wasm_externtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_functype_as_externtype_const(ty: &wasm_functype_t) -> &wasm_externtype_t {
     &ty.ext

--- a/crates/c_api/src/types/global.rs
+++ b/crates/c_api/src/types/global.rs
@@ -70,7 +70,7 @@ impl CGlobalType {
 /// Creates a new [`wasm_globaltype_t`] with the given content type and mutability.
 ///
 /// Wraps [`GlobalType::new`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_globaltype_new(
     ty: Box<wasm_valtype_t>,
@@ -85,14 +85,14 @@ pub extern "C" fn wasm_globaltype_new(
 }
 
 /// Returns a shared reference to the content type of the [`wasm_globaltype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_globaltype_content(gt: &wasm_globaltype_t) -> &wasm_valtype_t {
     &gt.ty().content
 }
 
 /// Returns the mutability of the [`wasm_globaltype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_globaltype_mutability(gt: &wasm_globaltype_t) -> wasm_mutability_t {
     match gt.ty().ty.mutability() {
@@ -102,7 +102,7 @@ pub extern "C" fn wasm_globaltype_mutability(gt: &wasm_globaltype_t) -> wasm_mut
 }
 
 /// Returns a mutable reference to the element type of [`wasm_globaltype_t`] as [`wasm_externtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_globaltype_as_externtype(
     ty: &mut wasm_globaltype_t,
@@ -111,7 +111,7 @@ pub extern "C" fn wasm_globaltype_as_externtype(
 }
 
 /// Returns a shared reference to the element type of [`wasm_globaltype_t`] as [`wasm_externtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_globaltype_as_externtype_const(
     ty: &wasm_globaltype_t,

--- a/crates/c_api/src/types/import.rs
+++ b/crates/c_api/src/types/import.rs
@@ -34,7 +34,7 @@ impl wasm_importtype_t {
 }
 
 /// Creates a new [`wasm_importtype_t`] from the given `module` and `name` namespace and extern type `ty`.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_importtype_new(
     module: &mut wasm_name_t,
@@ -53,21 +53,21 @@ pub extern "C" fn wasm_importtype_new(
 }
 
 /// Returns a shared reference to the module namespace of the [`wasm_importtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_importtype_module(it: &wasm_importtype_t) -> &wasm_name_t {
     &it.c_module
 }
 
 /// Returns a shared reference to the name namespace of the [`wasm_importtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_importtype_name(it: &wasm_importtype_t) -> &wasm_name_t {
     &it.c_name
 }
 
 /// Returns a shared reference to the extern type of the [`wasm_importtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_importtype_type(it: &wasm_importtype_t) -> &wasm_externtype_t {
     &it.c_ty

--- a/crates/c_api/src/types/memory.rs
+++ b/crates/c_api/src/types/memory.rs
@@ -62,7 +62,7 @@ impl CMemoryType {
 /// Creates a new [`wasm_memorytype_t`] with the given `limits`.
 ///
 /// Wraps [`MemoryType::new`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm_memorytype_t> {
     let memory_type = MemoryType::new(limits.min, limits.max()).unwrap();
@@ -70,14 +70,14 @@ pub extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm_memory
 }
 
 /// Returns a shared reference to the table limits of the [`wasm_memorytype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memorytype_limits(mt: &wasm_memorytype_t) -> &wasm_limits_t {
     &mt.ty().limits
 }
 
 /// Returns a mutable reference to the element type of [`wasm_memorytype_t`] as [`wasm_externtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memorytype_as_externtype(
     ty: &mut wasm_memorytype_t,
@@ -86,7 +86,7 @@ pub extern "C" fn wasm_memorytype_as_externtype(
 }
 
 /// Returns a shared reference to the element type of [`wasm_memorytype_t`] as [`wasm_externtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_memorytype_as_externtype_const(
     ty: &wasm_memorytype_t,

--- a/crates/c_api/src/types/table.rs
+++ b/crates/c_api/src/types/table.rs
@@ -65,7 +65,7 @@ impl CTableType {
 /// Creates a new [`wasm_tabletype_t`] with the element `ty` and `limits`.
 ///
 /// Wraps [`TableType::new`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_tabletype_new(
     ty: Box<wasm_valtype_t>,
@@ -79,21 +79,21 @@ pub extern "C" fn wasm_tabletype_new(
 }
 
 /// Returns a shared reference to the element type of the [`wasm_tabletype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_tabletype_element(tt: &wasm_tabletype_t) -> &wasm_valtype_t {
     &tt.ty().element
 }
 
 /// Returns a shared reference to the table limits of the [`wasm_tabletype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_tabletype_limits(tt: &wasm_tabletype_t) -> &wasm_limits_t {
     &tt.ty().limits
 }
 
 /// Returns a mutable reference to the element type of [`wasm_tabletype_t`] as [`wasm_externtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_tabletype_as_externtype(
     ty: &mut wasm_tabletype_t,
@@ -102,7 +102,7 @@ pub extern "C" fn wasm_tabletype_as_externtype(
 }
 
 /// Returns a shared reference to the element type of [`wasm_tabletype_t`] as [`wasm_externtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_tabletype_as_externtype_const(ty: &wasm_tabletype_t) -> &wasm_externtype_t {
     &ty.ext

--- a/crates/c_api/src/types/val.rs
+++ b/crates/c_api/src/types/val.rs
@@ -45,7 +45,7 @@ pub enum wasm_valkind_t {
 }
 
 /// Creates a new owned [`wasm_valtype_t`] from the [`wasm_valkind_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> {
     Box::new(wasm_valtype_t {
@@ -54,7 +54,7 @@ pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> 
 }
 
 /// Returns the [`wasm_valkind_t`] of the [`wasm_valtype_t`].
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub extern "C" fn wasm_valtype_kind(vt: &wasm_valtype_t) -> wasm_valkind_t {
     from_valtype(&vt.ty)

--- a/crates/c_api/src/val.rs
+++ b/crates/c_api/src/val.rs
@@ -145,7 +145,7 @@ impl wasm_val_t {
 /// # Safety
 ///
 /// The caller is responsible to provide a valid [`wasm_val_t`] that can safely be copied.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_val_copy(out: &mut MaybeUninit<wasm_val_t>, source: &wasm_val_t) {
     utils::initialize(out, source.clone());
@@ -157,7 +157,7 @@ pub unsafe extern "C" fn wasm_val_copy(out: &mut MaybeUninit<wasm_val_t>, source
 ///
 /// The caller is responsible to provide a valid [`wasm_val_t`] that can safely be deleted.
 /// The same [`wasm_val_t`] must not be deleted more than once.
-#[no_mangle]
+#[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
 #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
 pub unsafe extern "C" fn wasm_val_delete(val: *mut wasm_val_t) {
     ptr::drop_in_place(val);

--- a/crates/c_api/src/vec.rs
+++ b/crates/c_api/src/vec.rs
@@ -134,7 +134,7 @@ macro_rules! declare_vecs {
         #[doc = "# Note"]
         #[doc = ""]
         #[doc = concat!("Returns the resulting [`", stringify!($name), "`] in `out`.")]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn $empty(out: &mut $name) {
             out.size = 0;
@@ -146,7 +146,7 @@ macro_rules! declare_vecs {
         #[doc = "# Note"]
         #[doc = ""]
         #[doc = concat!("Returns the resulting [`", stringify!($name), "`] in `out`.")]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn $uninit(out: &mut $name, size: usize) {
             out.set_buffer(vec![Default::default(); size].into());
@@ -162,7 +162,7 @@ macro_rules! declare_vecs {
         #[doc = "# Safety"]
         #[doc = ""]
         #[doc = "It is the callers responsibility to provide a valid pair of `ptr` and `size`."]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub unsafe extern "C" fn $new $(<$lt>)? (
             out: &mut $name $(<$lt>)?,
@@ -178,7 +178,7 @@ macro_rules! declare_vecs {
         #[doc = "# Note"]
         #[doc = ""]
         #[doc = concat!("- Returns the resulting [`", stringify!($name), "`] in `out`.")]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn $copy $(<$lt>)? (
             out: &mut $name $(<$lt>)?,
@@ -188,7 +188,7 @@ macro_rules! declare_vecs {
         }
 
         #[doc = concat!("Frees memory associated to the [`", stringify!($name),"`].")]
-        #[no_mangle]
+        #[cfg_attr(not(feature = "prefix-symbols"), no_mangle)]
         #[cfg_attr(feature = "prefix-symbols", wasmi_c_api_macros::prefix_symbol)]
         pub extern "C" fn $delete $(<$lt>)? (out: &mut $name $(<$lt>)?) {
             out.take();


### PR DESCRIPTION
The `no_mangle` and `export_name` attributes cannot be used at the same time.
(Link: https://github.com/rust-lang/rust/issues/47446)

Since Clippy now warns about this we were notified about our misuse and this PR fixes it.