### PR TITLE
Add local `.wast` regression tests for Wasmi's `wide-arithmetic` proposal support

### DIFF
--- a/crates/wast/tests/local/wide-arithmetic.wast
+++ b/crates/wast/tests/local/wide-arithmetic.wast
@@ -2,12 +2,12 @@
     (func (export "i64.mul_wide_s(x,0)") (param $x i64) (result i64 i64)
         (i64.mul_wide_s (local.get $x) (i64.const 0))
     )
-    (func (export "i64.mul_wide_s(0,x)") (param $x i64) (result i64 i64)
-        (i64.mul_wide_s (i64.const 0) (local.get $x))
-    )
-
     (func (export "i64.mul_wide_s(x,1)") (param $x i64) (result i64 i64)
         (i64.mul_wide_s (local.get $x) (i64.const 1))
+    )
+
+    (func (export "i64.mul_wide_s(0,x)") (param $x i64) (result i64 i64)
+        (i64.mul_wide_s (i64.const 0) (local.get $x))
     )
     (func (export "i64.mul_wide_s(1,x)") (param $x i64) (result i64 i64)
         (i64.mul_wide_s (i64.const 1) (local.get $x))

--- a/crates/wast/tests/local/wide-arithmetic.wast
+++ b/crates/wast/tests/local/wide-arithmetic.wast
@@ -1,0 +1,41 @@
+(module
+    (func (export "i64.mul_wide_s(x,0)") (param $x i64) (result i64 i64)
+        (i64.mul_wide_s (local.get $x) (i64.const 0))
+    )
+    (func (export "i64.mul_wide_s(0,x)") (param $x i64) (result i64 i64)
+        (i64.mul_wide_s (i64.const 0) (local.get $x))
+    )
+
+    (func (export "i64.mul_wide_s(x,1)") (param $x i64) (result i64 i64)
+        (i64.mul_wide_s (local.get $x) (i64.const 1))
+    )
+    (func (export "i64.mul_wide_s(1,x)") (param $x i64) (result i64 i64)
+        (i64.mul_wide_s (i64.const 1) (local.get $x))
+    )
+)
+
+(assert_return
+    (invoke "i64.mul_wide_s(x,1)" (i64.const 0))
+    (i64.const 0) (i64.const 0)
+)
+(assert_return
+    (invoke "i64.mul_wide_s(x,1)" (i64.const 1))
+    (i64.const 1) (i64.const 0)
+)
+(assert_return
+    (invoke "i64.mul_wide_s(x,1)" (i64.const -1))
+    (i64.const -1) (i64.const -1)
+)
+
+(assert_return
+    (invoke "i64.mul_wide_s(1,x)" (i64.const 0))
+    (i64.const 0) (i64.const 0)
+)
+(assert_return
+    (invoke "i64.mul_wide_s(1,x)" (i64.const 1))
+    (i64.const 1) (i64.const 0)
+)
+(assert_return
+    (invoke "i64.mul_wide_s(1,x)" (i64.const -1))
+    (i64.const -1) (i64.const -1)
+)

--- a/crates/wast/tests/mod.rs
+++ b/crates/wast/tests/mod.rs
@@ -197,6 +197,7 @@ macro_rules! expand_tests {
             fn wasm_utf8_import_module("utf8-import-module");
             fn wasm_utf8_invalid_encoding("utf8-invalid-encoding");
             fn wasm_wide_arithmetic("proposals/wide-arithmetic/wide-arithmetic");
+            fn wasm_wide_arithmetic_local("../../local/wide-arithmetic");
 
             // Wasm `simd` tests
             fn wasm_simd_address("simd_address");


### PR DESCRIPTION
Follow-up to https://github.com/wasmi-labs/wasmi/pull/1545 to add `.wast` based regression tests.

cc @saulecabrera