### PR TITLE
Optimize memory accesses with constant `ptr` value

### DIFF
--- a/crates/core/src/untyped.rs
+++ b/crates/core/src/untyped.rs
@@ -191,7 +191,7 @@ macro_rules! gen_load_fn {
     (
         (fn $load_fn:ident, fn $load_at_fn:ident, $wrapped:ty => $ty:ty); $($rest:tt)*
     ) => {
-        #[doc = concat!("Executes a Wasmi `", stringify!($name), "` instruction.")]
+        #[doc = concat!("Executes a Wasmi `", stringify!($load_fn), "` instruction.")]
         ///
         /// # Errors
         ///
@@ -201,7 +201,7 @@ macro_rules! gen_load_fn {
             Self::load_extend::<$ty, $wrapped>(memory, ptr, offset)
         }
 
-        #[doc = concat!("Executes a Wasmi `", stringify!($name), "` instruction.")]
+        #[doc = concat!("Executes a Wasmi `", stringify!($load_at_fn), "` instruction.")]
         ///
         /// # Errors
         ///
@@ -285,7 +285,7 @@ macro_rules! gen_store_fn {
     (
         (fn $store_fn:ident, fn $store_at_fn:ident, $ty:ty => $wrapped:ty); $($rest:tt)*
     ) => {
-        #[doc = concat!("Executes a Wasmi `", stringify!($name), "` instruction.")]
+        #[doc = concat!("Executes a Wasmi `", stringify!($store_fn), "` instruction.")]
         ///
         /// # Errors
         ///
@@ -295,7 +295,7 @@ macro_rules! gen_store_fn {
             Self::store_wrap::<$ty, $wrapped>(memory, ptr, offset, value)
         }
 
-        #[doc = concat!("Executes a Wasmi `", stringify!($name), "` instruction.")]
+        #[doc = concat!("Executes a Wasmi `", stringify!($store_at_fn), "` instruction.")]
         ///
         /// # Errors
         ///

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -24,6 +24,7 @@ pub use self::{
     immeditate::{AnyConst16, AnyConst32, Const16, Const32},
     index::Reg,
     primitive::{
+        Address,
         Address32,
         BlockFuel,
         BranchOffset,

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -1921,6 +1921,14 @@ impl FuncTranslator {
             // Case: address overflows any legal memory index.
             return None;
         };
+        if let Some(max) = memory_type.maximum() {
+            // The memory's maximum size in bytes.
+            let max_size = max << memory_type.page_size_log2();
+            if address > max_size {
+                // Case: address overflows the memory's maximum size.
+                return None;
+            }
+        }
         if !memory_type.is_64() && address >= 1 << 32 {
             // Case: address overflows the 32-bit memory index.
             return None;

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -46,6 +46,7 @@ use crate::{
     engine::{config::FuelCosts, BlockType, EngineFunc},
     ir::{
         index,
+        Address,
         Address32,
         AnyConst16,
         BoundedRegSpan,
@@ -1909,7 +1910,7 @@ impl FuncTranslator {
     }
 
     /// Returns the effective address `ptr+offset` if it is valid.
-    fn effective_address(&self, mem: index::Memory, ptr: TypedVal, offset: u64) -> Option<u64> {
+    fn effective_address(&self, mem: index::Memory, ptr: TypedVal, offset: u64) -> Option<Address> {
         let memory_type = *self
             .module
             .get_type_of_memory(MemoryIdx::from(u32::from(mem)));
@@ -1933,6 +1934,10 @@ impl FuncTranslator {
             // Case: address overflows the 32-bit memory index.
             return None;
         }
+        let Ok(address) = Address::try_from(address) else {
+            // Case: address is too big for the system to handle properly.
+            return None;
+        };
         Some(address)
     }
 
@@ -1980,7 +1985,7 @@ impl FuncTranslator {
                 //       to the general case where `ptr` is zero and `offset` stores the
                 //       `ptr+offset` address value.
                 let zero_ptr = self.alloc.stack.alloc_const(0_u64)?;
-                (zero_ptr, address)
+                (zero_ptr, u64::from(address))
             }
         };
         let result = self.alloc.stack.push_dynamic()?;
@@ -2083,7 +2088,7 @@ impl FuncTranslator {
                 //       to the general case where `ptr` is zero and `offset` stores the
                 //       `ptr+offset` address value.
                 let zero_ptr = self.alloc.stack.alloc_const(0_u64)?;
-                (zero_ptr, address)
+                (zero_ptr, u64::from(address))
             }
         };
         if memory.is_default() {
@@ -2240,7 +2245,7 @@ impl FuncTranslator {
                     return self.translate_fstore_at(memory, address, value, make_instr_at);
                 }
                 let zero_ptr = self.alloc.stack.alloc_const(0_u64)?;
-                (zero_ptr, address)
+                (zero_ptr, u64::from(address))
             }
         };
         let (offset_hi, offset_lo) = Offset64::split(offset);

--- a/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/fuzz/mod.rs
@@ -372,8 +372,7 @@ fn fuzz_regression_16() {
             Instruction::copy(2, 0),
             Instruction::global_get(Reg::from(0), Global::from(0)),
             Instruction::global_set(Reg::from(0), Global::from(0)),
-            Instruction::store64_at(Reg::from(2), 2147483647_u32),
-            Instruction::trap(TrapCode::UnreachableCodeReached),
+            Instruction::trap(TrapCode::MemoryOutOfBounds),
         ])
         .run()
 }


### PR DESCRIPTION
This PR optimizes the Wasmi executor when executing load and store instructions with a constant `ptr` value.

Also this PR checks at translation time if a constant `ptr+offset` address is out of bounds for both the `memory.max()` and a system `usize` value and generates an appropriate trap in those cases instead of a load or store instruction.

Benchmarks didn't show a significant improvement, though this PR includes enough readability and type safety improvements that I still would want to merge it.