### PR TITLE
Deprecate `Module::new_streaming[_unchecked]` APIs

### DIFF
--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -244,6 +244,14 @@ impl Module {
     /// - If Wasmi cannot translate the Wasm bytecode.
     ///
     /// [`Config`]: crate::Config
+    #[deprecated(
+        since = "0.48.0",
+        note = "\
+            This API has been deprecated because it is inefficient and unserused. \
+            Please use the `Module::new` API instead if possible. \
+            If you have an urgent need for this API, please tell us at: https://github.com/wasmi-labs/wasmi \
+        "
+    )]
     pub fn new_streaming(engine: &Engine, stream: impl Read) -> Result<Self, Error> {
         ModuleParser::new(engine).parse_streaming(stream)
     }
@@ -293,6 +301,14 @@ impl Module {
     /// - If the Wasm bytecode fails to be compiled by Wasmi.
     ///
     /// [`Config`]: crate::Config
+    #[deprecated(
+        since = "0.48.0",
+        note = "\
+            This API has been deprecated because it is inefficient and unserused. \
+            Please use the `Module::new_unchecked` API instead if possible. \
+            If you have an urgent need for this API, please tell us at: https://github.com/wasmi-labs/wasmi \
+        "
+    )]
     pub unsafe fn new_streaming_unchecked(
         engine: &Engine,
         stream: impl Read,

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -336,6 +336,7 @@ impl WastRunner {
     /// Compiles the `wat` and eventually stores it for further processing.
     ///
     /// Returns the compiled Wasm module and its optional name.
+    #[expect(deprecated)]
     fn module_definition<'a>(
         &mut self,
         mut wat: QuoteWat<'a>,

--- a/fuzz/fuzz_targets/translate.rs
+++ b/fuzz/fuzz_targets/translate.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![expect(deprecated)]
 
 use arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;


### PR DESCRIPTION
The `Module::new_streaming[_unchecked]` APIs existed in Wasmi since the very beginning (thought differently named).
They implement the streaming Wasm module creation interface which is supposedly more efficient than the non-streaming API if Wasm bytes transmission and Wasm module translation are both slow. The idea is to stream in bytes in order to build up a Wasm module incrementally. However, the streaming nature adds overhead to parsing which kinda nullifies the gains. Also Wasmi translation is extremely fast, so streaming usually adds more overhead than is reduced.

As I am not 100% certain that nobody would ever have a serious use for this API, I will deprecate it first and let users know that they shall notify me here in case they have a valid use case for this API.

Removing the streaming APIs make room for a slightly more efficient and lightweight Wasm parser which could simplify the task at: https://github.com/wasmi-labs/wasmi/issues/1514