### PR TITLE
Fix `miri` cron CI job

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -28,4 +28,4 @@ jobs:
             # They have huge overhead for Wasmi and unnecessarily slow down Miri.
             # The Miri job should focus on finding undefined behavior instead or logic errors.
             CARGO_PROFILE_DEV_DEBUG_ASSERTIONS: "false"
-          run: cargo miri nextest run --target x86_64-unknown-linux-gnu --test spec_shim
+          run: cargo +nightly miri nextest run --target x86_64-unknown-linux-gnu -p wasmi_wast --release


### PR DESCRIPTION
This broke with https://github.com/wasmi-labs/wasmi/pull/1403.