### PR TITLE
`wasmi_core`: Add missing forwarding functions from the Wasm `relaxed-simd` proposal

### DIFF
--- a/crates/core/src/simd.rs
+++ b/crates/core/src/simd.rs
@@ -1751,6 +1751,48 @@ impl_v128_load_mxn_at! {
     fn v128_load32x2_u_at(memory: &[u8], address: usize) -> Result<V128, TrapCode> = (u32 => u64);
 }
 
+macro_rules! impl_forwarding_relaxed_ops {
+    (
+        $(
+            fn $name:ident(
+                $( $param_name:ident: $param_ty:ty ),* $(,)?
+            ) -> $ret_ty:ty
+            = $forward_fn:expr
+        );* $(;)?
+    ) => {
+        $(
+            #[doc = concat!("Executes a Wasm `", stringify!($name), "` instruction.")]
+            #[doc = ""]
+            #[doc = "# Note"]
+            #[doc = ""]
+            #[doc = "This is part of the `relaxed-simd` Wasm proposal."]
+            pub fn $name( $( $param_name: $param_ty ),* ) -> $ret_ty {
+                $forward_fn( $( $param_name ),* )
+            }
+        )*
+    };
+}
+impl_forwarding_relaxed_ops! {
+    fn i8x16_relaxed_swizzle(a: V128, s: V128) -> V128 = i8x16_swizzle;
+
+    fn i8x16_relaxed_laneselect(a: V128, b: V128, c: V128) -> V128 = v128_bitselect;
+    fn i16x8_relaxed_laneselect(a: V128, b: V128, c: V128) -> V128 = v128_bitselect;
+    fn i32x4_relaxed_laneselect(a: V128, b: V128, c: V128) -> V128 = v128_bitselect;
+    fn i64x2_relaxed_laneselect(a: V128, b: V128, c: V128) -> V128 = v128_bitselect;
+
+    fn f32x4_relaxed_min(lhs: V128, rhs: V128) -> V128 = f32x4_min;
+    fn f32x4_relaxed_max(lhs: V128, rhs: V128) -> V128 = f32x4_max;
+    fn f64x2_relaxed_min(lhs: V128, rhs: V128) -> V128 = f64x2_min;
+    fn f64x2_relaxed_max(lhs: V128, rhs: V128) -> V128 = f64x2_max;
+
+    fn i16x8_relaxed_q15mulr_s(a: V128, b: V128) -> V128 = i16x8_q15mulr_sat_s;
+
+    fn i32x4_relaxed_trunc_f32x4_s(input: V128) -> V128 = i32x4_trunc_sat_f32x4_s;
+    fn i32x4_relaxed_trunc_f32x4_u(input: V128) -> V128 = i32x4_trunc_sat_f32x4_u;
+    fn i32x4_relaxed_trunc_f64x2_s_zero(input: V128) -> V128 = i32x4_trunc_sat_f64x2_s_zero;
+    fn i32x4_relaxed_trunc_f64x2_u_zero(input: V128) -> V128 = i32x4_trunc_sat_f64x2_u_zero;
+}
+
 #[test]
 fn i32x4_dot_i16x8_s_works() {
     assert_eq!(

--- a/crates/core/src/simd.rs
+++ b/crates/core/src/simd.rs
@@ -1298,6 +1298,10 @@ pub fn i32x4_dot_i16x8_s(lhs: V128, rhs: V128) -> V128 {
 }
 
 /// Executes a Wasm `i16x8.relaxed_dot_i8x16_i7x16_s` instruction.
+/// 
+/// # Note
+/// 
+/// This is part of the `relaxed-simd` Wasm proposal.
 pub fn i16x8_relaxed_dot_i8x16_i7x16_s(lhs: V128, rhs: V128) -> V128 {
     fn dot(a: [i8; 2], b: [i8; 2]) -> i16 {
         let a = a.map(i16::from);
@@ -1310,6 +1314,10 @@ pub fn i16x8_relaxed_dot_i8x16_i7x16_s(lhs: V128, rhs: V128) -> V128 {
 }
 
 /// Executes a Wasm `i32x4.relaxed_dot_i8x16_i7x16_add_s` instruction.
+/// 
+/// # Note
+/// 
+/// This is part of the `relaxed-simd` Wasm proposal.
 pub fn i32x4_relaxed_dot_i8x16_i7x16_add_s(lhs: V128, rhs: V128, c: V128) -> V128 {
     let dot = i16x8_relaxed_dot_i8x16_i7x16_s(lhs, rhs);
     let ext = i32x4_extadd_pairwise_i16x8_s(dot);
@@ -1333,6 +1341,10 @@ macro_rules! impl_ternary_for {
     ( $( fn $name:ident(a: V128, b: V128, c: V128) -> V128 = $lanewise_expr:expr; )* ) => {
         $(
             #[doc = concat!("Executes a Wasm `", stringify!($name), "` instruction.")]
+            #[doc = ""]
+            #[doc = "# Note"]
+            #[doc = ""]
+            #[doc = "This is part of the `relaxed-simd` Wasm proposal."]
             pub fn $name(a: V128, b: V128, c: V128) -> V128 {
                 V128::lanewise_ternary(a, b, c, $lanewise_expr)
             }

--- a/crates/core/src/simd.rs
+++ b/crates/core/src/simd.rs
@@ -1298,9 +1298,9 @@ pub fn i32x4_dot_i16x8_s(lhs: V128, rhs: V128) -> V128 {
 }
 
 /// Executes a Wasm `i16x8.relaxed_dot_i8x16_i7x16_s` instruction.
-/// 
+///
 /// # Note
-/// 
+///
 /// This is part of the `relaxed-simd` Wasm proposal.
 pub fn i16x8_relaxed_dot_i8x16_i7x16_s(lhs: V128, rhs: V128) -> V128 {
     fn dot(a: [i8; 2], b: [i8; 2]) -> i16 {
@@ -1314,9 +1314,9 @@ pub fn i16x8_relaxed_dot_i8x16_i7x16_s(lhs: V128, rhs: V128) -> V128 {
 }
 
 /// Executes a Wasm `i32x4.relaxed_dot_i8x16_i7x16_add_s` instruction.
-/// 
+///
 /// # Note
-/// 
+///
 /// This is part of the `relaxed-simd` Wasm proposal.
 pub fn i32x4_relaxed_dot_i8x16_i7x16_add_s(lhs: V128, rhs: V128, c: V128) -> V128 {
     let dot = i16x8_relaxed_dot_i8x16_i7x16_s(lhs, rhs);


### PR DESCRIPTION
These methods are unused in Wasmi since Wasmi translates those `relaxed-simd` operators as their non-relaxed counterparts. However, for completeness I think it makes sense to add these missing `relaxed-simd` methods to `wasmi_core` since it tries to be a general purpose Wasm SIMD API.