### PR TITLE
Remove dependencies used only by the old `FuncTranslator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,10 +1701,8 @@ dependencies = [
 name = "wasmi"
 version = "0.49.1"
 dependencies = [
- "arrayvec",
  "assert_matches",
  "criterion",
- "multi-stash",
  "smallvec",
  "spin",
  "wasmi_collections 0.49.1",

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -30,8 +30,6 @@ spin = { version = "0.9", default-features = false, features = [
     "rwlock",
 ] }
 smallvec = { version = "1.13.1", features = ["union"] }
-multi-stash = { version = "0.2.0" }
-arrayvec = { version = "0.7.4", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -44,7 +42,6 @@ std = [
     "wasmi_collections/std",
     "wasmparser/std",
     "spin/std",
-    "arrayvec/std",
 ]
 hash-collections = [
     "wasmi_collections/hash-collections",


### PR DESCRIPTION
Partially closes https://github.com/wasmi-labs/wasmi/issues/1609.