### PR TITLE
Change `CompilationMode` default to `LazyTranslation`

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -82,8 +82,8 @@ pub struct Args {
     #[clap(long = "invoke", value_name = "FUNCTION")]
     invoke: Option<String>,
 
-    /// Enable lazy Wasm compilation.
-    #[clap(long = "compilation-mode", value_enum, default_value_t=CompilationMode::Eager)]
+    /// Select Wasmi's mode of compilation.
+    #[clap(long = "compilation-mode", value_enum, default_value_t=CompilationMode::LazyTranslation)]
     compilation_mode: CompilationMode,
 
     /// Enable execution fiel metering with N units of fuel.
@@ -104,8 +104,8 @@ pub struct Args {
 /// The chosen Wasmi compilation mode.
 #[derive(Debug, Default, Copy, Clone, ValueEnum)]
 enum CompilationMode {
-    #[default]
     Eager,
+    #[default]
     LazyTranslation,
     Lazy,
 }

--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -32,9 +32,9 @@ pub struct Config {
 #[derive(Debug, Default, Copy, Clone)]
 pub enum CompilationMode {
     /// The Wasm code is compiled eagerly to Wasmi bytecode.
-    #[default]
     Eager,
     /// The Wasm code is validated eagerly and translated lazily on first use.
+    #[default]
     LazyTranslation,
     /// The Wasm code is validated and translated lazily on first use.
     ///
@@ -333,7 +333,7 @@ impl Config {
 
     /// Sets the [`CompilationMode`] used for the [`Engine`].
     ///
-    /// By default [`CompilationMode::Eager`] is used.
+    /// By default [`CompilationMode::LazyTranslation`] is used.
     ///
     /// [`Engine`]: crate::Engine
     pub fn compilation_mode(&mut self, mode: CompilationMode) -> &mut Self {

--- a/crates/wasmi/tests/integration/fuel_consumption.rs
+++ b/crates/wasmi/tests/integration/fuel_consumption.rs
@@ -6,6 +6,7 @@ use wasmi::{Config, Engine, Error, Func, Linker, Module, Store};
 fn test_setup() -> (Store<()>, Linker<()>) {
     let mut config = Config::default();
     config.consume_fuel(true);
+    config.compilation_mode(wasmi::CompilationMode::Eager);
     let engine = Engine::new(&config);
     let store = Store::new(&engine, ());
     let linker = Linker::new(&engine);

--- a/crates/wasmi/tests/integration/fuel_metering.rs
+++ b/crates/wasmi/tests/integration/fuel_metering.rs
@@ -7,6 +7,7 @@ use wasmi::{core::TrapCode, Config, Engine, Error, Func, Linker, Module, Store};
 fn test_setup() -> (Store<()>, Linker<()>) {
     let mut config = Config::default();
     config.consume_fuel(true);
+    config.compilation_mode(wasmi::CompilationMode::Eager);
     let engine = Engine::new(&config);
     let store = Store::new(&engine, ());
     let linker = Linker::new(&engine);

--- a/crates/wast/tests/mod.rs
+++ b/crates/wast/tests/mod.rs
@@ -1,4 +1,4 @@
-use wasmi::Config;
+use wasmi::{CompilationMode, Config};
 use wasmi_wast::{ParsingMode, RunnerConfig, WastRunner};
 
 /// Runs the Wasm test spec identified by the given name.
@@ -88,7 +88,8 @@ fn test_config(consume_fuel: bool, parsing_mode: ParsingMode) -> RunnerConfig {
         .wasm_extended_const(true)
         .wasm_wide_arithmetic(true)
         .wasm_simd(true)
-        .consume_fuel(consume_fuel);
+        .consume_fuel(consume_fuel)
+        .compilation_mode(CompilationMode::Eager);
     RunnerConfig {
         config,
         parsing_mode,


### PR DESCRIPTION
The [`CompilationMode::LazyTranslation`](https://docs.rs/wasmi/latest/wasmi/enum.CompilationMode.html#variant.LazyTranslation) is a better default than `CompilationMode::Eager` since it is more efficient while still upholding the important invariant that Wasm is eagerly validated.

The problem with `CompilationMode::Eager` as the default is that the discoverability of the `CompilationMode` feature is not great which leads to many people trying out Wasmi to prematurely conclude that it is slow.