### PR TITLE
Improve GitHub Actions CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -211,8 +211,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
-      - name: Set up Rust cache
-        uses: Swatinem/rust-cache@v2
       - name: Install cargo-udeps
         run: |
           # Note: We use `|| true` because cargo install returns an error

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   # Pin nightly so that it does not invalidate GitHub Actions cache too frequently.
-  RUST_NIGHTLY_VERSION: nightly-2025-03-18
+  RUST_NIGHTLY_VERSION: nightly-2025-03-30
 
 jobs:
   check:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
+          components: rust-src
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Show Rust Toolchain

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Pin nightly so that it does not invalidate GitHub Actions cache too frequently.
+  RUST_NIGHTLY_VERSION: nightly-2025-03-18
+
 jobs:
   check:
     name: Build
@@ -79,7 +83,9 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Show Rust Toolchain
@@ -143,8 +149,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
           components: rustfmt
       - name: Foramtting
         run: cargo fmt --all -- --check
@@ -201,7 +208,9 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Install cargo-udeps
@@ -224,8 +233,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@master
         with:
-          # Pin nightly so that it does not invalidate GitHub Actions cache too frequently.
-          toolchain: nightly-2025-03-18
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -269,8 +277,9 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
           components: miri
           targets: x86_64-unknown-linux-gnu
       - name: Set up Rust cache
@@ -294,8 +303,9 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
           components: miri
           targets: x86_64-unknown-linux-gnu
       - name: Set up Rust cache
@@ -320,8 +330,9 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
           components: clippy
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
@@ -350,7 +361,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Generate code coverage


### PR DESCRIPTION
- All CI jobs that use Rust `nightly` now use the same pinned nightly Rust version. This helps with CI caching.
- The `udeps` job no longer uses caching as it is not really worth it.
- The used nightly Rust version has been update to `nightly-2025-03-30`.