### PR TITLE
Add `wasmi` Wasm `simd` proposal support skeleton

### DIFF
--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -55,7 +55,7 @@ prefer-btree-collections = [
     "wasmparser/prefer-btree-collections",
 ]
 wat = ["dep:wat", "std"]
-simd = ["wasmi_core/simd", "wasmi_ir/simd"]
+simd = ["wasmi_core/simd", "wasmi_ir/simd", "wasmparser/simd"]
 
 # Enables extra checks performed during Wasmi bytecode execution.
 #

--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -184,6 +184,7 @@ impl Config {
         features.set(WasmFeatures::CUSTOM_PAGE_SIZES, false);
         features.set(WasmFeatures::MEMORY64, true);
         features.set(WasmFeatures::WIDE_ARITHMETIC, false);
+        features.set(WasmFeatures::SIMD, cfg!(feature = "simd"));
         features
     }
 
@@ -355,6 +356,17 @@ impl Config {
     /// [`wide-arithmetic`]: https://github.com/WebAssembly/wide-arithmetic
     pub fn wasm_wide_arithmetic(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::WIDE_ARITHMETIC, enable);
+        self
+    }
+
+    /// Enable or disable the [`simd`] Wasm proposal for the [`Config`].
+    ///
+    /// Enabled by default.
+    ///
+    /// [`simd`]: https://github.com/WebAssembly/simd
+    #[cfg(feature = "simd")]
+    pub fn wasm_simd(&mut self, enable: bool) -> &mut Self {
+        self.features.set(WasmFeatures::SIMD, enable);
         self
     }
 

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "simd", expect(unused_variables))] // TODO: remove
+
 pub use self::call::{dispatch_host_func, ResumableHostError};
 use super::{cache::CachedInstance, InstructionPtr, Stack};
 use crate::{
@@ -1306,6 +1308,737 @@ impl<'engine> Executor<'engine> {
                 | Instr::RegisterList { .. }
                 | Instr::CallIndirectParams { .. }
                 | Instr::CallIndirectParamsImm16 { .. } => self.invalid_instruction_word()?,
+                #[cfg(feature = "simd")]
+                Instr::I8x16Splat { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16SplatImm { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Splat { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8SplatImm { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4Splat { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4SplatImm { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2Splat { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2SplatImm32 { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Splat { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4SplatImm { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Splat { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2SplatImm { result, value } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16ExtractLaneS {
+                    result,
+                    value,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16ExtractLaneU {
+                    result,
+                    value,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtractLaneS {
+                    result,
+                    value,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtractLaneU {
+                    result,
+                    value,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtractLane {
+                    result,
+                    value,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ExtractLane {
+                    result,
+                    value,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4ExtractLane {
+                    result,
+                    value,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2ExtractLane {
+                    result,
+                    value,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16ReplaceLane {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16ReplaceLaneImm {
+                    result,
+                    input,
+                    lane,
+                    value,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ReplaceLane {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ReplaceLaneImm {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ReplaceLane {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ReplaceLaneImm {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ReplaceLane {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ReplaceLaneImm32 {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4ReplaceLane {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4ReplaceLaneImm {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2ReplaceLane {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4ReplaceLaneImm32 {
+                    result,
+                    input,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Shuffle { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Swizzle {
+                    result,
+                    input,
+                    selector,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Add { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Add { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4Add { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2Add { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Sub { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Sub { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4Sub { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2Sub { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Mul { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4Mul { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2Mul { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4DotI16x8S { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Neg { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Neg { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4Neg { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2Neg { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtmulLowI8x16S { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtmulHighI8x16S { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtmulLowI8x16U { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtmulHighI8x16U { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtmulLowI16x8S { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtmulHighI16x8S { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtmulLowI16x8U { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtmulHighI16x8U { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ExtmulLowI32x4S { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ExtmulHighI32x4S { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ExtmulLowI32x4U { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ExtmulHighI32x4U { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtaddPairwiseI8x16S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtaddPairwiseI8x16U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtaddPairwiseI16x8S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtaddPairwiseI16x8U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16AddSatS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16AddSatU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8AddSatS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8AddSatU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16SubSatS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16SubSatU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8SubSatS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8SubSatU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Q15MulrSatS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16MinS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16MinU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8MinS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8MinU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4MinS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4MinU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16MaxS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16MaxU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8MaxS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8MaxU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4MaxS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4MaxU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16AvgrU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8AvgrU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Abs { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Abs { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4Abs { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2Abs { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Shl { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Shl { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4Shl { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2Shl { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16ShrS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16ShrU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ShrS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ShrU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ShrS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ShrU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ShrS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ShrU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128And { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Or { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Xor { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Andnot { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Not { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Bitselect { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Popcnt { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128AnyTrue { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16AllTrue { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8AllTrue { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4AllTrue { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2AllTrue { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Bitmask { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Bitmask { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4Bitmask { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2Bitmask { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Eq { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Eq { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4Eq { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2Eq { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Eq { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Eq { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16Ne { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8Ne { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4Ne { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2Ne { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Ne { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Ne { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16LtS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16LtU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8LtS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8LtU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4LtS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4LtU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2LtS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Lt { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Lt { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16LeS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16LeU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8LeS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8LeU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4LeS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4LeU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2LeS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Le { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Le { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16GtS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16GtU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8GtS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8GtU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4GtS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4GtU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2GtS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Gt { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Gt { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16GeS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16GeU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8GeS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8GeU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4GeS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4GeU { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2GeS { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Ge { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Ge { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Neg { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Neg { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Abs { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Abs { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Min { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Min { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Max { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Max { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Pmin { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Pmin { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Pmax { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Pmax { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Add { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Add { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Sub { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Sub { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Div { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Div { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Mul { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Mul { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Sqrt { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Sqrt { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Ceil { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Ceil { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Floor { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Floor { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Trunc { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Trunc { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4Nearest { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2Nearest { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4ConvertI32x4S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4ConvertI32x4U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2ConvertLowI32x4S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2ConvertLowI32x4U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4TruncSatF32x4S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4TruncSatF32x4U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4TruncSatF64x2SZero { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4TruncSatF64x2UZero { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F32x4DemoteF64x2Zero { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::F64x2PromoteLowF32x4 { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16NarrowI16x8S { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I8x16NarrowI16x8U { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8NarrowI32x4S { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8NarrowI32x4U { result, lhs, rhs } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtendLowI8x16S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtendHighI8x16S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtendLowI8x16U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I16x8ExtendHighI8x16U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtendLowI16x8S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtendHighI16x8S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtendLowI16x8U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I32x4ExtendHighI16x8U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ExtendLowI32x4S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ExtendHighI32x4S { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ExtendLowI32x4U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::I64x2ExtendHighI32x4U { result, input } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store { ptr, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128StoreOffset16 { ptr, value, offset } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128StoreAt { value, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store8Lane { ptr, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store8LaneOffset8 {
+                    ptr,
+                    value,
+                    offset,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store8LaneAt { value, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store16Lane { ptr, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store16LaneOffset8 {
+                    ptr,
+                    value,
+                    offset,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store16LaneAt { value, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store32Lane { ptr, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store32LaneOffset8 {
+                    ptr,
+                    value,
+                    offset,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store32LaneAt { value, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store64Lane { ptr, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store64LaneOffset8 {
+                    ptr,
+                    value,
+                    offset,
+                    lane,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Store64LaneAt { value, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128LoadAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128LoadOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32Zero { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32ZeroAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32ZeroOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load64Zero { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load64ZeroAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load64ZeroOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8Splat { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8SplatAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8SplatOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16Splat { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16SplatAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16SplatOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32Splat { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32SplatAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32SplatOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load64Splat { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load64SplatAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load64SplatOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8x8S { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8x8SAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8x8SOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8x8U { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8x8UAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8x8UOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16x4S { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16x4SAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16x4SOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16x4U { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16x4UAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16x4UOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32x2S { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32x2SAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32x2SOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32x2U { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32x2UAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32x2UOffset16 {
+                    result,
+                    ptr,
+                    offset,
+                } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8Lane { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load8LaneAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16Lane { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load16LaneAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32Lane { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load32LaneAt { result, address } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load64Lane { result, offset_lo } => todo!(),
+                #[cfg(feature = "simd")]
+                Instr::V128Load64LaneAt { result, address } => todo!(),
                 unsupported => panic!("encountered unsupported Wasmi instruction: {unsupported:?}"),
             }
         }

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -14,6 +14,9 @@ mod utils;
 mod visit;
 mod visit_register;
 
+#[cfg(feature = "simd")]
+mod simd;
+
 #[cfg(test)]
 mod tests;
 

--- a/crates/wasmi/src/engine/translator/simd/mod.rs
+++ b/crates/wasmi/src/engine/translator/simd/mod.rs
@@ -1,0 +1,1 @@
+mod visit;

--- a/crates/wasmi/src/engine/translator/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/simd/visit.rs
@@ -1,0 +1,1028 @@
+use crate::engine::translator::FuncTranslator;
+use wasmparser::{MemArg, VisitSimdOperator};
+
+impl<'a> VisitSimdOperator<'a> for FuncTranslator {
+    fn visit_v128_load(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load8x8_s(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load8x8_u(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load16x4_s(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load16x4_u(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load32x2_s(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load32x2_u(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load8_splat(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load16_splat(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load32_splat(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load64_splat(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load32_zero(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load64_zero(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_store(&mut self, _memarg: MemArg) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load8_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load16_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load32_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_load64_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_store8_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_store16_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_store32_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_store64_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_const(&mut self, _value: wasmparser::V128) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_shuffle(&mut self, _lanes: [u8; 16]) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_extract_lane_s(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_extract_lane_u(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_replace_lane(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extract_lane_s(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extract_lane_u(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_replace_lane(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extract_lane(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_replace_lane(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_extract_lane(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_replace_lane(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_extract_lane(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_replace_lane(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_extract_lane(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_replace_lane(&mut self, _lane: u8) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_swizzle(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_splat(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_splat(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_splat(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_splat(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_splat(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_splat(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_eq(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_ne(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_lt_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_lt_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_gt_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_gt_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_le_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_le_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_ge_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_ge_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_eq(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_ne(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_lt_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_lt_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_gt_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_gt_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_le_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_le_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_ge_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_ge_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_eq(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_ne(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_lt_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_lt_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_gt_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_gt_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_le_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_le_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_ge_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_ge_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_eq(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_ne(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_lt_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_gt_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_le_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_ge_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_eq(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_ne(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_lt(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_gt(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_le(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_ge(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_eq(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_ne(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_lt(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_gt(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_le(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_ge(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_not(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_and(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_andnot(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_or(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_xor(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_bitselect(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_v128_any_true(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_abs(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_neg(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_popcnt(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_all_true(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_bitmask(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_narrow_i16x8_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_narrow_i16x8_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_shl(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_shr_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_shr_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_add(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_add_sat_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_add_sat_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_sub(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_sub_sat_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_sub_sat_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_min_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_min_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_max_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_max_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_avgr_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extadd_pairwise_i8x16_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extadd_pairwise_i8x16_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_abs(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_neg(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_q15mulr_sat_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_all_true(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_bitmask(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_narrow_i32x4_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_narrow_i32x4_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extend_low_i8x16_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extend_high_i8x16_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extend_low_i8x16_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extend_high_i8x16_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_shl(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_shr_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_shr_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_add(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_add_sat_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_add_sat_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_sub(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_sub_sat_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_sub_sat_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_mul(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_min_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_min_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_max_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_max_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_avgr_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extmul_low_i8x16_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extmul_high_i8x16_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extmul_low_i8x16_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_extmul_high_i8x16_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extadd_pairwise_i16x8_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extadd_pairwise_i16x8_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_abs(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_neg(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_all_true(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_bitmask(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extend_low_i16x8_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extend_high_i16x8_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extend_low_i16x8_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extend_high_i16x8_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_shl(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_shr_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_shr_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_add(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_sub(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_mul(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_min_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_min_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_max_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_max_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_dot_i16x8_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extmul_low_i16x8_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extmul_high_i16x8_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extmul_low_i16x8_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_extmul_high_i16x8_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_abs(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_neg(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_all_true(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_bitmask(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_extend_low_i32x4_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_extend_high_i32x4_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_extend_low_i32x4_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_extend_high_i32x4_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_shl(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_shr_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_shr_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_add(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_sub(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_mul(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_extmul_low_i32x4_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_extmul_high_i32x4_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_extmul_low_i32x4_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_extmul_high_i32x4_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_ceil(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_floor(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_trunc(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_nearest(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_abs(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_neg(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_sqrt(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_add(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_sub(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_mul(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_div(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_min(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_max(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_pmin(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_pmax(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_ceil(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_floor(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_trunc(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_nearest(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_abs(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_neg(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_sqrt(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_add(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_sub(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_mul(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_div(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_min(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_max(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_pmin(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_pmax(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_trunc_sat_f32x4_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_trunc_sat_f32x4_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_convert_i32x4_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_convert_i32x4_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_trunc_sat_f64x2_s_zero(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_trunc_sat_f64x2_u_zero(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_convert_low_i32x4_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_convert_low_i32x4_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_demote_f64x2_zero(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_promote_low_f32x4(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_relaxed_swizzle(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_relaxed_trunc_f32x4_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_relaxed_trunc_f32x4_u(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_relaxed_trunc_f64x2_s_zero(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_relaxed_trunc_f64x2_u_zero(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_relaxed_madd(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_relaxed_nmadd(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_relaxed_madd(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_relaxed_nmadd(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i8x16_relaxed_laneselect(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_relaxed_laneselect(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_relaxed_laneselect(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i64x2_relaxed_laneselect(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_relaxed_min(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f32x4_relaxed_max(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_relaxed_min(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_f64x2_relaxed_max(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_relaxed_q15mulr_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i16x8_relaxed_dot_i8x16_i7x16_s(&mut self) -> Self::Output {
+        todo!()
+    }
+
+    fn visit_i32x4_relaxed_dot_i8x16_i7x16_add_s(&mut self) -> Self::Output {
+        todo!()
+    }
+}

--- a/crates/wasmi/src/engine/translator/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/simd/visit.rs
@@ -1,7 +1,7 @@
 use crate::engine::translator::FuncTranslator;
 use wasmparser::{MemArg, VisitSimdOperator};
 
-impl<'a> VisitSimdOperator<'a> for FuncTranslator {
+impl VisitSimdOperator<'_> for FuncTranslator {
     fn visit_v128_load(&mut self, _memarg: MemArg) -> Self::Output {
         todo!()
     }

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -100,6 +100,13 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     wasmparser::for_each_visit_operator!(impl_visit_operator);
 
+    #[cfg(feature = "simd")]
+    fn simd_visitor(
+        &mut self,
+    ) -> Option<&mut dyn wasmparser::VisitSimdOperator<'a, Output = Self::Output>> {
+        Some(self)
+    }
+
     fn visit_unreachable(&mut self) -> Self::Output {
         bail_unreachable!(self);
         self.push_base_instr(Instruction::trap(TrapCode::UnreachableCodeReached))?;


### PR DESCRIPTION
This add foundations for Wasm `simd` proposal support in the `wasmi` crate.