### PR TITLE
chore: fix some typos in comments

### DIFF
--- a/crates/fuzz/src/module.rs
+++ b/crates/fuzz/src/module.rs
@@ -26,7 +26,7 @@ impl FuzzModule {
         }
     }
 
-    /// Returns the machine readble [`WasmSource`] code.
+    /// Returns the machine readable [`WasmSource`] code.
     pub fn wasm(&self) -> WasmSource {
         WasmSource {
             bytes: self.module.to_bytes(),

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -173,7 +173,7 @@ impl Executor<'_> {
     /// - This advances the [`InstructionPtr`] to the next [`Instruction`].
     /// - This is done by encoding an [`Instruction::TableGet`] instruction
     ///   word following the actual instruction where the [`index::Table`]
-    ///   paremeter belongs to.
+    ///   parameter belongs to.
     /// - This is required for some instructions that do not fit into
     ///   a single instruction word and store a [`index::Table`] value in
     ///   another instruction word.
@@ -202,7 +202,7 @@ impl Executor<'_> {
     /// - This advances the [`InstructionPtr`] to the next [`Instruction`].
     /// - This is done by encoding an [`Instruction::TableGet`] instruction
     ///   word following the actual instruction where the [`index::Table`]
-    ///   paremeter belongs to.
+    ///   parameter belongs to.
     /// - This is required for some instructions that do not fit into
     ///   a single instruction word and store a [`index::Table`] value in
     ///   another instruction word.

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -136,7 +136,7 @@ impl Engine {
     ///
     /// # Note
     ///
-    /// Users should ues [`Engine::default`] to construct a default [`Engine`].
+    /// Users should use [`Engine::default`] to construct a default [`Engine`].
     pub fn new(config: &Config) -> Self {
         Self {
             inner: Arc::new(EngineInner::new(config)),

--- a/crates/wasmi/src/engine/translator/utils.rs
+++ b/crates/wasmi/src/engine/translator/utils.rs
@@ -108,7 +108,7 @@ impl super::FuncTranslator {
     /// # Note
     ///
     /// - Turns immediates that cannot be 16-bit encoded into function local constants.
-    /// - The behavior is different wether `memory64` is enabled or disabled.
+    /// - The behavior is different whether `memory64` is enabled or disabled.
     pub(super) fn as_index_type_const16(
         &mut self,
         provider: TypedProvider,
@@ -139,7 +139,7 @@ impl super::FuncTranslator {
     /// # Note
     ///
     /// - Turns immediates that cannot be 32-bit encoded into function local constants.
-    /// - The behavior is different wether `memory64` is enabled or disabled.
+    /// - The behavior is different whether `memory64` is enabled or disabled.
     pub(super) fn as_index_type_const32(
         &mut self,
         provider: TypedProvider,


### PR DESCRIPTION
 fix some typos in comments