### PR TITLE
Fix negated `select+f{32,64}.cmp` op-code fusion

### DIFF
--- a/crates/wasmi/src/engine/translator/comparator.rs
+++ b/crates/wasmi/src/engine/translator/comparator.rs
@@ -475,15 +475,15 @@ impl TryIntoCmpSelectInstr for Instruction {
             I::F32Ne { lhs, rhs, .. } => I::select_f32_eq(result, lhs, rhs),
             I::F32Lt { lhs, rhs, .. } => I::select_f32_lt(result, lhs, rhs),
             I::F32Le { lhs, rhs, .. } => I::select_f32_le(result, lhs, rhs),
-            I::F32NotLt { lhs, rhs, .. } => I::select_f32_lt(result, rhs, lhs),
-            I::F32NotLe { lhs, rhs, .. } => I::select_f32_le(result, rhs, lhs),
+            I::F32NotLt { lhs, rhs, .. } => I::select_f32_lt(result, lhs, rhs),
+            I::F32NotLe { lhs, rhs, .. } => I::select_f32_le(result, lhs, rhs),
             // f64
             I::F64Eq { lhs, rhs, .. } => I::select_f64_eq(result, lhs, rhs),
             I::F64Ne { lhs, rhs, .. } => I::select_f64_eq(result, lhs, rhs),
             I::F64Lt { lhs, rhs, .. } => I::select_f64_lt(result, lhs, rhs),
             I::F64Le { lhs, rhs, .. } => I::select_f64_le(result, lhs, rhs),
-            I::F64NotLt { lhs, rhs, .. } => I::select_f64_lt(result, rhs, lhs),
-            I::F64NotLe { lhs, rhs, .. } => I::select_f64_le(result, rhs, lhs),
+            I::F64NotLt { lhs, rhs, .. } => I::select_f64_lt(result, lhs, rhs),
+            I::F64NotLe { lhs, rhs, .. } => I::select_f64_le(result, lhs, rhs),
             _ => unreachable!("expected to successfully fuse cmp+select"),
         };
         Ok(CmpSelectFusion::Applied {

--- a/crates/wasmi/src/engine/translator/tests/op/select.rs
+++ b/crates/wasmi/src/engine/translator/tests/op/select.rs
@@ -455,16 +455,8 @@ fn test_cmp_select_eqz() {
             (CmpOp::I64GeU, Instruction::select_i64_lt_u, false),
             (CmpOp::F32Eq, Instruction::select_f32_eq, true),
             (CmpOp::F32Ne, Instruction::select_f32_eq, false),
-            (CmpOp::F32Lt, swap_cmp_select_ops!(Instruction::select_f32_lt), true),
-            (CmpOp::F32Le, swap_cmp_select_ops!(Instruction::select_f32_le), true),
-            (CmpOp::F32Gt, Instruction::select_f32_lt, true),
-            (CmpOp::F32Ge, Instruction::select_f32_le, true),
             (CmpOp::F64Eq, Instruction::select_f64_eq, true),
             (CmpOp::F64Ne, Instruction::select_f64_eq, false),
-            (CmpOp::F64Lt, swap_cmp_select_ops!(Instruction::select_f64_lt), true),
-            (CmpOp::F64Le, swap_cmp_select_ops!(Instruction::select_f64_le), true),
-            (CmpOp::F64Gt, Instruction::select_f64_lt, true),
-            (CmpOp::F64Ge, Instruction::select_f64_le, true),
         ] {
             run_test(op, kind, ty, expected, swap_operands)
         }


### PR DESCRIPTION
Removed invalid `.wast` tests instead of replacing them with valid ones since we now have proper `.wast` tests fully replacing them as of https://github.com/wasmi-labs/wasmi-tests/pull/5.