### PR TITLE
Unconfuse `rust-analyzer`

### DIFF
--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -3221,7 +3221,7 @@ trait BumpFuelConsumption {
 impl BumpFuelConsumption for Instruction {
     fn bump_fuel_consumption(&mut self, delta: u64) -> Result<(), Error> {
         match self {
-            Self::ConsumeFuel { block_fuel } => block_fuel.bump_by(delta).map_err(Into::into),
+            Self::ConsumeFuel { block_fuel } => block_fuel.bump_by(delta).map_err(Error::from),
             instr => panic!("expected `Instruction::ConsumeFuel` but found: {instr:?}"),
         }
     }


### PR DESCRIPTION
A bug in rust-analyzer but I want to get rid of the annoying warnings.