### PR TITLE
Update `string-interner` to v0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,9 +1344,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "string-interner"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3275464d7a9f2d4cac57c89c2ef96a8524dba2864c8d6f82e3980baf136f9b"
+checksum = "23de088478b31c349c9ba67816fa55d9355232d63c3afea8bf513e31f0f1d2c0"
 dependencies = [
  "hashbrown 0.15.2",
  "serde",

--- a/crates/collections/Cargo.toml
+++ b/crates/collections/Cargo.toml
@@ -15,7 +15,7 @@ exclude.workspace = true
 
 [dependencies]
 hashbrown = { version = "0.15.1", default-features = false, optional = true, features = ["default-hasher", "inline-more"] }
-string-interner = { version = "0.18", default-features = false, optional = true, features = ["inline-more", "backends"] }
+string-interner = { version = "0.19", default-features = false, optional = true, features = ["inline-more", "backends"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1366.

[`string-interner` v0.19 release notes](https://github.com/Robbepop/string-interner/releases/tag/v0.19.0)

cc @jonhoo