### PR TITLE
Fix module instantiation bug: `out of bounds memory access`

### DIFF
--- a/crates/wasmi/tests/integration/instantitation.rs
+++ b/crates/wasmi/tests/integration/instantitation.rs
@@ -1,0 +1,18 @@
+use wasmi::{
+    Engine, Instance, Module, Store
+};
+
+#[test]
+fn instantiate_out_of_memory() {
+    let wasm = r#"
+        (module
+            (memory (;0;) i64 1 1)
+            (func (export ""))
+            (data (i64.const -1095216660480) "\ff")
+        )
+    "#;
+    let engine = Engine::default();
+    let module = Module::new(&engine, &wasm).unwrap();
+    let mut store = Store::new(&engine, ());
+    Instance::new(&mut store, &module, &[]).unwrap_err();
+}

--- a/crates/wasmi/tests/integration/instantitation.rs
+++ b/crates/wasmi/tests/integration/instantitation.rs
@@ -1,6 +1,4 @@
-use wasmi::{
-    Engine, Instance, Module, Store
-};
+use wasmi::{Engine, Instance, Module, Store};
 
 #[test]
 fn instantiate_out_of_memory() {

--- a/crates/wasmi/tests/integration/mod.rs
+++ b/crates/wasmi/tests/integration/mod.rs
@@ -7,3 +7,4 @@ mod host_call_instantiation;
 mod host_calls_wasm;
 mod resource_limiter;
 mod resumable_call;
+mod instantitation;

--- a/crates/wasmi/tests/integration/mod.rs
+++ b/crates/wasmi/tests/integration/mod.rs
@@ -5,6 +5,6 @@ mod func;
 mod host_call_compilation;
 mod host_call_instantiation;
 mod host_calls_wasm;
+mod instantitation;
 mod resource_limiter;
 mod resumable_call;
-mod instantitation;


### PR DESCRIPTION
The following Wasm input was successfully instantiated in Wasmi whereas it should have failed with:
```
memory access out of bounds
```

```wasm
(module
  (memory (;0;) i64 1 1)
  (func (export ""))
  (data (i64.const -1095216660480) "\ff")
)
```