### PR TITLE
Implement `core::error::Error` for all error types

### DIFF
--- a/crates/core/src/untyped.rs
+++ b/crates/core/src/untyped.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "simd")]
 use crate::V128;
 use crate::{F32, F64};
-use core::fmt::{self, Display};
+use core::{error::Error, fmt::{self, Display}};
 
 /// An untyped value.
 ///
@@ -300,8 +300,7 @@ impl UntypedError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for UntypedError {}
+impl Error for UntypedError {}
 
 impl Display for UntypedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/core/src/untyped.rs
+++ b/crates/core/src/untyped.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "simd")]
 use crate::V128;
 use crate::{F32, F64};
-use core::{error::Error, fmt::{self, Display}};
+use core::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 /// An untyped value.
 ///

--- a/crates/ir/src/error.rs
+++ b/crates/ir/src/error.rs
@@ -24,5 +24,4 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -74,8 +74,7 @@ pub struct ResumableHostError {
     caller_results: RegSpan,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ResumableHostError {}
+impl core::error::Error for ResumableHostError {}
 
 impl fmt::Display for ResumableHostError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/wasmi/src/engine/limits/engine.rs
+++ b/crates/wasmi/src/engine/limits/engine.rs
@@ -1,4 +1,4 @@
-use core::fmt::{self, Display};
+use core::{error::Error, fmt::{self, Display}};
 
 /// An error that can occur upon parsing or compiling a Wasm module when [`EnforcedLimits`] are set.
 #[derive(Debug, Copy, Clone)]
@@ -23,8 +23,7 @@ pub enum EnforcedLimitsError {
     MinAvgBytesPerFunction { limit: u32, avg: u32 },
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for EnforcedLimitsError {}
+impl Error for EnforcedLimitsError {}
 
 impl Display for EnforcedLimitsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/wasmi/src/engine/limits/engine.rs
+++ b/crates/wasmi/src/engine/limits/engine.rs
@@ -1,4 +1,7 @@
-use core::{error::Error, fmt::{self, Display}};
+use core::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 /// An error that can occur upon parsing or compiling a Wasm module when [`EnforcedLimits`] are set.
 #[derive(Debug, Copy, Clone)]

--- a/crates/wasmi/src/engine/limits/stack.rs
+++ b/crates/wasmi/src/engine/limits/stack.rs
@@ -1,7 +1,6 @@
 use crate::core::UntypedVal;
 use core::{
-    fmt::{self, Display},
-    mem::size_of,
+    error::Error, fmt::{self, Display}, mem::size_of
 };
 
 /// Default value for initial value stack height in bytes.
@@ -31,8 +30,7 @@ pub enum LimitsError {
     InitialValueStackExceedsMaximum,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LimitsError {}
+impl Error for LimitsError {}
 
 impl Display for LimitsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/wasmi/src/engine/limits/stack.rs
+++ b/crates/wasmi/src/engine/limits/stack.rs
@@ -1,6 +1,8 @@
 use crate::core::UntypedVal;
 use core::{
-    error::Error, fmt::{self, Display}, mem::size_of
+    error::Error,
+    fmt::{self, Display},
+    mem::size_of,
 };
 
 /// Default value for initial value stack height in bytes.

--- a/crates/wasmi/src/engine/translator/error.rs
+++ b/crates/wasmi/src/engine/translator/error.rs
@@ -1,4 +1,4 @@
-use core::fmt::{self, Display};
+use core::{error::Error, fmt::{self, Display}};
 
 /// An error that may occur upon parsing, validating and translating Wasm.
 #[derive(Debug)]
@@ -43,8 +43,7 @@ impl TranslationError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TranslationError {}
+impl Error for TranslationError {}
 
 impl Display for TranslationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/wasmi/src/engine/translator/error.rs
+++ b/crates/wasmi/src/engine/translator/error.rs
@@ -1,4 +1,7 @@
-use core::{error::Error, fmt::{self, Display}};
+use core::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 /// An error that may occur upon parsing, validating and translating Wasm.
 #[derive(Debug)]

--- a/crates/wasmi/src/engine/translator/labels.rs
+++ b/crates/wasmi/src/engine/translator/labels.rs
@@ -61,8 +61,7 @@ pub enum LabelError {
     Unpinned { label: LabelRef },
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LabelError {}
+impl core::error::Error for LabelError {}
 
 impl Display for LabelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -141,8 +141,7 @@ impl Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -242,8 +241,7 @@ impl ErrorKind {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ErrorKind {}
+impl core::error::Error for ErrorKind {}
 
 impl Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/wasmi/src/func/error.rs
+++ b/crates/wasmi/src/func/error.rs
@@ -1,5 +1,5 @@
 use crate::core::FuncTypeError as CoreFuncTypeError;
-use core::{fmt, fmt::Display};
+use core::{error::Error, fmt::{self, Display}};
 
 /// Errors that can occur upon type checking function signatures.
 #[derive(Debug)]
@@ -28,8 +28,7 @@ impl From<CoreFuncTypeError> for FuncError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FuncError {}
+impl Error for FuncError {}
 
 impl Display for FuncError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/wasmi/src/func/error.rs
+++ b/crates/wasmi/src/func/error.rs
@@ -1,5 +1,8 @@
 use crate::core::FuncTypeError as CoreFuncTypeError;
-use core::{error::Error, fmt::{self, Display}};
+use core::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 /// Errors that can occur upon type checking function signatures.
 #[derive(Debug)]

--- a/crates/wasmi/src/global.rs
+++ b/crates/wasmi/src/global.rs
@@ -5,7 +5,7 @@ use crate::{
     value::WithType,
     Val,
 };
-use core::{fmt, fmt::Display, ptr::NonNull};
+use core::{error::Error, fmt::{self, Display}, ptr::NonNull};
 
 /// A raw index to a global variable entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -46,8 +46,7 @@ pub enum GlobalError {
     },
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for GlobalError {}
+impl Error for GlobalError {}
 
 impl Display for GlobalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/wasmi/src/global.rs
+++ b/crates/wasmi/src/global.rs
@@ -5,7 +5,11 @@ use crate::{
     value::WithType,
     Val,
 };
-use core::{error::Error, fmt::{self, Display}, ptr::NonNull};
+use core::{
+    error::Error,
+    fmt::{self, Display},
+    ptr::NonNull,
+};
 
 /// A raw index to a global variable entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -29,7 +29,8 @@ use alloc::{
     vec::Vec,
 };
 use core::{
-    fmt::{self, Debug, Display}, marker::PhantomData
+    fmt::{self, Debug, Display},
+    marker::PhantomData,
 };
 
 /// An error that may occur upon operating with [`Linker`] instances.

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -29,8 +29,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{
-    fmt::{self, Debug, Display},
-    marker::PhantomData,
+    fmt::{self, Debug, Display}, marker::PhantomData
 };
 
 /// An error that may occur upon operating with [`Linker`] instances.
@@ -150,8 +149,7 @@ impl LinkerError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LinkerError {}
+impl core::error::Error for LinkerError {}
 
 impl Display for LinkerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/wasmi/src/memory/error.rs
+++ b/crates/wasmi/src/memory/error.rs
@@ -1,5 +1,5 @@
 use super::MemoryType;
-use core::{fmt, fmt::Display};
+use core::{error::Error, fmt::{self, Display}};
 
 /// An error that may occur upon operating with virtual or linear memory.
 #[derive(Debug)]
@@ -32,8 +32,7 @@ pub enum MemoryError {
     MaximumSizeOverflow,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for MemoryError {}
+impl Error for MemoryError {}
 
 impl Display for MemoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/wasmi/src/memory/error.rs
+++ b/crates/wasmi/src/memory/error.rs
@@ -1,5 +1,8 @@
 use super::MemoryType;
-use core::{error::Error, fmt::{self, Display}};
+use core::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 /// An error that may occur upon operating with virtual or linear memory.
 #[derive(Debug)]

--- a/crates/wasmi/src/module/instantiate/error.rs
+++ b/crates/wasmi/src/module/instantiate/error.rs
@@ -6,7 +6,7 @@ use crate::{
     FuncType,
     Table,
 };
-use core::{fmt, fmt::Display};
+use core::{error::Error, fmt::{self, Display}};
 
 /// An error that may occur upon instantiation of a Wasm module.
 #[derive(Debug)]
@@ -57,8 +57,7 @@ pub enum InstantiationError {
     TooManyInstances,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for InstantiationError {}
+impl Error for InstantiationError {}
 
 impl Display for InstantiationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/wasmi/src/module/instantiate/error.rs
+++ b/crates/wasmi/src/module/instantiate/error.rs
@@ -6,7 +6,10 @@ use crate::{
     FuncType,
     Table,
 };
-use core::{error::Error, fmt::{self, Display}};
+use core::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 /// An error that may occur upon instantiation of a Wasm module.
 #[derive(Debug)]

--- a/crates/wasmi/src/module/read.rs
+++ b/crates/wasmi/src/module/read.rs
@@ -1,4 +1,7 @@
-use core::{error::Error, fmt::{self, Display}};
+use core::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 #[cfg(feature = "std")]
 use std::io;

--- a/crates/wasmi/src/module/read.rs
+++ b/crates/wasmi/src/module/read.rs
@@ -1,4 +1,4 @@
-use core::{fmt, fmt::Display};
+use core::{error::Error, fmt::{self, Display}};
 
 #[cfg(feature = "std")]
 use std::io;
@@ -12,8 +12,7 @@ pub enum ReadError {
     UnknownError,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ReadError {}
+impl Error for ReadError {}
 
 impl Display for ReadError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -35,7 +35,10 @@ use crate::{
 };
 use alloc::{boxed::Box, sync::Arc};
 use core::{
-    any::{type_name, TypeId}, fmt::{self, Debug}, mem, sync::atomic::{AtomicU32, Ordering}
+    any::{type_name, TypeId},
+    fmt::{self, Debug},
+    mem,
+    sync::atomic::{AtomicU32, Ordering},
 };
 
 /// A unique store index.

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -35,10 +35,7 @@ use crate::{
 };
 use alloc::{boxed::Box, sync::Arc};
 use core::{
-    any::{type_name, TypeId},
-    fmt::{self, Debug},
-    mem,
-    sync::atomic::{AtomicU32, Ordering},
+    any::{type_name, TypeId}, fmt::{self, Debug}, mem, sync::atomic::{AtomicU32, Ordering}
 };
 
 /// A unique store index.
@@ -447,8 +444,7 @@ pub enum FuelError {
     OutOfFuel,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for FuelError {}
+impl core::error::Error for FuelError {}
 
 impl fmt::Display for FuelError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/wasmi/src/table/error.rs
+++ b/crates/wasmi/src/table/error.rs
@@ -1,6 +1,9 @@
 use super::TableType;
 use crate::core::ValType;
-use core::{error::Error, fmt::{self, Display}};
+use core::{
+    error::Error,
+    fmt::{self, Display},
+};
 
 /// Errors that may occur upon operating with table entities.
 #[derive(Debug)]

--- a/crates/wasmi/src/table/error.rs
+++ b/crates/wasmi/src/table/error.rs
@@ -1,6 +1,6 @@
 use super::TableType;
 use crate::core::ValType;
-use core::{fmt, fmt::Display};
+use core::{error::Error, fmt::{self, Display}};
 
 /// Errors that may occur upon operating with table entities.
 #[derive(Debug)]
@@ -49,8 +49,7 @@ pub enum TableError {
     TooManyTables,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TableError {}
+impl Error for TableError {}
 
 impl Display for TableError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/wasmi/tests/integration/host_call_instantiation.rs
+++ b/crates/wasmi/tests/integration/host_call_instantiation.rs
@@ -27,7 +27,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 impl wasmi::core::HostError for Error {}
 
 #[test]


### PR DESCRIPTION
This way we no longer have to conditionally compile for `std`.