### PR TITLE
Fix const evaluation in `mul_wide` instructions

### DIFF
--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -3007,8 +3007,8 @@ impl FuncTranslator {
             }
             (Provider::Const(lhs), Provider::Const(rhs)) => {
                 let (result_lo, result_hi) = const_eval(lhs.into(), rhs.into());
-                self.alloc.stack.push_const(result_hi);
                 self.alloc.stack.push_const(result_lo);
+                self.alloc.stack.push_const(result_hi);
                 return Ok(());
             }
         };

--- a/crates/wasmi/src/engine/translator/tests/driver.rs
+++ b/crates/wasmi/src/engine/translator/tests/driver.rs
@@ -172,6 +172,7 @@ impl TranslationTest {
         let config = {
             let mut cfg = Config::default();
             cfg.wasm_tail_call(true);
+            cfg.wasm_wide_arithmetic(true);
             cfg
         };
         Self {

--- a/crates/wasmi/src/engine/translator/tests/op/mod.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/mod.rs
@@ -33,6 +33,7 @@ mod select;
 mod store;
 mod table;
 mod unary;
+mod wide_arithmetic;
 
 use super::{
     bspan,

--- a/crates/wasmi/src/engine/translator/tests/op/wide_arithmetic.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/wide_arithmetic.rs
@@ -1,0 +1,59 @@
+use super::*;
+use crate::core::wasm;
+
+/// A Wasm `wide-arithmetic` wide-mulitplication instruction.
+#[derive(Copy, Clone)]
+enum MulWideOp {
+    /// Signed
+    MulWideS,
+    /// Unsigned
+    MulWideU,
+}
+
+impl MulWideOp {
+    /// Returns the `.wat` formatted instruction name.
+    pub fn wat(self) -> &'static str {
+        match self {
+            MulWideOp::MulWideS => "i64.mul_wide_s",
+            MulWideOp::MulWideU => "i64.mul_wide_u",
+        }
+    }
+
+    /// Evaluates the inputs for the selected instruction.
+    pub fn eval(self, lhs: i64, rhs: i64) -> (i64, i64) {
+        match self {
+            MulWideOp::MulWideS => wasm::i64_mul_wide_s(lhs, rhs),
+            MulWideOp::MulWideU => wasm::i64_mul_wide_u(lhs, rhs),
+        }
+    }
+}
+
+fn const_eval_for(op: MulWideOp, lhs: i64, rhs: i64) {
+    let wat = op.wat();
+    let wasm = format!(
+        r"
+        (module
+            (func (result i64 i64)
+                i64.const {lhs}
+                i64.const {rhs}
+                {wat}
+            )
+        )
+    "
+    );
+    let (result_lo, result_hi) = op.eval(lhs, rhs);
+    TranslationTest::new(wasm)
+        .expect_func(
+            ExpectedFunc::new([Instruction::return_reg2_ext(-1, -2)])
+                .consts([result_lo, result_hi]),
+        )
+        .run()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn const_eval() {
+    for op in [MulWideOp::MulWideS, MulWideOp::MulWideU] {
+        const_eval_for(op, 288230376151711744, 288230376151711744);
+    }
+}


### PR DESCRIPTION
Fixed https://github.com/bytecodealliance/wasmtime/issues/10418.

The const-evaluator pushed the `lo` and `hi` values in reversed order back into the translation stack during const-eval. I checked the other `wide-arithmetic` instructions but there it was all working as expected.

This PR adds a regression test.