### PR TITLE
Add negated `[branch_]f{32,64}.not_{lt,le}` instructions

### DIFF
--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -767,6 +767,27 @@ macro_rules! for_each_op_grouped {
                     offset: BranchOffset16,
                 },
 
+                /// A fused `f32.not_lt` and branch instruction.
+                #[snake_name(branch_f32_not_lt)]
+                BranchF32NotLt {
+                    /// The left-hand side operand to the branch conditional.
+                    lhs: Reg,
+                    /// The right-hand side operand to the branch conditional.
+                    rhs: Reg,
+                    /// The 16-bit encoded branch offset.
+                    offset: BranchOffset16,
+                },
+                /// A fused `f32.not_le` and branch instruction.
+                #[snake_name(branch_f32_not_le)]
+                BranchF32NotLe {
+                    /// The left-hand side operand to the branch conditional.
+                    lhs: Reg,
+                    /// The right-hand side operand to the branch conditional.
+                    rhs: Reg,
+                    /// The 16-bit encoded branch offset.
+                    offset: BranchOffset16,
+                },
+
                 /// A fused `f64.eq` and branch instruction.
                 #[snake_name(branch_f64_eq)]
                 BranchF64Eq {
@@ -801,6 +822,27 @@ macro_rules! for_each_op_grouped {
                 /// A fused `f64.le` and branch instruction.
                 #[snake_name(branch_f64_le)]
                 BranchF64Le {
+                    /// The left-hand side operand to the branch conditional.
+                    lhs: Reg,
+                    /// The right-hand side operand to the branch conditional.
+                    rhs: Reg,
+                    /// The 16-bit encoded branch offset.
+                    offset: BranchOffset16,
+                },
+
+                /// A fused `f64.not_lt` and branch instruction.
+                #[snake_name(branch_f64_not_lt)]
+                BranchF64NotLt {
+                    /// The left-hand side operand to the branch conditional.
+                    lhs: Reg,
+                    /// The right-hand side operand to the branch conditional.
+                    rhs: Reg,
+                    /// The 16-bit encoded branch offset.
+                    offset: BranchOffset16,
+                },
+                /// A fused `f64.not_le` and branch instruction.
+                #[snake_name(branch_f64_not_le)]
+                BranchF64NotLe {
                     /// The left-hand side operand to the branch conditional.
                     lhs: Reg,
                     /// The right-hand side operand to the branch conditional.
@@ -3138,6 +3180,24 @@ macro_rules! for_each_op_grouped {
                     /// The register holding the right-hand side value.
                     rhs: Reg,
                 },
+                /// Negated Wasm `f32.lt` equivalent Wasmi instruction.
+                #[snake_name(f32_not_lt)]
+                F32NotLt{
+                    @result: Reg,
+                    /// The register holding the left-hand side value.
+                    lhs: Reg,
+                    /// The register holding the right-hand side value.
+                    rhs: Reg,
+                },
+                /// Negated Wasm `f32.le` equivalent Wasmi instruction.
+                #[snake_name(f32_not_le)]
+                F32NotLe{
+                    @result: Reg,
+                    /// The register holding the left-hand side value.
+                    lhs: Reg,
+                    /// The register holding the right-hand side value.
+                    rhs: Reg,
+                },
 
                 /// Wasm `f64.eq` equivalent Wasmi instruction.
                 #[snake_name(f64_eq)]
@@ -3169,6 +3229,24 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `f64.le` equivalent Wasmi instruction.
                 #[snake_name(f64_le)]
                 F64Le{
+                    @result: Reg,
+                    /// The register holding the left-hand side value.
+                    lhs: Reg,
+                    /// The register holding the right-hand side value.
+                    rhs: Reg,
+                },
+                /// Negated Wasm `f64.lt` equivalent Wasmi instruction.
+                #[snake_name(f64_not_lt)]
+                F64NotLt{
+                    @result: Reg,
+                    /// The register holding the left-hand side value.
+                    lhs: Reg,
+                    /// The register holding the right-hand side value.
+                    rhs: Reg,
+                },
+                /// Negated Wasm `f64.le` equivalent Wasmi instruction.
+                #[snake_name(f64_not_le)]
+                F64NotLe{
                     @result: Reg,
                     /// The register holding the left-hand side value.
                     lhs: Reg,

--- a/crates/ir/src/primitive.rs
+++ b/crates/ir/src/primitive.rs
@@ -270,11 +270,15 @@ macro_rules! for_each_comparator {
             F32Ne,
             F32Lt,
             F32Le,
+            F32NotLt,
+            F32NotLe,
 
             F64Eq,
             F64Ne,
             F64Lt,
             F64Le,
+            F64NotLt,
+            F64NotLe,
         }
     };
 }

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -355,6 +355,12 @@ impl<'engine> Executor<'engine> {
                 Instr::BranchF32Le { lhs, rhs, offset } => {
                     self.execute_branch_f32_le(lhs, rhs, offset)
                 }
+                Instr::BranchF32NotLt { lhs, rhs, offset } => {
+                    self.execute_branch_f32_not_lt(lhs, rhs, offset)
+                }
+                Instr::BranchF32NotLe { lhs, rhs, offset } => {
+                    self.execute_branch_f32_not_le(lhs, rhs, offset)
+                }
                 Instr::BranchF64Eq { lhs, rhs, offset } => {
                     self.execute_branch_f64_eq(lhs, rhs, offset)
                 }
@@ -366,6 +372,12 @@ impl<'engine> Executor<'engine> {
                 }
                 Instr::BranchF64Le { lhs, rhs, offset } => {
                     self.execute_branch_f64_le(lhs, rhs, offset)
+                }
+                Instr::BranchF64NotLt { lhs, rhs, offset } => {
+                    self.execute_branch_f64_not_lt(lhs, rhs, offset)
+                }
+                Instr::BranchF64NotLe { lhs, rhs, offset } => {
+                    self.execute_branch_f64_not_le(lhs, rhs, offset)
                 }
                 Instr::Copy { result, value } => self.execute_copy(result, value),
                 Instr::Copy2 { results, values } => self.execute_copy_2(results, values),
@@ -801,10 +813,14 @@ impl<'engine> Executor<'engine> {
                 Instr::F32Ne { result, lhs, rhs } => self.execute_f32_ne(result, lhs, rhs),
                 Instr::F32Lt { result, lhs, rhs } => self.execute_f32_lt(result, lhs, rhs),
                 Instr::F32Le { result, lhs, rhs } => self.execute_f32_le(result, lhs, rhs),
+                Instr::F32NotLt { result, lhs, rhs } => self.execute_f32_not_lt(result, lhs, rhs),
+                Instr::F32NotLe { result, lhs, rhs } => self.execute_f32_not_le(result, lhs, rhs),
                 Instr::F64Eq { result, lhs, rhs } => self.execute_f64_eq(result, lhs, rhs),
                 Instr::F64Ne { result, lhs, rhs } => self.execute_f64_ne(result, lhs, rhs),
                 Instr::F64Lt { result, lhs, rhs } => self.execute_f64_lt(result, lhs, rhs),
                 Instr::F64Le { result, lhs, rhs } => self.execute_f64_le(result, lhs, rhs),
+                Instr::F64NotLt { result, lhs, rhs } => self.execute_f64_not_lt(result, lhs, rhs),
+                Instr::F64NotLe { result, lhs, rhs } => self.execute_f64_not_le(result, lhs, rhs),
                 Instr::I32Clz { result, input } => self.execute_i32_clz(result, input),
                 Instr::I32Ctz { result, input } => self.execute_i32_ctz(result, input),
                 Instr::I32Popcnt { result, input } => self.execute_i32_popcnt(result, input),
@@ -2698,5 +2714,31 @@ impl UntypedValueExt for i64 {
 
     fn xor(x: Self, y: Self) -> bool {
         wasm::i64_bitxor(x, y) != 0
+    }
+}
+
+/// Extension method for [`UntypedVal`] required by the [`Executor`].
+trait UntypedValueCmpExt: Sized {
+    fn not_le(lhs: Self, rhs: Self) -> bool;
+    fn not_lt(lhs: Self, rhs: Self) -> bool;
+}
+
+impl UntypedValueCmpExt for f32 {
+    fn not_le(x: Self, y: Self) -> bool {
+        !wasm::f32_le(x, y)
+    }
+
+    fn not_lt(x: Self, y: Self) -> bool {
+        !wasm::f32_lt(x, y)
+    }
+}
+
+impl UntypedValueCmpExt for f64 {
+    fn not_le(x: Self, y: Self) -> bool {
+        !wasm::f64_le(x, y)
+    }
+
+    fn not_lt(x: Self, y: Self) -> bool {
+        !wasm::f64_lt(x, y)
     }
 }

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -1,4 +1,4 @@
-use super::{Executor, UntypedValueExt};
+use super::{Executor, UntypedValueCmpExt, UntypedValueExt};
 use crate::{
     core::{ReadAs, UntypedVal},
     engine::utils::unreachable_unchecked,
@@ -325,11 +325,15 @@ impl_execute_branch_binop! {
     (f32, Instruction::BranchF32Ne, execute_branch_f32_ne, cmp_ne),
     (f32, Instruction::BranchF32Lt, execute_branch_f32_lt, cmp_lt),
     (f32, Instruction::BranchF32Le, execute_branch_f32_le, cmp_le),
+    (f32, Instruction::BranchF32NotLt, execute_branch_f32_not_lt, UntypedValueCmpExt::not_lt),
+    (f32, Instruction::BranchF32NotLe, execute_branch_f32_not_le, UntypedValueCmpExt::not_le),
 
     (f64, Instruction::BranchF64Eq, execute_branch_f64_eq, cmp_eq),
     (f64, Instruction::BranchF64Ne, execute_branch_f64_ne, cmp_ne),
     (f64, Instruction::BranchF64Lt, execute_branch_f64_lt, cmp_lt),
     (f64, Instruction::BranchF64Le, execute_branch_f64_le, cmp_le),
+    (f64, Instruction::BranchF64NotLt, execute_branch_f64_not_lt, UntypedValueCmpExt::not_lt),
+    (f64, Instruction::BranchF64NotLe, execute_branch_f64_not_le, UntypedValueCmpExt::not_le),
 }
 
 macro_rules! impl_execute_branch_binop_imm16_rhs {
@@ -434,10 +438,22 @@ impl Executor<'_> {
             C::F32Ne => self.execute_branch_binop::<f32>(lhs, rhs, offset, cmp_ne),
             C::F32Lt => self.execute_branch_binop::<f32>(lhs, rhs, offset, cmp_lt),
             C::F32Le => self.execute_branch_binop::<f32>(lhs, rhs, offset, cmp_le),
+            C::F32NotLt => {
+                self.execute_branch_binop::<f32>(lhs, rhs, offset, UntypedValueCmpExt::not_lt)
+            }
+            C::F32NotLe => {
+                self.execute_branch_binop::<f32>(lhs, rhs, offset, UntypedValueCmpExt::not_le)
+            }
             C::F64Eq => self.execute_branch_binop::<f64>(lhs, rhs, offset, cmp_eq),
             C::F64Ne => self.execute_branch_binop::<f64>(lhs, rhs, offset, cmp_ne),
             C::F64Lt => self.execute_branch_binop::<f64>(lhs, rhs, offset, cmp_lt),
             C::F64Le => self.execute_branch_binop::<f64>(lhs, rhs, offset, cmp_le),
+            C::F64NotLt => {
+                self.execute_branch_binop::<f64>(lhs, rhs, offset, UntypedValueCmpExt::not_lt)
+            }
+            C::F64NotLe => {
+                self.execute_branch_binop::<f64>(lhs, rhs, offset, UntypedValueCmpExt::not_le)
+            }
         };
     }
 }

--- a/crates/wasmi/src/engine/executor/instrs/comparison.rs
+++ b/crates/wasmi/src/engine/executor/instrs/comparison.rs
@@ -1,4 +1,4 @@
-use super::Executor;
+use super::{Executor, UntypedValueCmpExt};
 use crate::{
     core::wasm,
     ir::{Const16, Reg},
@@ -27,11 +27,15 @@ impl Executor<'_> {
         (Instruction::F32Ne, execute_f32_ne, wasm::f32_ne),
         (Instruction::F32Lt, execute_f32_lt, wasm::f32_lt),
         (Instruction::F32Le, execute_f32_le, wasm::f32_le),
+        (Instruction::F32NotLt, execute_f32_not_lt, <f32 as UntypedValueCmpExt>::not_lt),
+        (Instruction::F32NotLe, execute_f32_not_le, <f32 as UntypedValueCmpExt>::not_le),
 
         (Instruction::F64Eq, execute_f64_eq, wasm::f64_eq),
         (Instruction::F64Ne, execute_f64_ne, wasm::f64_ne),
         (Instruction::F64Lt, execute_f64_lt, wasm::f64_lt),
         (Instruction::F64Le, execute_f64_le, wasm::f64_le),
+        (Instruction::F64NotLt, execute_f64_not_lt, <f64 as UntypedValueCmpExt>::not_lt),
+        (Instruction::F64NotLe, execute_f64_not_le, <f64 as UntypedValueCmpExt>::not_le),
     }
 }
 

--- a/crates/wasmi/src/engine/translator/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/instr_encoder.rs
@@ -1164,10 +1164,14 @@ impl UpdateBranchOffset for Instruction {
             I::BranchF32Ne { offset, .. } |
             I::BranchF32Lt { offset, .. } |
             I::BranchF32Le { offset, .. } |
+            I::BranchF32NotLt { offset, .. } |
+            I::BranchF32NotLe { offset, .. } |
             I::BranchF64Eq { offset, .. } |
             I::BranchF64Ne { offset, .. } |
             I::BranchF64Lt { offset, .. } |
             I::BranchF64Le { offset, .. } |
+            I::BranchF64NotLt { offset, .. } |
+            I::BranchF64NotLe { offset, .. } |
             I::BranchI32AndImm16 { offset, .. } |
             I::BranchI32OrImm16 { offset, .. } |
             I::BranchI32XorImm16 { offset, .. } |

--- a/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/cmp_br.rs
@@ -729,8 +729,29 @@ fn if_forward_multi_value() {
 
     test_for(CmpOp::F32Eq, Instruction::branch_f32_ne);
     test_for(CmpOp::F32Ne, Instruction::branch_f32_eq);
+    test_for(CmpOp::F32Lt, Instruction::branch_f32_not_lt);
+    test_for(CmpOp::F32Le, Instruction::branch_f32_not_le);
+    test_for(
+        CmpOp::F32Gt,
+        swap_cmp_br_ops!(Instruction::branch_f32_not_lt),
+    );
+    test_for(
+        CmpOp::F32Ge,
+        swap_cmp_br_ops!(Instruction::branch_f32_not_le),
+    );
+
     test_for(CmpOp::F64Eq, Instruction::branch_f64_ne);
     test_for(CmpOp::F64Ne, Instruction::branch_f64_eq);
+    test_for(CmpOp::F64Lt, Instruction::branch_f64_not_lt);
+    test_for(CmpOp::F64Le, Instruction::branch_f64_not_le);
+    test_for(
+        CmpOp::F64Gt,
+        swap_cmp_br_ops!(Instruction::branch_f64_not_lt),
+    );
+    test_for(
+        CmpOp::F64Ge,
+        swap_cmp_br_ops!(Instruction::branch_f64_not_le),
+    );
 }
 
 #[test]
@@ -821,8 +842,29 @@ fn if_forward() {
 
     test_for(CmpOp::F32Eq, Instruction::branch_f32_ne);
     test_for(CmpOp::F32Ne, Instruction::branch_f32_eq);
+    test_for(CmpOp::F32Lt, Instruction::branch_f32_not_lt);
+    test_for(CmpOp::F32Le, Instruction::branch_f32_not_le);
+    test_for(
+        CmpOp::F32Gt,
+        swap_cmp_br_ops!(Instruction::branch_f32_not_lt),
+    );
+    test_for(
+        CmpOp::F32Ge,
+        swap_cmp_br_ops!(Instruction::branch_f32_not_le),
+    );
+
     test_for(CmpOp::F64Eq, Instruction::branch_f64_ne);
     test_for(CmpOp::F64Ne, Instruction::branch_f64_eq);
+    test_for(CmpOp::F64Lt, Instruction::branch_f64_not_lt);
+    test_for(CmpOp::F64Le, Instruction::branch_f64_not_le);
+    test_for(
+        CmpOp::F64Gt,
+        swap_cmp_br_ops!(Instruction::branch_f64_not_lt),
+    );
+    test_for(
+        CmpOp::F64Ge,
+        swap_cmp_br_ops!(Instruction::branch_f64_not_le),
+    );
 }
 
 #[test]

--- a/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/i32_eqz.rs
@@ -61,8 +61,12 @@ fn binop_i32_eqz() {
         ("i64", "ge_u", Instruction::i64_lt_u),
         ("f32", "eq", Instruction::f32_ne),
         ("f32", "ne", Instruction::f32_eq),
+        ("f32", "lt", Instruction::f32_not_lt),
+        ("f32", "le", Instruction::f32_not_le),
         ("f64", "eq", Instruction::f64_ne),
         ("f64", "ne", Instruction::f64_eq),
+        ("f64", "lt", Instruction::f64_not_lt),
+        ("f64", "le", Instruction::f64_not_le),
     );
 }
 
@@ -252,8 +256,12 @@ fn binop_i32_eqz_double() {
         ("i64", "ge_u", swap_ops!(Instruction::i64_le_u)),
         ("f32", "eq", Instruction::f32_eq),
         ("f32", "ne", Instruction::f32_ne),
+        ("f32", "lt", Instruction::f32_lt),
+        ("f32", "le", Instruction::f32_le),
         ("f64", "eq", Instruction::f64_eq),
         ("f64", "ne", Instruction::f64_ne),
+        ("f64", "lt", Instruction::f64_lt),
+        ("f64", "le", Instruction::f64_le),
     );
 }
 

--- a/crates/wasmi/src/engine/translator/tests/op/i32_nez.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/i32_nez.rs
@@ -62,8 +62,12 @@ fn binop_i32_nez() {
         ("i64", "ge_u", swap_ops!(Instruction::i64_le_u)),
         ("f32", "eq", Instruction::f32_eq),
         ("f32", "ne", Instruction::f32_ne),
+        ("f32", "lt", Instruction::f32_lt),
+        ("f32", "le", Instruction::f32_le),
         ("f64", "eq", Instruction::f64_eq),
         ("f64", "ne", Instruction::f64_ne),
+        ("f64", "lt", Instruction::f64_lt),
+        ("f64", "le", Instruction::f64_le),
     );
 }
 


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1495.

## ToDos

- [x] Check how this affects performance.
    - Performance is not affected by our benchmarks. However, out benchmarks do not really cover float heavy computation very well. So we might be missing some proper data to verify.
    - In manual tests I saw lots of instances in compiled Wasm where these optimization could be applied.
- [x] Add new or extend existing translation tests.