### PR TITLE
Fix `memory64` `memory.grow` with an immediate `delta` parameter

### DIFF
--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5155,7 +5155,7 @@ macro_rules! for_each_op {
             MemoryGrowBy {
                 @result: Reg,
                 /// The number of pages to add to the memory.
-                delta: u32,
+                delta: Const32<u64>,
             },
 
             /// Wasm `memory.copy` instruction.

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -6,6 +6,7 @@ use crate::{
     ir::{
         index::{Data, Memory},
         Const16,
+        Const32,
         Instruction,
         Reg,
     },
@@ -86,7 +87,7 @@ impl Executor<'_> {
         &mut self,
         store: &mut Store<T>,
         result: Reg,
-        delta: u32,
+        delta: Const32<u64>,
     ) -> Result<(), Error> {
         let (store, mut resource_limiter) = store.store_inner_and_resource_limiter_ref();
         let delta = u64::from(delta);

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_grow.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_grow.rs
@@ -21,22 +21,24 @@ fn reg() {
         .run();
 }
 
-fn test_imm16(delta: u32) {
+fn test_imm32(index_ty: IndexType, memory_index: MemIdx, delta: u32) {
     assert!(delta != 0);
+    let index_ty = index_ty.wat();
     let wasm = &format!(
         r"
         (module
-            (memory $m 10)
-            (func (result i32)
-                (i32.const {delta})
-                (memory.grow $m)
+            (memory $mem0 {index_ty} 1)
+            (memory $mem1 {index_ty} 1)
+            (func (result {index_ty})
+                {index_ty}.const {delta}
+                memory.grow {memory_index}
             )
         )",
     );
     TranslationTest::new(wasm)
-        .expect_func_instrs([
+        .expect_func_instrs(iter_filter_opts![
             Instruction::memory_grow_by(Reg::from(0), delta),
-            Instruction::memory_index(0),
+            Instruction::memory_index(memory_index.0),
             Instruction::return_reg(Reg::from(0)),
         ])
         .run();
@@ -44,14 +46,22 @@ fn test_imm16(delta: u32) {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn imm16() {
-    test_imm16(1);
-    test_imm16(42);
-    test_imm16(u32::from(u16::MAX) - 1);
-    test_imm16(u32::from(u16::MAX));
-    test_imm16(u32::from(u16::MAX) + 1);
-    test_imm16(u32::MAX - 1);
-    test_imm16(u32::MAX);
+fn imm32() {
+    for delta in [
+        1,
+        42,
+        u32::from(u16::MAX) - 1,
+        u32::from(u16::MAX),
+        u32::from(u16::MAX) + 1,
+        u32::MAX - 1,
+        u32::MAX,
+    ] {
+        for mem_idx in [0, 1].map(MemIdx) {
+            for index_ty in [IndexType::Memory32, IndexType::Memory64] {
+                test_imm32(index_ty, mem_idx, delta)
+            }
+        }
+    }
 }
 
 #[test]

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -991,17 +991,24 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     fn visit_memory_grow(&mut self, mem: u32) -> Self::Output {
         bail_unreachable!(self);
-        let delta = self.alloc.stack.pop().map_const(u32::from);
         let memory = index::Memory::from(mem);
+        let memory_type = *self.module.get_type_of_memory(MemoryIdx::from(mem));
+        let delta = self.alloc.stack.pop();
+        let delta = self.as_index_type_const32(delta, memory_type.index_ty())?;
         let result = self.alloc.stack.push_dynamic()?;
-        if let Provider::Const(0) = delta {
-            // Case: growing by 0 pages.
-            //
-            // Since `memory.grow` returns the `memory.size` before the
-            // operation a `memory.grow` with `delta` of 0 can be translated
-            // as `memory.size` instruction instead.
-            self.push_fueled_instr(Instruction::memory_size(result, memory), FuelCosts::entity)?;
-            return Ok(());
+        if let Provider::Const(delta) = delta {
+            if u64::from(delta) == 0 {
+                // Case: growing by 0 pages.
+                //
+                // Since `memory.grow` returns the `memory.size` before the
+                // operation a `memory.grow` with `delta` of 0 can be translated
+                // as `memory.size` instruction instead.
+                self.push_fueled_instr(
+                    Instruction::memory_size(result, memory),
+                    FuelCosts::entity,
+                )?;
+                return Ok(());
+            }
         }
         let instr = match delta {
             Provider::Const(delta) => Instruction::memory_grow_by(result, delta),


### PR DESCRIPTION
This fixes a panic in the Wasmi translator when translating a `memory.grow` operation with a `i64` delta parameter under the `memory64` Wasm proposal.

This fix probably needs backporting for Wasmi 0.41.