### PR TITLE
Use relative path to `FuncTranslator` internals

### DIFF
--- a/crates/wasmi/src/engine/translator/func/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/simd/visit.rs
@@ -1,10 +1,11 @@
+use super::FuncTranslator;
 use crate::{
     core::{
         simd::{self, ImmLaneIdx32},
         FuelCostsProvider,
         V128,
     },
-    engine::translator::{func::provider::Provider, FuncTranslator},
+    engine::translator::func::provider::Provider,
     ir::{Const32, Instruction, Reg},
 };
 use core::array;


### PR DESCRIPTION
Small follow-up for #1532 .