### PR TITLE
Remove the `downcast-rs` dependency from `wasmi_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,12 +620,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,7 +1775,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
 dependencies = [
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "libm",
  "num-traits",
  "paste",
@@ -1791,7 +1785,6 @@ dependencies = [
 name = "wasmi_core"
 version = "0.46.0"
 dependencies = [
- "downcast-rs 2.0.1",
  "libm",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,12 +15,11 @@ exclude.workspace = true
 
 [dependencies]
 libm = { version = "0.2.11", default-features = false }
-downcast-rs = { version = "2.0.1", default-features = false, features = ["sync"] }
 
 [features]
 default = ["std"]
 # Use `no-default-features` for a `no_std` build.
-std = ["downcast-rs/std"]
+std = []
 # Enables the Wasm `simd` proposal.
 #
 # This also changes the size of `UntypedVal` from 64-bit to 128-bit

--- a/crates/core/src/host_error.rs
+++ b/crates/core/src/host_error.rs
@@ -64,8 +64,7 @@ pub trait HostError: 'static + Display + Debug + Any + Send + Sync {}
 impl dyn HostError {
     /// Returns `true` if `self` is of type `T`.
     pub fn is<T: HostError>(&self) -> bool {
-        let this: &dyn Any = self;
-        this.is::<T>()
+        (self as &dyn Any).is::<T>()
     }
 
     /// Downcasts the [`HostError`] into a shared reference to a `T` if possible.
@@ -73,8 +72,7 @@ impl dyn HostError {
     /// Returns `None` otherwise.
     #[inline]
     pub fn downcast_ref<T: HostError>(&self) -> Option<&T> {
-        let this: &dyn Any = self;
-        this.downcast_ref::<T>()
+        (self as &dyn Any).downcast_ref::<T>()
     }
 
     /// Downcasts the [`HostError`] into an exclusive reference to a `T` if possible.
@@ -82,8 +80,7 @@ impl dyn HostError {
     /// Returns `None` otherwise.
     #[inline]
     pub fn downcast_mut<T: HostError>(&mut self) -> Option<&mut T> {
-        let this: &mut dyn Any = self;
-        this.downcast_mut::<T>()
+        (self as &mut dyn Any).downcast_mut::<T>()
     }
 
     /// Consumes `self` to downcast the [`HostError`] into the `T` if possible.
@@ -94,8 +91,7 @@ impl dyn HostError {
     #[inline]
     pub fn downcast<T: HostError>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
         if self.is::<T>() {
-            let this: Box<dyn Any> = self;
-            let Ok(value) = this.downcast::<T>() else {
+            let Ok(value) = (self as Box<dyn Any>).downcast::<T>() else {
                 unreachable!(
                     "failed to downcast `HostError` to T (= {})",
                     type_name::<T>()

--- a/crates/core/src/host_error.rs
+++ b/crates/core/src/host_error.rs
@@ -1,5 +1,8 @@
-use core::fmt::{Debug, Display};
-use downcast_rs::{impl_downcast, DowncastSync};
+use alloc::boxed::Box;
+use core::{
+    any::{type_name, Any},
+    fmt::{Debug, Display},
+};
 
 /// Trait that allows the host to return custom error.
 ///
@@ -56,5 +59,51 @@ use downcast_rs::{impl_downcast, DowncastSync};
 ///     _ => panic!(),
 /// }
 /// ```
-pub trait HostError: 'static + Display + Debug + DowncastSync {}
-impl_downcast!(HostError);
+pub trait HostError: 'static + Display + Debug + Any + Send + Sync {}
+
+impl dyn HostError {
+    /// Returns `true` if `self` is of type `T`.
+    pub fn is<T: HostError>(&self) -> bool {
+        let this: &dyn Any = self;
+        this.is::<T>()
+    }
+
+    /// Downcasts the [`HostError`] into a shared reference to a `T` if possible.
+    ///
+    /// Returns `None` otherwise.
+    #[inline]
+    pub fn downcast_ref<T: HostError>(&self) -> Option<&T> {
+        let this: &dyn Any = self;
+        this.downcast_ref::<T>()
+    }
+
+    /// Downcasts the [`HostError`] into an exclusive reference to a `T` if possible.
+    ///
+    /// Returns `None` otherwise.
+    #[inline]
+    pub fn downcast_mut<T: HostError>(&mut self) -> Option<&mut T> {
+        let this: &mut dyn Any = self;
+        this.downcast_mut::<T>()
+    }
+
+    /// Consumes `self` to downcast the [`HostError`] into the `T` if possible.
+    ///
+    /// # Errors
+    ///
+    /// If `self` cannot be downcast to `T`.
+    #[inline]
+    pub fn downcast<T: HostError>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+        if self.is::<T>() {
+            let this: Box<dyn Any> = self;
+            let Ok(value) = this.downcast::<T>() else {
+                unreachable!(
+                    "failed to downcast `HostError` to T (= {})",
+                    type_name::<T>()
+                );
+            };
+            Ok(value)
+        } else {
+            Err(self)
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1513.
Blocked by https://github.com/wasmi-labs/wasmi/pull/1518.