### PR TITLE
Implement `v128.storeN_lane` SIMD instruction translation and execution

### DIFF
--- a/crates/core/src/simd.rs
+++ b/crates/core/src/simd.rs
@@ -95,6 +95,12 @@ macro_rules! impl_imm_lane_id {
                 }
             }
 
+            impl From<$name> for u8 {
+                fn from(lane: $name) -> u8 {
+                    lane.get()
+                }
+            }
+
             impl TryFrom<u8> for $name {
                 type Error = OutOfBoundsLaneIdx;
 

--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -268,6 +268,25 @@ impl Instruction {
     pub fn lane_and_memory_index(value: impl Into<u8>, memory: Memory) -> Self {
         Self::imm16_and_imm32(u16::from(value.into()), u32::from(memory))
     }
+
+    /// Returns `Some` lane and [`index::Memory`] if encoded properly.
+    ///
+    /// # Errors
+    ///
+    /// Returns back `self` if it was an incorrect [`Instruction`].
+    /// This allows for a better error message to inform the user.
+    pub fn filter_lane_and_memory<LaneType>(self) -> Result<(LaneType, index::Memory), Self>
+    where
+        LaneType: TryFrom<u8>,
+    {
+        if let Instruction::Imm16AndImm32 { imm16, imm32 } = self {
+            let Ok(lane) = LaneType::try_from(i16::from(imm16) as u16 as u8) else {
+                return Err(self);
+            };
+            return Ok((lane, index::Memory::from(u32::from(imm32))));
+        }
+        Err(self)
+    }
 }
 
 #[test]

--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -263,6 +263,11 @@ impl Instruction {
         }
         Err(self)
     }
+
+    /// Creates a new [`Instruction::Imm16AndImm32`] from the given `lane` and `memory` index.
+    pub fn lane_and_memory_index(value: impl Into<u8>, memory: Memory) -> Self {
+        Self::imm16_and_imm32(u16::from(value.into()), u32::from(memory))
+    }
 }
 
 #[test]

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1976,16 +1976,26 @@ impl<'engine> Executor<'engine> {
                     self.execute_v128_store_at(&mut store.inner, address, value)?
                 }
                 #[cfg(feature = "simd")]
-                Instr::V128Store8Lane { ptr, offset_lo } => todo!(),
+                Instr::V128Store8Lane { ptr, offset_lo } => {
+                    self.execute_v128_store8_lane(&mut store.inner, ptr, offset_lo)?
+                }
                 #[cfg(feature = "simd")]
                 Instr::V128Store8LaneOffset8 {
                     ptr,
                     value,
                     offset,
                     lane,
-                } => todo!(),
+                } => self.execute_v128_store8_lane_offset8(
+                    &mut store.inner,
+                    ptr,
+                    value,
+                    offset,
+                    lane,
+                )?,
                 #[cfg(feature = "simd")]
-                Instr::V128Store8LaneAt { value, address } => todo!(),
+                Instr::V128Store8LaneAt { value, address } => {
+                    self.execute_v128_store8_lane_at(&mut store.inner, value, address)?
+                }
                 #[cfg(feature = "simd")]
                 Instr::V128Store16Lane { ptr, offset_lo } => todo!(),
                 #[cfg(feature = "simd")]

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1997,38 +1997,68 @@ impl<'engine> Executor<'engine> {
                     self.execute_v128_store8_lane_at(&mut store.inner, value, address)?
                 }
                 #[cfg(feature = "simd")]
-                Instr::V128Store16Lane { ptr, offset_lo } => todo!(),
+                Instr::V128Store16Lane { ptr, offset_lo } => {
+                    self.execute_v128_store16_lane(&mut store.inner, ptr, offset_lo)?
+                }
                 #[cfg(feature = "simd")]
                 Instr::V128Store16LaneOffset8 {
                     ptr,
                     value,
                     offset,
                     lane,
-                } => todo!(),
+                } => self.execute_v128_store16_lane_offset8(
+                    &mut store.inner,
+                    ptr,
+                    value,
+                    offset,
+                    lane,
+                )?,
                 #[cfg(feature = "simd")]
-                Instr::V128Store16LaneAt { value, address } => todo!(),
+                Instr::V128Store16LaneAt { value, address } => {
+                    self.execute_v128_store16_lane_at(&mut store.inner, value, address)?
+                }
                 #[cfg(feature = "simd")]
-                Instr::V128Store32Lane { ptr, offset_lo } => todo!(),
+                Instr::V128Store32Lane { ptr, offset_lo } => {
+                    self.execute_v128_store32_lane(&mut store.inner, ptr, offset_lo)?
+                }
                 #[cfg(feature = "simd")]
                 Instr::V128Store32LaneOffset8 {
                     ptr,
                     value,
                     offset,
                     lane,
-                } => todo!(),
+                } => self.execute_v128_store32_lane_offset8(
+                    &mut store.inner,
+                    ptr,
+                    value,
+                    offset,
+                    lane,
+                )?,
                 #[cfg(feature = "simd")]
-                Instr::V128Store32LaneAt { value, address } => todo!(),
+                Instr::V128Store32LaneAt { value, address } => {
+                    self.execute_v128_store32_lane_at(&mut store.inner, value, address)?
+                }
                 #[cfg(feature = "simd")]
-                Instr::V128Store64Lane { ptr, offset_lo } => todo!(),
+                Instr::V128Store64Lane { ptr, offset_lo } => {
+                    self.execute_v128_store64_lane(&mut store.inner, ptr, offset_lo)?
+                }
                 #[cfg(feature = "simd")]
                 Instr::V128Store64LaneOffset8 {
                     ptr,
                     value,
                     offset,
                     lane,
-                } => todo!(),
+                } => self.execute_v128_store64_lane_offset8(
+                    &mut store.inner,
+                    ptr,
+                    value,
+                    offset,
+                    lane,
+                )?,
                 #[cfg(feature = "simd")]
-                Instr::V128Store64LaneAt { value, address } => todo!(),
+                Instr::V128Store64LaneAt { value, address } => {
+                    self.execute_v128_store64_lane_at(&mut store.inner, value, address)?
+                }
                 #[cfg(feature = "simd")]
                 Instr::V128Load { result, offset_lo } => {
                     self.execute_v128_load(&store.inner, result, offset_lo)?

--- a/crates/wasmi/src/engine/executor/instrs/simd.rs
+++ b/crates/wasmi/src/engine/executor/instrs/simd.rs
@@ -1,14 +1,25 @@
 use super::Executor;
 use crate::{
     core::{
-        simd,
-        simd::{ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx32, ImmLaneIdx4, ImmLaneIdx8},
+        simd::{self, ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx32, ImmLaneIdx4, ImmLaneIdx8},
         UntypedVal,
         WriteAs,
         V128,
     },
     engine::{executor::InstructionPtr, utils::unreachable_unchecked},
-    ir::{AnyConst32, Instruction, Reg, ShiftAmount},
+    ir::{
+        index,
+        Address32,
+        AnyConst32,
+        Instruction,
+        Offset64,
+        Offset64Lo,
+        Offset8,
+        Reg,
+        ShiftAmount,
+    },
+    store::StoreInner,
+    Error,
 };
 
 impl Executor<'_> {
@@ -489,5 +500,75 @@ impl Executor<'_> {
         (Instruction::I64x2ShlBy, execute_i64x2_shl_by, simd::i64x2_shl),
         (Instruction::I64x2ShrSBy, execute_i64x2_shr_s_by, simd::i64x2_shr_s),
         (Instruction::I64x2ShrUBy, execute_i64x2_shr_u_by, simd::i64x2_shr_u),
+    }
+}
+
+impl Executor<'_> {
+    /// Returns the optional `memory` parameter for a `load_at` [`Instruction`].
+    ///
+    /// # Note
+    ///
+    /// - Returns the default [`index::Memory`] if the parameter is missing.
+    /// - Bumps `self.ip` if a [`Instruction::MemoryIndex`] parameter was found.
+    #[inline(always)]
+    fn fetch_lane_and_memory<LaneType>(&mut self, delta: usize) -> (LaneType, index::Memory)
+    where
+        LaneType: TryFrom<u8>,
+    {
+        let mut addr: InstructionPtr = self.ip;
+        addr.add(delta);
+        match addr.get().filter_lane_and_memory() {
+            Ok(value) => value,
+            Err(instr) => unsafe {
+                unreachable_unchecked!(
+                    "expected an `Instruction::Imm16AndImm32` but found: {instr:?}"
+                )
+            },
+        }
+    }
+
+    pub fn execute_v128_store8_lane(
+        &mut self,
+        store: &mut StoreInner,
+        ptr: Reg,
+        offset_lo: Offset64Lo,
+    ) -> Result<(), Error> {
+        let (value, offset_hi) = self.fetch_value_and_offset_hi();
+        let (lane, memory) = self.fetch_lane_and_memory(2);
+        let offset = Offset64::combine(offset_hi, offset_lo);
+        let ptr = self.get_register_as::<u64>(ptr);
+        let v128 = self.get_register_as::<V128>(value);
+        let memory = self.fetch_memory_bytes_mut(memory, store);
+        simd::v128_store8_lane(memory, ptr, u64::from(offset), v128, lane)?;
+        self.try_next_instr_at(3)
+    }
+
+    pub fn execute_v128_store8_lane_offset8(
+        &mut self,
+        store: &mut StoreInner,
+        ptr: Reg,
+        value: Reg,
+        offset: Offset8,
+        lane: ImmLaneIdx16,
+    ) -> Result<(), Error> {
+        let ptr = self.get_register_as::<u64>(ptr);
+        let offset = u64::from(Offset64::from(offset));
+        let v128 = self.get_register_as::<V128>(value);
+        let memory = self.fetch_default_memory_bytes_mut();
+        simd::v128_store8_lane(memory, ptr, offset, v128, lane)?;
+        self.try_next_instr()
+    }
+
+    pub fn execute_v128_store8_lane_at(
+        &mut self,
+        store: &mut StoreInner,
+        value: Reg,
+        address: Address32,
+    ) -> Result<(), Error> {
+        let (lane, memory) = self.fetch_lane_and_memory(1);
+        let v128 = self.get_register_as::<V128>(value);
+        let memory = self.fetch_memory_bytes_mut(memory, store);
+        simd::v128_store8_lane_at(memory, usize::from(address), v128, lane)?;
+        self.try_next_instr_at(2)
     }
 }

--- a/crates/wasmi/src/engine/executor/instrs/simd.rs
+++ b/crates/wasmi/src/engine/executor/instrs/simd.rs
@@ -2,6 +2,7 @@ use super::Executor;
 use crate::{
     core::{
         simd::{self, ImmLaneIdx16, ImmLaneIdx2, ImmLaneIdx32, ImmLaneIdx4, ImmLaneIdx8},
+        TrapCode,
         UntypedVal,
         WriteAs,
         V128,
@@ -526,12 +527,82 @@ impl Executor<'_> {
             },
         }
     }
+}
 
-    pub fn execute_v128_store8_lane(
+macro_rules! impl_execute_v128_store_lane {
+    (
+        $( (Instruction::$op:ident, $lane_ty:ty, $exec:ident, $eval:expr) ),* $(,)?
+    ) => {
+        $(
+            #[doc = concat!("Executes an [`Instruction::", stringify!($op), "`] instruction.")]
+            pub fn $exec(
+                &mut self,
+                store: &mut StoreInner,
+                ptr: Reg,
+                offset_lo: Offset64Lo,
+            ) -> Result<(), Error> {
+                self.execute_v128_store_lane::<$lane_ty>(store, ptr, offset_lo, $eval)
+            }
+        )*
+    };
+}
+
+macro_rules! impl_execute_v128_store_lane_offset16 {
+    (
+        $( (Instruction::$op:ident, $lane_ty:ty, $exec:ident, $eval:expr) ),* $(,)?
+    ) => {
+        $(
+            #[doc = concat!("Executes an [`Instruction::", stringify!($op), "`] instruction.")]
+            pub fn $exec(
+                &mut self,
+                store: &mut StoreInner,
+                ptr: Reg,
+                value: Reg,
+                offset: Offset8,
+                lane: $lane_ty,
+            ) -> Result<(), Error> {
+                self.execute_v128_store_lane_offset8::<$lane_ty>(store, ptr, value, offset, lane, $eval)
+            }
+        )*
+    };
+}
+
+macro_rules! impl_execute_v128_store_lane_at {
+    (
+        $( (Instruction::$op:ident, $lane_ty:ty, $exec:ident, $eval:expr) ),* $(,)?
+    ) => {
+        $(
+            #[doc = concat!("Executes an [`Instruction::", stringify!($op), "`] instruction.")]
+            pub fn $exec(
+                &mut self,
+                store: &mut StoreInner,
+                value: Reg,
+                address: Address32,
+            ) -> Result<(), Error> {
+                self.execute_v128_store_lane_at::<$lane_ty>(store, value, address, $eval)
+            }
+        )*
+    };
+}
+
+type V128StoreLane<LaneType> = fn(
+    memory: &mut [u8],
+    ptr: u64,
+    offset: u64,
+    value: V128,
+    lane: LaneType,
+) -> Result<(), TrapCode>;
+
+type V128StoreLaneAt<LaneType> =
+    fn(memory: &mut [u8], address: usize, value: V128, lane: LaneType) -> Result<(), TrapCode>;
+
+impl Executor<'_> {
+    fn execute_v128_store_lane<LaneType>(
         &mut self,
         store: &mut StoreInner,
         ptr: Reg,
         offset_lo: Offset64Lo,
+        eval: V128StoreLane<LaneType>,
     ) -> Result<(), Error> {
         let (value, offset_hi) = self.fetch_value_and_offset_hi();
         let (lane, memory) = self.fetch_lane_and_memory(2);
@@ -543,32 +614,58 @@ impl Executor<'_> {
         self.try_next_instr_at(3)
     }
 
-    pub fn execute_v128_store8_lane_offset8(
+    impl_execute_v128_store_lane! {
+        (Instruction::V128Store8Lane, ImmLaneIdx16, execute_v128_store8_lane, simd::v128_store8_lane),
+        (Instruction::V128Store16Lane, ImmLaneIdx8, execute_v128_store16_lane, simd::v128_store16_lane),
+        (Instruction::V128Store32Lane, ImmLaneIdx4, execute_v128_store32_lane, simd::v128_store32_lane),
+        (Instruction::V128Store64Lane, ImmLaneIdx2, execute_v128_store64_lane, simd::v128_store64_lane),
+    }
+
+    fn execute_v128_store_lane_offset8<LaneType>(
         &mut self,
         store: &mut StoreInner,
         ptr: Reg,
         value: Reg,
         offset: Offset8,
-        lane: ImmLaneIdx16,
+        lane: LaneType,
+        eval: V128StoreLane<LaneType>,
     ) -> Result<(), Error> {
         let ptr = self.get_register_as::<u64>(ptr);
         let offset = u64::from(Offset64::from(offset));
         let v128 = self.get_register_as::<V128>(value);
         let memory = self.fetch_default_memory_bytes_mut();
-        simd::v128_store8_lane(memory, ptr, offset, v128, lane)?;
+        eval(memory, ptr, offset, v128, lane)?;
         self.try_next_instr()
     }
 
-    pub fn execute_v128_store8_lane_at(
+    impl_execute_v128_store_lane_offset16! {
+        (Instruction::V128Store8LaneOffset8, ImmLaneIdx16, execute_v128_store8_lane_offset8, simd::v128_store8_lane),
+        (Instruction::V128Store16LaneOffset8, ImmLaneIdx8, execute_v128_store16_lane_offset8, simd::v128_store16_lane),
+        (Instruction::V128Store32LaneOffset8, ImmLaneIdx4, execute_v128_store32_lane_offset8, simd::v128_store32_lane),
+        (Instruction::V128Store64LaneOffset8, ImmLaneIdx2, execute_v128_store64_lane_offset8, simd::v128_store64_lane),
+    }
+
+    fn execute_v128_store_lane_at<LaneType>(
         &mut self,
         store: &mut StoreInner,
         value: Reg,
         address: Address32,
-    ) -> Result<(), Error> {
-        let (lane, memory) = self.fetch_lane_and_memory(1);
+        eval: V128StoreLaneAt<LaneType>,
+    ) -> Result<(), Error>
+    where
+        LaneType: TryFrom<u8> + Into<u8>,
+    {
+        let (lane, memory) = self.fetch_lane_and_memory::<LaneType>(1);
         let v128 = self.get_register_as::<V128>(value);
         let memory = self.fetch_memory_bytes_mut(memory, store);
-        simd::v128_store8_lane_at(memory, usize::from(address), v128, lane)?;
+        eval(memory, usize::from(address), v128, lane)?;
         self.try_next_instr_at(2)
+    }
+
+    impl_execute_v128_store_lane_at! {
+        (Instruction::V128Store8LaneAt, ImmLaneIdx16, execute_v128_store8_lane_at, simd::v128_store8_lane_at),
+        (Instruction::V128Store16LaneAt, ImmLaneIdx8, execute_v128_store16_lane_at, simd::v128_store16_lane_at),
+        (Instruction::V128Store32LaneAt, ImmLaneIdx4, execute_v128_store32_lane_at, simd::v128_store32_lane_at),
+        (Instruction::V128Store64LaneAt, ImmLaneIdx2, execute_v128_store64_lane_at, simd::v128_store64_lane_at),
     }
 }

--- a/crates/wasmi/src/engine/executor/instrs/utils.rs
+++ b/crates/wasmi/src/engine/executor/instrs/utils.rs
@@ -1,3 +1,9 @@
+use super::Executor;
+use crate::{
+    ir::{index::Memory, Offset64Hi, Reg},
+    store::StoreInner,
+};
+
 macro_rules! impl_unary_executors {
     ( $( (Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
@@ -18,4 +24,53 @@ macro_rules! impl_binary_executors {
             }
         )*
     };
+}
+
+impl Executor<'_> {
+    /// Returns the register `value` and `offset` parameters for a `load` [`Instruction`].
+    pub fn fetch_value_and_offset_hi(&self) -> (Reg, Offset64Hi) {
+        // Safety: Wasmi translation guarantees that `Instruction::RegisterAndImm32` exists.
+        unsafe { self.fetch_reg_and_offset_hi() }
+    }
+
+    /// Fetches the bytes of the default memory at index 0.
+    #[inline]
+    pub fn fetch_default_memory_bytes_mut(&mut self) -> &mut [u8] {
+        // Safety: the `self.cache.memory` pointer is always synchronized
+        //         conservatively whenever it could have been invalidated.
+        unsafe { self.cache.memory.data_mut() }
+    }
+
+    /// Fetches the bytes of the given `memory`.
+    #[inline]
+    pub fn fetch_memory_bytes_mut<'exec, 'store, 'bytes>(
+        &'exec mut self,
+        memory: Memory,
+        store: &'store mut StoreInner,
+    ) -> &'bytes mut [u8]
+    where
+        'exec: 'bytes,
+        'store: 'bytes,
+    {
+        match memory.is_default() {
+            true => self.fetch_default_memory_bytes_mut(),
+            false => self.fetch_non_default_memory_bytes_mut(memory, store),
+        }
+    }
+
+    /// Fetches the bytes of the given non-default `memory`.
+    #[cold]
+    #[inline]
+    pub fn fetch_non_default_memory_bytes_mut<'exec, 'store, 'bytes>(
+        &'exec mut self,
+        memory: Memory,
+        store: &'store mut StoreInner,
+    ) -> &'bytes mut [u8]
+    where
+        'exec: 'bytes,
+        'store: 'bytes,
+    {
+        let memory = self.get_memory(memory);
+        store.resolve_memory_mut(&memory).data_mut()
+    }
 }

--- a/crates/wasmi/src/engine/executor/instrs/utils.rs
+++ b/crates/wasmi/src/engine/executor/instrs/utils.rs
@@ -4,6 +4,9 @@ use crate::{
     store::StoreInner,
 };
 
+#[cfg(doc)]
+use crate::ir::Instruction;
+
 macro_rules! impl_unary_executors {
     ( $( (Instruction::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(

--- a/crates/wasmi/src/engine/translator/simd/mod.rs
+++ b/crates/wasmi/src/engine/translator/simd/mod.rs
@@ -1,12 +1,25 @@
 mod visit;
 
-use super::{utils::Wrap, FuncTranslator};
+use super::{utils::Wrap, FuncTranslator, Instr, TypedProvider};
 use crate::{
-    core::{simd, TypedVal, V128},
-    engine::{translator::provider::Provider, FuelCosts},
-    ir::{Instruction, IntoShiftAmount, Reg},
+    core::{simd, simd::ImmLaneIdx16, TrapCode, TypedVal, V128},
+    engine::{translator::Provider, FuelCosts},
+    ir::{
+        index,
+        index::Memory,
+        Address32,
+        AnyConst16,
+        Instruction,
+        IntoShiftAmount,
+        Offset16,
+        Offset64,
+        Offset64Lo,
+        Offset8,
+        Reg,
+    },
     Error,
 };
+use wasmparser::MemArg;
 
 trait IntoLane {
     type LaneType: TryFrom<u8>;
@@ -215,5 +228,139 @@ impl FuncTranslator {
             self.alloc.instr_encoder.append_instr(param)?;
         }
         Ok(())
+    }
+
+    fn translate_v128_store8_lane(&mut self, memarg: MemArg, lane: u8) -> Result<(), Error> {
+        bail_unreachable!(self);
+        let Ok(lane) = ImmLaneIdx16::try_from(lane) else {
+            panic!("encountered out of bounds lane index: {lane}");
+        };
+        let (ptr, v128) = self.alloc.stack.pop2();
+        let v128 = match v128 {
+            Provider::Register(v128) => v128,
+            Provider::Const(v128) => {
+                // Case: with `v128` being an immediate value we can extract its
+                //       lane value and translate as a more efficient non-SIMD operation.
+                let v128 = V128::from(v128);
+                let value = simd::i8x16_extract_lane_s(v128, lane);
+                return self.translate_v128_store8_lane_imm::<i32, i8, i8>(
+                    memarg,
+                    ptr,
+                    value,
+                    Instruction::i32_store8_imm,
+                    Instruction::i32_store8_offset16_imm,
+                    Instruction::i32_store8_at_imm,
+                );
+            }
+        };
+        let (memory, offset) = Self::decode_memarg(memarg);
+        let (ptr, offset) = match ptr {
+            Provider::Register(ptr) => (ptr, offset),
+            Provider::Const(ptr) => {
+                let Some(address) = self.effective_address(memory, ptr, offset) else {
+                    return self.translate_trap(TrapCode::MemoryOutOfBounds);
+                };
+                if let Ok(address) = Address32::try_from(address) {
+                    return self.translate_v128_store8_lane_at(
+                        memory,
+                        address,
+                        v128,
+                        lane,
+                        Instruction::v128_store8_lane_at,
+                    );
+                }
+                // Case: we cannot use specialized encoding and thus have to fall back
+                //       to the general case where `ptr` is zero and `offset` stores the
+                //       `ptr+offset` address value.
+                let zero_ptr = self.alloc.stack.alloc_const(0_u64)?;
+                (zero_ptr, u64::from(address))
+            }
+        };
+        if let Ok(Some(_)) = self.translate_v128_store_lane_mem0(
+            memory,
+            ptr,
+            offset,
+            v128,
+            lane,
+            Instruction::v128_store8_lane_offset8,
+        ) {
+            return Ok(());
+        }
+        let (offset_hi, offset_lo) = Offset64::split(offset);
+        let instr = Instruction::v128_store8_lane(ptr, offset_lo);
+        let param = Instruction::register_and_offset_hi(v128, offset_hi);
+        let memidx = Instruction::memory_index(memory);
+        self.push_fueled_instr(instr, FuelCosts::store)?;
+        self.alloc.instr_encoder.append_instr(param)?;
+        if !memory.is_default() {
+            self.alloc.instr_encoder.append_instr(memidx)?;
+        }
+        Ok(())
+    }
+
+    fn translate_v128_store8_lane_imm<Src, Wrapped, Field>(
+        &mut self,
+        memarg: MemArg,
+        ptr: TypedProvider,
+        src: Src,
+        make_instr_imm: fn(ptr: Reg, offset_lo: Offset64Lo) -> Instruction,
+        make_instr_offset16_imm: fn(ptr: Reg, offset: Offset16, value: Field) -> Instruction,
+        make_instr_at_imm: fn(value: Field, address: Address32) -> Instruction,
+    ) -> Result<(), Error>
+    where
+        Src: Copy + Wrap<Wrapped> + From<TypedVal> + Into<TypedVal>,
+        Field: TryFrom<Wrapped> + Into<AnyConst16>,
+    {
+        self.translate_istore_wrap_impl::<Src, Wrapped, Field>(
+            memarg,
+            ptr,
+            Provider::Const(src.into()),
+            |_, _| unreachable!(),
+            make_instr_imm,
+            |_, _, _| unreachable!(),
+            make_instr_offset16_imm,
+            |_, _| unreachable!(),
+            make_instr_at_imm,
+        )
+    }
+
+    fn translate_v128_store8_lane_at<LaneType>(
+        &mut self,
+        memory: index::Memory,
+        address: Address32,
+        value: Reg,
+        lane: LaneType,
+        make_instr_at: fn(value: Reg, address: Address32) -> Instruction,
+    ) -> Result<(), Error>
+    where
+        LaneType: Into<u8>,
+    {
+        self.push_fueled_instr(make_instr_at(value, address), FuelCosts::store)?;
+        self.alloc
+            .instr_encoder
+            .append_instr(Instruction::lane_and_memory_index(lane, memory))?;
+        Ok(())
+    }
+
+    fn translate_v128_store_lane_mem0<LaneType>(
+        &mut self,
+        memory: Memory,
+        ptr: Reg,
+        offset: u64,
+        value: Reg,
+        lane: LaneType,
+        make_instr_offset8: fn(Reg, Reg, Offset8, LaneType) -> Instruction,
+    ) -> Result<Option<Instr>, Error> {
+        if !memory.is_default() {
+            return Ok(None);
+        }
+        let Ok(offset8) = Offset8::try_from(offset) else {
+            return Ok(None);
+        };
+        let instr = self.push_fueled_instr(
+            make_instr_offset8(ptr, value, offset8, lane),
+            FuelCosts::store,
+        )?;
+        Ok(Some(instr))
     }
 }

--- a/crates/wasmi/src/engine/translator/simd/mod.rs
+++ b/crates/wasmi/src/engine/translator/simd/mod.rs
@@ -231,7 +231,7 @@ impl FuncTranslator {
     }
 
     #[allow(clippy::type_complexity)]
-    fn translate_v128_store8_lane<T: IntoLane>(
+    fn translate_v128_store_lane<T: IntoLane>(
         &mut self,
         memarg: MemArg,
         lane: u8,
@@ -272,7 +272,7 @@ impl FuncTranslator {
                     return self.translate_trap(TrapCode::MemoryOutOfBounds);
                 };
                 if let Ok(address) = Address32::try_from(address) {
-                    return self.translate_v128_store8_lane_at::<T>(
+                    return self.translate_v128_store_lane_at::<T>(
                         memory,
                         address,
                         v128,
@@ -304,7 +304,7 @@ impl FuncTranslator {
         Ok(())
     }
 
-    fn translate_v128_store8_lane_imm<Src, Wrapped, Field>(
+    fn translate_v128_store_lane_imm<Src, Wrapped, Field>(
         &mut self,
         memarg: MemArg,
         ptr: TypedProvider,
@@ -330,7 +330,7 @@ impl FuncTranslator {
         )
     }
 
-    fn translate_v128_store8_lane_at<T: IntoLane>(
+    fn translate_v128_store_lane_at<T: IntoLane>(
         &mut self,
         memory: index::Memory,
         address: Address32,

--- a/crates/wasmi/src/engine/translator/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/simd/visit.rs
@@ -161,12 +161,30 @@ impl VisitSimdOperator<'_> for FuncTranslator {
         )
     }
 
-    fn visit_v128_store32_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
-        todo!()
+    fn visit_v128_store32_lane(&mut self, memarg: MemArg, lane: u8) -> Self::Output {
+        self.translate_v128_store_lane::<i32>(
+            memarg,
+            lane,
+            Instruction::v128_store32_lane,
+            Instruction::v128_store32_lane_offset8,
+            Instruction::v128_store32_lane_at,
+            |this, memarg, ptr, lane, v128| {
+                todo!()
+            },
+        )
     }
 
-    fn visit_v128_store64_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
-        todo!()
+    fn visit_v128_store64_lane(&mut self, memarg: MemArg, lane: u8) -> Self::Output {
+        self.translate_v128_store_lane::<i64>(
+            memarg,
+            lane,
+            Instruction::v128_store64_lane,
+            Instruction::v128_store64_lane_offset8,
+            Instruction::v128_store64_lane_at,
+            |this, memarg, ptr, lane, v128| {
+                todo!()
+            },
+        )
     }
 
     fn visit_v128_const(&mut self, value: wasmparser::V128) -> Self::Output {

--- a/crates/wasmi/src/engine/translator/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/simd/visit.rs
@@ -120,7 +120,24 @@ impl VisitSimdOperator<'_> for FuncTranslator {
     }
 
     fn visit_v128_store8_lane(&mut self, memarg: MemArg, lane: u8) -> Self::Output {
-        self.translate_v128_store8_lane(memarg, lane)
+        self.translate_v128_store8_lane::<i8>(
+            memarg,
+            lane,
+            Instruction::v128_store8_lane,
+            Instruction::v128_store8_lane_offset8,
+            Instruction::v128_store8_lane_at,
+            |this, memarg, ptr, lane, v128| {
+                let value = simd::i8x16_extract_lane_s(v128, lane);
+                this.translate_v128_store8_lane_imm::<i32, i8, i8>(
+                    memarg,
+                    ptr,
+                    value,
+                    Instruction::i32_store8_imm,
+                    Instruction::i32_store8_offset16_imm,
+                    Instruction::i32_store8_at_imm,
+                )
+            },
+        )
     }
 
     fn visit_v128_store16_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {

--- a/crates/wasmi/src/engine/translator/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/simd/visit.rs
@@ -120,7 +120,7 @@ impl VisitSimdOperator<'_> for FuncTranslator {
     }
 
     fn visit_v128_store8_lane(&mut self, memarg: MemArg, lane: u8) -> Self::Output {
-        self.translate_v128_store8_lane::<i8>(
+        self.translate_v128_store_lane::<i8>(
             memarg,
             lane,
             Instruction::v128_store8_lane,
@@ -128,7 +128,7 @@ impl VisitSimdOperator<'_> for FuncTranslator {
             Instruction::v128_store8_lane_at,
             |this, memarg, ptr, lane, v128| {
                 let value = simd::i8x16_extract_lane_s(v128, lane);
-                this.translate_v128_store8_lane_imm::<i32, i8, i8>(
+                this.translate_v128_store_lane_imm::<i32, i8, i8>(
                     memarg,
                     ptr,
                     value,
@@ -141,7 +141,7 @@ impl VisitSimdOperator<'_> for FuncTranslator {
     }
 
     fn visit_v128_store16_lane(&mut self, memarg: MemArg, lane: u8) -> Self::Output {
-        self.translate_v128_store8_lane::<i16>(
+        self.translate_v128_store_lane::<i16>(
             memarg,
             lane,
             Instruction::v128_store16_lane,
@@ -149,7 +149,7 @@ impl VisitSimdOperator<'_> for FuncTranslator {
             Instruction::v128_store16_lane_at,
             |this, memarg, ptr, lane, v128| {
                 let value = simd::i16x8_extract_lane_s(v128, lane);
-                this.translate_v128_store8_lane_imm::<i32, i16, i16>(
+                this.translate_v128_store_lane_imm::<i32, i16, i16>(
                     memarg,
                     ptr,
                     value,

--- a/crates/wasmi/src/engine/translator/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/simd/visit.rs
@@ -119,8 +119,8 @@ impl VisitSimdOperator<'_> for FuncTranslator {
         todo!()
     }
 
-    fn visit_v128_store8_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
-        todo!()
+    fn visit_v128_store8_lane(&mut self, memarg: MemArg, lane: u8) -> Self::Output {
+        self.translate_v128_store8_lane(memarg, lane)
     }
 
     fn visit_v128_store16_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {

--- a/crates/wasmi/src/engine/translator/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/simd/visit.rs
@@ -140,8 +140,25 @@ impl VisitSimdOperator<'_> for FuncTranslator {
         )
     }
 
-    fn visit_v128_store16_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {
-        todo!()
+    fn visit_v128_store16_lane(&mut self, memarg: MemArg, lane: u8) -> Self::Output {
+        self.translate_v128_store8_lane::<i16>(
+            memarg,
+            lane,
+            Instruction::v128_store16_lane,
+            Instruction::v128_store16_lane_offset8,
+            Instruction::v128_store16_lane_at,
+            |this, memarg, ptr, lane, v128| {
+                let value = simd::i16x8_extract_lane_s(v128, lane);
+                this.translate_v128_store8_lane_imm::<i32, i16, i16>(
+                    memarg,
+                    ptr,
+                    value,
+                    Instruction::i32_store16_imm,
+                    Instruction::i32_store16_offset16_imm,
+                    Instruction::i32_store16_at_imm,
+                )
+            },
+        )
     }
 
     fn visit_v128_store32_lane(&mut self, _memarg: MemArg, _lane: u8) -> Self::Output {

--- a/crates/wasmi/src/engine/translator/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/simd/visit.rs
@@ -169,7 +169,18 @@ impl VisitSimdOperator<'_> for FuncTranslator {
             Instruction::v128_store32_lane_offset8,
             Instruction::v128_store32_lane_at,
             |this, memarg, ptr, lane, v128| {
-                todo!()
+                let value = simd::i32x4_extract_lane(v128, lane);
+                this.translate_istore_wrap_impl::<i32, i32, i16>(
+                    memarg,
+                    ptr,
+                    Provider::Const(value.into()),
+                    Instruction::store32,
+                    Instruction::i32_store_imm16,
+                    Instruction::store32_offset16,
+                    Instruction::i32_store_offset16_imm16,
+                    Instruction::store32_at,
+                    Instruction::i32_store_at_imm16,
+                )
             },
         )
     }
@@ -182,7 +193,18 @@ impl VisitSimdOperator<'_> for FuncTranslator {
             Instruction::v128_store64_lane_offset8,
             Instruction::v128_store64_lane_at,
             |this, memarg, ptr, lane, v128| {
-                todo!()
+                let value = simd::i64x2_extract_lane(v128, lane);
+                this.translate_istore_wrap_impl::<i64, i64, i16>(
+                    memarg,
+                    ptr,
+                    Provider::Const(value.into()),
+                    Instruction::store64,
+                    Instruction::i64_store_imm16,
+                    Instruction::store64_offset16,
+                    Instruction::i64_store_offset16_imm16,
+                    Instruction::store64_at,
+                    Instruction::i64_store_at_imm16,
+                )
             },
         )
     }

--- a/crates/wast/tests/mod.rs
+++ b/crates/wast/tests/mod.rs
@@ -251,8 +251,8 @@ macro_rules! expand_tests {
             fn wasm_simd_splat("simd_splat");
             fn wasm_simd_store("simd_store");
             fn wasm_simd_store16_lane("simd_store16_lane");
-            #[ignore] fn wasm_simd_store32_lane("simd_store32_lane");
-            #[ignore] fn wasm_simd_store64_lane("simd_store64_lane");
+            fn wasm_simd_store32_lane("simd_store32_lane");
+            fn wasm_simd_store64_lane("simd_store64_lane");
             fn wasm_simd_store8_lane("simd_store8_lane");
         }
     };

--- a/crates/wast/tests/mod.rs
+++ b/crates/wast/tests/mod.rs
@@ -253,7 +253,7 @@ macro_rules! expand_tests {
             #[ignore] fn wasm_simd_store16_lane("simd_store16_lane");
             #[ignore] fn wasm_simd_store32_lane("simd_store32_lane");
             #[ignore] fn wasm_simd_store64_lane("simd_store64_lane");
-            #[ignore] fn wasm_simd_store8_lane("simd_store8_lane");
+            fn wasm_simd_store8_lane("simd_store8_lane");
         }
     };
 }

--- a/crates/wast/tests/mod.rs
+++ b/crates/wast/tests/mod.rs
@@ -250,7 +250,7 @@ macro_rules! expand_tests {
             #[ignore] fn wasm_simd_load_zero("simd_load_zero");
             fn wasm_simd_splat("simd_splat");
             fn wasm_simd_store("simd_store");
-            #[ignore] fn wasm_simd_store16_lane("simd_store16_lane");
+            fn wasm_simd_store16_lane("simd_store16_lane");
             #[ignore] fn wasm_simd_store32_lane("simd_store32_lane");
             #[ignore] fn wasm_simd_store64_lane("simd_store64_lane");
             fn wasm_simd_store8_lane("simd_store8_lane");


### PR DESCRIPTION
| | Instruction |
|:-:|:--|
| ✅ | `v128.store8_lane(m: memarg, data: v128, imm: ImmLaneIdx16)` |
| ✅ | `v128.store16_lane(m: memarg, data: v128, imm: ImmLaneIdx8)` |
| ✅ | `v128.store32_lane(m: memarg, data: v128, imm: ImmLaneIdx4)` |
| ✅ | `v128.store64_lane(m: memarg, data: v128, imm: ImmLaneIdx2)` |