### PR TITLE
Add `ExecutionTest` utility

### DIFF
--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::{
-    core::{TrapCode, F32},
+    core::TrapCode,
     engine::EngineFunc,
     ir::{index::Global, BranchOffset, BranchOffset16, RegSpan},
     tests::{AssertResults, AssertTrap, ExecutionTest},
@@ -254,24 +254,11 @@ fn fuzz_regression_13_codegen() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_13_execute() {
-    use crate::{Engine, Linker, Store};
     let wasm = include_str!("wat/fuzz_13.wat");
-    let engine = Engine::default();
-    let mut store = <Store<()>>::new(&engine, ());
-    let linker = Linker::new(&engine);
-    let module = Module::new(&engine, wasm).unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .ensure_no_start(&mut store)
-        .unwrap();
-    let func = instance
-        .get_func(&store, "")
-        .unwrap()
-        .typed::<(), (i32, i32, i32)>(&store)
-        .unwrap();
-    let (x, y, z) = func.call(&mut store, ()).unwrap();
-    assert!(x == 0 && y == 0 && z == 0);
+    ExecutionTest::default()
+        .wasm(wasm)
+        .call::<(), (i32, i32, i32)>("", ())
+        .assert_results((0, 0, 0));
 }
 
 #[test]
@@ -316,26 +303,11 @@ fn fuzz_regression_15_01_codegen() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn fuzz_regression_15_01_execute() {
-    // Note: we can remove this test case once the bug is fixed
-    //       since this is a codegen bug and not an executor bug.
-    use crate::{Engine, Linker, Store};
-    let wasm: &str = include_str!("wat/fuzz_15_01.wat");
-    let engine = Engine::default();
-    let mut store = <Store<()>>::new(&engine, ());
-    let linker = Linker::new(&engine);
-    let module = Module::new(&engine, wasm).unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .ensure_no_start(&mut store)
-        .unwrap();
-    let func = instance
-        .get_func(&store, "")
-        .unwrap()
-        .typed::<i64, F32>(&store)
-        .unwrap();
-    let result = func.call(&mut store, 1).unwrap();
-    assert_eq!(result, 10.0);
+    let wasm = include_str!("wat/fuzz_15_01.wat");
+    ExecutionTest::default()
+        .wasm(wasm)
+        .call::<i64, f32>("", 1)
+        .assert_results(10.0);
 }
 
 #[test]
@@ -455,20 +427,11 @@ fn audit_0_codegen() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn audit_0_execution() {
-    use crate::{Engine, Instance, Store};
     let wasm = include_str!("wat/audit_0.wat");
-    let engine = Engine::default();
-    let mut store = <Store<()>>::new(&engine, ());
-    let module = Module::new(&engine, wasm).unwrap();
-    let instance = Instance::new(&mut store, &module, &[]).unwrap();
-    let func = instance
-        .get_func(&store, "")
-        .unwrap()
-        .typed::<(), (i32, i32, i32, i32)>(&store)
-        .unwrap();
-    let result = func.call(&mut store, ()).unwrap();
-    std::println!("result = {result:?}");
-    assert_eq!(result, (0, 1, 0, 1));
+    ExecutionTest::default()
+        .wasm(wasm)
+        .call::<(), (i32, i32, i32, i32)>("", ())
+        .assert_results((0, 1, 0, 1));
 }
 
 #[test]

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     core::{TrapCode, F32},
     engine::EngineFunc,
     ir::{index::Global, BranchOffset, BranchOffset16, RegSpan},
+    tests::{AssertResults, ExecutionTest},
     Val,
 };
 
@@ -523,17 +524,9 @@ fn audit_2_codegen() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn audit_2_execution() {
-    use crate::{Engine, Instance, Store};
     let wasm = include_str!("wat/audit_2.wat");
-    let engine = Engine::default();
-    let mut store = <Store<()>>::new(&engine, ());
-    let module = Module::new(&engine, wasm).unwrap();
-    let instance = Instance::new(&mut store, &module, &[]).unwrap();
-    let func = instance.get_func(&store, "").unwrap();
-    let inputs = [Val::I32(1)];
-    let mut results = [0_i32; 4].map(Val::from);
-    let expected = [1_i32; 4];
-    func.call(&mut store, &inputs[..], &mut results[..])
-        .unwrap();
-    assert_eq!(results.map(|v| v.i32().unwrap()), expected,);
+    ExecutionTest::default()
+        .wasm(wasm)
+        .call::<i32, (i32, i32, i32, i32)>("", 1)
+        .assert_results((1, 1, 1, 1));
 }

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -79,6 +79,9 @@ extern crate std;
 #[macro_use]
 mod foreach_tuple;
 
+#[cfg(test)]
+pub mod tests;
+
 mod engine;
 mod error;
 mod externref;

--- a/crates/wasmi/src/tests.rs
+++ b/crates/wasmi/src/tests.rs
@@ -64,13 +64,13 @@ where
     }
 
     /// Calls the function named `func_name` with `args` and returns the result.
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// If no Wasm source was set before.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// - If instantiation fails.
     /// - If starting the instance fails.
     /// - If there is no function named `func_name`.

--- a/crates/wasmi/src/tests.rs
+++ b/crates/wasmi/src/tests.rs
@@ -1,0 +1,156 @@
+use crate::{
+    core::TrapCode,
+    Config,
+    Engine,
+    Error,
+    Linker,
+    Module,
+    Store,
+    WasmParams,
+    WasmResults,
+};
+use core::{fmt::Debug, mem};
+
+/// Wasmi execution test runner.
+pub struct ExecutionTest<T> {
+    /// The underlying engine that is tested.
+    engine: Engine,
+    /// The store data which is used for the calls.
+    data: T,
+    /// The compiled Wasm module that is used for the calls.
+    module: Option<Module>,
+}
+
+impl Default for ExecutionTest<()> {
+    fn default() -> Self {
+        Self {
+            engine: Engine::default(),
+            data: (),
+            module: None,
+        }
+    }
+}
+
+impl<T> ExecutionTest<T>
+where
+    T: Default + PartialEq + Eq,
+{
+    /// Creates a new [`ExecutionTest`] with default initialized data.
+    pub fn new() -> Self {
+        Self {
+            engine: Engine::default(),
+            data: T::default(),
+            module: None,
+        }
+    }
+
+    /// Creates a new [`ExecutionTest`] with the given `config` and default initialized data.
+    pub fn with_config(config: Config) -> Self {
+        let engine = Engine::new(&config);
+        let data = <T as Default>::default();
+        Self {
+            engine,
+            data,
+            module: None,
+        }
+    }
+
+    /// Sets the Wasm source that this [`ExecutionTest`] uses for its calls.
+    pub fn wasm(&mut self, wasm: &str) -> &mut Self {
+        assert!(self.module.is_none(), "already provided Wasm input");
+        let module = Module::new(&self.engine, wasm).unwrap();
+        self.module = Some(module);
+        self
+    }
+
+    /// Calls the function named `func_name` with `args` and returns the result.
+    /// 
+    /// # Panics
+    /// 
+    /// If no Wasm source was set before.
+    /// 
+    /// # Errors
+    /// 
+    /// - If instantiation fails.
+    /// - If starting the instance fails.
+    /// - If there is no function named `func_name`.
+    /// - If the call fails or traps.
+    pub fn call<Args, Results>(&mut self, func_name: &str, args: Args) -> Result<Results, Error>
+    where
+        Args: WasmParams,
+        Results: WasmResults,
+    {
+        let Some(module) = &self.module else {
+            panic!("need Wasm before calling")
+        };
+        let data = mem::take(&mut self.data);
+        let mut store = <Store<T>>::new(&self.engine, data);
+        let linker = Linker::new(&self.engine);
+        let results = linker
+            .instantiate(&mut store, &module)?
+            .start(&mut store)?
+            .get_typed_func::<Args, Results>(&store, func_name)?
+            .call(&mut store, args)?;
+        _ = mem::replace(&mut self.data, store.into_data());
+        Ok(results)
+    }
+
+    /// Sets the store data to `data`.
+    pub fn data(&mut self, data: T) -> &mut Self {
+        self.data = data;
+        self
+    }
+
+    /// Asserts that the store data is as `expected`.
+    pub fn assert_data(&mut self, expected: impl AsRef<T>) -> &mut Self {
+        assert!(&self.data == expected.as_ref());
+        self
+    }
+}
+
+/// Convenience trait to assert that some call results are as expected.
+pub trait AssertResults {
+    /// The expected call result type.
+    type Val;
+
+    /// Panics if the `Result<Args, _>::Ok` value is not `expected`.
+    fn assert_results(&self, expected: Self::Val);
+}
+
+impl<T, E> AssertResults for Result<T, E>
+where
+    T: PartialEq + Debug,
+    Self: Debug,
+{
+    type Val = T;
+
+    fn assert_results(&self, expected: T) {
+        let results = match self {
+            Ok(results) => results,
+            Err(_) => panic!("must have Ok value but found: {self:?}"),
+        };
+        assert_eq!(results, &expected)
+    }
+}
+
+/// Convenience trait to assert that some call traps are as expected.
+pub trait AssertTrap {
+    /// Panics if the `Result<Args, _>::Err` value is not `expected`.
+    fn assert_trap(&self, expected: TrapCode);
+}
+
+impl<T> AssertTrap for Result<T, Error>
+where
+    Self: Debug,
+{
+    fn assert_trap(&self, expected: TrapCode) {
+        let error = match self {
+            Ok(_) => panic!("must have Err value but found: {self:?}"),
+            Err(error) => error,
+        };
+        let Some(trap) = error.as_trap_code() else {
+            panic!("must have trap code Err but found: {error:?}")
+        };
+        assert_eq!(trap, expected)
+    }
+}


### PR DESCRIPTION
So far Wasmi only has a proper testing abstraction for translation tests, namely `TranslationTest`. With this PR we also add a proper abstraction for execution tests that do not necessitate a whole `.wast` file.