### PR TITLE
Re-design `GlobalEntity` API

### DIFF
--- a/crates/wasmi/src/global.rs
+++ b/crates/wasmi/src/global.rs
@@ -185,20 +185,8 @@ impl GlobalEntity {
                 encountered: new_value.ty(),
             });
         }
-        self.set_untyped(new_value.into());
+        self.value = new_value.into();
         Ok(())
-    }
-
-    /// Sets a new untyped value for the global variable.
-    ///
-    /// # Note
-    ///
-    /// This is an inherently unsafe API and only exists to allow
-    /// for efficient `global.set` through the interpreter which is
-    /// safe since the interpreter only handles validated Wasm code
-    /// where the checks in [`Global::set`] cannot fail.
-    pub(crate) fn set_untyped(&mut self, new_value: UntypedVal) {
-        self.value = new_value;
     }
 
     /// Returns the current value of the global variable.
@@ -207,8 +195,8 @@ impl GlobalEntity {
     }
 
     /// Returns the current untyped value of the global variable.
-    pub(crate) fn get_untyped(&self) -> UntypedVal {
-        self.value
+    pub(crate) fn get_untyped(&self) -> &UntypedVal {
+        &self.value
     }
 
     /// Returns a pointer to the untyped value of the global variable.


### PR DESCRIPTION
Carved out from #1460.

This is in anticipation to simplify merging of the original PR.