### PR TITLE
Make `FromWasmparser` impls only use pub APIs

### DIFF
--- a/crates/wasmi/src/module/utils.rs
+++ b/crates/wasmi/src/module/utils.rs
@@ -1,4 +1,4 @@
-use crate::{core::ValType, FuncType, GlobalType, IndexType, MemoryType, Mutability, TableType};
+use crate::{core::ValType, FuncType, GlobalType, MemoryType, Mutability, TableType};
 use wasmparser::AbstractHeapType;
 
 /// Types that can be created from `wasmparser` definitions.
@@ -22,11 +22,18 @@ impl FromWasmparser<wasmparser::TableType> for TableType {
         let element = WasmiValueType::from(table_type.element_type).into_inner();
         let minimum: u64 = table_type.initial;
         let maximum: Option<u64> = table_type.maximum;
-        let index_ty = match table_type.table64 {
-            true => IndexType::I64,
-            false => IndexType::I32,
-        };
-        Self::new_impl(element, index_ty, minimum, maximum)
+        match table_type.table64 {
+            true => Self::new64(element, minimum, maximum),
+            false => {
+                let Ok(minimum) = u32::try_from(minimum) else {
+                    panic!("invalid 32-bit table.minimum: {minimum}")
+                };
+                let Ok(maximum) = maximum.map(u32::try_from).transpose() else {
+                    panic!("invalid 32-bit table.maximum: {maximum:?}")
+                };
+                Self::new(element, minimum, maximum)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Carved out from #1460.

This is in anticipation to simplify merging the original PR.