### PR TITLE
Bump `nextest` (`miri`) timeout: 360s -> 600s

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
 [profile.default-miri]
-slow-timeout = { period = "180s", terminate-after = 2 }
+slow-timeout = { period = "120s", terminate-after = 5 }
 test-threads = "num-cpus"
 fail-fast = false


### PR DESCRIPTION
The `miri` CI jobs are very flaky since they often hit the timeout threshold.

This new timeout threshold that this PR nearly doubles should give us a bit of room.