### PR TITLE
Deprecate `InstancePre` and `Linker::instantiate`

### DIFF
--- a/crates/cli/src/context.rs
+++ b/crates/cli/src/context.rs
@@ -51,8 +51,7 @@ impl Context {
         wasmi_wasi::add_to_linker(&mut linker, |ctx| ctx)
             .map_err(|error| anyhow!("failed to add WASI definitions to the linker: {error}"))?;
         let instance = linker
-            .instantiate(&mut store, &module)
-            .and_then(|pre| pre.start(&mut store))
+            .instantiate_and_start(&mut store, &module)
             .map_err(|error| anyhow!("failed to instantiate and start the Wasm module: {error}"))?;
         Ok(Self {
             module,

--- a/crates/fuzz/src/oracle/wasmi.rs
+++ b/crates/fuzz/src/oracle/wasmi.rs
@@ -80,10 +80,7 @@ impl DifferentialOracleMeta for WasmiOracle {
         let mut store = Store::new(&engine, limiter);
         store.limiter(|lim| lim);
         let module = Module::new(store.engine(), wasm).unwrap();
-        let Ok(unstarted_instance) = linker.instantiate(&mut store, &module) else {
-            return None;
-        };
-        let Ok(instance) = unstarted_instance.ensure_no_start(&mut store) else {
+        let Ok(instance) = linker.instantiate_and_start(&mut store, &module) else {
             return None;
         };
         Some(Self {

--- a/crates/wasi/tests/wasi_wat.rs
+++ b/crates/wasi/tests/wasi_wat.rs
@@ -16,11 +16,7 @@ pub fn load_instance_from_wat(wasm: &[u8]) -> (Store<WasiCtx>, wasmi::Instance) 
     let mut store = Store::new(&engine, wasi);
 
     add_to_linker(&mut linker, |ctx| ctx).unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     (store, instance)
 }
 

--- a/crates/wasmi/benches/bench/mod.rs
+++ b/crates/wasmi/benches/bench/mod.rs
@@ -58,11 +58,7 @@ pub fn load_instance_from_file(file_name: &str) -> (wasmi::Store<()>, wasmi::Ins
     let module = load_module_from_file(file_name);
     let linker = <wasmi::Linker<()>>::new(module.engine());
     let mut store = wasmi::Store::new(module.engine(), ());
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     (store, instance)
 }
 
@@ -85,10 +81,6 @@ pub fn load_instance_from_wat(wasm: &[u8]) -> (wasmi::Store<()>, wasmi::Instance
     let module = wasmi::Module::new(&engine, wasm).unwrap();
     let linker = <wasmi::Linker<()>>::new(&engine);
     let mut store = wasmi::Store::new(&engine, ());
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     (store, instance)
 }

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -460,7 +460,7 @@ fn bench_instantiate_using(c: &mut Criterion, name: &str) {
         let linker = <Linker<()>>::new(module.engine());
         b.iter(|| {
             let mut store = Store::new(module.engine(), ());
-            let _instance = linker.instantiate(&mut store, &module).unwrap();
+            let _instance = linker.instantiate_and_start(&mut store, &module).unwrap();
         })
     });
 }
@@ -726,10 +726,7 @@ fn bench_instantiate_contract(c: &mut Criterion, name: &str, path: &str) {
             )
             .unwrap();
         b.iter(|| {
-            let _instance = linker
-                .instantiate(&mut store, &module)
-                .unwrap()
-                .ensure_no_start(&mut store);
+            let _instance = linker.instantiate_and_start(&mut store, &module).unwrap();
         })
     });
 }
@@ -1245,11 +1242,7 @@ fn bench_execute_host_calls(c: &mut Criterion) {
     linker.define("benchmark", "host/1", host1).unwrap();
     linker.define("benchmark", "host/8", host8).unwrap();
     linker.define("benchmark", "host/16", host16).unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .ensure_no_start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     for n in [0, 1, 8, 16] {
         bench_with(&mut g, &mut store, &instance, n);
     }

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -134,6 +134,8 @@ pub mod errors {
 
 #[expect(deprecated)]
 pub use self::linker::{state, LinkerBuilder};
+#[expect(deprecated)]
+pub use self::module::InstancePre;
 pub use self::{
     core::{GlobalType, Mutability},
     engine::{
@@ -175,7 +177,6 @@ pub use self::{
         CustomSectionsIter,
         ExportType,
         ImportType,
-        InstancePre,
         Module,
         ModuleExportsIter,
         ModuleImportsIter,

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -4,7 +4,9 @@ mod pre;
 #[cfg(test)]
 mod tests;
 
-pub use self::{error::InstantiationError, pre::InstancePre};
+pub use self::error::InstantiationError;
+#[expect(deprecated)]
+pub use self::pre::InstancePre;
 use super::{element::ElementSegmentKind, export, ConstExpr, InitDataSegment, Module};
 use crate::{
     core::{MemoryError, UntypedVal},
@@ -46,6 +48,7 @@ impl Module {
     ///
     /// [`Linker`]: struct.Linker.html
     /// [`Func`]: [`crate::Func`]
+    #[expect(deprecated)]
     pub(crate) fn instantiate<I>(
         &self,
         mut context: impl AsContextMut,

--- a/crates/wasmi/src/module/instantiate/pre.rs
+++ b/crates/wasmi/src/module/instantiate/pre.rs
@@ -9,11 +9,16 @@ use crate::{module::FuncIdx, AsContextMut, Error, Instance, InstanceEntityBuilde
 /// conformant module instantiation. This API provides control over the precise instantiation
 /// process with regard to this need.
 #[derive(Debug)]
+#[deprecated(
+    since = "0.49.0",
+    note = "enable fuel-metering and set fuel to zero if you want to prevent `start` function execution."
+)]
 pub struct InstancePre {
     handle: Instance,
     builder: InstanceEntityBuilder,
 }
 
+#[expect(deprecated)]
 impl InstancePre {
     /// Creates a new [`InstancePre`].
     pub(super) fn new(handle: Instance, builder: InstanceEntityBuilder) -> Self {

--- a/crates/wasmi/src/module/instantiate/tests.rs
+++ b/crates/wasmi/src/module/instantiate/tests.rs
@@ -37,10 +37,7 @@ fn try_instantiate_from_wat(wasm: &str) -> Result<(Store<()>, Instance), Error> 
     let init = Val::default(table_type.element());
     let table = Table::new(&mut store, table_type, init)?;
     linker.define("env", "table", table)?;
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)?;
+    let instance = linker.instantiate_and_start(&mut store, &module)?;
     Ok((store, instance))
 }
 

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -11,6 +11,8 @@ mod parser;
 mod read;
 pub(crate) mod utils;
 
+#[expect(deprecated)]
+pub use self::instantiate::InstancePre;
 use self::{
     builder::ModuleBuilder,
     custom_section::{CustomSections, CustomSectionsBuilder},
@@ -24,7 +26,7 @@ pub use self::{
     export::{ExportType, FuncIdx, MemoryIdx, ModuleExportsIter, TableIdx},
     global::GlobalIdx,
     import::{FuncTypeIdx, ImportName},
-    instantiate::{InstancePre, InstantiationError},
+    instantiate::InstantiationError,
     read::{Read, ReadError},
 };
 pub(crate) use self::{

--- a/crates/wasmi/src/tests.rs
+++ b/crates/wasmi/src/tests.rs
@@ -87,8 +87,7 @@ where
         let mut store = <Store<T>>::new(&self.engine, data);
         let linker = Linker::new(&self.engine);
         let results = linker
-            .instantiate(&mut store, module)?
-            .start(&mut store)?
+            .instantiate_and_start(&mut store, module)?
             .get_typed_func::<Args, Results>(&store, func_name)?
             .call(&mut store, args)?;
         _ = mem::replace(&mut self.data, store.into_data());

--- a/crates/wasmi/tests/integration/call_hook.rs
+++ b/crates/wasmi/tests/integration/call_hook.rs
@@ -51,11 +51,7 @@ fn execute_wasm_fn_a(
     )
     "#;
     let module = Module::new(store.engine(), wasm).unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(store.as_context_mut())
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     let wasm_fn = instance
         .get_export(store.as_context(), "wasm_fn_a")
         .and_then(Extern::into_func)

--- a/crates/wasmi/tests/integration/call_host_via_engine.rs
+++ b/crates/wasmi/tests/integration/call_host_via_engine.rs
@@ -104,11 +104,7 @@ fn host_tail_calls_0() {
             caller.data() + a
         })
         .unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     let test = instance
         .get_typed_func::<i32, i32>(&mut store, "test")
         .unwrap();
@@ -144,11 +140,7 @@ fn host_tail_calls_1() {
             caller.data() + a
         })
         .unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     let test = instance
         .get_typed_func::<i32, i32>(&mut store, "test")
         .unwrap();

--- a/crates/wasmi/tests/integration/fuel_consumption.rs
+++ b/crates/wasmi/tests/integration/fuel_consumption.rs
@@ -26,11 +26,7 @@ fn create_module(store: &Store<()>, bytes: &[u8]) -> Module {
 fn default_test_setup(wasm: &[u8]) -> (Store<()>, Func) {
     let (mut store, linker) = test_setup();
     let module = create_module(&store, wasm);
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     let func = instance.get_func(&store, "test").unwrap();
     (store, func)
 }

--- a/crates/wasmi/tests/integration/fuel_metering.rs
+++ b/crates/wasmi/tests/integration/fuel_metering.rs
@@ -27,11 +27,7 @@ fn create_module(store: &Store<()>, bytes: &[u8]) -> Module {
 fn default_test_setup(wasm: &[u8]) -> (Store<()>, Func) {
     let (mut store, linker) = test_setup();
     let module = create_module(&store, wasm);
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     let func = instance.get_func(&store, "test").unwrap();
     (store, func)
 }

--- a/crates/wasmi/tests/integration/host_call_compilation.rs
+++ b/crates/wasmi/tests/integration/host_call_compilation.rs
@@ -32,11 +32,7 @@ fn test_compile_in_host_call() {
             },
         )
         .unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .ensure_no_start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     instance
         .get_typed_func::<(), ()>(&mut store, "run")
         .unwrap()

--- a/crates/wasmi/tests/integration/host_call_instantiation.rs
+++ b/crates/wasmi/tests/integration/host_call_instantiation.rs
@@ -56,19 +56,13 @@ fn test_instantiate_in_host_call() {
                 let linker = linker.clone();
                 let module = module.clone();
                 let _instance = linker
-                    .instantiate(&mut store, &module)
-                    .unwrap()
-                    .ensure_no_start(&mut store)
+                    .instantiate_and_start(&mut store, &module)
                     .map_err(|_| wasmi::Error::host(Error::InstantiationFailed))?;
                 Ok(())
             },
         )
         .unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .ensure_no_start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     let run = instance
         .get_typed_func::<(), ()>(&mut store, "run")
         .unwrap();

--- a/crates/wasmi/tests/integration/host_calls_wasm.rs
+++ b/crates/wasmi/tests/integration/host_calls_wasm.rs
@@ -38,11 +38,7 @@ fn host_calls_wasm() {
         )
         "#;
     let module = Module::new(store.engine(), wasm).unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     let wasm_fn = instance
         .get_export(&store, "wasm_fn")
         .and_then(Extern::into_func)

--- a/crates/wasmi/tests/integration/resource_limiter.rs
+++ b/crates/wasmi/tests/integration/resource_limiter.rs
@@ -55,7 +55,7 @@ impl Test {
         );
         let (mut store, linker) = test_setup(limits);
         let module = create_module(&store, wasm.as_bytes())?;
-        let instance = linker.instantiate(&mut store, &module)?.start(&mut store)?;
+        let instance = linker.instantiate_and_start(&mut store, &module)?;
         let memory_grow = instance.get_func(&store, "memory_grow").unwrap();
         let memory_size = instance.get_func(&store, "memory_size").unwrap();
         let table_grow = instance.get_func(&store, "table_grow").unwrap();

--- a/crates/wasmi/tests/integration/resumable_call.rs
+++ b/crates/wasmi/tests/integration/resumable_call.rs
@@ -58,11 +58,7 @@ fn resumable_call_smoldot_common(wasm: &str) -> (Store<TestData>, TypedFunc<(), 
     // host function, returns 10 if the output is 0 and
     // returns 20 otherwise.
     let module = Module::new(store.engine(), wasm).unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     let wasm_fn = instance.get_typed_func::<(), i32>(&store, "test").unwrap();
     (store, wasm_fn)
 }
@@ -249,11 +245,7 @@ fn resumable_call() {
             )
             "#;
     let module = Module::new(store.engine(), wasm).unwrap();
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .unwrap()
-        .start(&mut store)
-        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
     let wasm_fn = instance
         .get_export(&store, "wasm_fn")
         .and_then(Extern::into_func)

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -438,8 +438,7 @@ impl WastRunner {
     fn instantiate_module(&mut self, module: &wasmi::Module) -> Result<Instance> {
         let previous_fuel = self.store.get_fuel().ok();
         _ = self.store.set_fuel(1_000);
-        let instance_pre = self.linker.instantiate(&mut self.store, module)?;
-        let instance = instance_pre.start(&mut self.store)?;
+        let instance = self.linker.instantiate_and_start(&mut self.store, module)?;
         if let Some(fuel) = previous_fuel {
             _ = self.store.set_fuel(fuel);
         }

--- a/fuzz/fuzz_targets/execute.rs
+++ b/fuzz/fuzz_targets/execute.rs
@@ -93,10 +93,7 @@ fuzz_target!(|input: FuzzInput| {
         }
     };
     let module = status.unwrap();
-    let Ok(unstarted_instance) = linker.instantiate(&mut store, &module) else {
-        return;
-    };
-    let Ok(instance) = unstarted_instance.ensure_no_start(&mut store) else {
+    let Ok(instance) = linker.instantiate_and_start(&mut store, &module) else {
         return;
     };
 


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1572.

This also adds a new `Linker::instantiate_and_start` method which should be used instead. Later we are planning to rename this new `Linker::instantiate_and_start` back to `Linker::instantiate`.

Users who want to prevent running a `start` function should use one of the following options:

- Enable fuel metering and set fuel to zero before instantiating a Wasm module. This way any `start` function execution will immediately trap with `out of fuel`.
- Use an external tool to inspect or adjust Wasm modules prior to instantiation.