### PR TITLE
Add local preservation translation benchmark

### DIFF
--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -57,6 +57,7 @@ criterion_group!(
         bench_translate_case_best,
         bench_translate_case_worst_stackbomb_small,
         bench_translate_case_worst_stackbomb_big,
+        bench_translate_preserve_all_locals,
 );
 criterion_group!(
     name = bench_group_instantiate;
@@ -436,6 +437,17 @@ fn bench_translate_case_worst_stackbomb_big(c: &mut Criterion) {
         b.iter_with_large_drop(|| {
             let engine = Engine::default();
             let _ = Module::new(&engine, wasm).unwrap();
+        })
+    });
+}
+
+fn bench_translate_preserve_all_locals(c: &mut Criterion) {
+    let id = format!("translate/case/preserve-all-locals/");
+    c.bench_function(&id, |b| {
+        let wasm = load_wasm_from_file("benches/wat/preserve-all-locals.wat");
+        b.iter_with_large_drop(|| {
+            let engine = Engine::default();
+            let _ = Module::new(&engine, &wasm[..]).unwrap();
         })
     });
 }

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -442,7 +442,7 @@ fn bench_translate_case_worst_stackbomb_big(c: &mut Criterion) {
 }
 
 fn bench_translate_preserve_all_locals(c: &mut Criterion) {
-    let id = format!("translate/case/preserve-all-locals/");
+    let id = "translate/case/preserve-all-locals/".to_string();
     c.bench_function(&id, |b| {
         let wasm = load_wasm_from_file("benches/wat/preserve-all-locals.wat");
         b.iter_with_large_drop(|| {

--- a/crates/wasmi/benches/wat/preserve-all-locals.wat
+++ b/crates/wasmi/benches/wat/preserve-all-locals.wat
@@ -1,0 +1,84 @@
+(module
+    (func (export "run") (param i32) (result i32)
+        (local i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
+        ;; Push 100 locals onto the stack.
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 10
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 20
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 30
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 40
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 50
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 60
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 70
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 80
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 90
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 100
+        ;; Now push a sequence of blocks and `local.get` to force preservation of all locals.
+        (block
+            (local.get 0)
+            (block
+                (local.get 1)
+                (block
+                    (local.get 2)
+                    (block
+                        (local.get 3)
+                        (block
+                            (local.get 4)
+                            (block
+                                (local.get 5)
+                                (block
+                                    (local.get 6)
+                                    (block
+                                        (local.get 7)
+                                        (block
+                                            (local.get 8)
+                                            (block
+                                                (local.get 9)
+                                                (block
+                                                    (local.get 10)
+                                                    (drop)
+                                                )
+                                                (drop)
+                                            )
+                                            (drop)
+                                        )
+                                        (drop)
+                                    )
+                                    (drop)
+                                )
+                                (drop)
+                            )
+                            (drop)
+                        )
+                        (drop)
+                    )
+                    (drop)
+                )
+                (drop)
+            )
+            (drop)
+        )
+        ;; Drop all 100 operands from the stack.
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        ;; Return input to caller.
+        (local.get 0)
+    )
+)

--- a/crates/wasmi/benches/wat/preserve-all-locals.wat
+++ b/crates/wasmi/benches/wat/preserve-all-locals.wat
@@ -1,7 +1,7 @@
 (module
     (func (export "run") (param i32) (result i32)
         (local i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
-        ;; Push 100 locals onto the stack.
+        ;; Push some locals onto the stack.
         (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
         (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 10
         (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
@@ -22,6 +22,46 @@
         (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 90
         (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
         (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 100
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 110
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 120
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 130
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 140
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 150
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 160
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 170
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 180
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 190
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 200
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 210
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 220
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 230
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 240
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 250
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 260
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 270
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 280
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 290
+        (local.get 1) (local.get 2) (local.get 3) (local.get 4) (local.get  5)
+        (local.get 6) (local.get 7) (local.get 8) (local.get 9) (local.get 10) ;; 300
         ;; Now push a sequence of blocks and `local.get` to force preservation of all locals.
         (block
             (local.get 0)
@@ -67,7 +107,7 @@
             )
             (drop)
         )
-        ;; Drop all 100 operands from the stack.
+        ;; Drop all operands from the stack.
         (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
         (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
         (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
@@ -77,7 +117,27 @@
         (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
         (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
         (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) ;; 100
         (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) ;; 200
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop)
+        (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) (drop) ;; 300
         ;; Return input to caller.
         (local.get 0)
     )


### PR DESCRIPTION
I added this benchmark in order to have a better comparison between `main` and #1512.