### PR TITLE
Fix some SIMD bugs found by fuzzing

### DIFF
--- a/crates/wasmi/src/engine/translator/simd/mod.rs
+++ b/crates/wasmi/src/engine/translator/simd/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 use wasmparser::MemArg;
 
 trait IntoLane {
-    type LaneType: TryFrom<u8> + Into<u8>;
+    type LaneType: Copy + TryFrom<u8> + Into<u8>;
 }
 
 macro_rules! impl_into_lane_for {
@@ -295,12 +295,10 @@ impl FuncTranslator {
         let (offset_hi, offset_lo) = Offset64::split(offset);
         let instr = make_instr(ptr, offset_lo);
         let param = Instruction::register_and_offset_hi(v128, offset_hi);
-        let memidx = Instruction::memory_index(memory);
+        let param2 = Instruction::lane_and_memory_index(lane, memory);
         self.push_fueled_instr(instr, FuelCosts::store)?;
         self.append_instr(param)?;
-        if !memory.is_default() {
-            self.append_instr(memidx)?;
-        }
+        self.append_instr(param2)?;
         Ok(())
     }
 

--- a/crates/wasmi/src/engine/translator/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/simd/visit.rs
@@ -297,6 +297,7 @@ impl VisitSimdOperator<'_> for FuncTranslator {
     }
 
     fn visit_i8x16_shuffle(&mut self, lanes: [u8; 16]) -> Self::Output {
+        bail_unreachable!(self);
         let selector: [ImmLaneIdx32; 16] = array::from_fn(|i| {
             let Ok(lane) = ImmLaneIdx32::try_from(lanes[i]) else {
                 panic!("encountered out of bounds lane at index {i}: {}", lanes[i])


### PR DESCRIPTION
- Fixed a bug in `i8x16.shuffle` translation where it missed a trivial check for reachability.
- Fixed an encoding bug for `v128.storeN_lane` instructions with offsets that could not be 8-bit encoded.
- Fixed a bug in `v128.shift` instruction translation with immediate `rhs` shift amounts.