### PR TITLE
Remove unused `StoreInner` API

### DIFF
--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -54,10 +54,6 @@ impl Module {
     where
         I: IntoIterator<Item = Extern, IntoIter: ExactSizeIterator>,
     {
-        context
-            .as_context_mut()
-            .store
-            .check_new_instances_limit(1)?;
         let mut context = context.as_context_mut().store;
         if !context.can_create_more_instances(1) {
             return Err(Error::from(InstantiationError::TooManyInstances));

--- a/crates/wasmi/src/store.rs
+++ b/crates/wasmi/src/store.rs
@@ -5,7 +5,6 @@ use crate::{
     externref::{ExternObject, ExternObjectEntity, ExternObjectIdx},
     func::{FuncInOut, HostFuncEntity, Trampoline, TrampolineEntity, TrampolineIdx},
     memory::DataSegment,
-    module::InstantiationError,
     Config,
     DataSegmentEntity,
     DataSegmentIdx,
@@ -1210,19 +1209,6 @@ impl<T> Store<T> {
             }
         }
         true
-    }
-
-    pub(crate) fn check_new_instances_limit(
-        &mut self,
-        num_new_instances: usize,
-    ) -> Result<(), InstantiationError> {
-        let (inner, mut limiter) = self.store_inner_and_resource_limiter_ref();
-        if let Some(limiter) = limiter.as_resource_limiter() {
-            if inner.instances.len().saturating_add(num_new_instances) > limiter.instances() {
-                return Err(InstantiationError::TooManyInstances);
-            }
-        }
-        Ok(())
     }
 
     pub(crate) fn store_inner_and_resource_limiter_ref(


### PR DESCRIPTION
This was an oversight in https://github.com/wasmi-labs/wasmi/pull/1474.