### PR TITLE
Improve debug output of differential fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,9 +274,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -691,6 +691,7 @@ dependencies = [
  "wasm-smith",
  "wasmi 0.40.0",
  "wasmi_fuzz",
+ "wasmprinter",
 ]
 
 [[package]]
@@ -797,9 +798,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -830,19 +831,19 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1203,9 +1204,9 @@ checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
@@ -1239,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -1265,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -1608,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.223.0"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e636076193fa68103e937ac951b5f2f587624097017d764b8984d9c0f149464"
+checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
 dependencies = [
  "leb128",
 ]
@@ -2002,24 +2003,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "223.0.0"
+version = "224.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59b2ba8a2ff9f06194b7be9524f92e45e70149f4dacc0d0c7ad92b59ac875e4"
+checksum = "d722a51e62b669d17e5a9f6bc8ec210178b37d869114355aa46989686c5c6391"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.223.0",
+ "wasm-encoder 0.224.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.223.0"
+version = "1.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662786915c427e4918ff01eabb3c4756d4d947cd8f635761526b4cc9da2eaaad"
+checksum = "71dece6a7dd5bcbcf8d256606c7fb3faa36286d46bf3f98185407719a5ceede2"
 dependencies = [
- "wast 223.0.0",
+ "wast 224.0.0",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,10 +16,11 @@ wasmi = { workspace = true, features = ["std"] }
 wasm-smith = "0.221.0"
 libfuzzer-sys = "0.4.7"
 arbitrary = "1.3.2"
+wasmprinter = { version = "0.221.0", optional = true }
 
 [features]
 default = []
-differential = ["wasmi_fuzz/differential"]
+differential = ["wasmi_fuzz/differential", "dep:wasmprinter"]
 
 [[bin]]
 name = "translate"


### PR DESCRIPTION
Using the new `FuzzInput` struct we now have properly supported `Debug` output on detected fuzzing failure test cases.

- This debug output shows the chosen Wasm runtime oracle, the `wasm_smith` module configuration and the Wasm source as `.wat` source code.
- In contrast to the already implemented `crash-inputs` feature this information is properly displayed on CI consoles.

## Example

```console
Failing input:

        fuzz/artifacts/differential/crash-ec8b55496c8cf9fd654f076239bf3f25d37e6a43

Output of `std::fmt::Debug`:

        FuzzInput {
            chosen_oracle: Wasmtime,
            module: Module {
                config: Config {
                    available_imports: None,
                    exports: None,
                    allow_start_export: true,
                    allowed_instructions: InstructionKinds(
                        FlagSet(NumericInt | Numeric | VectorInt | Vector | Reference | Parametric | Variable | Table | MemoryInt | Memory | Control | Aggregate),
                    ),
                    allow_floats: true,
                    bulk_memory_enabled: true,
                    canonicalize_nans: true,
                    disallow_traps: false,
                    exceptions_enabled: false,
                    export_everything: true,
                    gc_enabled: false,
                    custom_page_sizes_enabled: false,
                    generate_custom_sections: false,
                    max_aliases: 1000,
                    max_components: 10,
                    max_data_segments: 10,
                    max_element_segments: 253,
                    max_elements: 973,
                    max_exports: 297,
                    max_funcs: 740,
                    max_globals: 910,
                    max_imports: 70,
                    max_instances: 10,
                    max_instructions: 917,
                    max_memories: 25,
                    max_memory32_bytes: 1040383744,
                    max_memory64_bytes: 0,
                    max_modules: 10,
                    max_nesting_depth: 10,
                    max_table_elements: 183033,
                    max_tables: 1,
                    max_tags: 0,
                    max_type_size: 1000,
                    max_types: 507,
                    max_values: 10,
                    memory64_enabled: false,
                    memory_max_size_required: false,
                    memory_offset_choices: MemoryOffsetChoices(
                        90,
                        9,
                        1,
                    ),
                    min_data_segments: 0,
                    min_element_segments: 0,
                    min_elements: 0,
                    min_exports: 0,
                    min_funcs: 0,
                    min_globals: 0,
                    min_imports: 0,
                    min_memories: 0,
                    min_tables: 0,
                    min_tags: 0,
                    min_types: 0,
                    min_uleb_size: 0,
                    multi_value_enabled: true,
                    reference_types_enabled: false,
                    relaxed_simd_enabled: false,
                    saturating_float_to_int_enabled: true,
                    sign_extension_ops_enabled: true,
                    shared_everything_threads_enabled: false,
                    simd_enabled: false,
                    tail_call_enabled: true,
                    table_max_size_required: false,
                    threads_enabled: false,
                    allow_invalid_funcs: false,
                    wide_arithmetic_enabled: false,
                    extended_const_enabled: true,
                },
                ...: "...",
            },
            wasm: 
            (module
              (type (;0;) (func))
              (global (;0;) (mut i32) i32.const 1000)
              (export "" (func 0))
              (func (;0;) (type 0)
                global.get 0
                i32.eqz
                if ;; label = @1
                  unreachable
                end
                global.get 0
                i32.const 1
                i32.sub
                global.set 0
              )
            )
            ,
        }

Reproduce with:

        cargo fuzz run -O --features=differential differential fuzz/artifacts/differential/crash-ec8b55496c8cf9fd654f076239bf3f25d37e6a43

Minimize test case with:

        cargo fuzz tmin -O --features=differential differential fuzz/artifacts/differential/crash-ec8b55496c8cf9fd654f076239bf3f25d37e6a43

────────────────────────────────────────────────────────────────────────────────

Error: Fuzz target exited with exit status: 77
```