### PR TITLE
Redesign `bulk-memory` instruction variants

### DIFF
--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -4775,8 +4775,8 @@ macro_rules! for_each_op_grouped {
                 /// # Encoding
                 ///
                 /// Followed by [`Instruction::TableIndex`] encoding the Wasm `table` instance.
-                #[snake_name(table_fill_exact)]
-                TableFillExact {
+                #[snake_name(table_fill_imm)]
+                TableFillImm {
                     /// The start index of the table to fill.
                     dst: Reg,
                     /// The number of elements to fill.

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5129,57 +5129,6 @@ macro_rules! for_each_op_grouped {
                     /// The number of copied bytes.
                     len: Reg,
                 },
-                /// Variant of [`Instruction::MemoryCopy`] with a constant 16-bit `dst` index.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the `dst` Wasm linear memory instance
-                /// 2. [`Instruction::MemoryIndex`]: the `src` Wasm linear memory instance
-                #[snake_name(memory_copy_to)]
-                MemoryCopyTo {
-                    /// The start index of the `dst` memory.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` memory.
-                    src: Reg,
-                    /// The number of copied bytes.
-                    len: Reg,
-                },
-                /// Variant of [`Instruction::MemoryCopy`] with a constant 16-bit `src` index.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the `dst` Wasm linear memory instance
-                /// 2. [`Instruction::MemoryIndex`]: the `src` Wasm linear memory instance
-                #[snake_name(memory_copy_from)]
-                MemoryCopyFrom {
-                    /// The start index of the `dst` memory.
-                    dst: Reg,
-                    /// The start index of the `src` memory.
-                    src: Const16<u64>,
-                    /// The number of copied bytes.
-                    len: Reg,
-                },
-                /// Variant of [`Instruction::MemoryCopy`] with a constant 16-bit `dst` and `src` indices.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the `dst` Wasm linear memory instance
-                /// 2. [`Instruction::MemoryIndex`]: the `src` Wasm linear memory instance
-                #[snake_name(memory_copy_from_to)]
-                MemoryCopyFromTo {
-                    /// The start index of the `dst` memory.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` memory.
-                    src: Const16<u64>,
-                    /// The number of copied bytes.
-                    len: Reg,
-                },
                 /// Variant of [`Instruction::MemoryCopy`] with a constant 16-bit `len` field.
                 ///
                 /// # Note
@@ -5198,69 +5147,6 @@ macro_rules! for_each_op_grouped {
                     dst: Reg,
                     /// The start index of the `src` memory.
                     src: Reg,
-                    /// The number of copied bytes.
-                    len: Const16<u64>,
-                },
-                /// Variant of [`Instruction::MemoryCopy`] with a constant 16-bit `len` and `dst`.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the memories.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the `dst` Wasm linear memory instance
-                /// 2. [`Instruction::MemoryIndex`]: the `src` Wasm linear memory instance
-                #[snake_name(memory_copy_to_exact)]
-                MemoryCopyToExact {
-                    /// The start index of the `dst` memory.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` memory.
-                    src: Reg,
-                    /// The number of copied bytes.
-                    len: Const16<u64>,
-                },
-                /// Variant of [`Instruction::MemoryCopy`] with a constant 16-bit `len` and `src`.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the memories.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the `dst` Wasm linear memory instance
-                /// 2. [`Instruction::MemoryIndex`]: the `src` Wasm linear memory instance
-                #[snake_name(memory_copy_from_exact)]
-                MemoryCopyFromExact {
-                    /// The start index of the `dst` memory.
-                    dst: Reg,
-                    /// The start index of the `src` memory.
-                    src: Const16<u64>,
-                    /// The number of copied bytes.
-                    len: Const16<u64>,
-                },
-                /// Variant of [`Instruction::MemoryCopy`] with a constant 16-bit `len` and `src`.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the memories.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the `dst` Wasm linear memory instance
-                /// 2. [`Instruction::MemoryIndex`]: the `src` Wasm linear memory instance
-                #[snake_name(memory_copy_from_to_exact)]
-                MemoryCopyFromToExact {
-                    /// The start index of the `dst` memory.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` memory.
-                    src: Const16<u64>,
                     /// The number of copied bytes.
                     len: Const16<u64>,
                 },

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5293,8 +5293,8 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// 1. [`Instruction::MemoryIndex`]: the Wasm `memory` instance
                 /// 1. [`Instruction::DataIndex`]: the `data` segment to initialize the memory
-                #[snake_name(memory_init_exact)]
-                MemoryInitExact {
+                #[snake_name(memory_init_imm)]
+                MemoryInitImm {
                     /// The start index of the `dst` memory.
                     dst: Reg,
                     /// The start index of the `src` data segment.

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -4746,8 +4746,8 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// 1. [`Instruction::TableIndex`]: the Wasm `table` instance
                 /// 2. [`Instruction::ElemIndex`]: the Wasm `element` segment instance
-                #[snake_name(table_init_exact)]
-                TableInitExact {
+                #[snake_name(table_init_imm)]
+                TableInitImm {
                     /// The start index of the `dst` table.
                     dst: Reg,
                     /// The start index of the `src` table.

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5285,57 +5285,6 @@ macro_rules! for_each_op_grouped {
                     /// The number of bytes to initialize.
                     len: Reg,
                 },
-                /// Variant of [`Instruction::MemoryInit`] with a constant 16-bit `dst` index.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the Wasm `memory` instance
-                /// 1. [`Instruction::DataIndex`]: the `data` segment to initialize the memory
-                #[snake_name(memory_init_to)]
-                MemoryInitTo {
-                    /// The start index of the `dst` memory.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` data segment.
-                    src: Reg,
-                    /// The number of initialized bytes.
-                    len: Reg,
-                },
-                /// Variant of [`Instruction::MemoryInit`] with a constant 16-bit `src` index.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the Wasm `memory` instance
-                /// 1. [`Instruction::DataIndex`]: the `data` segment to initialize the memory
-                #[snake_name(memory_init_from)]
-                MemoryInitFrom {
-                    /// The start index of the `dst` memory.
-                    dst: Reg,
-                    /// The start index of the `src` data segment.
-                    src: Const16<u32>,
-                    /// The number of initialized bytes.
-                    len: Reg,
-                },
-                /// Variant of [`Instruction::MemoryInit`] with a constant 16-bit `dst` and `src` indices.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the Wasm `memory` instance
-                /// 1. [`Instruction::DataIndex`]: the `data` segment to initialize the memory
-                #[snake_name(memory_init_from_to)]
-                MemoryInitFromTo {
-                    /// The start index of the `dst` memory.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` data segment.
-                    src: Const16<u32>,
-                    /// The number of initialized bytes.
-                    len: Reg,
-                },
                 /// Variant of [`Instruction::MemoryInit`] with a constant 16-bit `len` field.
                 ///
                 /// # Encoding
@@ -5350,57 +5299,6 @@ macro_rules! for_each_op_grouped {
                     dst: Reg,
                     /// The start index of the `src` data segment.
                     src: Reg,
-                    /// The number of initialized bytes.
-                    len: Const16<u32>,
-                },
-                /// Variant of [`Instruction::MemoryInit`] with a constant 16-bit `len` and `dst`.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the Wasm `memory` instance
-                /// 1. [`Instruction::DataIndex`]: the `data` segment to initialize the memory
-                #[snake_name(memory_init_to_exact)]
-                MemoryInitToExact {
-                    /// The start index of the `dst` memory.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` data segment.
-                    src: Reg,
-                    /// The number of initialized bytes.
-                    len: Const16<u32>,
-                },
-                /// Variant of [`Instruction::MemoryInit`] with a constant 16-bit `len` and `src`.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the Wasm `memory` instance
-                /// 1. [`Instruction::DataIndex`]: the `data` segment to initialize the memory
-                #[snake_name(memory_init_from_exact)]
-                MemoryInitFromExact {
-                    /// The start index of the `dst` memory.
-                    dst: Reg,
-                    /// The start index of the `src` data segment.
-                    src: Const16<u32>,
-                    /// The number of initialized bytes.
-                    len: Const16<u32>,
-                },
-                /// Variant of [`Instruction::MemoryInit`] with a constant 16-bit `len` and `src`.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the Wasm `memory` instance
-                /// 1. [`Instruction::DataIndex`]: the `data` segment to initialize the memory
-                #[snake_name(memory_init_from_to_exact)]
-                MemoryInitFromToExact {
-                    /// The start index of the `dst` memory.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` data segment.
-                    src: Const16<u32>,
                     /// The number of initialized bytes.
                     len: Const16<u32>,
                 },

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -4770,20 +4770,6 @@ macro_rules! for_each_op_grouped {
                     /// The value of the filled elements.
                     value: Reg,
                 },
-                /// Variant of [`Instruction::TableFill`] with 16-bit constant `dst` index.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::TableIndex`] encoding the Wasm `table` instance.
-                #[snake_name(table_fill_at)]
-                TableFillAt {
-                    /// The start index of the table to fill.
-                    dst: Const16<u64>,
-                    /// The number of elements to fill.
-                    len: Reg,
-                    /// The value of the filled elements.
-                    value: Reg,
-                },
                 /// Variant of [`Instruction::TableFill`] with 16-bit constant `len` index.
                 ///
                 /// # Encoding
@@ -4793,20 +4779,6 @@ macro_rules! for_each_op_grouped {
                 TableFillExact {
                     /// The start index of the table to fill.
                     dst: Reg,
-                    /// The number of elements to fill.
-                    len: Const16<u64>,
-                    /// The value of the filled elements.
-                    value: Reg,
-                },
-                /// Variant of [`Instruction::TableFill`] with 16-bit constant `dst` and `len` fields.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::TableIndex`] encoding the Wasm `table` instance.
-                #[snake_name(table_fill_at_exact)]
-                TableFillAtExact {
-                    /// The start index of the table to fill.
-                    dst: Const16<u64>,
                     /// The number of elements to fill.
                     len: Const16<u64>,
                     /// The value of the filled elements.

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5167,20 +5167,6 @@ macro_rules! for_each_op_grouped {
                     /// The number of bytes to fill.
                     len: Reg,
                 },
-                /// Variant of [`Instruction::MemoryFill`] with 16-bit constant `dst` index.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::MemoryIndex`] encoding the Wasm `memory` instance.
-                #[snake_name(memory_fill_at)]
-                MemoryFillAt {
-                    /// The start index of the memory to fill.
-                    dst: Const16<u64>,
-                    /// The byte value used to fill the memory.
-                    value: Reg,
-                    /// The number of bytes to fill.
-                    len: Reg,
-                },
                 /// Variant of [`Instruction::MemoryFill`] with constant fill `value`.
                 ///
                 /// # Encoding
@@ -5209,34 +5195,6 @@ macro_rules! for_each_op_grouped {
                     /// The number of bytes to fill.
                     len: Const16<u64>,
                 },
-                /// Variant of [`Instruction::MemoryFill`] with constant `dst` index and `value`.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::MemoryIndex`] encoding the Wasm `memory` instance.
-                #[snake_name(memory_fill_at_imm)]
-                MemoryFillAtImm {
-                    /// The start index of the memory to fill.
-                    dst: Const16<u64>,
-                    /// The byte value used to fill the memory.
-                    value: u8,
-                    /// The number of bytes to fill.
-                    len: Reg,
-                },
-                /// Variant of [`Instruction::MemoryFill`] with constant `dst` index and `len`.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::MemoryIndex`] encoding the Wasm `memory` instance.
-                #[snake_name(memory_fill_at_exact)]
-                MemoryFillAtExact {
-                    /// The start index of the memory to fill.
-                    dst: Const16<u64>,
-                    /// The byte value used to fill the memory.
-                    value: Reg,
-                    /// The number of bytes to fill.
-                    len: Const16<u64>,
-                },
                 /// Variant of [`Instruction::MemoryFill`] with constant fill `value` and `len`.
                 ///
                 /// # Encoding
@@ -5246,20 +5204,6 @@ macro_rules! for_each_op_grouped {
                 MemoryFillImmExact {
                     /// The start index of the memory to fill.
                     dst: Reg,
-                    /// The byte value used to fill the memory.
-                    value: u8,
-                    /// The number of bytes to fill.
-                    len: Const16<u64>,
-                },
-                /// Variant of [`Instruction::MemoryFill`] with constant `dst` index, fill `value` and `len`.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::MemoryIndex`] encoding the Wasm `memory` instance.
-                #[snake_name(memory_fill_at_imm_exact)]
-                MemoryFillAtImmExact {
-                    /// The start index of the memory to fill.
-                    dst: Const16<u64>,
                     /// The byte value used to fill the memory.
                     value: u8,
                     /// The number of bytes to fill.

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5141,8 +5141,8 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// 1. [`Instruction::MemoryIndex`]: the `dst` Wasm linear memory instance
                 /// 2. [`Instruction::MemoryIndex`]: the `src` Wasm linear memory instance
-                #[snake_name(memory_copy_exact)]
-                MemoryCopyExact {
+                #[snake_name(memory_copy_imm)]
+                MemoryCopyImm {
                     /// The start index of the `dst` memory.
                     dst: Reg,
                     /// The start index of the `src` memory.

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -4693,57 +4693,6 @@ macro_rules! for_each_op_grouped {
                     /// The number of copied elements.
                     len: Reg,
                 },
-                /// Variant of [`Instruction::TableCopy`] with a constant 16-bit `dst` index.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the `dst` Wasm table instance
-                /// 2. [`Instruction::TableIndex`]: the `src` Wasm table instance
-                #[snake_name(table_copy_to)]
-                TableCopyTo {
-                    /// The start index of the `dst` table.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` table.
-                    src: Reg,
-                    /// The number of copied elements.
-                    len: Reg,
-                },
-                /// Variant of [`Instruction::TableCopy`] with a constant 16-bit `src` index.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the `dst` Wasm table instance
-                /// 2. [`Instruction::TableIndex`]: the `src` Wasm table instance
-                #[snake_name(table_copy_from)]
-                TableCopyFrom {
-                    /// The start index of the `dst` table.
-                    dst: Reg,
-                    /// The start index of the `src` table.
-                    src: Const16<u64>,
-                    /// The number of copied elements.
-                    len: Reg,
-                },
-                /// Variant of [`Instruction::TableCopy`] with a constant 16-bit `dst` and `src` indices.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the `dst` Wasm table instance
-                /// 2. [`Instruction::TableIndex`]: the `src` Wasm table instance
-                #[snake_name(table_copy_from_to)]
-                TableCopyFromTo {
-                    /// The start index of the `dst` table.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` table.
-                    src: Const16<u64>,
-                    /// The number of copied elements.
-                    len: Reg,
-                },
                 /// Variant of [`Instruction::TableCopy`] with a constant 16-bit `len` field.
                 ///
                 /// # Note
@@ -4762,69 +4711,6 @@ macro_rules! for_each_op_grouped {
                     dst: Reg,
                     /// The start index of the `src` table.
                     src: Reg,
-                    /// The number of copied elements.
-                    len: Const16<u64>,
-                },
-                /// Variant of [`Instruction::TableCopy`] with a constant 16-bit `len` and `dst`.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the tables.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the `dst` Wasm table instance
-                /// 2. [`Instruction::TableIndex`]: the `src` Wasm table instance
-                #[snake_name(table_copy_to_exact)]
-                TableCopyToExact {
-                    /// The start index of the `dst` table.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` table.
-                    src: Reg,
-                    /// The number of copied elements.
-                    len: Const16<u64>,
-                },
-                /// Variant of [`Instruction::TableCopy`] with a constant 16-bit `len` and `src`.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the tables.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the `dst` Wasm table instance
-                /// 2. [`Instruction::TableIndex`]: the `src` Wasm table instance
-                #[snake_name(table_copy_from_exact)]
-                TableCopyFromExact {
-                    /// The start index of the `dst` table.
-                    dst: Reg,
-                    /// The start index of the `src` table.
-                    src: Const16<u64>,
-                    /// The number of copied elements.
-                    len: Const16<u64>,
-                },
-                /// Variant of [`Instruction::TableCopy`] with a constant 16-bit `len` and `src`.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the tables.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the `dst` Wasm table instance
-                /// 2. [`Instruction::TableIndex`]: the `src` Wasm table instance
-                #[snake_name(table_copy_from_to_exact)]
-                TableCopyFromToExact {
-                    /// The start index of the `dst` table.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` table.
-                    src: Const16<u64>,
                     /// The number of copied elements.
                     len: Const16<u64>,
                 },

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -4734,57 +4734,6 @@ macro_rules! for_each_op_grouped {
                     /// The number of copied elements.
                     len: Reg,
                 },
-                /// Variant of [`Instruction::TableInit`] with a constant 16-bit `dst` index.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the Wasm `table` instance
-                /// 2. [`Instruction::ElemIndex`]: the Wasm `element` segment instance
-                #[snake_name(table_init_to)]
-                TableInitTo {
-                    /// The start index of the `dst` table.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` table.
-                    src: Reg,
-                    /// The number of copied elements.
-                    len: Reg,
-                },
-                /// Variant of [`Instruction::TableInit`] with a constant 16-bit `src` index.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the Wasm `table` instance
-                /// 2. [`Instruction::ElemIndex`]: the Wasm `element` segment instance
-                #[snake_name(table_init_from)]
-                TableInitFrom {
-                    /// The start index of the `dst` table.
-                    dst: Reg,
-                    /// The start index of the `src` table.
-                    src: Const16<u32>,
-                    /// The number of copied elements.
-                    len: Reg,
-                },
-                /// Variant of [`Instruction::TableInit`] with a constant 16-bit `dst` and `src` indices.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the Wasm `table` instance
-                /// 2. [`Instruction::ElemIndex`]: the Wasm `element` segment instance
-                #[snake_name(table_init_from_to)]
-                TableInitFromTo {
-                    /// The start index of the `dst` table.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` table.
-                    src: Const16<u32>,
-                    /// The number of copied elements.
-                    len: Reg,
-                },
                 /// Variant of [`Instruction::TableInit`] with a constant 16-bit `len` field.
                 ///
                 /// # Note
@@ -4803,69 +4752,6 @@ macro_rules! for_each_op_grouped {
                     dst: Reg,
                     /// The start index of the `src` table.
                     src: Reg,
-                    /// The number of copied elements.
-                    len: Const16<u32>,
-                },
-                /// Variant of [`Instruction::TableInit`] with a constant 16-bit `len` and `dst`.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the tables.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the Wasm `table` instance
-                /// 2. [`Instruction::ElemIndex`]: the Wasm `element` segment instance
-                #[snake_name(table_init_to_exact)]
-                TableInitToExact {
-                    /// The start index of the `dst` table.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` table.
-                    src: Reg,
-                    /// The number of copied elements.
-                    len: Const16<u32>,
-                },
-                /// Variant of [`Instruction::TableInit`] with a constant 16-bit `len` and `src`.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the tables.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the Wasm `table` instance
-                /// 2. [`Instruction::ElemIndex`]: the Wasm `element` segment instance
-                #[snake_name(table_init_from_exact)]
-                TableInitFromExact {
-                    /// The start index of the `dst` table.
-                    dst: Reg,
-                    /// The start index of the `src` table.
-                    src: Const16<u32>,
-                    /// The number of copied elements.
-                    len: Const16<u32>,
-                },
-                /// Variant of [`Instruction::TableInit`] with a constant 16-bit `len` and `src`.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the tables.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the Wasm `table` instance
-                /// 2. [`Instruction::ElemIndex`]: the Wasm `element` segment instance
-                #[snake_name(table_init_from_to_exact)]
-                TableInitFromToExact {
-                    /// The start index of the `dst` table.
-                    dst: Const16<u64>,
-                    /// The start index of the `src` table.
-                    src: Const16<u32>,
                     /// The number of copied elements.
                     len: Const16<u32>,
                 },

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5103,7 +5103,7 @@ macro_rules! for_each_op_grouped {
                 /// # Encoding
                 ///
                 /// Followed by [`Instruction::MemoryIndex`] encoding the Wasm `memory` instance.
-                #[snake_name(memory_grow_by)]
+                #[snake_name(memory_grow_imm)]
                 MemoryGrowImm {
                     @result: Reg,
                     /// The number of pages to add to the memory.

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5104,7 +5104,7 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by [`Instruction::MemoryIndex`] encoding the Wasm `memory` instance.
                 #[snake_name(memory_grow_by)]
-                MemoryGrowBy {
+                MemoryGrowImm {
                     @result: Reg,
                     /// The number of pages to add to the memory.
                     delta: Const32<u64>,

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1170,7 +1170,7 @@ impl<'engine> Executor<'engine> {
                 Instr::MemoryGrow { result, delta } => {
                     self.execute_memory_grow(store, result, delta)?
                 }
-                Instr::MemoryGrowBy { result, delta } => {
+                Instr::MemoryGrowImm { result, delta } => {
                     self.execute_memory_grow_by(store, result, delta)?
                 }
                 Instr::MemoryCopy { dst, src, len } => {

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1171,7 +1171,7 @@ impl<'engine> Executor<'engine> {
                     self.execute_memory_grow(store, result, delta)?
                 }
                 Instr::MemoryGrowImm { result, delta } => {
-                    self.execute_memory_grow_by(store, result, delta)?
+                    self.execute_memory_grow_imm(store, result, delta)?
                 }
                 Instr::MemoryCopy { dst, src, len } => {
                     self.execute_memory_copy(store.inner_mut(), dst, src, len)?

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1096,7 +1096,7 @@ impl<'engine> Executor<'engine> {
                     self.execute_table_copy(store.inner_mut(), dst, src, len)?
                 }
                 Instr::TableCopyImm { dst, src, len } => {
-                    self.execute_table_copy_exact(store.inner_mut(), dst, src, len)?
+                    self.execute_table_copy_imm(store.inner_mut(), dst, src, len)?
                 }
                 Instr::TableInit { dst, src, len } => {
                     self.execute_table_init(store.inner_mut(), dst, src, len)?

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1182,26 +1182,14 @@ impl<'engine> Executor<'engine> {
                 Instr::MemoryFill { dst, value, len } => {
                     self.execute_memory_fill(store.inner_mut(), dst, value, len)?
                 }
-                Instr::MemoryFillAt { dst, value, len } => {
-                    self.execute_memory_fill_at(store.inner_mut(), dst, value, len)?
-                }
                 Instr::MemoryFillImm { dst, value, len } => {
                     self.execute_memory_fill_imm(store.inner_mut(), dst, value, len)?
                 }
                 Instr::MemoryFillExact { dst, value, len } => {
                     self.execute_memory_fill_exact(store.inner_mut(), dst, value, len)?
                 }
-                Instr::MemoryFillAtImm { dst, value, len } => {
-                    self.execute_memory_fill_at_imm(store.inner_mut(), dst, value, len)?
-                }
-                Instr::MemoryFillAtExact { dst, value, len } => {
-                    self.execute_memory_fill_at_exact(store.inner_mut(), dst, value, len)?
-                }
                 Instr::MemoryFillImmExact { dst, value, len } => {
                     self.execute_memory_fill_imm_exact(store.inner_mut(), dst, value, len)?
-                }
-                Instr::MemoryFillAtImmExact { dst, value, len } => {
-                    self.execute_memory_fill_at_imm_exact(store.inner_mut(), dst, value, len)?
                 }
                 Instr::MemoryInit { dst, src, len } => {
                     self.execute_memory_init(store.inner_mut(), dst, src, len)?

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1176,8 +1176,8 @@ impl<'engine> Executor<'engine> {
                 Instr::MemoryCopy { dst, src, len } => {
                     self.execute_memory_copy(store.inner_mut(), dst, src, len)?
                 }
-                Instr::MemoryCopyExact { dst, src, len } => {
-                    self.execute_memory_copy_exact(store.inner_mut(), dst, src, len)?
+                Instr::MemoryCopyImm { dst, src, len } => {
+                    self.execute_memory_copy_imm(store.inner_mut(), dst, src, len)?
                 }
                 Instr::MemoryFill { dst, value, len } => {
                     self.execute_memory_fill(store.inner_mut(), dst, value, len)?

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1206,8 +1206,8 @@ impl<'engine> Executor<'engine> {
                 Instr::MemoryInit { dst, src, len } => {
                     self.execute_memory_init(store.inner_mut(), dst, src, len)?
                 }
-                Instr::MemoryInitExact { dst, src, len } => {
-                    self.execute_memory_init_exact(store.inner_mut(), dst, src, len)?
+                Instr::MemoryInitImm { dst, src, len } => {
+                    self.execute_memory_init_imm(store.inner_mut(), dst, src, len)?
                 }
                 Instr::TableIndex { .. }
                 | Instr::MemoryIndex { .. }

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1107,8 +1107,8 @@ impl<'engine> Executor<'engine> {
                 Instr::TableFill { dst, len, value } => {
                     self.execute_table_fill(store.inner_mut(), dst, len, value)?
                 }
-                Instr::TableFillExact { dst, len, value } => {
-                    self.execute_table_fill_exact(store.inner_mut(), dst, len, value)?
+                Instr::TableFillImm { dst, len, value } => {
+                    self.execute_table_fill_imm(store.inner_mut(), dst, len, value)?
                 }
                 Instr::TableGrow {
                     result,

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1095,26 +1095,8 @@ impl<'engine> Executor<'engine> {
                 Instr::TableCopy { dst, src, len } => {
                     self.execute_table_copy(store.inner_mut(), dst, src, len)?
                 }
-                Instr::TableCopyTo { dst, src, len } => {
-                    self.execute_table_copy_to(store.inner_mut(), dst, src, len)?
-                }
-                Instr::TableCopyFrom { dst, src, len } => {
-                    self.execute_table_copy_from(store.inner_mut(), dst, src, len)?
-                }
-                Instr::TableCopyFromTo { dst, src, len } => {
-                    self.execute_table_copy_from_to(store.inner_mut(), dst, src, len)?
-                }
                 Instr::TableCopyExact { dst, src, len } => {
                     self.execute_table_copy_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::TableCopyToExact { dst, src, len } => {
-                    self.execute_table_copy_to_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::TableCopyFromExact { dst, src, len } => {
-                    self.execute_table_copy_from_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::TableCopyFromToExact { dst, src, len } => {
-                    self.execute_table_copy_from_to_exact(store.inner_mut(), dst, src, len)?
                 }
                 Instr::TableInit { dst, src, len } => {
                     self.execute_table_init(store.inner_mut(), dst, src, len)?

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1206,26 +1206,8 @@ impl<'engine> Executor<'engine> {
                 Instr::MemoryInit { dst, src, len } => {
                     self.execute_memory_init(store.inner_mut(), dst, src, len)?
                 }
-                Instr::MemoryInitTo { dst, src, len } => {
-                    self.execute_memory_init_to(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryInitFrom { dst, src, len } => {
-                    self.execute_memory_init_from(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryInitFromTo { dst, src, len } => {
-                    self.execute_memory_init_from_to(store.inner_mut(), dst, src, len)?
-                }
                 Instr::MemoryInitExact { dst, src, len } => {
                     self.execute_memory_init_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryInitToExact { dst, src, len } => {
-                    self.execute_memory_init_to_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryInitFromExact { dst, src, len } => {
-                    self.execute_memory_init_from_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryInitFromToExact { dst, src, len } => {
-                    self.execute_memory_init_from_to_exact(store.inner_mut(), dst, src, len)?
                 }
                 Instr::TableIndex { .. }
                 | Instr::MemoryIndex { .. }

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1101,8 +1101,8 @@ impl<'engine> Executor<'engine> {
                 Instr::TableInit { dst, src, len } => {
                     self.execute_table_init(store.inner_mut(), dst, src, len)?
                 }
-                Instr::TableInitExact { dst, src, len } => {
-                    self.execute_table_init_exact(store.inner_mut(), dst, src, len)?
+                Instr::TableInitImm { dst, src, len } => {
+                    self.execute_table_init_imm(store.inner_mut(), dst, src, len)?
                 }
                 Instr::TableFill { dst, len, value } => {
                     self.execute_table_fill(store.inner_mut(), dst, len, value)?

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1176,26 +1176,8 @@ impl<'engine> Executor<'engine> {
                 Instr::MemoryCopy { dst, src, len } => {
                     self.execute_memory_copy(store.inner_mut(), dst, src, len)?
                 }
-                Instr::MemoryCopyTo { dst, src, len } => {
-                    self.execute_memory_copy_to(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryCopyFrom { dst, src, len } => {
-                    self.execute_memory_copy_from(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryCopyFromTo { dst, src, len } => {
-                    self.execute_memory_copy_from_to(store.inner_mut(), dst, src, len)?
-                }
                 Instr::MemoryCopyExact { dst, src, len } => {
                     self.execute_memory_copy_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryCopyToExact { dst, src, len } => {
-                    self.execute_memory_copy_to_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryCopyFromExact { dst, src, len } => {
-                    self.execute_memory_copy_from_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryCopyFromToExact { dst, src, len } => {
-                    self.execute_memory_copy_from_to_exact(store.inner_mut(), dst, src, len)?
                 }
                 Instr::MemoryFill { dst, value, len } => {
                     self.execute_memory_fill(store.inner_mut(), dst, value, len)?

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1107,14 +1107,8 @@ impl<'engine> Executor<'engine> {
                 Instr::TableFill { dst, len, value } => {
                     self.execute_table_fill(store.inner_mut(), dst, len, value)?
                 }
-                Instr::TableFillAt { dst, len, value } => {
-                    self.execute_table_fill_at(store.inner_mut(), dst, len, value)?
-                }
                 Instr::TableFillExact { dst, len, value } => {
                     self.execute_table_fill_exact(store.inner_mut(), dst, len, value)?
-                }
-                Instr::TableFillAtExact { dst, len, value } => {
-                    self.execute_table_fill_at_exact(store.inner_mut(), dst, len, value)?
                 }
                 Instr::TableGrow {
                     result,

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1101,26 +1101,8 @@ impl<'engine> Executor<'engine> {
                 Instr::TableInit { dst, src, len } => {
                     self.execute_table_init(store.inner_mut(), dst, src, len)?
                 }
-                Instr::TableInitTo { dst, src, len } => {
-                    self.execute_table_init_to(store.inner_mut(), dst, src, len)?
-                }
-                Instr::TableInitFrom { dst, src, len } => {
-                    self.execute_table_init_from(store.inner_mut(), dst, src, len)?
-                }
-                Instr::TableInitFromTo { dst, src, len } => {
-                    self.execute_table_init_from_to(store.inner_mut(), dst, src, len)?
-                }
                 Instr::TableInitExact { dst, src, len } => {
                     self.execute_table_init_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::TableInitToExact { dst, src, len } => {
-                    self.execute_table_init_to_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::TableInitFromExact { dst, src, len } => {
-                    self.execute_table_init_from_exact(store.inner_mut(), dst, src, len)?
-                }
-                Instr::TableInitFromToExact { dst, src, len } => {
-                    self.execute_table_init_from_to_exact(store.inner_mut(), dst, src, len)?
                 }
                 Instr::TableFill { dst, len, value } => {
                     self.execute_table_fill(store.inner_mut(), dst, len, value)?

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -151,48 +151,6 @@ impl Executor<'_> {
         self.execute_memory_copy_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::MemoryCopyTo`].
-    pub fn execute_memory_copy_to(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Reg,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u64 = self.get_register_as(src);
-        let len: u64 = self.get_register_as(len);
-        self.execute_memory_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::MemoryCopyFrom`].
-    pub fn execute_memory_copy_from(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Const16<u64>,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u64 = src.into();
-        let len: u64 = self.get_register_as(len);
-        self.execute_memory_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::MemoryCopyFromTo`].
-    pub fn execute_memory_copy_from_to(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Const16<u64>,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u64 = src.into();
-        let len: u64 = self.get_register_as(len);
-        self.execute_memory_copy_impl(store, dst, src, len)
-    }
-
     /// Executes an [`Instruction::MemoryCopyExact`].
     pub fn execute_memory_copy_exact(
         &mut self,
@@ -203,48 +161,6 @@ impl Executor<'_> {
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let src: u64 = self.get_register_as(src);
-        let len: u64 = len.into();
-        self.execute_memory_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::MemoryCopyToExact`].
-    pub fn execute_memory_copy_to_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Reg,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u64 = self.get_register_as(src);
-        let len: u64 = len.into();
-        self.execute_memory_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::MemoryCopyFromExact`].
-    pub fn execute_memory_copy_from_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Const16<u64>,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u64 = src.into();
-        let len: u64 = len.into();
-        self.execute_memory_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::MemoryCopyFromToExact`].
-    pub fn execute_memory_copy_from_to_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Const16<u64>,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u64 = src.into();
         let len: u64 = len.into();
         self.execute_memory_copy_impl(store, dst, src, len)
     }

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -385,8 +385,8 @@ impl Executor<'_> {
         self.execute_memory_init_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::MemoryInitExact`].
-    pub fn execute_memory_init_exact(
+    /// Executes an [`Instruction::MemoryInitImm`].
+    pub fn execute_memory_init_imm(
         &mut self,
         store: &mut StoreInner,
         dst: Reg,

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -385,48 +385,6 @@ impl Executor<'_> {
         self.execute_memory_init_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::MemoryInitTo`].
-    pub fn execute_memory_init_to(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Reg,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u32 = self.get_register_as(src);
-        let len: u32 = self.get_register_as(len);
-        self.execute_memory_init_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::MemoryInitFrom`].
-    pub fn execute_memory_init_from(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Const16<u32>,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u32 = src.into();
-        let len: u32 = self.get_register_as(len);
-        self.execute_memory_init_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::MemoryInitFromTo`].
-    pub fn execute_memory_init_from_to(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Const16<u32>,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u32 = src.into();
-        let len: u32 = self.get_register_as(len);
-        self.execute_memory_init_impl(store, dst, src, len)
-    }
-
     /// Executes an [`Instruction::MemoryInitExact`].
     pub fn execute_memory_init_exact(
         &mut self,
@@ -437,48 +395,6 @@ impl Executor<'_> {
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let src: u32 = self.get_register_as(src);
-        let len: u32 = len.into();
-        self.execute_memory_init_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::MemoryInitToExact`].
-    pub fn execute_memory_init_to_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Reg,
-        len: Const16<u32>,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u32 = self.get_register_as(src);
-        let len: u32 = len.into();
-        self.execute_memory_init_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::MemoryInitFromExact`].
-    pub fn execute_memory_init_from_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Const16<u32>,
-        len: Const16<u32>,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u32 = src.into();
-        let len: u32 = len.into();
-        self.execute_memory_init_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::MemoryInitFromToExact`].
-    pub fn execute_memory_init_from_to_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Const16<u32>,
-        len: Const16<u32>,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u32 = src.into();
         let len: u32 = len.into();
         self.execute_memory_init_impl(store, dst, src, len)
     }

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -80,7 +80,7 @@ impl Executor<'_> {
         self.execute_memory_grow_impl(store, result, delta, &mut resource_limiter)
     }
 
-    /// Executes an [`Instruction::MemoryGrowBy`].
+    /// Executes an [`Instruction::MemoryGrowImm`].
     pub fn execute_memory_grow_by(
         &mut self,
         store: &mut PrunedStore,

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -81,7 +81,7 @@ impl Executor<'_> {
     }
 
     /// Executes an [`Instruction::MemoryGrowImm`].
-    pub fn execute_memory_grow_by(
+    pub fn execute_memory_grow_imm(
         &mut self,
         store: &mut PrunedStore,
         result: Reg,

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -151,8 +151,8 @@ impl Executor<'_> {
         self.execute_memory_copy_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::MemoryCopyExact`].
-    pub fn execute_memory_copy_exact(
+    /// Executes an [`Instruction::MemoryCopyImm`].
+    pub fn execute_memory_copy_imm(
         &mut self,
         store: &mut StoreInner,
         dst: Reg,

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -249,20 +249,6 @@ impl Executor<'_> {
         self.execute_memory_fill_impl(store, dst, value, len)
     }
 
-    /// Executes an [`Instruction::MemoryFillAt`].
-    pub fn execute_memory_fill_at(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        value: Reg,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let value: u8 = self.get_register_as(value);
-        let len: u64 = self.get_register_as(len);
-        self.execute_memory_fill_impl(store, dst, value, len)
-    }
-
     /// Executes an [`Instruction::MemoryFillImm`].
     pub fn execute_memory_fill_imm(
         &mut self,
@@ -272,19 +258,6 @@ impl Executor<'_> {
         len: Reg,
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
-        let len: u64 = self.get_register_as(len);
-        self.execute_memory_fill_impl(store, dst, value, len)
-    }
-
-    /// Executes an [`Instruction::MemoryFillAtImm`].
-    pub fn execute_memory_fill_at_imm(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        value: u8,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
         let len: u64 = self.get_register_as(len);
         self.execute_memory_fill_impl(store, dst, value, len)
     }
@@ -303,20 +276,6 @@ impl Executor<'_> {
         self.execute_memory_fill_impl(store, dst, value, len)
     }
 
-    /// Executes an [`Instruction::MemoryFillAtExact`].
-    pub fn execute_memory_fill_at_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        value: Reg,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let value: u8 = self.get_register_as(value);
-        let len: u64 = len.into();
-        self.execute_memory_fill_impl(store, dst, value, len)
-    }
-
     /// Executes an [`Instruction::MemoryFillImmExact`].
     pub fn execute_memory_fill_imm_exact(
         &mut self,
@@ -326,19 +285,6 @@ impl Executor<'_> {
         len: Const16<u64>,
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
-        let len: u64 = len.into();
-        self.execute_memory_fill_impl(store, dst, value, len)
-    }
-
-    /// Executes an [`Instruction::MemoryFillAtImmExact`].
-    pub fn execute_memory_fill_at_imm_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        value: u8,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
         let len: u64 = len.into();
         self.execute_memory_fill_impl(store, dst, value, len)
     }

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -153,48 +153,6 @@ impl Executor<'_> {
         self.execute_table_copy_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::TableCopyTo`].
-    pub fn execute_table_copy_to(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Reg,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u64 = self.get_register_as(src);
-        let len: u64 = self.get_register_as(len);
-        self.execute_table_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::TableCopyFrom`].
-    pub fn execute_table_copy_from(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Const16<u64>,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u64 = src.into();
-        let len: u64 = self.get_register_as(len);
-        self.execute_table_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::TableCopyFromTo`].
-    pub fn execute_table_copy_from_to(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Const16<u64>,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u64 = src.into();
-        let len: u64 = self.get_register_as(len);
-        self.execute_table_copy_impl(store, dst, src, len)
-    }
-
     /// Executes an [`Instruction::TableCopyExact`].
     pub fn execute_table_copy_exact(
         &mut self,
@@ -205,48 +163,6 @@ impl Executor<'_> {
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let src: u64 = self.get_register_as(src);
-        let len: u64 = len.into();
-        self.execute_table_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::TableCopyToExact`].
-    pub fn execute_table_copy_to_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Reg,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u64 = self.get_register_as(src);
-        let len: u64 = len.into();
-        self.execute_table_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::TableCopyFromExact`].
-    pub fn execute_table_copy_from_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Const16<u64>,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u64 = src.into();
-        let len: u64 = len.into();
-        self.execute_table_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::TableCopyFromToExact`].
-    pub fn execute_table_copy_from_to_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Const16<u64>,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u64 = src.into();
         let len: u64 = len.into();
         self.execute_table_copy_impl(store, dst, src, len)
     }

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -209,8 +209,8 @@ impl Executor<'_> {
         self.execute_table_init_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::TableInitExact`].
-    pub fn execute_table_init_exact(
+    /// Executes an [`Instruction::TableInitImm`].
+    pub fn execute_table_init_imm(
         &mut self,
         store: &mut StoreInner,
         dst: Reg,

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -255,8 +255,8 @@ impl Executor<'_> {
         self.execute_table_fill_impl(store, dst, len, value)
     }
 
-    /// Executes an [`Instruction::TableFillExact`].
-    pub fn execute_table_fill_exact(
+    /// Executes an [`Instruction::TableFillImm`].
+    pub fn execute_table_fill_imm(
         &mut self,
         store: &mut StoreInner,
         dst: Reg,

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -209,48 +209,6 @@ impl Executor<'_> {
         self.execute_table_init_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::TableInitTo`].
-    pub fn execute_table_init_to(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Reg,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u32 = self.get_register_as(src);
-        let len: u32 = self.get_register_as(len);
-        self.execute_table_init_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::TableInitFrom`].
-    pub fn execute_table_init_from(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Const16<u32>,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u32 = src.into();
-        let len: u32 = self.get_register_as(len);
-        self.execute_table_init_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::TableInitFromTo`].
-    pub fn execute_table_init_from_to(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Const16<u32>,
-        len: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u32 = src.into();
-        let len: u32 = self.get_register_as(len);
-        self.execute_table_init_impl(store, dst, src, len)
-    }
-
     /// Executes an [`Instruction::TableInitExact`].
     pub fn execute_table_init_exact(
         &mut self,
@@ -261,48 +219,6 @@ impl Executor<'_> {
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let src: u32 = self.get_register_as(src);
-        let len: u32 = len.into();
-        self.execute_table_init_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::TableInitToExact`].
-    pub fn execute_table_init_to_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Reg,
-        len: Const16<u32>,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u32 = self.get_register_as(src);
-        let len: u32 = len.into();
-        self.execute_table_init_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::TableInitFromExact`].
-    pub fn execute_table_init_from_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Const16<u32>,
-        len: Const16<u32>,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u32 = src.into();
-        let len: u32 = len.into();
-        self.execute_table_init_impl(store, dst, src, len)
-    }
-
-    /// Executes an [`Instruction::TableInitFromToExact`].
-    pub fn execute_table_init_from_to_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        src: Const16<u32>,
-        len: Const16<u32>,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let src: u32 = src.into();
         let len: u32 = len.into();
         self.execute_table_init_impl(store, dst, src, len)
     }

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -255,19 +255,6 @@ impl Executor<'_> {
         self.execute_table_fill_impl(store, dst, len, value)
     }
 
-    /// Executes an [`Instruction::TableFillAt`].
-    pub fn execute_table_fill_at(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        len: Reg,
-        value: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
-        let len: u64 = self.get_register_as(len);
-        self.execute_table_fill_impl(store, dst, len, value)
-    }
-
     /// Executes an [`Instruction::TableFillExact`].
     pub fn execute_table_fill_exact(
         &mut self,
@@ -277,19 +264,6 @@ impl Executor<'_> {
         value: Reg,
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
-        let len: u64 = len.into();
-        self.execute_table_fill_impl(store, dst, len, value)
-    }
-
-    /// Executes an [`Instruction::TableFillAtExact`].
-    pub fn execute_table_fill_at_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Const16<u64>,
-        len: Const16<u64>,
-        value: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = dst.into();
         let len: u64 = len.into();
         self.execute_table_fill_impl(store, dst, len, value)
     }

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_copy.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_copy.rs
@@ -101,12 +101,15 @@ fn testcase_copy_from(src: u64) -> TranslationTest {
 
 fn test_copy_from16(src: u64) {
     testcase_copy_from(src)
-        .expect_func_instrs([
-            Instruction::memory_copy_from(Reg::from(0), u64imm16(src), Reg::from(1)),
-            Instruction::memory_index(0),
-            Instruction::memory_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_copy(Reg::from(0), Reg::from(-1), Reg::from(1)),
+                Instruction::memory_index(0),
+                Instruction::memory_index(1),
+                Instruction::Return,
+            ])
+            .consts([src]),
+        )
         .run()
 }
 
@@ -157,12 +160,15 @@ fn testcase_copy_to(dst: u64) -> TranslationTest {
 
 fn test_copy_to16(dst: u64) {
     testcase_copy_to(dst)
-        .expect_func_instrs([
-            Instruction::memory_copy_to(u64imm16(dst), Reg::from(0), Reg::from(1)),
-            Instruction::memory_index(0),
-            Instruction::memory_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_copy(Reg::from(-1), Reg::from(0), Reg::from(1)),
+                Instruction::memory_index(0),
+                Instruction::memory_index(1),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -213,12 +219,15 @@ fn testcase_copy_from_to(dst: u64, src: u64) -> TranslationTest {
 
 fn test_copy_from_to16(dst: u64, src: u64) {
     testcase_copy_from_to(dst, src)
-        .expect_func_instrs([
-            Instruction::memory_copy_from_to(u64imm16(dst), u64imm16(src), Reg::from(0)),
-            Instruction::memory_index(0),
-            Instruction::memory_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_copy(Reg::from(-1), Reg::from(-2), Reg::from(0)),
+                Instruction::memory_index(0),
+                Instruction::memory_index(1),
+                Instruction::Return,
+            ])
+            .consts([dst, src]),
+        )
         .run()
 }
 
@@ -228,6 +237,9 @@ fn copy_from_to16() {
     let values = [0, 1, u64::from(u16::MAX) - 1, u64::from(u16::MAX)];
     for dst in values {
         for src in values {
+            if dst == src {
+                continue;
+            }
             test_copy_from_to16(dst, src);
         }
     }
@@ -288,12 +300,15 @@ fn testcase_copy_to_exact(dst: u64, len: u64) -> TranslationTest {
 
 fn test_copy_to_exact16(dst: u64, len: u64) {
     testcase_copy_to_exact(dst, len)
-        .expect_func_instrs([
-            Instruction::memory_copy_to_exact(u64imm16(dst), Reg::from(0), u64imm16(len)),
-            Instruction::memory_index(0),
-            Instruction::memory_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_copy_exact(Reg::from(-1), Reg::from(0), u64imm16(len)),
+                Instruction::memory_index(0),
+                Instruction::memory_index(1),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -363,12 +378,15 @@ fn testcase_copy_from_exact(src: u64, len: u64) -> TranslationTest {
 
 fn test_copy_from_exact16(src: u64, len: u64) {
     testcase_copy_from_exact(src, len)
-        .expect_func_instrs([
-            Instruction::memory_copy_from_exact(Reg::from(0), u64imm16(src), u64imm16(len)),
-            Instruction::memory_index(0),
-            Instruction::memory_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_copy_exact(Reg::from(0), Reg::from(-1), u64imm16(len)),
+                Instruction::memory_index(0),
+                Instruction::memory_index(1),
+                Instruction::Return,
+            ])
+            .consts([src]),
+        )
         .run()
 }
 
@@ -438,12 +456,15 @@ fn testcase_copy_from_to_exact(dst: u64, src: u64, len: u64) -> TranslationTest 
 
 fn test_copy_from_to_exact16(dst: u64, src: u64, len: u64) {
     testcase_copy_from_to_exact(dst, src, len)
-        .expect_func_instrs([
-            Instruction::memory_copy_from_to_exact(u64imm16(dst), u64imm16(src), u64imm16(len)),
-            Instruction::memory_index(0),
-            Instruction::memory_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_copy_exact(Reg::from(-1), Reg::from(-2), u64imm16(len)),
+                Instruction::memory_index(0),
+                Instruction::memory_index(1),
+                Instruction::Return,
+            ])
+            .consts([dst, src]),
+        )
         .run()
 }
 
@@ -453,6 +474,9 @@ fn copy_from_to_exact16() {
     let values = [0, 1, u64::from(u16::MAX) - 1, u64::from(u16::MAX)];
     for dst in values {
         for src in values {
+            if dst == src {
+                continue;
+            }
             for len in values {
                 test_copy_from_to_exact16(dst, src, len);
             }

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_copy.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_copy.rs
@@ -44,7 +44,7 @@ fn testcase_copy_exact(len: u64) -> TranslationTest {
 fn test_copy_exact16(len: u64) {
     testcase_copy_exact(len)
         .expect_func_instrs([
-            Instruction::memory_copy_exact(Reg::from(0), Reg::from(1), u64imm16(len)),
+            Instruction::memory_copy_imm(Reg::from(0), Reg::from(1), u64imm16(len)),
             Instruction::memory_index(0),
             Instruction::memory_index(1),
             Instruction::Return,
@@ -302,7 +302,7 @@ fn test_copy_to_exact16(dst: u64, len: u64) {
     testcase_copy_to_exact(dst, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::memory_copy_exact(Reg::from(-1), Reg::from(0), u64imm16(len)),
+                Instruction::memory_copy_imm(Reg::from(-1), Reg::from(0), u64imm16(len)),
                 Instruction::memory_index(0),
                 Instruction::memory_index(1),
                 Instruction::Return,
@@ -380,7 +380,7 @@ fn test_copy_from_exact16(src: u64, len: u64) {
     testcase_copy_from_exact(src, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::memory_copy_exact(Reg::from(0), Reg::from(-1), u64imm16(len)),
+                Instruction::memory_copy_imm(Reg::from(0), Reg::from(-1), u64imm16(len)),
                 Instruction::memory_index(0),
                 Instruction::memory_index(1),
                 Instruction::Return,
@@ -458,7 +458,7 @@ fn test_copy_from_to_exact16(dst: u64, src: u64, len: u64) {
     testcase_copy_from_to_exact(dst, src, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::memory_copy_exact(Reg::from(-1), Reg::from(-2), u64imm16(len)),
+                Instruction::memory_copy_imm(Reg::from(-1), Reg::from(-2), u64imm16(len)),
                 Instruction::memory_index(0),
                 Instruction::memory_index(1),
                 Instruction::Return,

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_fill.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_fill.rs
@@ -132,11 +132,14 @@ fn testcase_fill_at(dst: u64) -> TranslationTest {
 
 fn test_fill_at16(dst: u64) {
     testcase_fill_at(dst)
-        .expect_func_instrs([
-            Instruction::memory_fill_at(u64imm16(dst), Reg::from(0), Reg::from(1)),
-            Instruction::memory_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_fill(Reg::from(-1), Reg::from(0), Reg::from(1)),
+                Instruction::memory_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -185,11 +188,14 @@ fn testcase_fill_at_imm(dst: u64, value: u64) -> TranslationTest {
 
 fn test_fill_at16_imm(dst: u64, value: u64) {
     testcase_fill_at_imm(dst, value)
-        .expect_func_instrs([
-            Instruction::memory_fill_at_imm(u64imm16(dst), value as u8, Reg::from(0)),
-            Instruction::memory_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_fill_imm(Reg::from(-1), value as u8, Reg::from(0)),
+                Instruction::memory_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -267,11 +273,14 @@ fn testcase_fill_at_exact(dst: u64, len: u64) -> TranslationTest {
 
 fn test_fill_at_exact16(dst: u64, len: u64) {
     testcase_fill_at_exact(dst, len)
-        .expect_func_instrs([
-            Instruction::memory_fill_at_exact(u64imm16(dst), Reg::from(0), u64imm16(len)),
-            Instruction::memory_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_fill_exact(Reg::from(-1), Reg::from(0), u64imm16(len)),
+                Instruction::memory_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -421,11 +430,14 @@ fn testcase_fill_at_imm_exact(dst: u64, value: u64, len: u64) -> TranslationTest
 
 fn test_fill_at_imm_exact16(dst: u64, value: u64, len: u64) {
     testcase_fill_at_imm_exact(dst, value, len)
-        .expect_func_instrs([
-            Instruction::memory_fill_at_imm_exact(u64imm16(dst), value as u8, u64imm16(len)),
-            Instruction::memory_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_fill_imm_exact(Reg::from(-1), value as u8, u64imm16(len)),
+                Instruction::memory_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_grow.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_grow.rs
@@ -37,7 +37,7 @@ fn test_imm32(index_ty: IndexType, memory_index: MemIdx, delta: u32) {
     );
     TranslationTest::new(wasm)
         .expect_func_instrs(iter_filter_opts![
-            Instruction::memory_grow_by(Reg::from(0), delta),
+            Instruction::memory_grow_imm(Reg::from(0), delta),
             Instruction::memory_index(memory_index.0),
             Instruction::return_reg(Reg::from(0)),
         ])

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_init.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_init.rs
@@ -44,7 +44,7 @@ fn testcase_init_exact(len: u32) -> TranslationTest {
 fn test_copy_exact16(len: u32) {
     testcase_init_exact(len)
         .expect_func_instrs([
-            Instruction::memory_init_exact(Reg::from(0), Reg::from(1), u32imm16(len)),
+            Instruction::memory_init_imm(Reg::from(0), Reg::from(1), u32imm16(len)),
             Instruction::memory_index(0),
             Instruction::data_index(0),
             Instruction::Return,
@@ -298,7 +298,7 @@ fn test_copy_to_exact16(dst: u64, len: u32) {
     testcase_init_to_exact(dst, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::memory_init_exact(Reg::from(-1), Reg::from(0), u32imm16(len)),
+                Instruction::memory_init_imm(Reg::from(-1), Reg::from(0), u32imm16(len)),
                 Instruction::memory_index(0),
                 Instruction::data_index(0),
                 Instruction::Return,
@@ -372,7 +372,7 @@ fn test_copy_from_exact16(src: u32, len: u32) {
     testcase_init_from_exact(src, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::memory_init_exact(Reg::from(0), Reg::from(-1), u32imm16(len)),
+                Instruction::memory_init_imm(Reg::from(0), Reg::from(-1), u32imm16(len)),
                 Instruction::memory_index(0),
                 Instruction::data_index(0),
                 Instruction::Return,
@@ -446,7 +446,7 @@ fn test_copy_from_to_exact16(dst: u64, src: u32, len: u32) {
     testcase_init_from_to_exact(dst, src, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::memory_init_exact(Reg::from(-1), Reg::from(-2), u32imm16(len)),
+                Instruction::memory_init_imm(Reg::from(-1), Reg::from(-2), u32imm16(len)),
                 Instruction::memory_index(0),
                 Instruction::data_index(0),
                 Instruction::Return,

--- a/crates/wasmi/src/engine/translator/tests/op/memory/memory_init.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/memory/memory_init.rs
@@ -101,12 +101,15 @@ fn testcase_init_from(src: u32) -> TranslationTest {
 
 fn test_copy_from16(src: u32) {
     testcase_init_from(src)
-        .expect_func_instrs([
-            Instruction::memory_init_from(Reg::from(0), u32imm16(src), Reg::from(1)),
-            Instruction::memory_index(0),
-            Instruction::data_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_init(Reg::from(0), Reg::from(-1), Reg::from(1)),
+                Instruction::memory_index(0),
+                Instruction::data_index(0),
+                Instruction::Return,
+            ])
+            .consts([src]),
+        )
         .run()
 }
 
@@ -157,12 +160,15 @@ fn testcase_init_to(dst: u64) -> TranslationTest {
 
 fn test_copy_to16(dst: u64) {
     testcase_init_to(dst)
-        .expect_func_instrs([
-            Instruction::memory_init_to(u64imm16(dst), Reg::from(0), Reg::from(1)),
-            Instruction::memory_index(0),
-            Instruction::data_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_init(Reg::from(-1), Reg::from(0), Reg::from(1)),
+                Instruction::memory_index(0),
+                Instruction::data_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -213,12 +219,15 @@ fn testcase_init_from_to(dst: u64, src: u32) -> TranslationTest {
 
 fn test_copy_from_to16(dst: u64, src: u32) {
     testcase_init_from_to(dst, src)
-        .expect_func_instrs([
-            Instruction::memory_init_from_to(u64imm16(dst), u32imm16(src), Reg::from(0)),
-            Instruction::memory_index(0),
-            Instruction::data_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_init(Reg::from(-1), Reg::from(-2), Reg::from(0)),
+                Instruction::memory_index(0),
+                Instruction::data_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst, u64::from(src)]),
+        )
         .run()
 }
 
@@ -228,6 +237,9 @@ fn init_from_to16() {
     let values = [0, 1, u32::from(u16::MAX) - 1, u32::from(u16::MAX)];
     for dst in values {
         for src in values {
+            if dst == src {
+                continue;
+            }
             test_copy_from_to16(u64::from(dst), src);
         }
     }
@@ -284,12 +296,15 @@ fn testcase_init_to_exact(dst: u64, len: u32) -> TranslationTest {
 
 fn test_copy_to_exact16(dst: u64, len: u32) {
     testcase_init_to_exact(dst, len)
-        .expect_func_instrs([
-            Instruction::memory_init_to_exact(u64imm16(dst), Reg::from(0), u32imm16(len)),
-            Instruction::memory_index(0),
-            Instruction::data_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_init_exact(Reg::from(-1), Reg::from(0), u32imm16(len)),
+                Instruction::memory_index(0),
+                Instruction::data_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -355,12 +370,15 @@ fn testcase_init_from_exact(src: u32, len: u32) -> TranslationTest {
 
 fn test_copy_from_exact16(src: u32, len: u32) {
     testcase_init_from_exact(src, len)
-        .expect_func_instrs([
-            Instruction::memory_init_from_exact(Reg::from(0), u32imm16(src), u32imm16(len)),
-            Instruction::memory_index(0),
-            Instruction::data_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_init_exact(Reg::from(0), Reg::from(-1), u32imm16(len)),
+                Instruction::memory_index(0),
+                Instruction::data_index(0),
+                Instruction::Return,
+            ])
+            .consts([src]),
+        )
         .run()
 }
 
@@ -426,12 +444,15 @@ fn testcase_init_from_to_exact(dst: u64, src: u32, len: u32) -> TranslationTest 
 
 fn test_copy_from_to_exact16(dst: u64, src: u32, len: u32) {
     testcase_init_from_to_exact(dst, src, len)
-        .expect_func_instrs([
-            Instruction::memory_init_from_to_exact(u64imm16(dst), u32imm16(src), u32imm16(len)),
-            Instruction::memory_index(0),
-            Instruction::data_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::memory_init_exact(Reg::from(-1), Reg::from(-2), u32imm16(len)),
+                Instruction::memory_index(0),
+                Instruction::data_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst, u64::from(src)]),
+        )
         .run()
 }
 
@@ -441,6 +462,9 @@ fn init_from_to_exact16() {
     let values = [0, 1, u32::from(u16::MAX) - 1, u32::from(u16::MAX)];
     for dst in values {
         for src in values {
+            if dst == src {
+                continue;
+            }
             for len in values {
                 test_copy_from_to_exact16(u64::from(dst), src, len);
             }

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_copy.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_copy.rs
@@ -120,12 +120,15 @@ fn testcase_copy_from(ty: ValType, src: u64) -> TranslationTest {
 
 fn test_copy_from16(ty: ValType, src: u64) {
     testcase_copy_from(ty, src)
-        .expect_func_instrs([
-            Instruction::table_copy_from(Reg::from(0), u64imm16(src), Reg::from(1)),
-            Instruction::table_index(0),
-            Instruction::table_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_copy(Reg::from(0), Reg::from(-1), Reg::from(1)),
+                Instruction::table_index(0),
+                Instruction::table_index(1),
+                Instruction::Return,
+            ])
+            .consts([src]),
+        )
         .run()
 }
 
@@ -185,12 +188,15 @@ fn testcase_copy_to(ty: ValType, dst: u64) -> TranslationTest {
 
 fn test_copy_to16(ty: ValType, dst: u64) {
     testcase_copy_to(ty, dst)
-        .expect_func_instrs([
-            Instruction::table_copy_to(u64imm16(dst), Reg::from(0), Reg::from(1)),
-            Instruction::table_index(0),
-            Instruction::table_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_copy(Reg::from(-1), Reg::from(0), Reg::from(1)),
+                Instruction::table_index(0),
+                Instruction::table_index(1),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -250,12 +256,15 @@ fn testcase_copy_from_to(ty: ValType, dst: u64, src: u64) -> TranslationTest {
 
 fn test_copy_from_to16(ty: ValType, dst: u64, src: u64) {
     testcase_copy_from_to(ty, dst, src)
-        .expect_func_instrs([
-            Instruction::table_copy_from_to(u64imm16(dst), u64imm16(src), Reg::from(0)),
-            Instruction::table_index(0),
-            Instruction::table_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_copy(Reg::from(-1), Reg::from(-2), Reg::from(0)),
+                Instruction::table_index(0),
+                Instruction::table_index(1),
+                Instruction::Return,
+            ])
+            .consts([dst, src]),
+        )
         .run()
 }
 
@@ -269,6 +278,9 @@ fn copy_from_to16() {
     let values = [0, 1, u64::from(u16::MAX) - 1, u64::from(u16::MAX)];
     for dst in values {
         for src in values {
+            if dst == src {
+                continue;
+            }
             test_for(dst, src);
         }
     }
@@ -334,12 +346,15 @@ fn testcase_copy_to_exact(ty: ValType, dst: u64, len: u64) -> TranslationTest {
 
 fn test_copy_to_exact16(ty: ValType, dst: u64, len: u64) {
     testcase_copy_to_exact(ty, dst, len)
-        .expect_func_instrs([
-            Instruction::table_copy_to_exact(u64imm16(dst), Reg::from(0), u64imm16(len)),
-            Instruction::table_index(0),
-            Instruction::table_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_copy_exact(Reg::from(-1), Reg::from(0), u64imm16(len)),
+                Instruction::table_index(0),
+                Instruction::table_index(1),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -418,12 +433,15 @@ fn testcase_copy_from_exact(ty: ValType, src: u64, len: u64) -> TranslationTest 
 
 fn test_copy_from_exact16(ty: ValType, src: u64, len: u64) {
     testcase_copy_from_exact(ty, src, len)
-        .expect_func_instrs([
-            Instruction::table_copy_from_exact(Reg::from(0), u64imm16(src), u64imm16(len)),
-            Instruction::table_index(0),
-            Instruction::table_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_copy_exact(Reg::from(0), Reg::from(-1), u64imm16(len)),
+                Instruction::table_index(0),
+                Instruction::table_index(1),
+                Instruction::Return,
+            ])
+            .consts([src]),
+        )
         .run()
 }
 
@@ -502,12 +520,15 @@ fn testcase_copy_from_to_exact(ty: ValType, dst: u64, src: u64, len: u64) -> Tra
 
 fn test_copy_from_to_exact16(ty: ValType, dst: u64, src: u64, len: u64) {
     testcase_copy_from_to_exact(ty, dst, src, len)
-        .expect_func_instrs([
-            Instruction::table_copy_from_to_exact(u64imm16(dst), u64imm16(src), u64imm16(len)),
-            Instruction::table_index(0),
-            Instruction::table_index(1),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_copy_exact(Reg::from(-1), Reg::from(-2), u64imm16(len)),
+                Instruction::table_index(0),
+                Instruction::table_index(1),
+                Instruction::Return,
+            ])
+            .consts([dst, src]),
+        )
         .run()
 }
 
@@ -521,6 +542,9 @@ fn copy_from_to_exact16() {
     let values = [0, 1, u64::from(u16::MAX) - 1, u64::from(u16::MAX)];
     for dst in values {
         for src in values {
+            if dst == src {
+                continue;
+            }
             for len in values {
                 test_for(dst, src, len);
             }

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_copy.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_copy.rs
@@ -348,7 +348,7 @@ fn test_copy_to_exact16(ty: ValType, dst: u64, len: u64) {
     testcase_copy_to_exact(ty, dst, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::table_copy_exact(Reg::from(-1), Reg::from(0), u64imm16(len)),
+                Instruction::table_copy_imm(Reg::from(-1), Reg::from(0), u64imm16(len)),
                 Instruction::table_index(0),
                 Instruction::table_index(1),
                 Instruction::Return,
@@ -435,7 +435,7 @@ fn test_copy_from_exact16(ty: ValType, src: u64, len: u64) {
     testcase_copy_from_exact(ty, src, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::table_copy_exact(Reg::from(0), Reg::from(-1), u64imm16(len)),
+                Instruction::table_copy_imm(Reg::from(0), Reg::from(-1), u64imm16(len)),
                 Instruction::table_index(0),
                 Instruction::table_index(1),
                 Instruction::Return,
@@ -522,7 +522,7 @@ fn test_copy_from_to_exact16(ty: ValType, dst: u64, src: u64, len: u64) {
     testcase_copy_from_to_exact(ty, dst, src, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::table_copy_exact(Reg::from(-1), Reg::from(-2), u64imm16(len)),
+                Instruction::table_copy_imm(Reg::from(-1), Reg::from(-2), u64imm16(len)),
                 Instruction::table_index(0),
                 Instruction::table_index(1),
                 Instruction::Return,

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_fill.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_fill.rs
@@ -114,11 +114,14 @@ fn testcase_fill_at(ty: ValType, dst: u64) -> TranslationTest {
 
 fn test_fill_at16(ty: ValType, dst: u64) {
     testcase_fill_at(ty, dst)
-        .expect_func_instrs([
-            Instruction::table_fill_at(u64imm16(dst), Reg::from(1), Reg::from(0)),
-            Instruction::table_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_fill(Reg::from(-1), Reg::from(1), Reg::from(0)),
+                Instruction::table_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -176,11 +179,14 @@ fn testcase_fill_at_exact(ty: ValType, dst: u64, len: u64) -> TranslationTest {
 
 fn test_fill_at_exact16(ty: ValType, dst: u64, len: u64) {
     testcase_fill_at_exact(ty, dst, len)
-        .expect_func_instrs([
-            Instruction::table_fill_at_exact(u64imm16(dst), u64imm16(len), Reg::from(0)),
-            Instruction::table_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_fill_exact(Reg::from(-1), u64imm16(len), Reg::from(0)),
+                Instruction::table_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_fill.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_fill.rs
@@ -51,7 +51,7 @@ fn testcase_fill_exact(ty: ValType, len: u64) -> TranslationTest {
 fn test_fill_exact16(ty: ValType, len: u64) {
     testcase_fill_exact(ty, len)
         .expect_func_instrs([
-            Instruction::table_fill_exact(Reg::from(0), u64imm16(len), Reg::from(1)),
+            Instruction::table_fill_imm(Reg::from(0), u64imm16(len), Reg::from(1)),
             Instruction::table_index(0),
             Instruction::Return,
         ])
@@ -181,7 +181,7 @@ fn test_fill_at_exact16(ty: ValType, dst: u64, len: u64) {
     testcase_fill_at_exact(ty, dst, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::table_fill_exact(Reg::from(-1), u64imm16(len), Reg::from(0)),
+                Instruction::table_fill_imm(Reg::from(-1), u64imm16(len), Reg::from(0)),
                 Instruction::table_index(0),
                 Instruction::Return,
             ])

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_init.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_init.rs
@@ -54,7 +54,7 @@ fn testcase_init_exact(ty: ValType, len: u32) -> TranslationTest {
 fn test_init_exact16(ty: ValType, len: u32) {
     testcase_init_exact(ty, len)
         .expect_func_instrs([
-            Instruction::table_init_exact(Reg::from(0), Reg::from(1), u32imm16(len)),
+            Instruction::table_init_imm(Reg::from(0), Reg::from(1), u32imm16(len)),
             Instruction::table_index(0),
             Instruction::elem_index(0),
             Instruction::Return,
@@ -344,7 +344,7 @@ fn test_init_to_exact16(ty: ValType, dst: u64, len: u32) {
     testcase_init_to_exact(ty, dst, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::table_init_exact(Reg::from(-1), Reg::from(0), u32imm16(len)),
+                Instruction::table_init_imm(Reg::from(-1), Reg::from(0), u32imm16(len)),
                 Instruction::table_index(0),
                 Instruction::elem_index(0),
                 Instruction::Return,
@@ -427,7 +427,7 @@ fn test_init_from_exact16(ty: ValType, src: u32, len: u32) {
     testcase_init_from_exact(ty, src, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::table_init_exact(Reg::from(0), Reg::from(-1), u32imm16(len)),
+                Instruction::table_init_imm(Reg::from(0), Reg::from(-1), u32imm16(len)),
                 Instruction::table_index(0),
                 Instruction::elem_index(0),
                 Instruction::Return,
@@ -510,7 +510,7 @@ fn test_init_from_to_exact16(ty: ValType, dst: u64, src: u32, len: u32) {
     testcase_init_from_to_exact(ty, dst, src, len)
         .expect_func(
             ExpectedFunc::new([
-                Instruction::table_init_exact(Reg::from(-1), Reg::from(-2), u32imm16(len)),
+                Instruction::table_init_imm(Reg::from(-1), Reg::from(-2), u32imm16(len)),
                 Instruction::table_index(0),
                 Instruction::elem_index(0),
                 Instruction::Return,

--- a/crates/wasmi/src/engine/translator/tests/op/table/table_init.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/table/table_init.rs
@@ -120,12 +120,15 @@ fn testcase_init_from(ty: ValType, src: u32) -> TranslationTest {
 
 fn test_init_from16(ty: ValType, src: u32) {
     testcase_init_from(ty, src)
-        .expect_func_instrs([
-            Instruction::table_init_from(Reg::from(0), u32imm16(src), Reg::from(1)),
-            Instruction::table_index(0),
-            Instruction::elem_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_init(Reg::from(0), Reg::from(-1), Reg::from(1)),
+                Instruction::table_index(0),
+                Instruction::elem_index(0),
+                Instruction::Return,
+            ])
+            .consts([src]),
+        )
         .run()
 }
 
@@ -185,12 +188,15 @@ fn testcase_init_to(ty: ValType, dst: u64) -> TranslationTest {
 
 fn test_init_to16(ty: ValType, dst: u64) {
     testcase_init_to(ty, dst)
-        .expect_func_instrs([
-            Instruction::table_init_to(u64imm16(dst), Reg::from(0), Reg::from(1)),
-            Instruction::table_index(0),
-            Instruction::elem_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_init(Reg::from(-1), Reg::from(0), Reg::from(1)),
+                Instruction::table_index(0),
+                Instruction::elem_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -250,12 +256,15 @@ fn testcase_init_from_to(ty: ValType, dst: u64, src: u32) -> TranslationTest {
 
 fn test_init_from_to16(ty: ValType, dst: u64, src: u32) {
     testcase_init_from_to(ty, dst, src)
-        .expect_func_instrs([
-            Instruction::table_init_from_to(u64imm16(dst), u32imm16(src), Reg::from(0)),
-            Instruction::table_index(0),
-            Instruction::elem_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_init(Reg::from(-1), Reg::from(-2), Reg::from(0)),
+                Instruction::table_index(0),
+                Instruction::elem_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst, u64::from(src)]),
+        )
         .run()
 }
 
@@ -269,6 +278,9 @@ fn init_from_to16() {
     let values = [0, 1, u32::from(u16::MAX) - 1, u32::from(u16::MAX)];
     for dst in values {
         for src in values {
+            if dst == src {
+                continue;
+            }
             test_for(u64::from(dst), src);
         }
     }
@@ -330,12 +342,15 @@ fn testcase_init_to_exact(ty: ValType, dst: u64, len: u32) -> TranslationTest {
 
 fn test_init_to_exact16(ty: ValType, dst: u64, len: u32) {
     testcase_init_to_exact(ty, dst, len)
-        .expect_func_instrs([
-            Instruction::table_init_to_exact(u64imm16(dst), Reg::from(0), u32imm16(len)),
-            Instruction::table_index(0),
-            Instruction::elem_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_init_exact(Reg::from(-1), Reg::from(0), u32imm16(len)),
+                Instruction::table_index(0),
+                Instruction::elem_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst]),
+        )
         .run()
 }
 
@@ -410,12 +425,15 @@ fn testcase_init_from_exact(ty: ValType, src: u32, len: u32) -> TranslationTest 
 
 fn test_init_from_exact16(ty: ValType, src: u32, len: u32) {
     testcase_init_from_exact(ty, src, len)
-        .expect_func_instrs([
-            Instruction::table_init_from_exact(Reg::from(0), u32imm16(src), u32imm16(len)),
-            Instruction::table_index(0),
-            Instruction::elem_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_init_exact(Reg::from(0), Reg::from(-1), u32imm16(len)),
+                Instruction::table_index(0),
+                Instruction::elem_index(0),
+                Instruction::Return,
+            ])
+            .consts([src]),
+        )
         .run()
 }
 
@@ -490,12 +508,15 @@ fn testcase_init_from_to_exact(ty: ValType, dst: u64, src: u32, len: u32) -> Tra
 
 fn test_init_from_to_exact16(ty: ValType, dst: u64, src: u32, len: u32) {
     testcase_init_from_to_exact(ty, dst, src, len)
-        .expect_func_instrs([
-            Instruction::table_init_from_to_exact(u64imm16(dst), u32imm16(src), u32imm16(len)),
-            Instruction::table_index(0),
-            Instruction::elem_index(0),
-            Instruction::Return,
-        ])
+        .expect_func(
+            ExpectedFunc::new([
+                Instruction::table_init_exact(Reg::from(-1), Reg::from(-2), u32imm16(len)),
+                Instruction::table_index(0),
+                Instruction::elem_index(0),
+                Instruction::Return,
+            ])
+            .consts([dst, u64::from(src)]),
+        )
         .run()
 }
 
@@ -509,6 +530,9 @@ fn init_from_to_exact16() {
     let values = [0, 1, u32::from(u16::MAX) - 1, u32::from(u16::MAX)];
     for dst in values {
         for src in values {
+            if dst == src {
+                continue;
+            }
             for len in values {
                 test_for(u64::from(dst), src, len);
             }

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -3180,7 +3180,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let len = <Provider<Const16<u32>>>::new(len, &mut self.alloc.stack)?;
         let instr = match len {
             Provider::Register(len) => Instruction::table_init(dst, src, len),
-            Provider::Const(len) => Instruction::table_init_exact(dst, src, len),
+            Provider::Const(len) => Instruction::table_init_imm(dst, src, len),
         };
         self.push_fueled_instr(instr, FuelCostsProvider::instance)?;
         self.alloc

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -3088,36 +3088,13 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
     fn visit_memory_init(&mut self, data_index: u32, mem: u32) -> Self::Output {
         bail_unreachable!(self);
         let memory = index::Memory::from(mem);
-        let memory_type = *self.module.get_type_of_memory(MemoryIdx::from(mem));
         let (dst, src, len) = self.alloc.stack.pop3();
-        let dst = self.as_index_type_const16(dst, memory_type.index_ty())?;
-        let src = <Provider<Const16<u32>>>::new(src, &mut self.alloc.stack)?;
+        let dst = self.alloc.stack.provider2reg(&dst)?;
+        let src = self.alloc.stack.provider2reg(&src)?;
         let len = <Provider<Const16<u32>>>::new(len, &mut self.alloc.stack)?;
-        let instr = match (dst, src, len) {
-            (Provider::Register(dst), Provider::Register(src), Provider::Register(len)) => {
-                Instruction::memory_init(dst, src, len)
-            }
-            (Provider::Register(dst), Provider::Register(src), Provider::Const(len)) => {
-                Instruction::memory_init_exact(dst, src, len)
-            }
-            (Provider::Register(dst), Provider::Const(src), Provider::Register(len)) => {
-                Instruction::memory_init_from(dst, src, len)
-            }
-            (Provider::Register(dst), Provider::Const(src), Provider::Const(len)) => {
-                Instruction::memory_init_from_exact(dst, src, len)
-            }
-            (Provider::Const(dst), Provider::Register(src), Provider::Register(len)) => {
-                Instruction::memory_init_to(dst, src, len)
-            }
-            (Provider::Const(dst), Provider::Register(src), Provider::Const(len)) => {
-                Instruction::memory_init_to_exact(dst, src, len)
-            }
-            (Provider::Const(dst), Provider::Const(src), Provider::Register(len)) => {
-                Instruction::memory_init_from_to(dst, src, len)
-            }
-            (Provider::Const(dst), Provider::Const(src), Provider::Const(len)) => {
-                Instruction::memory_init_from_to_exact(dst, src, len)
-            }
+        let instr = match len {
+            Provider::Register(len) => Instruction::memory_init(dst, src, len),
+            Provider::Const(len) => Instruction::memory_init_exact(dst, src, len),
         };
         self.push_fueled_instr(instr, FuelCostsProvider::instance)?;
         self.alloc

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -3154,7 +3154,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
         let instr = match len {
             Provider::Register(len) => Instruction::memory_copy(dst, src, len),
-            Provider::Const(len) => Instruction::memory_copy_exact(dst, src, len),
+            Provider::Const(len) => Instruction::memory_copy_imm(dst, src, len),
         };
         self.push_fueled_instr(instr, FuelCostsProvider::instance)?;
         self.alloc

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -3236,7 +3236,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         };
         let instr = match len {
             Provider::Register(len) => Instruction::table_fill(dst, len, value),
-            Provider::Const(len) => Instruction::table_fill_exact(dst, len, value),
+            Provider::Const(len) => Instruction::table_fill_imm(dst, len, value),
         };
         self.push_fueled_instr(instr, FuelCostsProvider::instance)?;
         self.alloc

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -3175,35 +3175,12 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
     fn visit_table_init(&mut self, elem_index: u32, table: u32) -> Self::Output {
         bail_unreachable!(self);
         let (dst, src, len) = self.alloc.stack.pop3();
-        let table_type = *self.module.get_type_of_table(TableIdx::from(table));
-        let dst = self.as_index_type_const16(dst, table_type.index_ty())?;
-        let src = <Provider<Const16<u32>>>::new(src, &mut self.alloc.stack)?;
+        let dst = self.alloc.stack.provider2reg(&dst)?;
+        let src = self.alloc.stack.provider2reg(&src)?;
         let len = <Provider<Const16<u32>>>::new(len, &mut self.alloc.stack)?;
-        let instr = match (dst, src, len) {
-            (Provider::Register(dst), Provider::Register(src), Provider::Register(len)) => {
-                Instruction::table_init(dst, src, len)
-            }
-            (Provider::Register(dst), Provider::Register(src), Provider::Const(len)) => {
-                Instruction::table_init_exact(dst, src, len)
-            }
-            (Provider::Register(dst), Provider::Const(src), Provider::Register(len)) => {
-                Instruction::table_init_from(dst, src, len)
-            }
-            (Provider::Register(dst), Provider::Const(src), Provider::Const(len)) => {
-                Instruction::table_init_from_exact(dst, src, len)
-            }
-            (Provider::Const(dst), Provider::Register(src), Provider::Register(len)) => {
-                Instruction::table_init_to(dst, src, len)
-            }
-            (Provider::Const(dst), Provider::Register(src), Provider::Const(len)) => {
-                Instruction::table_init_to_exact(dst, src, len)
-            }
-            (Provider::Const(dst), Provider::Const(src), Provider::Register(len)) => {
-                Instruction::table_init_from_to(dst, src, len)
-            }
-            (Provider::Const(dst), Provider::Const(src), Provider::Const(len)) => {
-                Instruction::table_init_from_to_exact(dst, src, len)
-            }
+        let instr = match len {
+            Provider::Register(len) => Instruction::table_init(dst, src, len),
+            Provider::Const(len) => Instruction::table_init_exact(dst, src, len),
         };
         self.push_fueled_instr(instr, FuelCostsProvider::instance)?;
         self.alloc

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -3094,7 +3094,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let len = <Provider<Const16<u32>>>::new(len, &mut self.alloc.stack)?;
         let instr = match len {
             Provider::Register(len) => Instruction::memory_init(dst, src, len),
-            Provider::Const(len) => Instruction::memory_init_exact(dst, src, len),
+            Provider::Const(len) => Instruction::memory_init_imm(dst, src, len),
         };
         self.push_fueled_instr(instr, FuelCostsProvider::instance)?;
         self.alloc

--- a/crates/wasmi/src/engine/translator/visit.rs
+++ b/crates/wasmi/src/engine/translator/visit.rs
@@ -1014,7 +1014,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             }
         }
         let instr = match delta {
-            Provider::Const(delta) => Instruction::memory_grow_by(result, delta),
+            Provider::Const(delta) => Instruction::memory_grow_imm(result, delta),
             Provider::Register(delta) => Instruction::memory_grow(result, delta),
         };
         self.push_fueled_instr(instr, FuelCostsProvider::instance)?;


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1488.

Reduces total non-SIMD instruction count from 459 to 429. (-30)

## ToDo

- [x] Implement re-designed instruction variants:
    - [x] `memory.copy`
    - [x] `memory.fill`
    - [x] `memory.init`
    - [x] `table.copy`
    - [x] `table.fill`
    - [x] `table.init`
- [x] Check how performance is affected by the changes.
    - **Verdict:** performance is not significantly affected by these changes.