### PR TITLE
Fix incorrect optimization in `i64.mul_wide_s` translation

### DIFF
--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -3247,10 +3247,10 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
     }
 
     fn visit_i64_mul_wide_s(&mut self) -> Self::Output {
-        self.translate_i64_mul_wide_sx(Instruction::i64_mul_wide_s, wasm::i64_mul_wide_s)
+        self.translate_i64_mul_wide_sx(Instruction::i64_mul_wide_s, wasm::i64_mul_wide_s, true)
     }
 
     fn visit_i64_mul_wide_u(&mut self) -> Self::Output {
-        self.translate_i64_mul_wide_sx(Instruction::i64_mul_wide_u, wasm::i64_mul_wide_u)
+        self.translate_i64_mul_wide_sx(Instruction::i64_mul_wide_u, wasm::i64_mul_wide_u, false)
     }
 }


### PR DESCRIPTION
Closes #1544 .

cc @saulecabrera

Minified example that caused the bug:

```wat
(module
  (func (export "run") (param i64) (result i64 i64)
    (i64.mul_wide_s
      (i64.add
        (local.get 0)
        (i64.const -3)
      )
      (i64.const 1)
    )
  )
)
```

Summary: The Wasmi translator incorrectly applied an optimization for `i64.mul_wide_s` when one of its operands was `i64.const 1` and the other operand was not known to never be negative. In cases where the other operand was negative the result after the optimization was incorrect.