### PR TITLE
Fix bug in `v128.replace_lane` execution

### DIFF
--- a/crates/wasmi/src/engine/executor/instrs/simd.rs
+++ b/crates/wasmi/src/engine/executor/instrs/simd.rs
@@ -223,37 +223,37 @@ impl Executor<'_> {
         lane: ImmLaneIdx16,
         value: i8,
     ) {
-        self.execute_replace_lane_impl(result, input, lane, value, simd::i8x16_replace_lane)
+        self.execute_replace_lane_impl(result, input, lane, value, 1, simd::i8x16_replace_lane)
     }
 
     /// Executes an [`Instruction::I16x8ReplaceLaneImm`] instruction.
     pub fn execute_i16x8_replace_lane_imm(&mut self, result: Reg, input: Reg, lane: ImmLaneIdx8) {
         let value = self.fetch_const32_as::<i32>() as i16;
-        self.execute_replace_lane_impl(result, input, lane, value, simd::i16x8_replace_lane)
+        self.execute_replace_lane_impl(result, input, lane, value, 2, simd::i16x8_replace_lane)
     }
 
     /// Executes an [`Instruction::I32x4ReplaceLaneImm`] instruction.
     pub fn execute_i32x4_replace_lane_imm(&mut self, result: Reg, input: Reg, lane: ImmLaneIdx4) {
         let value = self.fetch_const32_as::<i32>();
-        self.execute_replace_lane_impl(result, input, lane, value, simd::i32x4_replace_lane)
+        self.execute_replace_lane_impl(result, input, lane, value, 2, simd::i32x4_replace_lane)
     }
 
     /// Executes an [`Instruction::I64x2ReplaceLaneImm32`] instruction.
     pub fn execute_i64x2_replace_lane_imm32(&mut self, result: Reg, input: Reg, lane: ImmLaneIdx2) {
         let value = self.fetch_i64const32();
-        self.execute_replace_lane_impl(result, input, lane, value, simd::i64x2_replace_lane)
+        self.execute_replace_lane_impl(result, input, lane, value, 2, simd::i64x2_replace_lane)
     }
 
     /// Executes an [`Instruction::F32x4ReplaceLaneImm`] instruction.
     pub fn execute_f32x4_replace_lane_imm(&mut self, result: Reg, input: Reg, lane: ImmLaneIdx4) {
         let value = self.fetch_const32_as::<f32>();
-        self.execute_replace_lane_impl(result, input, lane, value, simd::f32x4_replace_lane)
+        self.execute_replace_lane_impl(result, input, lane, value, 2, simd::f32x4_replace_lane)
     }
 
     /// Executes an [`Instruction::F64x2ReplaceLaneImm32`] instruction.
     pub fn execute_f64x2_replace_lane_imm32(&mut self, result: Reg, input: Reg, lane: ImmLaneIdx2) {
         let value = self.fetch_f64const32();
-        self.execute_replace_lane_impl(result, input, lane, value, simd::f64x2_replace_lane)
+        self.execute_replace_lane_impl(result, input, lane, value, 2, simd::f64x2_replace_lane)
     }
 
     /// Generically execute a SIMD replace lane instruction.
@@ -263,11 +263,12 @@ impl Executor<'_> {
         input: Reg,
         lane: LaneType,
         value: T,
+        delta: usize,
         eval: fn(V128, LaneType, T) -> V128,
     ) {
         let input = self.get_register_as::<V128>(input);
         self.set_register_as::<V128>(result, eval(input, lane, value));
-        self.next_instr_at(2);
+        self.next_instr_at(delta);
     }
 
     impl_unary_executors! {


### PR DESCRIPTION
The bug was that for `i8x16.replace_lane` with an immediate `i8` value the instruction pointer was bumped by 2 instead of 1.

Test case:

```wasm
(module
    (global (;0;) (mut i64) i64.const 0)
    (global (;1;) (mut v128) v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000)
    (global (;2;) (mut i32) i32.const 1000)
    (func (export "0") (result v128)
        (local v128)
        i32.const 1633902446
        i32x4.splat
        f32x4.ceil
        local.tee 0
        v128.const i32x4 0x7fc00000 0x7fc00000 0x7fc00000 0x7fc00000
        local.get 0
        local.get 0
        f32x4.eq
        v128.bitselect
        i32.const 1633902446
        i8x16.replace_lane 14
        loop (result v128) ;; label = @1
            global.get 2
            i32.eqz
            if ;; label = @2
            unreachable
            end
            global.get 2
            i32.const 0
            i32.sub
            global.set 2
            i32.const 1869182049
            f64.const 0x1.100d0d0d02e34p+470 (;=3239726080489628000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000;)
            i64.reinterpret_f64
            global.get 0
            i64.xor
            global.set 0
            drop
            v128.const i32x4 0x10000000 0x00000000 0x0000000f 0x00000000
        end
        global.get 1
        v128.xor
        global.set 1
    )
)
```

Execute via:

```sh
#!/bin/bash

wasmtime --invoke 0 fuzz-fail.wat # returns 129508203819726074458362647973118304110
cargo run -p wasmi_cli --features simd fuzz-fail.wat --invoke 0 # error with: unreachable
```