### PR TITLE
Clean up and refactor `FuncTranslator`'s `ControlFrame` types

### DIFF
--- a/crates/wasmi/src/engine/translator/func/control_frame.rs
+++ b/crates/wasmi/src/engine/translator/func/control_frame.rs
@@ -43,8 +43,8 @@ impl BlockHeight {
 pub struct BlockControlFrame {
     /// The type of the [`BlockControlFrame`].
     block_type: BlockType,
-    /// The number of branches to this [`BlockControlFrame`].
-    len_branches: usize,
+    /// This is `true` if there is at leat one branch to the [`BlockControlFrame`].
+    is_branched_to: bool,
     /// The value stack height upon entering the [`BlockControlFrame`].
     stack_height: BlockHeight,
     /// Label representing the end of the [`BlockControlFrame`].
@@ -77,7 +77,7 @@ impl BlockControlFrame {
     ) -> Self {
         Self {
             block_type,
-            len_branches: 0,
+            is_branched_to: false,
             stack_height,
             end_label,
             branch_params,
@@ -87,17 +87,12 @@ impl BlockControlFrame {
 
     /// Returns `true` if at least one branch targets this [`BlockControlFrame`].
     pub fn is_branched_to(&self) -> bool {
-        self.len_branches() >= 1
+        self.is_branched_to
     }
 
-    /// Returns the number of branches to this [`BlockControlFrame`].
-    fn len_branches(&self) -> usize {
-        self.len_branches
-    }
-
-    /// Bumps the number of branches to this [`BlockControlFrame`] by 1.
-    fn bump_branches(&mut self) {
-        self.len_branches += 1;
+    /// Makes the [`BlockControlFrame`] aware that there is a branch to it.
+    fn branch_to(&mut self) {
+        self.is_branched_to = true;
     }
 
     /// Returns an iterator over the registers holding the branching parameters of the [`BlockControlFrame`].
@@ -148,8 +143,8 @@ impl BlockControlFrame {
 pub struct LoopControlFrame {
     /// The type of the [`LoopControlFrame`].
     block_type: BlockType,
-    /// The number of branches to this [`BlockControlFrame`].
-    len_branches: usize,
+    /// This is `true` if there is at leat one branch to the [`LoopControlFrame`].
+    is_branched_to: bool,
     /// Label representing the head of the [`LoopControlFrame`].
     head_label: LabelRef,
     /// The branch parameters of the [`LoopControlFrame`].
@@ -178,16 +173,16 @@ impl LoopControlFrame {
     ) -> Self {
         Self {
             block_type,
-            len_branches: 0,
+            is_branched_to: false,
             head_label,
             branch_params,
             consume_fuel,
         }
     }
 
-    /// Bumps the number of branches to this [`LoopControlFrame`] by 1.
-    fn bump_branches(&mut self) {
-        self.len_branches += 1;
+    /// Makes the [`BlockControlFrame`] aware that there is a branch to it.
+    fn branch_to(&mut self) {
+        self.is_branched_to = true;
     }
 
     /// Returns an iterator over the registers holding the branching parameters of the [`LoopControlFrame`].
@@ -224,8 +219,8 @@ impl LoopControlFrame {
 pub struct IfControlFrame {
     /// The type of the [`IfControlFrame`].
     block_type: BlockType,
-    /// The number of branches to this [`BlockControlFrame`].
-    len_branches: usize,
+    /// This is `true` if there is at leat one branch to the [`IfControlFrame`].
+    is_branched_to: bool,
     /// The value stack height upon entering the [`IfControlFrame`].
     stack_height: BlockHeight,
     /// Label representing the end of the [`IfControlFrame`].
@@ -328,7 +323,7 @@ impl IfControlFrame {
         };
         Self {
             block_type,
-            len_branches: 0,
+            is_branched_to: false,
             stack_height,
             end_label,
             branch_params,
@@ -341,17 +336,12 @@ impl IfControlFrame {
 
     /// Returns `true` if at least one branch targets this [`IfControlFrame`].
     pub fn is_branched_to(&self) -> bool {
-        self.len_branches() >= 1
+        self.is_branched_to
     }
 
-    /// Returns the number of branches to this [`IfControlFrame`].
-    fn len_branches(&self) -> usize {
-        self.len_branches
-    }
-
-    /// Bumps the number of branches to this [`IfControlFrame`] by 1.
-    pub fn bump_branches(&mut self) {
-        self.len_branches += 1;
+    /// Makes the [`IfControlFrame`] aware that there is a branch to it.
+    pub fn branch_to(&mut self) {
+        self.is_branched_to = true;
     }
 
     /// Returns an iterator over the registers holding the branching parameters of the [`IfControlFrame`].
@@ -581,12 +571,12 @@ impl ControlFrame {
         }
     }
 
-    /// Bumps the number of branches to this [`ControlFrame`] by 1.
-    pub fn bump_branches(&mut self) {
+    /// Makes the [`ControlFrame`] aware that there is a branch to it.
+    pub fn branch_to(&mut self) {
         match self {
-            ControlFrame::Block(frame) => frame.bump_branches(),
-            ControlFrame::Loop(frame) => frame.bump_branches(),
-            ControlFrame::If(frame) => frame.bump_branches(),
+            ControlFrame::Block(frame) => frame.branch_to(),
+            ControlFrame::Loop(frame) => frame.branch_to(),
+            ControlFrame::If(frame) => frame.branch_to(),
             Self::Unreachable(frame) => {
                 panic!("tried to `bump_branches` on an unreachable control frame: {frame:?}")
             }

--- a/crates/wasmi/src/engine/translator/func/control_frame.rs
+++ b/crates/wasmi/src/engine/translator/func/control_frame.rs
@@ -481,32 +481,13 @@ impl IfControlFrame {
 
 /// An unreachable control flow frame of any kind.
 #[derive(Debug, Copy, Clone)]
-pub struct UnreachableControlFrame {
-    /// The kind of the unreachable control flow frame.
-    pub kind: ControlFrameKind,
-}
-
-/// The kind of a control flow frame.
-#[derive(Debug, Copy, Clone)]
-pub enum ControlFrameKind {
+pub enum UnreachableControlFrame {
     /// A basic `block` control flow frame.
     Block,
     /// A `loop` control flow frame.
     Loop,
     /// An `if` and `else` block control flow frame.
     If,
-}
-
-impl UnreachableControlFrame {
-    /// Creates a new [`UnreachableControlFrame`] with the given type and kind.
-    pub fn new(kind: ControlFrameKind) -> Self {
-        Self { kind }
-    }
-
-    /// Returns the [`ControlFrameKind`] of the [`UnreachableControlFrame`].
-    pub fn kind(&self) -> ControlFrameKind {
-        self.kind
-    }
 }
 
 /// A control flow frame.

--- a/crates/wasmi/src/engine/translator/func/instr_encoder.rs
+++ b/crates/wasmi/src/engine/translator/func/instr_encoder.rs
@@ -4,7 +4,6 @@ use crate::{
         func::{
             stack::RegisterSpace,
             utils::FromProviders as _,
-            FuelInfo,
             LabelRef,
             LabelRegistry,
             LogicalizeCmpInstr,
@@ -16,7 +15,7 @@ use crate::{
             ValueStack,
         },
         relink_result::RelinkResult as _,
-        utils::WasmInteger,
+        utils::{FuelInfo, WasmInteger},
         visit_register::VisitInputRegisters as _,
         BumpFuelConsumption as _,
     },

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -45,7 +45,7 @@ use crate::{
         code_map::CompiledFuncEntity,
         translator::{
             labels::{LabelRef, LabelRegistry},
-            utils::{WasmFloat, WasmInteger, Wrap},
+            utils::{FuelInfo, WasmFloat, WasmInteger, Wrap},
             WasmTranslator,
         },
         BlockType,
@@ -225,27 +225,6 @@ impl WasmTranslator<'_> for FuncTranslator {
         let instrs = self.alloc.instr_encoder.drain_instrs();
         finalize(CompiledFuncEntity::new(len_registers, instrs, func_consts));
         Ok(self.into_allocations())
-    }
-}
-
-/// Fuel metering information for a certain translation state.
-#[derive(Debug, Clone)]
-pub enum FuelInfo {
-    /// Fuel metering is disabled.
-    None,
-    /// Fuel metering is enabled with the following information.
-    Some {
-        /// The [`FuelCostsProvider`] for the function translation.
-        costs: FuelCostsProvider,
-        /// Index to the current [`Instruction::ConsumeFuel`] of a parent [`ControlFrame`].
-        instr: Instr,
-    },
-}
-
-impl FuelInfo {
-    /// Create a new [`FuelInfo`] for enabled fuel metering.
-    pub fn some(costs: FuelCostsProvider, instr: Instr) -> Self {
-        Self::Some { costs, instr }
     }
 }
 

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -2109,7 +2109,7 @@ impl FuncTranslator {
         match self.alloc.control_stack.acquire_target(relative_depth) {
             AcquiredTarget::Return(_frame) => self.translate_return(),
             AcquiredTarget::Branch(frame) => {
-                frame.bump_branches();
+                frame.branch_to();
                 let branch_dst = frame.branch_destination();
                 let branch_params = frame.branch_params(&engine);
                 self.translate_copy_branch_params(branch_params)?;
@@ -2222,7 +2222,7 @@ impl FuncTranslator {
                     )?;
                 }
                 AcquiredTarget::Branch(frame) => {
-                    frame.bump_branches();
+                    frame.branch_to();
                     let branch_params = frame.branch_params(&engine);
                     let branch_dst = frame.branch_destination();
                     let branch_offset = self.alloc.instr_encoder.try_resolve_label(branch_dst)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -34,7 +34,7 @@ use self::{
     utils::FromProviders as _,
 };
 pub use self::{
-    control_frame::{ControlFrame, ControlFrameKind},
+    control_frame::ControlFrame,
     control_stack::ControlStack,
     instr_encoder::{Instr, InstrEncoder},
     stack::TypedProvider,

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -309,7 +309,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                     .instr_encoder
                     .try_resolve_label(frame.end_label())?;
                 // We are jumping to the end of the `if` so technically we need to bump branches.
-                frame.bump_branches();
+                frame.branch_to();
                 self.push_base_instr(Instruction::branch(end_offset))?;
             }
             self.reachable = true;
@@ -395,7 +395,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             AcquiredTarget::Return(frame) => frame,
             AcquiredTarget::Branch(frame) => frame,
         };
-        frame.bump_branches();
+        frame.branch_to();
         let branch_dst = frame.branch_destination();
         let branch_params = frame.branch_params(&engine);
         if branch_params.is_empty() {

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -9,7 +9,6 @@ use super::{
         UnreachableControlFrame,
     },
     stack::TypedProvider,
-    ControlFrameKind,
     FuncTranslator,
     TypedVal,
 };
@@ -111,7 +110,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             // frames and precisely know when the code is reachable again.
             self.alloc
                 .control_stack
-                .push_frame(UnreachableControlFrame::new(ControlFrameKind::Block));
+                .push_frame(UnreachableControlFrame::Block);
             return Ok(());
         }
         self.preserve_locals()?;
@@ -143,7 +142,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             // See `visit_block` for rational of tracking unreachable control flow.
             self.alloc
                 .control_stack
-                .push_frame(UnreachableControlFrame::new(ControlFrameKind::Loop));
+                .push_frame(UnreachableControlFrame::Loop);
             return Ok(());
         }
         self.preserve_locals()?;
@@ -193,7 +192,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             // frames and precisely know when the code is reachable again.
             self.alloc
                 .control_stack
-                .push_frame(UnreachableControlFrame::new(ControlFrameKind::If));
+                .push_frame(UnreachableControlFrame::If);
             return Ok(());
         }
         let condition = self.alloc.stack.pop();
@@ -280,7 +279,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
     fn visit_else(&mut self) -> Self::Output {
         let mut frame = match self.alloc.control_stack.pop_frame() {
             ControlFrame::If(frame) => frame,
-            ControlFrame::Unreachable(frame) if matches!(frame.kind(), ControlFrameKind::If) => {
+            ControlFrame::Unreachable(frame @ UnreachableControlFrame::If) => {
                 // Case: `else` branch for unreachable `if` block.
                 //
                 // In this case we can simply ignore the entire `else`

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -111,10 +111,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             // frames and precisely know when the code is reachable again.
             self.alloc
                 .control_stack
-                .push_frame(UnreachableControlFrame::new(
-                    ControlFrameKind::Block,
-                    block_type,
-                ));
+                .push_frame(UnreachableControlFrame::new(ControlFrameKind::Block));
             return Ok(());
         }
         self.preserve_locals()?;
@@ -146,10 +143,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             // See `visit_block` for rational of tracking unreachable control flow.
             self.alloc
                 .control_stack
-                .push_frame(UnreachableControlFrame::new(
-                    ControlFrameKind::Loop,
-                    block_type,
-                ));
+                .push_frame(UnreachableControlFrame::new(ControlFrameKind::Loop));
             return Ok(());
         }
         self.preserve_locals()?;
@@ -172,7 +166,6 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         )?;
         self.alloc.instr_encoder.reset_last_instr();
         // Create loop header label and immediately pin it.
-        let stack_height = BlockHeight::new(self.engine(), self.alloc.stack.height(), block_type)?;
         let header = self.alloc.instr_encoder.new_label();
         self.alloc.instr_encoder.pin_label(header);
         // Optionally create the loop's [`Instruction::ConsumeFuel`].
@@ -186,7 +179,6 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         self.alloc.control_stack.push_frame(LoopControlFrame::new(
             block_type,
             header,
-            stack_height,
             branch_params,
             consume_fuel,
         ));
@@ -201,10 +193,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             // frames and precisely know when the code is reachable again.
             self.alloc
                 .control_stack
-                .push_frame(UnreachableControlFrame::new(
-                    ControlFrameKind::If,
-                    block_type,
-                ));
+                .push_frame(UnreachableControlFrame::new(ControlFrameKind::If));
             return Ok(());
         }
         let condition = self.alloc.stack.pop();

--- a/crates/wasmi/src/engine/translator/utils.rs
+++ b/crates/wasmi/src/engine/translator/utils.rs
@@ -1,5 +1,6 @@
+use super::Instr;
 use crate::{
-    core::{Typed, TypedVal, ValType},
+    core::{FuelCostsProvider, Typed, TypedVal, ValType},
     ir::{Const16, Sign},
     ExternRef,
     FuncRef,
@@ -139,4 +140,25 @@ impl_wrap_for! {
     u64 => u8,
     u64 => u16,
     u64 => u32,
+}
+
+/// Fuel metering information for a certain translation state.
+#[derive(Debug, Clone)]
+pub enum FuelInfo {
+    /// Fuel metering is disabled.
+    None,
+    /// Fuel metering is enabled with the following information.
+    Some {
+        /// The [`FuelCostsProvider`] for the function translation.
+        costs: FuelCostsProvider,
+        /// Index to the current [`Instruction::ConsumeFuel`] of a parent [`ControlFrame`].
+        instr: Instr,
+    },
+}
+
+impl FuelInfo {
+    /// Create a new [`FuelInfo`] for enabled fuel metering.
+    pub fn some(costs: FuelCostsProvider, instr: Instr) -> Self {
+        Self::Some { costs, instr }
+    }
 }

--- a/crates/wasmi/src/engine/translator/utils.rs
+++ b/crates/wasmi/src/engine/translator/utils.rs
@@ -6,6 +6,9 @@ use crate::{
     FuncRef,
 };
 
+#[cfg(doc)]
+use crate::ir::Instruction;
+
 macro_rules! impl_typed_for {
     ( $( $ty:ident ),* $(,)? ) => {
         $(
@@ -151,7 +154,7 @@ pub enum FuelInfo {
     Some {
         /// The [`FuelCostsProvider`] for the function translation.
         costs: FuelCostsProvider,
-        /// Index to the current [`Instruction::ConsumeFuel`] of a parent [`ControlFrame`].
+        /// Index to the current [`Instruction::ConsumeFuel`] of a parent Wasm control frame.
         instr: Instr,
     },
 }


### PR DESCRIPTION
This also reduces the `mem::size_of::<ControlFrame>` from 48 bytes to 40 bytes.