### PR TITLE
implement `WasmTy` for `V128`

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -2667,23 +2667,6 @@ impl Executor<'_> {
             },
         }
     }
-
-    /// Fetches the [`Reg`] and [`Offset64Hi`] parameters for a load or store [`Instruction`].
-    unsafe fn fetch_reg_and_lane<LaneType>(&self, delta: usize) -> (Reg, LaneType)
-    where
-        LaneType: TryFrom<u8>,
-    {
-        let mut addr: InstructionPtr = self.ip;
-        addr.add(delta);
-        match addr.get().filter_register_and_lane::<LaneType>() {
-            Ok(value) => value,
-            Err(instr) => unsafe {
-                unreachable_unchecked!(
-                    "expected an `Instruction::RegisterAndImm32` but found: {instr:?}"
-                )
-            },
-        }
-    }
 }
 
 impl Executor<'_> {

--- a/crates/wasmi/src/engine/executor/instrs/simd.rs
+++ b/crates/wasmi/src/engine/executor/instrs/simd.rs
@@ -41,6 +41,32 @@ impl Executor<'_> {
         }
     }
 
+    /// Fetches the [`Reg`] and [`Offset64Hi`] parameters for a load or store [`Instruction`].
+    unsafe fn fetch_reg_and_lane<LaneType>(&self, delta: usize) -> (Reg, LaneType)
+    where
+        LaneType: TryFrom<u8>,
+    {
+        let mut addr: InstructionPtr = self.ip;
+        addr.add(delta);
+        match addr.get().filter_register_and_lane::<LaneType>() {
+            Ok(value) => value,
+            Err(instr) => unsafe {
+                unreachable_unchecked!(
+                    "expected an `Instruction::RegisterAndImm32` but found: {instr:?}"
+                )
+            },
+        }
+    }
+
+    /// Returns the register `value` and `lane` parameters for a `load` [`Instruction`].
+    pub fn fetch_value_and_lane<LaneType>(&self, delta: usize) -> (Reg, LaneType)
+    where
+        LaneType: TryFrom<u8>,
+    {
+        // Safety: Wasmi translation guarantees that `Instruction::RegisterAndImm32` exists.
+        unsafe { self.fetch_reg_and_lane::<LaneType>(delta) }
+    }
+
     /// Fetches a [`Reg`] from an [`Instruction::Const32`] instruction parameter.
     fn fetch_const32_as<T>(&self) -> T
     where

--- a/crates/wasmi/src/engine/executor/instrs/simd.rs
+++ b/crates/wasmi/src/engine/executor/instrs/simd.rs
@@ -23,6 +23,9 @@ use crate::{
     Error,
 };
 
+#[cfg(doc)]
+use crate::ir::Offset64Hi;
+
 impl Executor<'_> {
     /// Fetches a [`Reg`] from an [`Instruction::Register`] instruction parameter.
     fn fetch_register(&self) -> Reg {

--- a/crates/wasmi/src/engine/executor/instrs/utils.rs
+++ b/crates/wasmi/src/engine/executor/instrs/utils.rs
@@ -36,15 +36,6 @@ impl Executor<'_> {
         unsafe { self.fetch_reg_and_offset_hi() }
     }
 
-    /// Returns the register `value` and `lane` parameters for a `load` [`Instruction`].
-    pub fn fetch_value_and_lane<LaneType>(&self, delta: usize) -> (Reg, LaneType)
-    where
-        LaneType: TryFrom<u8>,
-    {
-        // Safety: Wasmi translation guarantees that `Instruction::RegisterAndImm32` exists.
-        unsafe { self.fetch_reg_and_lane::<LaneType>(delta) }
-    }
-
     /// Fetches the bytes of the default memory at index 0.
     pub fn fetch_default_memory_bytes(&self) -> &[u8] {
         // Safety: the `self.cache.memory` pointer is always synchronized

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -2242,7 +2242,7 @@ impl FuncTranslator {
             },
         };
         self.push_fueled_instr(instr, FuelCosts::store)?;
-        self.alloc.instr_encoder.append_instr(param)?;
+        self.append_instr(param)?;
         if !memory.is_default() {
             self.alloc
                 .instr_encoder
@@ -2540,7 +2540,7 @@ impl FuncTranslator {
             }
         };
         self.push_fueled_instr(instr, FuelCosts::base)?;
-        self.alloc.instr_encoder.append_instr(param)?;
+        self.append_instr(param)?;
         Ok(())
     }
 
@@ -2584,7 +2584,7 @@ impl FuncTranslator {
             ),
         };
         self.push_fueled_instr(instr, FuelCosts::base)?;
-        self.alloc.instr_encoder.append_instr(param)?;
+        self.append_instr(param)?;
         Ok(())
     }
 
@@ -2628,7 +2628,7 @@ impl FuncTranslator {
             ),
         };
         self.push_fueled_instr(instr, FuelCosts::base)?;
-        self.alloc.instr_encoder.append_instr(param)?;
+        self.append_instr(param)?;
         Ok(())
     }
 
@@ -2924,7 +2924,7 @@ impl FuncTranslator {
                 }
             },
         };
-        self.alloc.instr_encoder.append_instr(param_instr)?;
+        self.append_instr(param_instr)?;
         self.translate_br_table_targets_simple(&[value])?;
         self.reachable = false;
         Ok(())

--- a/crates/wasmi/src/func/into_func.rs
+++ b/crates/wasmi/src/func/into_func.rs
@@ -3,7 +3,7 @@ use super::{
     TrampolineEntity,
 };
 use crate::{
-    core::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedVal, ValType, F32, F64},
+    core::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedVal, ValType, F32, F64, V128},
     Caller,
     Error,
     ExternRef,
@@ -162,7 +162,9 @@ pub trait WasmTy: From<UntypedVal> + Into<UntypedVal> + Send {
 }
 
 macro_rules! impl_wasm_type {
-    ( $( type $rust_type:ty = $wasmi_type:ident );* $(;)? ) => {
+    ( $(
+        type $rust_type:ty = $wasmi_type:ident );* $(;)?
+    ) => {
         $(
             impl WasmTy for $rust_type {
                 #[inline]
@@ -182,6 +184,7 @@ impl_wasm_type! {
     type F64 = F64;
     type f32 = F32;
     type f64 = F64;
+    type V128 = V128;
     type FuncRef = FuncRef;
     type ExternRef = ExternRef;
 }

--- a/crates/wasmi/src/func/into_func.rs
+++ b/crates/wasmi/src/func/into_func.rs
@@ -3,7 +3,7 @@ use super::{
     TrampolineEntity,
 };
 use crate::{
-    core::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedVal, ValType, F32, F64, V128},
+    core::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedVal, ValType, F32, F64},
     Caller,
     Error,
     ExternRef,
@@ -11,6 +11,9 @@ use crate::{
     FuncType,
 };
 use core::{array, iter::FusedIterator};
+
+#[cfg(feature = "simd")]
+use crate::core::V128;
 
 /// Closures and functions that can be used as host functions.
 pub trait IntoFunc<T, Params, Results>: Send + Sync + 'static {
@@ -163,9 +166,11 @@ pub trait WasmTy: From<UntypedVal> + Into<UntypedVal> + Send {
 
 macro_rules! impl_wasm_type {
     ( $(
+        $( #[$attr:meta] )*
         type $rust_type:ty = $wasmi_type:ident );* $(;)?
     ) => {
         $(
+            $( #[$attr] )*
             impl WasmTy for $rust_type {
                 #[inline]
                 fn ty() -> ValType {
@@ -184,6 +189,7 @@ impl_wasm_type! {
     type F64 = F64;
     type f32 = F32;
     type f64 = F64;
+    #[cfg(feature = "simd")]
     type V128 = V128;
     type FuncRef = FuncRef;
     type ExternRef = ExternRef;


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1435.

- This allows using `V128` values in the `TypedFunc` API.
- This PR also fixes some minor warnings when compiling `wasmi` without the `simd` feature enabled.