### PR TITLE
Convert some translation tests to `.wast` tests

### DIFF
--- a/crates/wast/tests/local/op/i32-add.wast
+++ b/crates/wast/tests/local/op/i32-add.wast
@@ -32,9 +32,9 @@
 (assert_return (invoke "i32.add(0,x)" (i32.const 0x80000000)) (i32.const 0x80000000))
 
 (module
-    (import "utils" "identity.i32" (func $indentity.i32 (param i32) (result i32)))
+    (import "utils" "identity.i32" (func $identity.i32 (param i32) (result i32)))
     (func (export "i32.add(0,temp)") (param i32) (result i32)
-        (i32.add (i32.const 0) (call $indentity.i32 (local.get 0)))
+        (i32.add (i32.const 0) (call $identity.i32 (local.get 0)))
     )
 )
 (assert_return (invoke "i32.add(0,temp)" (i32.const 0)) (i32.const 0))

--- a/crates/wast/tests/local/op/i32-add.wast
+++ b/crates/wast/tests/local/op/i32-add.wast
@@ -1,0 +1,153 @@
+(module
+    (func (export "identity.i32") (param i32) (result i32)
+        (local.get 0)
+    )
+)
+(register "utils")
+
+;; Identity
+
+(module
+    (func (export "i32.add(x,0)") (param i32) (result i32)
+        (i32.add (local.get 0) (i32.const 0))
+    )
+)
+(assert_return (invoke "i32.add(x,0)" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "i32.add(x,0)" (i32.const 1)) (i32.const 1))
+(assert_return (invoke "i32.add(x,0)" (i32.const -1)) (i32.const -1))
+(assert_return (invoke "i32.add(x,0)" (i32.const 42)) (i32.const 42))
+(assert_return (invoke "i32.add(x,0)" (i32.const 0x7FFFFFFF)) (i32.const 0x7FFFFFFF))
+(assert_return (invoke "i32.add(x,0)" (i32.const 0x80000000)) (i32.const 0x80000000))
+
+(module
+    (func (export "i32.add(0,x)") (param i32) (result i32)
+        (i32.add (i32.const 0) (local.get 0))
+    )
+)
+(assert_return (invoke "i32.add(0,x)" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "i32.add(0,x)" (i32.const 1)) (i32.const 1))
+(assert_return (invoke "i32.add(0,x)" (i32.const -1)) (i32.const -1))
+(assert_return (invoke "i32.add(0,x)" (i32.const 42)) (i32.const 42))
+(assert_return (invoke "i32.add(0,x)" (i32.const 0x7FFFFFFF)) (i32.const 0x7FFFFFFF))
+(assert_return (invoke "i32.add(0,x)" (i32.const 0x80000000)) (i32.const 0x80000000))
+
+(module
+    (import "utils" "identity.i32" (func $indentity.i32 (param i32) (result i32)))
+    (func (export "i32.add(0,temp)") (param i32) (result i32)
+        (i32.add (i32.const 0) (call $indentity.i32 (local.get 0)))
+    )
+)
+(assert_return (invoke "i32.add(0,temp)" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "i32.add(0,temp)" (i32.const 1)) (i32.const 1))
+(assert_return (invoke "i32.add(0,temp)" (i32.const -1)) (i32.const -1))
+(assert_return (invoke "i32.add(0,temp)" (i32.const 42)) (i32.const 42))
+(assert_return (invoke "i32.add(0,temp)" (i32.const 0x7FFFFFFF)) (i32.const 0x7FFFFFFF))
+(assert_return (invoke "i32.add(0,temp)" (i32.const 0x80000000)) (i32.const 0x80000000))
+
+;; Small `lhs` or `rhs` Constants
+
+(module
+    (func (export "i32.add(x,1)") (param i32) (result i32)
+        (i32.add (local.get 0) (i32.const 1))
+    )
+)
+(assert_return (invoke "i32.add(x,1)" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "i32.add(x,1)" (i32.const 1)) (i32.const 2))
+(assert_return (invoke "i32.add(x,1)" (i32.const -1)) (i32.const 0))
+(assert_return (invoke "i32.add(x,1)" (i32.const 42)) (i32.const 43))
+(assert_return (invoke "i32.add(x,1)" (i32.const 0x7FFFFFFF)) (i32.const 0x80000000))
+(assert_return (invoke "i32.add(x,1)" (i32.const 0x80000000)) (i32.const 0x80000001))
+
+(module
+    (func (export "i32.add(x,-1)") (param i32) (result i32)
+        (i32.add (local.get 0) (i32.const -1))
+    )
+)
+(assert_return (invoke "i32.add(x,-1)" (i32.const 0)) (i32.const -1))
+(assert_return (invoke "i32.add(x,-1)" (i32.const 1)) (i32.const 0))
+(assert_return (invoke "i32.add(x,-1)" (i32.const -1)) (i32.const -2))
+(assert_return (invoke "i32.add(x,-1)" (i32.const 42)) (i32.const 41))
+(assert_return (invoke "i32.add(x,-1)" (i32.const 0x7FFFFFFF)) (i32.const 0x7FFFFFFE))
+(assert_return (invoke "i32.add(x,-1)" (i32.const 0x80000000)) (i32.const 0x7FFFFFFF))
+
+(module
+    (func (export "i32.add(1,x)") (param i32) (result i32)
+        (i32.add (i32.const 1) (local.get 0))
+    )
+)
+(assert_return (invoke "i32.add(1,x)" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "i32.add(1,x)" (i32.const 1)) (i32.const 2))
+(assert_return (invoke "i32.add(1,x)" (i32.const -1)) (i32.const 0))
+(assert_return (invoke "i32.add(1,x)" (i32.const 42)) (i32.const 43))
+(assert_return (invoke "i32.add(1,x)" (i32.const 0x7FFFFFFF)) (i32.const 0x80000000))
+(assert_return (invoke "i32.add(1,x)" (i32.const 0x80000000)) (i32.const 0x80000001))
+
+(module
+    (func (export "i32.add(-1,x)") (param i32) (result i32)
+        (i32.add (i32.const -1) (local.get 0))
+    )
+)
+(assert_return (invoke "i32.add(-1,x)" (i32.const 0)) (i32.const -1))
+(assert_return (invoke "i32.add(-1,x)" (i32.const 1)) (i32.const 0))
+(assert_return (invoke "i32.add(-1,x)" (i32.const -1)) (i32.const -2))
+(assert_return (invoke "i32.add(-1,x)" (i32.const 42)) (i32.const 41))
+(assert_return (invoke "i32.add(-1,x)" (i32.const 0x7FFFFFFF)) (i32.const 0x7FFFFFFE))
+(assert_return (invoke "i32.add(-1,x)" (i32.const 0x80000000)) (i32.const 0x7FFFFFFF))
+
+;; Constant Folding
+
+(module
+    (func (export "i32.add(0,0)") (result i32)
+        (i32.add (i32.const 0) (i32.const 0))
+    )
+)
+(assert_return (invoke "i32.add(0,0)") (i32.const 0))
+
+(module
+    (func (export "i32.add(0,1)") (result i32)
+        (i32.add (i32.const 0) (i32.const 1))
+    )
+)
+(assert_return (invoke "i32.add(0,1)") (i32.const 1))
+
+(module
+    (func (export "i32.add(1,0)") (result i32)
+        (i32.add (i32.const 1) (i32.const 0))
+    )
+)
+(assert_return (invoke "i32.add(1,0)") (i32.const 1))
+
+(module
+    (func (export "i32.add(1,-1)") (result i32)
+        (i32.add (i32.const 1) (i32.const -1))
+    )
+)
+(assert_return (invoke "i32.add(1,-1)") (i32.const 0))
+
+(module
+    (func (export "i32.add(max,-1)") (result i32)
+        (i32.add (i32.const 0x7FFFFFFF) (i32.const -1))
+    )
+)
+(assert_return (invoke "i32.add(max,-1)") (i32.const 0x7FFFFFFE))
+
+(module
+    (func (export "i32.add(max,1)") (result i32)
+        (i32.add (i32.const 0x7FFFFFFF) (i32.const 1))
+    )
+)
+(assert_return (invoke "i32.add(max,1)") (i32.const 0x80000000))
+
+(module
+    (func (export "i32.add(min,-1)") (result i32)
+        (i32.add (i32.const 0x80000000) (i32.const -1))
+    )
+)
+(assert_return (invoke "i32.add(min,-1)") (i32.const 0x7FFFFFFF))
+
+(module
+    (func (export "i32.add(min,1)") (result i32)
+        (i32.add (i32.const 0x80000000) (i32.const 1))
+    )
+)
+(assert_return (invoke "i32.add(min,1)") (i32.const 0x80000001))

--- a/crates/wast/tests/mod.rs
+++ b/crates/wast/tests/mod.rs
@@ -209,6 +209,7 @@ macro_rules! expand_tests {
             fn wasmi_many_inout("../../local/many-inout");
             fn wasmi_copy_span("../../local/copy-span");
             fn wasmi_audit("../../local/audit");
+            fn wasmi_i32_add("../../local/op/i32-add");
 
             // Wasm `simd` tests
             fn wasm_simd_address("simd_address");


### PR DESCRIPTION
This is in anticipation of #1512.