### PR TITLE
Remove ancient and redundant `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,0 @@
-root = true
-[*]
-indent_style=space
-indent_size = 4
-end_of_line=lf
-charset=utf-8
-trim_trailing_whitespace=true
-max_line_length=120
-insert_final_newline=true


### PR DESCRIPTION
We already have `.rustfmt.toml` to specify how to format source code.