### PR TITLE
CLI: enable Wasm `custom-page-sizes` proposal by default

### DIFF
--- a/crates/cli/src/context.rs
+++ b/crates/cli/src/context.rs
@@ -33,6 +33,7 @@ impl Context {
             config.consume_fuel(true);
         }
         config.compilation_mode(compilation_mode);
+        config.wasm_custom_page_sizes(true);
         let engine = wasmi::Engine::new(&config);
         let wasm =
             fs::read(wasm_file).map_err(|_| anyhow!("failed to read Wasm file {wasm_file:?}"))?;


### PR DESCRIPTION
We do not (yet) have CLI options to enable or disable Wasm proposals, so it is more usable to just enable all available ones at the moment so users can try them out.