### PR TITLE
Fix Wasmi CLI `.wat` files support

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 exclude.workspace = true
 
 [dependencies]
-wasmi = { workspace = true }
+wasmi = { workspace = true, features = ["wat"] }
 wasmi_wasi = { workspace = true }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
During debugging I found out that the Wasmi CLI can no longer read Wat files. The reason is that we forgot to enable the `wat` crate feature for Wasmi during some refactorings. Trivial fix.

This fix needs to be backported to Wasmi v0.41.