### PR TITLE
`wasmi_ir`: add support for the Wasm `simd` proposal

### DIFF
--- a/crates/ir/Cargo.toml
+++ b/crates/ir/Cargo.toml
@@ -26,3 +26,4 @@ default = ["std"]
 std = [
     "wasmi_core/std",
 ]
+simd = ["wasmi_core/simd"]

--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -1,3 +1,5 @@
+#[cfg(all(feature = "simd", doc))]
+use crate::core::simd::V128;
 #[cfg(feature = "simd")]
 use crate::core::simd::{ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx4, ImmLaneIdx8};
 use crate::{core::TrapCode, for_each_op, index::*, primitive::Offset64Hi, *};

--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -37,6 +37,7 @@ macro_rules! define_enum {
         /// `#Encoding` section of its documentation if it requires more than a single
         /// instruction for its encoding.
         #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+        #[non_exhaustive]
         #[repr(u16)]
         pub enum Instruction {
             $(

--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -1,4 +1,13 @@
-use crate::{core::TrapCode, for_each_op, index::*, primitive::Offset64Hi, *};
+use crate::{
+    core::{
+        simd::{ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx4, ImmLaneIdx8},
+        TrapCode,
+    },
+    for_each_op,
+    index::*,
+    primitive::Offset64Hi,
+    *,
+};
 use ::core::num::{NonZeroI32, NonZeroI64, NonZeroU32, NonZeroU64};
 
 macro_rules! define_enum {

--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -1,13 +1,6 @@
-use crate::{
-    core::{
-        simd::{ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx4, ImmLaneIdx8},
-        TrapCode,
-    },
-    for_each_op,
-    index::*,
-    primitive::Offset64Hi,
-    *,
-};
+#[cfg(feature = "simd")]
+use crate::core::simd::{ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx4, ImmLaneIdx8};
+use crate::{core::TrapCode, for_each_op, index::*, primitive::Offset64Hi, *};
 use ::core::num::{NonZeroI32, NonZeroI64, NonZeroU32, NonZeroU64};
 
 macro_rules! define_enum {

--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -5,6 +5,7 @@ macro_rules! define_enum {
     (
         $(
             $( #[doc = $doc:literal] )*
+            $( #[cfg(feature = $feature_name:literal)] )?
             #[snake_name($snake_name:ident)]
             $name:ident
             $(
@@ -42,6 +43,7 @@ macro_rules! define_enum {
         pub enum Instruction {
             $(
                 $( #[doc = $doc] )*
+                $( #[cfg(feature = $feature_name)] )?
                 $name
                 $(
                     {
@@ -61,6 +63,7 @@ macro_rules! define_enum {
         impl Instruction {
             $(
                 #[doc = concat!("Creates a new [`Instruction::", stringify!($name), "`].")]
+                $( #[cfg(feature = $feature_name)] )?
                 pub fn $snake_name(
                     $(
                         $( $result_name: impl Into<$result_ty>, )?
@@ -102,6 +105,7 @@ macro_rules! define_result {
     (
         $(
             $( #[doc = $doc:literal] )*
+            $( #[cfg(feature = $feature_name:literal)] )?
             #[snake_name($snake_name:ident)]
             $name:ident
             $(
@@ -125,6 +129,7 @@ macro_rules! define_result {
             pub fn result(&self) -> Option<$crate::Reg> {
                 match *self {
                     $(
+                        $( #[cfg(feature = $feature_name)] )?
                         Self::$name { $( $( $result_name, )? )* .. } => {
                             IntoReg::into_reg((
                                 $( $( $result_name )? )*

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6891,7 +6891,7 @@ macro_rules! for_each_op {
             /// Wasm `v128.and` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(v128_and)]
-            V128and {
+            V128And {
                 @result: Reg,
                 /// Register holding the `lhs` of the instruction.
                 lhs: Reg,
@@ -6901,7 +6901,7 @@ macro_rules! for_each_op {
             /// Wasm `v128.or` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(v128_or)]
-            V128or {
+            V128Or {
                 @result: Reg,
                 /// Register holding the `lhs` of the instruction.
                 lhs: Reg,
@@ -6911,7 +6911,7 @@ macro_rules! for_each_op {
             /// Wasm `v128.xor` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(v128_xor)]
-            V128xor {
+            V128Xor {
                 @result: Reg,
                 /// Register holding the `lhs` of the instruction.
                 lhs: Reg,
@@ -6921,7 +6921,7 @@ macro_rules! for_each_op {
             /// Wasm `v128.andnot` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(v128_andnot)]
-            V128andnot {
+            V128Andnot {
                 @result: Reg,
                 /// Register holding the `lhs` of the instruction.
                 lhs: Reg,

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -8036,8 +8036,8 @@ macro_rules! for_each_op {
             V128StoreOffset16 {
                 /// The register storing the `pointer` of the store instruction.
                 ptr: Reg,
-                /// The lower 32-bit of the 64-bit load `offset`.
-                offset_lo: Offset64Lo,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
             },
             /// Variant of [`Instruction::V128Store`] with 32-bit immediate address.
             ///
@@ -8051,9 +8051,9 @@ macro_rules! for_each_op {
             V128StoreAt {
                 /// The value to be stored.
                 value: Reg,
-                /// The constant address to store the value.
+                /// The 32-bit constant address to store the value.
                 address: Address32,
-            }
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6887,6 +6887,55 @@ macro_rules! for_each_op {
                 /// Register holding the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `v128.and` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_and)]
+            V128and {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `v128.or` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_or)]
+            V128or {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `v128.xor` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_xor)]
+            V128xor {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `v128.andnot` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_andnot)]
+            V128andnot {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `v128.not` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_not)]
+            V128Not {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            }
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6936,6 +6936,21 @@ macro_rules! for_each_op {
                 /// Register holding the `input` of the instruction.
                 input: Reg,
             },
+
+            /// Wasm `v128.bitselect` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Register`] encoding the `selector`.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_bitselect)]
+            V128Bitselect {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6165,6 +6165,31 @@ macro_rules! for_each_op {
                 /// The lane of the replaced value.
                 lane: ImmLaneIdx4,
             },
+
+            /// Wasm `i8x16.shuffle` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Register`] encoding the `selector` of type [`V128`].
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_shuffle)]
+            I8x16Shuffle {
+                @result: Reg,
+                /// The register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.swizzle` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_swizzle)]
+            I8x16Swizzle {
+                @result: Reg,
+                /// The register holding the `input` of the instruction.
+                input: Reg,
+                /// The register holding the `selector` of the instruction.
+                selector: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6466,6 +6466,39 @@ macro_rules! for_each_op {
                 /// Register holding the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `i16x8.extadd_pairwise_i8x16_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extadd_pairwise_i8x16_s)]
+            I16x8ExtaddPairwiseI8x16S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i16x8.extadd_pairwise_i8x16_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extadd_pairwise_i8x16_u)]
+            I16x8ExtaddPairwiseI8x16U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.extadd_pairwise_i16x8_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extadd_pairwise_i16x8_s)]
+            I32x4ExtaddPairwiseI16x8S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.extadd_pairwise_i16x8_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extadd_pairwise_i16x8_u)]
+            I32x4ExtaddPairwiseI16x8U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -7707,6 +7707,87 @@ macro_rules! for_each_op {
                 /// Register holding the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `f32x4.sqrt` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_sqrt)]
+            F32x4Sqrt {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f64x2.sqrt` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_sqrt)]
+            F64x2Sqrt {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f32x4.ceil` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_ceil)]
+            F32x4Ceil {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f64x2.ceil` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_ceil)]
+            F64x2Ceil {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f32x4.floor` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_floor)]
+            F32x4Floor {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f64x2.floor` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_floor)]
+            F64x2Floor {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f32x4.trunc` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_trunc)]
+            F32x4Trunc {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f64x2.trunc` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_trunc)]
+            F64x2Trunc {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f32x4.nearest` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_nearest)]
+            F32x4Nearest {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f64x2.nearest` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_nearest)]
+            F64x2Nearest {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6301,6 +6301,17 @@ macro_rules! for_each_op {
                 /// The register storing the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `i32x4.dot_i16x8_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_dot_i16x8_s)]
+            I32x4DotI16x8S {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            }
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6345,6 +6345,127 @@ macro_rules! for_each_op {
                 /// Register holding the `input` of the instruction.
                 input: Reg,
             },
+
+            /// Wasm `i16x8.extmul_low_i8x16_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extmul_low_i8x16_s)]
+            I16x8ExtmulLowI8x16S {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.extmul_high_i8x16_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extmul_high_i8x16_s)]
+            I16x8ExtmulHighI8x16S {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.extmul_low_i8x16_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extmul_low_i8x16_u)]
+            I16x8ExtmulLowI8x16U {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.extmul_high_i8x16_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extmul_high_i8x16_u)]
+            I16x8ExtmulHighI8x16U {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.extmul_low_i16x8_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extmul_low_i16x8_s)]
+            I32x4ExtmulLowI16x8S {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.extmul_high_i16x8_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extmul_high_i16x8_s)]
+            I32x4ExtmulHighI16x8S {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.extmul_low_i16x8_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extmul_low_i16x8_u)]
+            I32x4ExtmulLowI16x8U {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.extmul_high_i16x8_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extmul_high_i16x8_u)]
+            I32x4ExtmulHighI16x8U {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.extmul_low_i32x4_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_extmul_low_i32x4_s)]
+            I64x2ExtmulLowI32x4S {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.extmul_high_i32x4_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_extmul_high_i32x4_s)]
+            I64x2ExtmulHighI32x4S {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.extmul_low_i32x4_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_extmul_low_i32x4_u)]
+            I64x2ExtmulLowI32x4U {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.extmul_high_i32x4_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_extmul_high_i32x4_u)]
+            I64x2ExtmulHighI32x4U {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5815,6 +5815,108 @@ macro_rules! for_each_op {
                 /// The table which holds the called function at the index.
                 table: Table,
             },
+
+            /// Wasm `i8x16.splat` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_splat)]
+            I8x16Splat {
+                @result: Reg,
+                /// The value to be splatted.
+                value: Reg,
+            },
+            /// Variant of [`Instruction::I8x16Splat`] with immediate `value` parameter.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_splat_imm)]
+            I8x16SplatImm {
+                @result: Reg,
+                /// The value to be splatted.
+                value: i8,
+            },
+
+            /// Wasm `i16x8.splat` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_splat)]
+            I16x8Splat {
+                @result: Reg,
+                /// The value to be splatted.
+                value: Reg,
+            },
+            /// Variant of [`Instruction::I16x8Splat`] with immediate `value` parameter.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_splat_imm)]
+            I16x8SplatImm {
+                @result: Reg,
+                /// The value to be splatted.
+                value: i16,
+            },
+
+            /// Wasm `i32x4.splat` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_splat)]
+            I32x4Splat {
+                @result: Reg,
+                /// The value to be splatted.
+                value: Reg,
+            },
+            /// Variant of [`Instruction::I32x4Splat`] with immediate `value` parameter.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_splat_imm)]
+            I32x4SplatImm {
+                @result: Reg,
+                /// The value to be splatted.
+                value: i32,
+            },
+
+            /// Wasm `i64x2.splat` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_splat)]
+            I64x2Splat {
+                @result: Reg,
+                /// The value to be splatted.
+                value: Reg,
+            },
+            /// Variant of [`Instruction::I64x2Splat`] with a 32-bit immediate `value` parameter.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_splat_imm)]
+            I64x2SplatImm32 {
+                @result: Reg,
+                /// The value to be splatted.
+                value: Const32<i64>,
+            },
+
+            /// Wasm `f32x4.splat` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_splat)]
+            F32x4Splat {
+                @result: Reg,
+                /// The value to be splatted.
+                value: Reg,
+            },
+            /// Variant of [`Instruction::F32x4Splat`] with immediate `value` parameter.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_splat_imm)]
+            F32x4SplatImm {
+                @result: Reg,
+                /// The value to be splatted.
+                value: Const32<f32>,
+            },
+
+            /// Wasm `f64x2.splat` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_splat)]
+            F64x2Splat {
+                @result: Reg,
+                /// The value to be splatted.
+                value: Reg,
+            },
+            /// Variant of [`Instruction::F64x2Splat`] with immediate `value` parameter.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_splat_imm)]
+            F64x2SplatImm {
+                @result: Reg,
+                /// The value to be splatted.
+                value: Const32<f64>,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6733,6 +6733,39 @@ macro_rules! for_each_op {
                 /// Register holding the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `i8x16.abs` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_abs)]
+            I8x16Abs {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i16x8.abs` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_abs)]
+            I16x8Abs {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.abs` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_abs)]
+            I32x4Abs {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i64x2.abs` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_abs)]
+            I64x2Abs {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6580,6 +6580,17 @@ macro_rules! for_each_op {
                 /// Register holding the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `i16x8.q15mulr_sat_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_q15mulr_sat_s)]
+            I16x8Q15MulrSatS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6591,6 +6591,127 @@ macro_rules! for_each_op {
                 /// Register holding the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `i8x16.min_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_min_s)]
+            I8x16MinS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.min_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_min_u)]
+            I8x16MinU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.min_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_min_s)]
+            I16x8MinS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.min_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_min_u)]
+            I16x8MinU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.min_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_min_s)]
+            I32x4MinS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.min_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_min_u)]
+            I32x4MinU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.max_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_max_s)]
+            I8x16MaxS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.max_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_max_u)]
+            I8x16MaxU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.max_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_max_s)]
+            I16x8MaxS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.max_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_max_u)]
+            I16x8MaxU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.max_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_max_s)]
+            I32x4MaxS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.max_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_max_u)]
+            I32x4MaxU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6311,7 +6311,7 @@ macro_rules! for_each_op {
                 lhs: Reg,
                 /// The register storing the `rhs` of the instruction.
                 rhs: Reg,
-            }
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -8252,6 +8252,604 @@ macro_rules! for_each_op {
                 /// The 32-bit constant address to store the value.
                 address: Address32,
             },
+
+            /// Wasm `v128.load` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load)]
+            V128Load {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load_at)]
+            V128LoadAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load_offset16)]
+            V128LoadOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load32_zero` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32_zero)]
+            V128Load32Zero {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load32Zero`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32_zero_at)]
+            V128Load32ZeroAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load32Zero`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32_zero_offset16)]
+            V128Load32ZeroOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load64_zero` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load64_zero)]
+            V128Load64Zero {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load64Zero`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load64_zero_at)]
+            V128Load64ZeroAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load64Zero`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load64_zero_offset16)]
+            V128Load64ZeroOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load8_splat` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8_splat)]
+            V128Load8Splat {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load8Splat`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8_splat_at)]
+            V128Load8SplatAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load8Splat`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8_splat_offset16)]
+            V128Load8SplatOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load16_splat` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16_splat)]
+            V128Load16Splat {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load16Splat`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16_splat_at)]
+            V128Load16SplatAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load16Splat`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16_splat_offset16)]
+            V128Load16SplatOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load32_splat` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32_splat)]
+            V128Load32Splat {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load32Splat`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32_splat_at)]
+            V128Load32SplatAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load32Splat`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32_splat_offset16)]
+            V128Load32SplatOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load64_splat` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load64_splat)]
+            V128Load64Splat {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load64Splat`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load64_splat_at)]
+            V128Load64SplatAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load64Splat`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load64_splat_offset16)]
+            V128Load64SplatOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load8x8_s` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8x8_s)]
+            V128Load8x8S {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load8x8S`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8x8_s_at)]
+            V128Load8x8SAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load8x8S`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8x8_s_offset16)]
+            V128Load8x8SOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load8x8_u` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8x8_u)]
+            V128Load8x8U {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load8x8U`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8x8_u_at)]
+            V128Load8x8UAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load8x8U`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8x8_u_offset16)]
+            V128Load8x8UOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load16x4_s` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16x4_s)]
+            V128Load16x4S {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load16x4S`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16x4_s_at)]
+            V128Load16x4SAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load16x4S`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16x4_s_offset16)]
+            V128Load16x4SOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load16x4_u` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16x4_u)]
+            V128Load16x4U {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load16x4U`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16x4_u_at)]
+            V128Load16x4UAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load16x4U`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16x4_u_offset16)]
+            V128Load16x4UOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load32x2_s` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32x2_s)]
+            V128Load32x2S {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load32x2S`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32x2_s_at)]
+            V128Load32x2SAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load32x2S`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32x2_s_offset16)]
+            V128Load32x2SOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
+
+            /// Wasm `v128.load32x2_u` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32x2_u)]
+            V128Load32x2U {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load32x2U`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding the `memory_index`.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32x2_u_at)]
+            V128Load32x2UAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+            /// Variant of [`Instruction::V128Load32x2U`] with a 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32x2_u_offset16)]
+            V128Load32x2UOffset16 {
+                @result: Reg,
+                /// Register holding the `ptr` of the instruction.
+                ptr: Reg,
+                /// The 16-bit encoded offset of the `load` instruction.
+                offset: Offset16,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5917,6 +5917,63 @@ macro_rules! for_each_op {
                 /// The value to be splatted.
                 value: Const32<f64>,
             },
+
+            /// Wasm `i8x16.extract_lane_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_extract_lane_s)]
+            I8x16ExtractLaneS {
+                value: Reg,
+                lane: ImmLaneIdx16,
+            },
+            /// Wasm `i8x16.extract_lane_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_extract_lane_u)]
+            I8x16ExtractLaneU {
+                value: Reg,
+                lane: ImmLaneIdx16,
+            },
+            /// Wasm `i16x8.extract_lane_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extract_lane_s)]
+            I16x8ExtractLaneS {
+                value: Reg,
+                lane: ImmLaneIdx8,
+            },
+            /// Wasm `i16x8.extract_lane_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extract_lane_u)]
+            I16x8ExtractLaneU {
+                value: Reg,
+                lane: ImmLaneIdx8,
+            },
+            /// Wasm `i32x4.extract_lane` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extract_lane)]
+            I32x4ExtractLane {
+                value: Reg,
+                lane: ImmLaneIdx4,
+            },
+            /// Wasm `i64x2.extract_lane` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_extract_lane)]
+            I64x2ExtractLane {
+                value: Reg,
+                lane: ImmLaneIdx2,
+            },
+            /// Wasm `f32x4.extract_lane` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_extract_lane)]
+            F32x4ExtractLane {
+                value: Reg,
+                lane: ImmLaneIdx4,
+            },
+            /// Wasm `f64x2.extract_lane` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_extract_lane)]
+            F64x2ExtractLane {
+                value: Reg,
+                lane: ImmLaneIdx2,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -7032,6 +7032,487 @@ macro_rules! for_each_op {
                 /// Register holding the `input` of the instruction.
                 input: Reg,
             },
+
+            /// Wasm `i8x16.eq` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_eq)]
+            I8x16Eq {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.eq` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_eq)]
+            I16x8Eq {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.eq` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_eq)]
+            I32x4Eq {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.eq` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_eq)]
+            I64x2Eq {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.eq` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_eq)]
+            F32x4Eq {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.eq` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_eq)]
+            F64x2Eq {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.ne` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_ne)]
+            I8x16Ne {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.ne` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_ne)]
+            I16x8Ne {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.ne` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_ne)]
+            I32x4Ne {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.ne` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_ne)]
+            I64x2Ne {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.ne` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_ne)]
+            F32x4Ne {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.ne` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_ne)]
+            F64x2Ne {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.lt_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_lt_s)]
+            I8x16LtS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.lt_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_lt_u)]
+            I8x16LtU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.lt_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_lt_s)]
+            I16x8LtS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.lt_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_lt_u)]
+            I16x8LtU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.lt_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_lt_s)]
+            I32x4LtS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.lt_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_lt_u)]
+            I32x4LtU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.lt_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_lt_s)]
+            I64x2LtS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.lt` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_lt)]
+            F32x4Lt {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.lt` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_lt)]
+            F64x2Lt {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.le_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_le_s)]
+            I8x16LeS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.le_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_le_u)]
+            I8x16LeU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.le_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_le_s)]
+            I16x8LeS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.le_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_le_u)]
+            I16x8LeU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.le_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_le_s)]
+            I32x4LeS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.le_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_le_u)]
+            I32x4LeU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.le_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_le_s)]
+            I64x2LeS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.le` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_le)]
+            F32x4Le {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.le` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_le)]
+            F64x2Le {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.gt_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_gt_s)]
+            I8x16GtS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.gt_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_gt_u)]
+            I8x16GtU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.gt_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_gt_s)]
+            I16x8GtS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.gt_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_gt_u)]
+            I16x8GtU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.gt_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_gt_s)]
+            I32x4GtS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.gt_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_gt_u)]
+            I32x4GtU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.gt_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_gt_s)]
+            I64x2GtS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.gt` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_gt)]
+            F32x4Gt {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.gt` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_gt)]
+            F64x2Gt {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.ge_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_ge_s)]
+            I8x16GeS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.ge_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_ge_u)]
+            I8x16GeU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.ge_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_ge_s)]
+            I16x8GeS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.ge_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_ge_u)]
+            I16x8GeU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.ge_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_ge_s)]
+            I32x4GeS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.ge_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_ge_u)]
+            I32x4GeU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.ge_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_ge_s)]
+            I64x2GeS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.ge` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_ge)]
+            F32x4Ge {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.ge` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_ge)]
+            F64x2Ge {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6190,6 +6190,117 @@ macro_rules! for_each_op {
                 /// The register holding the `selector` of the instruction.
                 selector: Reg,
             },
+
+            /// Wasm `i8x16.add` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_add)]
+            I8x16Add {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.add` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_add)]
+            I16x8Add {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.add` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_add)]
+            I32x4Add {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.add` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_add)]
+            I64x2Add {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.sub` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_sub)]
+            I8x16Sub {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.sub` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_sub)]
+            I16x8Sub {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.sub` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_sub)]
+            I32x4Sub {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.sub` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_sub)]
+            I64x2Sub {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.mul` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_mul)]
+            I16x8Mul {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.mul` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_mul)]
+            I32x4Mul {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.mul` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_mul)]
+            I64x2Mul {
+                @result: Reg,
+                /// The register storing the `lhs` of the instruction.
+                lhs: Reg,
+                /// The register storing the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6312,6 +6312,39 @@ macro_rules! for_each_op {
                 /// The register storing the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `i8x16.neg` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_neg)]
+            I8x16Neg {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i16x8.neg` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_neg)]
+            I16x8Neg {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.neg` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_neg)]
+            I32x4Neg {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i64x2.neg` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_neg)]
+            I64x2Neg {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -8850,6 +8850,166 @@ macro_rules! for_each_op {
                 /// The 16-bit encoded offset of the `load` instruction.
                 offset: Offset16,
             },
+
+            /// Wasm `v128.load8_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. [`Instruction::RegisterAndImm32`] encoding `input` and `lane_index`.
+            /// 3. Optional [`Instruction::MemoryIndex`] encoding the `memory_index` used.
+            ///
+            /// # Note
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            ///
+            /// The `lane_index` is of type [`ImmLaneIdx16`].
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8_lane)]
+            V128Load8Lane {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load8Lane`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `input` and `lane_index`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding the `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load8_lane_at)]
+            V128Load8LaneAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+
+            /// Wasm `v128.load16_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. [`Instruction::RegisterAndImm32`] encoding `input` and `lane_index`.
+            /// 3. Optional [`Instruction::MemoryIndex`] encoding the `memory_index` used.
+            ///
+            /// # Note
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            ///
+            /// The `lane_index` is of type [`ImmLaneIdx8`].
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16_lane)]
+            V128Load16Lane {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load16Lane`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `input` and `lane_index`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding the `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load16_lane_at)]
+            V128Load16LaneAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+
+            /// Wasm `v128.load32_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. [`Instruction::RegisterAndImm32`] encoding `input` and `lane_index`.
+            /// 3. Optional [`Instruction::MemoryIndex`] encoding the `memory_index` used.
+            ///
+            /// # Note
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            ///
+            /// The `lane_index` is of type [`ImmLaneIdx4`].
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32_lane)]
+            V128Load32Lane {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load32Lane`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `input` and `lane_index`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding the `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load32_lane_at)]
+            V128Load32LaneAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
+
+            /// Wasm `v128.load64_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+            /// 2. [`Instruction::RegisterAndImm32`] encoding `input` and `lane_index`.
+            /// 3. Optional [`Instruction::MemoryIndex`] encoding the `memory_index` used.
+            ///
+            /// # Note
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            ///
+            /// The `lane_index` is of type [`ImmLaneIdx2`].
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load64_lane)]
+            V128Load64Lane {
+                @result: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Load64Lane`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// 1. [`Instruction::RegisterAndImm32`] encoding `input` and `lane_index`.
+            /// 2. Optional [`Instruction::MemoryIndex`] encoding the `memory_index` used.
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_load64_lane_at)]
+            V128Load64LaneAt {
+                @result: Reg,
+                /// The `ptr+offset` address of the load instruction.
+                address: Address32,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -7869,6 +7869,47 @@ macro_rules! for_each_op {
                 /// Register holding the `input` of the instruction.
                 input: Reg,
             },
+
+            /// Wasm `i8x16.narrow_i16x8_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_narrow_i16x8_s)]
+            I8x16NarrowI16x8S {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Regstier holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.narrow_i16x8_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_narrow_i16x8_u)]
+            I8x16NarrowI16x8U {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Regstier holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.narrow_i32x4_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_narrow_i32x4_s)]
+            I16x8NarrowI32x4S {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Regstier holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.narrow_i32x4_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_narrow_i32x4_u)]
+            I16x8NarrowI32x4U {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Regstier holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5922,56 +5922,80 @@ macro_rules! for_each_op {
             #[cfg(feature = "simd")]
             #[snake_name(i8x16_extract_lane_s)]
             I8x16ExtractLaneS {
+                @result: Reg,
+                /// The input [`V128`].
                 value: Reg,
+                /// The lane to extract the value.
                 lane: ImmLaneIdx16,
             },
             /// Wasm `i8x16.extract_lane_u` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(i8x16_extract_lane_u)]
             I8x16ExtractLaneU {
+                @result: Reg,
+                /// The input [`V128`].
                 value: Reg,
+                /// The lane to extract the value.
                 lane: ImmLaneIdx16,
             },
             /// Wasm `i16x8.extract_lane_s` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(i16x8_extract_lane_s)]
             I16x8ExtractLaneS {
+                @result: Reg,
+                /// The input [`V128`].
                 value: Reg,
+                /// The lane to extract the value.
                 lane: ImmLaneIdx8,
             },
             /// Wasm `i16x8.extract_lane_u` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(i16x8_extract_lane_u)]
             I16x8ExtractLaneU {
+                @result: Reg,
+                /// The input [`V128`].
                 value: Reg,
+                /// The lane to extract the value.
                 lane: ImmLaneIdx8,
             },
             /// Wasm `i32x4.extract_lane` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(i32x4_extract_lane)]
             I32x4ExtractLane {
+                @result: Reg,
+                /// The input [`V128`].
                 value: Reg,
+                /// The lane to extract the value.
                 lane: ImmLaneIdx4,
             },
             /// Wasm `i64x2.extract_lane` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(i64x2_extract_lane)]
             I64x2ExtractLane {
+                @result: Reg,
+                /// The input [`V128`].
                 value: Reg,
+                /// The lane to extract the value.
                 lane: ImmLaneIdx2,
             },
             /// Wasm `f32x4.extract_lane` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(f32x4_extract_lane)]
             F32x4ExtractLane {
+                @result: Reg,
+                /// The input [`V128`].
                 value: Reg,
+                /// The lane to extract the value.
                 lane: ImmLaneIdx4,
             },
             /// Wasm `f64x2.extract_lane` instruction.
             #[cfg(feature = "simd")]
             #[snake_name(f64x2_extract_lane)]
             F64x2ExtractLane {
+                @result: Reg,
+                /// The input [`V128`].
                 value: Reg,
+                /// The lane to extract the value.
                 lane: ImmLaneIdx2,
             },
         }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6935,7 +6935,7 @@ macro_rules! for_each_op {
                 @result: Reg,
                 /// Register holding the `input` of the instruction.
                 input: Reg,
-            }
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5998,6 +5998,173 @@ macro_rules! for_each_op {
                 /// The lane to extract the value.
                 lane: ImmLaneIdx2,
             },
+
+            /// Wasm `i8x16.replace_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Register`] encoding `value`.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_replace_lane)]
+            I8x16ReplaceLane {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx16,
+            },
+            /// Variant of [`Instruction::I8x16ReplaceLane`] with imediate `value`.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_replace_lane_imm)]
+            I8x16ReplaceLaneImm {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx16,
+                /// The value replacing the `lane` in `input`.
+                value: i8,
+            },
+            /// Wasm `i16x8.replace_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Register`] encoding `value`.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_replace_lane)]
+            I16x8ReplaceLane {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx8,
+            },
+            /// Variant of [`Instruction::I16x8ReplaceLane`] with imediate `value`.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Const32`] encoding the immediate `value` of type `i16`.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_replace_lane_imm)]
+            I16x8ReplaceLaneImm {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx8,
+            },
+            /// Wasm `i32x4.replace_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Register`] encoding `value`.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_replace_lane)]
+            I32x4ReplaceLane {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx4,
+            },
+            /// Variant of [`Instruction::I32x4ReplaceLaneImm`] with imediate `value`.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Register`] encoding the immediate `value` of type `i32`.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_replace_lane_imm)]
+            I32x4ReplaceLaneImm {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx4,
+            },
+            /// Wasm `i64x2.replace_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Register`] encoding `value`.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_replace_lane)]
+            I64x2ReplaceLane {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx2,
+            },
+            /// Variant of [`Instruction::I64x2ReplaceLane`] with imediate 32-bit `value`.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::I64Const32`] encoding the 32-bit `value`.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_replace_lane_imm32)]
+            I64x2ReplaceLaneImm32 {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx2,
+            },
+            /// Wasm `f32x4.replace_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Register`] encoding `value`.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_replace_lane)]
+            F32x4ReplaceLane {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx4,
+            },
+            /// Variant of [`Instruction::F32x4ReplaceLane`] with immediate `value`.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Const32`] encoding `value` of type `f32`.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_replace_lane_imm)]
+            F32x4ReplaceLaneImm {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx4,
+            },
+            /// Wasm `f64x2.replace_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::Register`] encoding `value`.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_replace_lane)]
+            F64x2ReplaceLane {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx2,
+            },
+            /// Variant of [`Instruction::F64x2ReplaceLane`] with 32-bit immediate `value`.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by [`Instruction::F64Const32`] encoding the 32-bit immediate `value`.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_replace_lane_imm32)]
+            F32x4ReplaceLaneImm32 {
+                @result: Reg,
+                /// The input [`V128`] that gets a value replaced.
+                input: Reg,
+                /// The lane of the replaced value.
+                lane: ImmLaneIdx4,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6766,6 +6766,127 @@ macro_rules! for_each_op {
                 /// Register holding the `input` of the instruction.
                 input: Reg,
             },
+
+            /// Wasm `i8x16.shl` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_shl)]
+            I8x16Shl {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.shl` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_shl)]
+            I16x8Shl {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.shl` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_shl)]
+            I32x4Shl {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.shl` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_shl)]
+            I64x2Shl {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.shr_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_shr_s)]
+            I8x16ShrS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.shr_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_shr_u)]
+            I8x16ShrU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.shr_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_shr_s)]
+            I16x8ShrS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.shr_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_shr_u)]
+            I16x8ShrU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.shr_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_shr_s)]
+            I32x4ShrS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i32x4.shr_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_shr_u)]
+            I32x4ShrU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.shr_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_shr_s)]
+            I64x2ShrS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i64x2.shr_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_shr_u)]
+            I64x2ShrU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -8007,6 +8007,53 @@ macro_rules! for_each_op {
                 /// Register holding the `input` of the instruction.
                 input: Reg,
             },
+
+            /// Wasm `v128.store` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// - [`Instruction::RegisterAndImm32`]: encoding `value` and `offset_hi`
+            /// - Optional [`Instruction::MemoryIndex`]: encoding memory index used
+            ///
+            /// If [`Instruction::MemoryIndex`] is missing the default memory is used.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store)]
+            V128Store {
+                /// The register storing the `pointer` of the store instruction.
+                ptr: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Store`] with 16-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store_offset16)]
+            V128StoreOffset16 {
+                /// The register storing the `pointer` of the store instruction.
+                ptr: Reg,
+                /// The lower 32-bit of the 64-bit load `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Store`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Optionally followed by an [`Instruction::MemoryIndex`] encoding `memory`.
+            ///
+            /// Operates on the default Wasm memory instance if missing.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store_at)]
+            V128StoreAt {
+                /// The value to be stored.
+                value: Reg,
+                /// The constant address to store the value.
+                address: Address32,
+            }
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -7513,6 +7513,39 @@ macro_rules! for_each_op {
                 /// Register holding the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `f32x4.neg` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_neg)]
+            F32x4Neg {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f64x2.neg` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_neg)]
+            F64x2Neg {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f32x4.abs` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_abs)]
+            F32x4Abs {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f64x2.abs` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_abs)]
+            F64x2Abs {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6499,6 +6499,87 @@ macro_rules! for_each_op {
                 /// Register holding the `input` of the instruction.
                 input: Reg,
             },
+
+            /// Wasm `i8x16.add_sat_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_add_sat_s)]
+            I8x16AddSatS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.add_sat_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_add_sat_u)]
+            I8x16AddSatU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.add_sat_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_add_sat_s)]
+            I16x8AddSatS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.add_sat_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_add_sat_u)]
+            I16x8AddSatU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.sub_sat_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_sub_sat_s)]
+            I8x16SubSatS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i8x16.sub_sat_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_sub_sat_u)]
+            I8x16SubSatU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.sub_sat_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_sub_sat_s)]
+            I16x8SubSatS {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.sub_sat_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_sub_sat_u)]
+            I16x8SubSatU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -7788,6 +7788,87 @@ macro_rules! for_each_op {
                 /// Register holding the `input` of the instruction.
                 input: Reg,
             },
+
+            /// Wasm `f32x4.convert_i32x4_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_convert_i32x4_s)]
+            F32x4ConvertI32x4S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f32x4.convert_i32x4_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_convert_i32x4_u)]
+            F32x4ConvertI32x4U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f64x2.convert_low_i32x4_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_convert_low_i32x4_s)]
+            F64x2ConvertLowI32x4S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f64x2.convert_low_i32x4_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_convert_low_i32x4_u)]
+            F64x2ConvertLowI32x4U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.trunc_sat_f32x4_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_trunc_sat_f32x4_s)]
+            I32x4TruncSatF32x4S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.trunc_sat_f32x4_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_trunc_sat_f32x4_u)]
+            I32x4TruncSatF32x4U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.trunc_sat_f64x2_s_zero` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_trunc_sat_f64x2_s_zero)]
+            I32x4TruncSatF64x2SZero {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.trunc_sat_f64x2_u_zero` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_trunc_sat_f64x2_u_zero)]
+            I32x4TruncSatF64x2UZero {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f32x4.demote_f64x2_zero` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_demote_f64x2_zero)]
+            F32x4DemoteF64x2Zero {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `f64x2.promote_low_f32x4` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_promote_low_f32x4)]
+            F64x2PromoteLowF32x4 {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6951,6 +6951,87 @@ macro_rules! for_each_op {
                 /// Register holding the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `i8x16.popcnt` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_popcnt)]
+            I8x16Popcnt {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `v128.any_true` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_any_true)]
+            V128AnyTrue {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i8x16.all_true` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_all_true)]
+            I8x16AllTrue {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i16x8.all_true` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_all_true)]
+            I16x8AllTrue {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.all_true` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_all_true)]
+            I32x4AllTrue {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i64x2.all_true` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_all_true)]
+            I64x2AllTrue {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i8x16.bitmask` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_bitmask)]
+            I8x16Bitmask {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i16x8.bitmask` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_bitmask)]
+            I16x8Bitmask {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.bitmask` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_bitmask)]
+            I32x4Bitmask {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i64x2.bitmask` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_bitmask)]
+            I64x2Bitmask {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -6712,6 +6712,27 @@ macro_rules! for_each_op {
                 /// Register holding the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `i8x16.avgr_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i8x16_avgr_u)]
+            I8x16AvgrU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `i16x8.avgr_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_avgr_u)]
+            I16x8AvgrU {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -8056,6 +8056,202 @@ macro_rules! for_each_op {
                 /// The 32-bit constant address to store the value.
                 address: Address32,
             },
+
+            /// Wasm `v128.store8_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// - [`Instruction::RegisterAndImm32`]: encoding `value` and `offset_hi`
+            /// - [`Instruction::Imm16AndImm32`]: encoding `lane_index` and `memory_index` respectively
+            ///
+            /// The `lane_index` is of type [`ImmLaneIdx16`].
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store8_lane)]
+            V128Store8Lane {
+                /// Register storing the `ptr` of the instruction.
+                ptr: Reg,
+                /// The lower 32-bit of the 64-bit store `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Store8Lane`] with an 8-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store8_lane_offset8)]
+            V128Store8LaneOffset8 {
+                /// Register storing the `ptr` of the instruction.
+                ptr: Reg,
+                /// Register storing the `value` of the instruction.
+                value: Reg,
+                /// The 8-bit store `offset`.
+                offset: Offset8,
+                /// The lane of the stored [`V128`] `value`.
+                lane: ImmLaneIdx16,
+            },
+            /// Variant of [`Instruction::V128Store8Lane`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by an [`Instruction::Imm16AndImm32`] encoding `lane_index` and `memory_index` respectively.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store8_lane_at)]
+            V128Store8LaneAt {
+                /// The value to be stored.
+                value: Reg,
+                /// The 32-bit constant address to store the value.
+                address: Address32,
+            },
+
+            /// Wasm `v128.store16_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// - [`Instruction::RegisterAndImm32`]: encoding `value` and `offset_hi`
+            /// - [`Instruction::Imm16AndImm32`]: encoding `lane_index` and `memory_index` respectively
+            ///
+            /// The `lane_index` is of type [`ImmLaneIdx8`].
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store16_lane)]
+            V128Store16Lane {
+                /// Register storing the `ptr` of the instruction.
+                ptr: Reg,
+                /// The lower 32-bit of the 64-bit store `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Store16Lane`] with an 8-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store16_lane_offset8)]
+            V128Store16LaneOffset8 {
+                /// Register storing the `ptr` of the instruction.
+                ptr: Reg,
+                /// Register storing the `value` of the instruction.
+                value: Reg,
+                /// The 8-bit store `offset`.
+                offset: Offset8,
+                /// The lane of the stored [`V128`] `value`.
+                lane: ImmLaneIdx8,
+            },
+            /// Variant of [`Instruction::V128Store16Lane`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by an [`Instruction::Imm16AndImm32`] encoding `lane_index` and `memory_index` respectively.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store16_lane_at)]
+            V128Store16LaneAt {
+                /// The value to be stored.
+                value: Reg,
+                /// The 32-bit constant address to store the value.
+                address: Address32,
+            },
+
+            /// Wasm `v128.store32_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// - [`Instruction::RegisterAndImm32`]: encoding `value` and `offset_hi`
+            /// - [`Instruction::Imm16AndImm32`]: encoding `lane_index` and `memory_index` respectively
+            ///
+            /// The `lane_index` is of type [`ImmLaneIdx4`].
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store32_lane)]
+            V128Store32Lane {
+                /// Register storing the `ptr` of the instruction.
+                ptr: Reg,
+                /// The lower 32-bit of the 64-bit store `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Store32Lane`] with an 8-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store32_lane_offset8)]
+            V128Store32LaneOffset8 {
+                /// Register storing the `ptr` of the instruction.
+                ptr: Reg,
+                /// Register storing the `value` of the instruction.
+                value: Reg,
+                /// The 8-bit store `offset`.
+                offset: Offset8,
+                /// The lane of the stored [`V128`] `value`.
+                lane: ImmLaneIdx4,
+            },
+            /// Variant of [`Instruction::V128Store32Lane`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by an [`Instruction::Imm16AndImm32`] encoding `lane_index` and `memory_index` respectively.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store32_lane_at)]
+            V128Store32LaneAt {
+                /// The value to be stored.
+                value: Reg,
+                /// The 32-bit constant address to store the value.
+                address: Address32,
+            },
+
+            /// Wasm `v128.store64_lane` instruction.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by
+            ///
+            /// - [`Instruction::RegisterAndImm32`]: encoding `value` and `offset_hi`
+            /// - [`Instruction::Imm16AndImm32`]: encoding `lane_index` and `memory_index` respectively
+            ///
+            /// The `lane_index` is of type [`ImmLaneIdx2`].
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store64_lane)]
+            V128Store64Lane {
+                /// Register storing the `ptr` of the instruction.
+                ptr: Reg,
+                /// The lower 32-bit of the 64-bit store `offset`.
+                offset_lo: Offset64Lo,
+            },
+            /// Variant of [`Instruction::V128Store64Lane`] with an 8-bit offset.
+            ///
+            /// # Note
+            ///
+            /// Operates on the default Wasm memory instance.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store64_lane_offset8)]
+            V128Store64LaneOffset8 {
+                /// Register storing the `ptr` of the instruction.
+                ptr: Reg,
+                /// Register storing the `value` of the instruction.
+                value: Reg,
+                /// The 8-bit store `offset`.
+                offset: Offset8,
+                /// The lane of the stored [`V128`] `value`.
+                lane: ImmLaneIdx2,
+            },
+            /// Variant of [`Instruction::V128Store64Lane`] with 32-bit immediate address.
+            ///
+            /// # Encoding
+            ///
+            /// Followed by an [`Instruction::Imm16AndImm32`] encoding `lane_index` and `memory_index` respectively.
+            #[cfg(feature = "simd")]
+            #[snake_name(v128_store64_lane_at)]
+            V128Store64LaneAt {
+                /// The value to be stored.
+                value: Reg,
+                /// The 32-bit constant address to store the value.
+                address: Address32,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -8036,6 +8036,8 @@ macro_rules! for_each_op {
             V128StoreOffset16 {
                 /// The register storing the `pointer` of the store instruction.
                 ptr: Reg,
+                /// The register storing the `value` of the store instruction.
+                value: Reg,
                 /// The 16-bit encoded offset of the `load` instruction.
                 offset: Offset16,
             },

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -7546,6 +7546,167 @@ macro_rules! for_each_op {
                 /// Register holding the `input` of the instruction.
                 input: Reg,
             },
+
+            /// Wasm `f32x4.min` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_min)]
+            F32x4Min {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.min` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_min)]
+            F64x2Min {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.max` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_max)]
+            F32x4Max {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.max` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_max)]
+            F64x2Max {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.pmin` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_pmin)]
+            F32x4Pmin {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.pmin` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_pmin)]
+            F64x2Pmin {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.pmax` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_pmax)]
+            F32x4Pmax {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.pmax` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_pmax)]
+            F64x2Pmax {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.add` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_add)]
+            F32x4Add {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.add` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_add)]
+            F64x2Add {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.sub` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_sub)]
+            F32x4Sub {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.sub` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_sub)]
+            F64x2Sub {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.div` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_div)]
+            F32x4Div {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.div` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_div)]
+            F64x2Div {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f32x4.mul` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f32x4_mul)]
+            F32x4Mul {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
+            /// Wasm `f64x2.mul` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(f64x2_mul)]
+            F64x2Mul {
+                @result: Reg,
+                /// Register holding the `lhs` of the instruction.
+                lhs: Reg,
+                /// Register holding the `rhs` of the instruction.
+                rhs: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -7910,6 +7910,103 @@ macro_rules! for_each_op {
                 /// Regstier holding the `rhs` of the instruction.
                 rhs: Reg,
             },
+
+            /// Wasm `i16x8.extend_low_i8x16_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extend_low_i8x16_s)]
+            I16x8ExtendLowI8x16S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i16x8.extend_high_i8x16_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extend_high_i8x16_s)]
+            I16x8ExtendHighI8x16S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i16x8.extend_low_i8x16_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extend_low_i8x16_u)]
+            I16x8ExtendLowI8x16U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i16x8.extend_high_i8x16_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i16x8_extend_high_i8x16_u)]
+            I16x8ExtendHighI8x16U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.extend_low_i16x8_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extend_low_i16x8_s)]
+            I32x4ExtendLowI16x8S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.extend_high_i16x8_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extend_high_i16x8_s)]
+            I32x4ExtendHighI16x8S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.extend_low_i16x8_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extend_low_i16x8_u)]
+            I32x4ExtendLowI16x8U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i32x4.extend_high_i16x8_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i32x4_extend_high_i16x8_u)]
+            I32x4ExtendHighI16x8U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i64x2.extend_low_i32x4_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_extend_low_i32x4_s)]
+            I64x2ExtendLowI32x4S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i64x2.extend_high_i32x4_s` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_extend_high_i32x4_s)]
+            I64x2ExtendHighI32x4S {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i64x2.extend_low_i32x4_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_extend_low_i32x4_u)]
+            I64x2ExtendLowI32x4U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
+            /// Wasm `i64x2.extend_high_i32x4_u` instruction.
+            #[cfg(feature = "simd")]
+            #[snake_name(i64x2_extend_high_i32x4_u)]
+            I64x2ExtendHighI32x4U {
+                @result: Reg,
+                /// Register holding the `input` of the instruction.
+                input: Reg,
+            },
         }
     };
 }

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -36,6 +36,7 @@ pub use self::{
         Offset64,
         Offset64Hi,
         Offset64Lo,
+        Offset8,
         ShiftAmount,
         Sign,
     },

--- a/crates/ir/src/primitive.rs
+++ b/crates/ir/src/primitive.rs
@@ -462,6 +462,27 @@ impl From<Offset64> for u64 {
     }
 }
 
+/// An 8-bit encoded load or store address offset.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Offset8(u8);
+
+impl TryFrom<u64> for Offset8 {
+    type Error = OutOfBoundsConst;
+
+    fn try_from(address: u64) -> Result<Self, Self::Error> {
+        u8::try_from(address)
+            .map(Self)
+            .map_err(|_| OutOfBoundsConst)
+    }
+}
+
+impl From<Offset8> for Offset64 {
+    fn from(offset: Offset8) -> Self {
+        Offset64(u64::from(offset.0))
+    }
+}
+
 /// A 16-bit encoded load or store address offset.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]

--- a/crates/ir/src/visit_regs.rs
+++ b/crates/ir/src/visit_regs.rs
@@ -1,11 +1,6 @@
-use crate::{
-    core::{
-        simd::{ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx4, ImmLaneIdx8},
-        TrapCode,
-    },
-    index::*,
-    *,
-};
+#[cfg(feature = "simd")]
+use crate::core::simd::{ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx4, ImmLaneIdx8};
+use crate::{core::TrapCode, index::*, *};
 
 impl Instruction {
     /// Visit [`Reg`]s of `self` via the `visitor`.
@@ -105,11 +100,9 @@ impl_host_visitor_for!(
     Offset64Lo,
     Offset64Hi,
     Address32,
-    ImmLaneIdx16,
-    ImmLaneIdx2,
-    ImmLaneIdx4,
-    ImmLaneIdx8,
 );
+#[cfg(feature = "simd")]
+impl_host_visitor_for!(ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx4, ImmLaneIdx8,);
 
 /// Type-wrapper to signal that the wrapped [`Reg`], [`RegSpan`] (etc.) is a result.
 pub struct Res<T>(T);

--- a/crates/ir/src/visit_regs.rs
+++ b/crates/ir/src/visit_regs.rs
@@ -73,6 +73,7 @@ impl_host_visitor_for!(
     i8,
     i16,
     u16,
+    i32,
     u32,
     TrapCode,
     BlockFuel,

--- a/crates/ir/src/visit_regs.rs
+++ b/crates/ir/src/visit_regs.rs
@@ -1,4 +1,11 @@
-use crate::{core::TrapCode, index::*, *};
+use crate::{
+    core::{
+        simd::{ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx4, ImmLaneIdx8},
+        TrapCode,
+    },
+    index::*,
+    *,
+};
 
 impl Instruction {
     /// Visit [`Reg`]s of `self` via the `visitor`.
@@ -98,6 +105,10 @@ impl_host_visitor_for!(
     Offset64Lo,
     Offset64Hi,
     Address32,
+    ImmLaneIdx16,
+    ImmLaneIdx2,
+    ImmLaneIdx4,
+    ImmLaneIdx8,
 );
 
 /// Type-wrapper to signal that the wrapped [`Reg`], [`RegSpan`] (etc.) is a result.

--- a/crates/ir/src/visit_regs.rs
+++ b/crates/ir/src/visit_regs.rs
@@ -138,6 +138,7 @@ macro_rules! impl_host_visitor {
     (
         $(
             $( #[doc = $doc:literal] )*
+            $( #[cfg(feature = $feature_name:literal)] )?
             #[snake_name($snake_name:ident)]
             $name:ident
             $(
@@ -156,6 +157,7 @@ macro_rules! impl_host_visitor {
             fn host_visitor<V: VisitRegs>(self, visitor: &mut V) {
                 match self {
                     $(
+                        $( #[cfg(feature = $feature_name)] )?
                         Instruction::$name { $( $( $result_name, )? $( $field_name, )* )? } => {
                             $(
                                 $( Res($result_name).host_visitor(visitor); )?

--- a/crates/ir/src/visit_regs.rs
+++ b/crates/ir/src/visit_regs.rs
@@ -95,6 +95,7 @@ impl_host_visitor_for!(
     Const32<T>,
     Sign<T>,
     ShiftAmount<T>,
+    Offset8,
     Offset16,
     Offset64,
     Offset64Lo,

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -55,7 +55,7 @@ prefer-btree-collections = [
     "wasmparser/prefer-btree-collections",
 ]
 wat = ["dep:wat", "std"]
-simd = ["wasmi_core/simd"]
+simd = ["wasmi_core/simd", "wasmi_ir/simd"]
 
 # Enables extra checks performed during Wasmi bytecode execution.
 #

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1306,6 +1306,7 @@ impl<'engine> Executor<'engine> {
                 | Instr::RegisterList { .. }
                 | Instr::CallIndirectParams { .. }
                 | Instr::CallIndirectParamsImm16 { .. } => self.invalid_instruction_word()?,
+                unsupported => panic!("encountered unsupported Wasmi instruction: {unsupported:?}"),
             }
         }
     }


### PR DESCRIPTION
Implements `wasmi_ir` part of https://github.com/wasmi-labs/wasmi/issues/1364.

- Adds the `simd` crate feature to `wasmi_ir`.
- Adds `Instruction` variants for all Wasm `simd` instructions when `simd` crate feature is enabled.

Link to Wasm 3.0 Spec: https://webassembly.github.io/spec/core/appendix/index-instructions.html

🟡 Means that the Wasm instruction has no Wasmi instruction counterpart by design.

| Status | Wasm `simd` Instruction |
|:-:|:-|
| 🟡 | `v128.const(imm: ImmByte[16]) -> v128` |
| ✅ | `i8x16.splat(x: i32) -> v128` |
| ✅ | `i16x8.splat(x: i32) -> v128` |
| ✅ | `i32x4.splat(x: i32) -> v128` |
| ✅ | `i64x2.splat(x: i64) -> v128` |
| ✅ | `f32x4.splat(x: f32) -> v128` |
| ✅ | `f64x2.splat(x: f64) -> v128` |
|  |  |
| ✅ | `i8x16.extract_lane_s(a: v128, imm: ImmLaneIdx16) -> i32` |
| ✅ | `i8x16.extract_lane_u(a: v128, imm: ImmLaneIdx16) -> i32` |
| ✅ | `i16x8.extract_lane_s(a: v128, imm: ImmLaneIdx8) -> i32` |
| ✅ | `i16x8.extract_lane_u(a: v128, imm: ImmLaneIdx8) -> i32` |
| ✅ | `i32x4.extract_lane(a: v128, imm: ImmLaneIdx4) -> i32` |
| ✅ | `i64x2.extract_lane(a: v128, imm: ImmLaneIdx2) -> i64` |
| ✅ | `f32x4.extract_lane(a: v128, imm: ImmLaneIdx4) -> f32` |
| ✅ | `f64x2.extract_lane(a: v128, imm: ImmLaneIdx2) -> f64` |
| ✅ | `i8x16.replace_lane(a: v128, imm: ImmLaneIdx16, x: i32) -> v128` |
| ✅ | `i16x8.replace_lane(a: v128, imm: ImmLaneIdx8, x: i32) -> v128` |
| ✅ | `i32x4.replace_lane(a: v128, imm: ImmLaneIdx4, x: i32) -> v128` |
| ✅ | `i64x2.replace_lane(a: v128, imm: ImmLaneIdx2, x: i64) -> v128` |
| ✅ | `f32x4.replace_lane(a: v128, imm: ImmLaneIdx4, x: f32) -> v128` |
| ✅ | `f64x2.replace_lane(a: v128, imm: ImmLaneIdx2, x: f64) -> v128` |
|  |  |
| ✅ | `i8x16.shuffle(a: v128, b: v128, imm: ImmLaneIdx32[16]) -> v128` |
| ✅ | `i8x16.swizzle(a: v128, s: v128) -> v128` |
|  |  |
| ✅ | `i8x16.add(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.add(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.add(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.add(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.sub(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.sub(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.sub(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.sub(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.mul(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.mul(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.mul(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.dot_i16x8_s(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.neg(a: v128) -> v128` |
| ✅ | `i16x8.neg(a: v128) -> v128` |
| ✅ | `i32x4.neg(a: v128) -> v128` |
| ✅ | `i64x2.neg(a: v128) -> v128` |
|  |  |
| ✅ | `i16x8.extmul_low_i8x16_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.extmul_high_i8x16_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.extmul_low_i8x16_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.extmul_high_i8x16_u(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.extmul_low_i16x8_s(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.extmul_high_i16x8_s(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.extmul_low_i16x8_u(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.extmul_high_i16x8_u(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.extmul_low_i32x4_s(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.extmul_high_i32x4_s(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.extmul_low_i32x4_u(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.extmul_high_i32x4_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.extadd_pairwise_i8x16_s(a: v128) -> v128` |
| ✅ | `i16x8.extadd_pairwise_i8x16_u(a: v128) -> v128` |
| ✅ | `i32x4.extadd_pairwise_i16x8_s(a: v128) -> v128` |
| ✅ | `i32x4.extadd_pairwise_i16x8_u(a: v128) -> v128` |
|  |  |
| ✅ | `i8x16.add_sat_s(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.add_sat_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.add_sat_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.add_sat_u(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.sub_sat_s(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.sub_sat_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.sub_sat_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.sub_sat_u(a: v128, b: v128) -> v128` |
|  |  |
| ✅ | `i16x8.q15mulr_sat_s(a: v128, b: v128) -> v128` |
|  |  |
| ✅ | `i8x16.min_s(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.min_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.min_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.min_u(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.min_s(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.min_u(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.max_s(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.max_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.max_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.max_u(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.max_s(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.max_u(a: v128, b: v128) -> v128` |
|  |  |
| ✅ | `i8x16.avgr_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.avgr_u(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.abs(a: v128) -> v128` |
| ✅ | `i16x8.abs(a: v128) -> v128` |
| ✅ | `i32x4.abs(a: v128) -> v128` |
| ✅ | `i64x2.abs(a: v128) -> v128` |
|  |  |
| ✅ | `i8x16.shl(a: v128, y: i32) -> v128` |
| ✅ | `i16x8.shl(a: v128, y: i32) -> v128` |
| ✅ | `i32x4.shl(a: v128, y: i32) -> v128` |
| ✅ | `i64x2.shl(a: v128, y: i32) -> v128` |
| ✅ | `i8x16.shr_s(a: v128, y: i32) -> v128` |
| ✅ | `i8x16.shr_u(a: v128, y: i32) -> v128` |
| ✅ | `i16x8.shr_s(a: v128, y: i32) -> v128` |
| ✅ | `i16x8.shr_u(a: v128, y: i32) -> v128` |
| ✅ | `i32x4.shr_s(a: v128, y: i32) -> v128` |
| ✅ | `i32x4.shr_u(a: v128, y: i32) -> v128` |
| ✅ | `i64x2.shr_s(a: v128, y: i32) -> v128` |
| ✅ | `i64x2.shr_u(a: v128, y: i32) -> v128` |
|  |  |
| ✅ | `v128.and(a: v128, b: v128) -> v128` |
| ✅ | `v128.or(a: v128, b: v128) -> v128` |
| ✅ | `v128.xor(a: v128, b: v128) -> v128` |
| ✅ | `v128.not(a: v128) -> v128` |
| ✅ | `v128.andnot(a: v128, b: v128) -> v128` |
|  |  |
| ✅ | `v128.bitselect(v1: v128, v2: v128, c: v128) -> v128` |
| ✅  | `i8x16.popcnt(v: v128) -> v128` |
| ✅  | `v128.any_true(a: v128) -> i32` |
| ✅  | `i8x16.all_true(a: v128) -> i32` |
| ✅  | `i16x8.all_true(a: v128) -> i32` |
| ✅  | `i32x4.all_true(a: v128) -> i32` |
| ✅  | `i64x2.all_true(a: v128) -> i32` |
|  ✅ | `i8x16.bitmask(a: v128) -> i32` |
| ✅  | `i16x8.bitmask(a: v128) -> i32` |
| ✅  | `i32x4.bitmask(a: v128) -> i32` |
| ✅  | `i64x2.bitmask(a: v128) -> i32` |
|  |  |
| ✅ | `i8x16.eq(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.eq(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.eq(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.eq(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.eq(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.eq(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.ne(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.ne(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.ne(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.ne(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.ne(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.ne(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.lt_s(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.lt_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.lt_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.lt_u(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.lt_s(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.lt_u(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.lt_s(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.lt(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.lt(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.le_s(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.le_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.le_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.le_u(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.le_s(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.le_u(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.le_s(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.le(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.le(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.gt_s(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.gt_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.gt_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.gt_u(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.gt_s(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.gt_u(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.gt_s(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.gt(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.gt(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.ge_s(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.ge_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.ge_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.ge_u(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.ge_s(a: v128, b: v128) -> v128` |
| ✅ | `i32x4.ge_u(a: v128, b: v128) -> v128` |
| ✅ | `i64x2.ge_s(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.ge(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.ge(a: v128, b: v128) -> v128` |
|  |  |
| ✅ | `v128.load(m: memarg) -> v128` |
| ✅ | `v128.load32_zero(m: memarg) -> v128` |
| ✅ | `v128.load64_zero(m: memarg) -> v128` |
| ✅ | `v128.load8_splat(m: memarg) -> v128` |
| ✅ | `v128.load16_splat(m: memarg) -> v128` |
| ✅ | `v128.load32_splat(m: memarg) -> v128` |
| ✅ | `v128.load64_splat(m: memarg) -> v128` |
| ✅ | `v128.load8_lane(m: memarg, x: v128, imm: ImmLaneIdx16) -> v128` |
| ✅ | `v128.load16_lane(m: memarg, x: v128, imm: ImmLaneIdx8) -> v128` |
| ✅ | `v128.load32_lane(m: memarg, x: v128, imm: ImmLaneIdx4) -> v128` |
| ✅ | `v128.load64_lane(m: memarg, x: v128, imm: ImmLaneIdx2) -> v128` |
| ✅ | `v128.load8x8_s(m: memarg)` |
| ✅ | `v128.load8x8_u(m: memarg)` |
| ✅ | `v128.load16x4_s(m: memarg)` |
| ✅ | `v128.load16x4_u(m: memarg)` |
| ✅ | `v128.load32x2_s(m: memarg)` |
| ✅ | `v128.load32x2_u(m: memarg)` |
|  |  |
| ✅ | `v128.store(m: memarg, data: v128)` |
| ✅ | `v128.store8_lane(m: memarg, data: v128, imm: ImmLaneIdx16)` |
| ✅ | `v128.store16_lane(m: memarg, data: v128, imm: ImmLaneIdx8)` |
| ✅ | `v128.store32_lane(m: memarg, data: v128, imm: ImmLaneIdx4)` |
| ✅ | `v128.store64_lane(m: memarg, data: v128, imm: ImmLaneIdx2)` |
|  |  |
| ✅ | `f32x4.neg(a: v128) -> v128` |
| ✅ | `f64x2.neg(a: v128) -> v128` |
| ✅ | `f32x4.abs(a: v128) -> v128` |
| ✅ | `f64x2.abs(a: v128) -> v128` |
| ✅ | `f32x4.min(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.min(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.max(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.max(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.pmin(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.pmin(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.pmax(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.pmax(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.add(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.add(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.sub(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.sub(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.div(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.div(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.mul(a: v128, b: v128) -> v128` |
| ✅ | `f64x2.mul(a: v128, b: v128) -> v128` |
| ✅ | `f32x4.sqrt(a: v128) -> v128` |
| ✅ | `f64x2.sqrt(a: v128) -> v128` |
| ✅ | `f32x4.ceil(a: v128) -> v128` |
| ✅ | `f64x2.ceil(a: v128) -> v128` |
| ✅ | `f32x4.floor(a: v128) -> v128` |
| ✅ | `f64x2.floor(a: v128) -> v128` |
| ✅ | `f32x4.trunc(a: v128) -> v128` |
| ✅ | `f64x2.trunc(a: v128) -> v128` |
| ✅ | `f32x4.nearest(a: v128) -> v128` |
| ✅ | `f64x2.nearest(a: v128) -> v128` |
|  |  |
|✅  | `f32x4.convert_i32x4_s(a: v128) -> v128` |
| ✅ | `f32x4.convert_i32x4_u(a: v128) -> v128` |
| ✅ | `f64x2.convert_low_i32x4_s(a: v128) -> v128` |
| ✅ | `f64x2.convert_low_i32x4_u(a: v128) -> v128` |
| ✅ | `i32x4.trunc_sat_f32x4_s(a: v128) -> v128` |
| ✅ | `i32x4.trunc_sat_f32x4_u(a: v128) -> v128` |
| ✅ | `i32x4.trunc_sat_f64x2_s_zero(a: v128) -> v128` |
| ✅ | `i32x4.trunc_sat_f64x2_u_zero(a: v128) -> v128` |
| ✅ | `f32x4.demote_f64x2_zero(a: v128) -> v128` |
| ✅ | `f64x2.promote_low_f32x4(a: v128) -> v128` |
|  |  |
| ✅ | `i8x16.narrow_i16x8_s(a: v128, b: v128) -> v128` |
| ✅ | `i8x16.narrow_i16x8_u(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.narrow_i32x4_s(a: v128, b: v128) -> v128` |
| ✅ | `i16x8.narrow_i32x4_u(a: v128, b: v128) -> v128` |
|  |  |
| ✅ | `i16x8.extend_low_i8x16_s(a: v128) -> v128` |
| ✅ | `i16x8.extend_high_i8x16_s(a: v128) -> v128` |
| ✅ | `i16x8.extend_low_i8x16_u(a: v128) -> v128` |
| ✅ | `i16x8.extend_high_i8x16_u(a: v128) -> v128` |
| ✅ | `i32x4.extend_low_i16x8_s(a: v128) -> v128` |
| ✅ | `i32x4.extend_high_i16x8_s(a: v128) -> v128` |
| ✅ | `i32x4.extend_low_i16x8_u(a: v128) -> v128` |
| ✅ | `i32x4.extend_high_i16x8_u(a: v128) -> v128` |
| ✅ | `i64x2.extend_low_i32x4_s(a: v128) -> v128` |
| ✅ | `i64x2.extend_high_i32x4_s(a: v128) -> v128` |
| ✅ | `i64x2.extend_low_i32x4_u(a: v128) -> v128` |
| ✅ | `i64x2.extend_high_i32x4_u(a: v128) -> v128` |