### PR TITLE
Remove `Instruction::Copy{Span,Many}` variants

### DIFF
--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -174,13 +174,9 @@ impl Instruction {
         Self::copy2(span, [value0.into(), value1.into()])
     }
 
-    /// Creates a new [`Instruction::CopyManyNonOverlapping`].
-    pub fn copy_many_non_overlapping_ext(
-        results: RegSpan,
-        head0: impl Into<Reg>,
-        head1: impl Into<Reg>,
-    ) -> Self {
-        Self::copy_many_non_overlapping(results, [head0.into(), head1.into()])
+    /// Creates a new [`Instruction::CopyMany`].
+    pub fn copy_many_ext(results: RegSpan, head0: impl Into<Reg>, head1: impl Into<Reg>) -> Self {
+        Self::copy_many(results, [head0.into(), head1.into()])
     }
 
     /// Creates a new [`Instruction::Register2`] instruction parameter.

--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -174,11 +174,6 @@ impl Instruction {
         Self::copy2(span, [value0.into(), value1.into()])
     }
 
-    /// Creates a new [`Instruction::CopyMany`].
-    pub fn copy_many_ext(results: RegSpan, head0: impl Into<Reg>, head1: impl Into<Reg>) -> Self {
-        Self::copy_many(results, [head0.into(), head1.into()])
-    }
-
     /// Creates a new [`Instruction::CopyManyNonOverlapping`].
     pub fn copy_many_non_overlapping_ext(
         results: RegSpan,

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -1044,8 +1044,8 @@ macro_rules! for_each_op_grouped {
                 ///     - [`Instruction::Register`]
                 ///     - [`Instruction::Register2`]
                 ///     - [`Instruction::Register3`]
-                #[snake_name(copy_many_non_overlapping)]
-                CopyManyNonOverlapping {
+                #[snake_name(copy_many)]
+                CopyMany {
                     @results: RegSpan,
                     /// The first two input registers to copy.
                     values: [Reg; 2],

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -1026,22 +1026,6 @@ macro_rules! for_each_op_grouped {
                     /// The 32-bit encoded `i64` immediate value to copy.
                     value: Const32<f64>,
                 },
-                /// Copies `len` contiguous `values` [`RegSpan`] into `results` [`RegSpan`].
-                ///
-                /// Copies registers: `registers[results..results+len] <- registers[values..values+len]`
-                ///
-                /// # Note
-                ///
-                /// This [`Instruction`] serves as an optimization for cases were it is possible
-                /// to copy whole spans instead of many individual register values bit by bit.
-                #[snake_name(copy_span)]
-                CopySpan {
-                    @results: RegSpan,
-                    /// The contiguous registers holding the inputs of this instruction.
-                    values: RegSpan,
-                    /// The amount of copied registers.
-                    len: u16,
-                },
                 /// Variant of [`Instruction::CopySpan`] that assumes that `results` and `values` span do not overlap.
                 #[snake_name(copy_span_non_overlapping)]
                 CopySpanNonOverlapping {
@@ -1050,23 +1034,6 @@ macro_rules! for_each_op_grouped {
                     values: RegSpan,
                     /// The amount of copied registers.
                     len: u16,
-                },
-                /// Copies some [`Reg`] values into `results` [`RegSpan`].
-                ///
-                /// # Encoding
-                ///
-                /// Must be followed by
-                ///
-                /// 1. Zero or more [`Instruction::RegisterList`]
-                /// 2. Followed by one of
-                ///     - [`Instruction::Register`]
-                ///     - [`Instruction::Register2`]
-                ///     - [`Instruction::Register3`]
-                #[snake_name(copy_many)]
-                CopyMany {
-                    @results: RegSpan,
-                    /// The first two input registers to copy.
-                    values: [Reg; 2],
                 },
                 /// Variant of [`Instruction::CopyMany`] that assumes that `results` and `values` do not overlap.
                 ///

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -1027,8 +1027,8 @@ macro_rules! for_each_op_grouped {
                     value: Const32<f64>,
                 },
                 /// Variant of [`Instruction::CopySpan`] that assumes that `results` and `values` span do not overlap.
-                #[snake_name(copy_span_non_overlapping)]
-                CopySpanNonOverlapping {
+                #[snake_name(copy_span)]
+                CopySpan {
                     @results: RegSpan,
                     /// The contiguous registers holding the inputs of this instruction.
                     values: RegSpan,

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -396,11 +396,11 @@ impl<'engine> Executor<'engine> {
                 Instr::CopyImm32 { result, value } => self.execute_copy_imm32(result, value),
                 Instr::CopyI64Imm32 { result, value } => self.execute_copy_i64imm32(result, value),
                 Instr::CopyF64Imm32 { result, value } => self.execute_copy_f64imm32(result, value),
-                Instr::CopySpanNonOverlapping {
+                Instr::CopySpan {
                     results,
                     values,
                     len,
-                } => self.execute_copy_span_non_overlapping(results, values, len),
+                } => self.execute_copy_span(results, values, len),
                 Instr::CopyMany { results, values } => self.execute_copy_many(results, values),
                 Instr::ReturnCallInternal0 { func } => {
                     self.execute_return_call_internal_0(store.inner_mut(), EngineFunc::from(func))?

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -396,17 +396,11 @@ impl<'engine> Executor<'engine> {
                 Instr::CopyImm32 { result, value } => self.execute_copy_imm32(result, value),
                 Instr::CopyI64Imm32 { result, value } => self.execute_copy_i64imm32(result, value),
                 Instr::CopyF64Imm32 { result, value } => self.execute_copy_f64imm32(result, value),
-                Instr::CopySpan {
-                    results,
-                    values,
-                    len,
-                } => self.execute_copy_span(results, values, len),
                 Instr::CopySpanNonOverlapping {
                     results,
                     values,
                     len,
                 } => self.execute_copy_span_non_overlapping(results, values, len),
-                Instr::CopyMany { results, values } => self.execute_copy_many(results, values),
                 Instr::CopyManyNonOverlapping { results, values } => {
                     self.execute_copy_many_non_overlapping(results, values)
                 }

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -401,9 +401,7 @@ impl<'engine> Executor<'engine> {
                     values,
                     len,
                 } => self.execute_copy_span_non_overlapping(results, values, len),
-                Instr::CopyManyNonOverlapping { results, values } => {
-                    self.execute_copy_many_non_overlapping(results, values)
-                }
+                Instr::CopyMany { results, values } => self.execute_copy_many(results, values),
                 Instr::ReturnCallInternal0 { func } => {
                     self.execute_return_call_internal_0(store.inner_mut(), EngineFunc::from(func))?
                 }

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -159,7 +159,12 @@ impl Executor<'_> {
                 self.execute_copy_span_impl(results, values, len);
                 self.execute_branch(offset)
             }
-            _ => {}
+            unexpected => {
+                // Safety: Wasmi translator guarantees that one of the above `Instruction` variants exists.
+                unsafe {
+                    unreachable_unchecked!("expected target for `Instruction::BranchTableSpan` but found: {unexpected:?}")
+                }
+            }
         }
     }
 

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -173,11 +173,11 @@ impl Executor<'_> {
             // Note: we explicitly do _not_ handle branch table returns here for technical reasons.
             //       They are executed as the next conventional instruction in the pipeline, no special treatment required.
             Instruction::BranchTableTarget { results, offset } => {
-                self.execute_copy_many_non_overlapping_impl(ip_list, results, &[]);
+                self.execute_copy_many_impl(ip_list, results, &[]);
                 self.execute_branch(offset)
             }
             Instruction::BranchTableTargetNonOverlapping { results, offset } => {
-                self.execute_copy_many_non_overlapping_impl(ip_list, results, &[]);
+                self.execute_copy_many_impl(ip_list, results, &[]);
                 self.execute_branch(offset)
             }
             Instruction::Return => {

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -152,11 +152,11 @@ impl Executor<'_> {
             // Note: we explicitly do _not_ handle branch table returns here for technical reasons.
             //       They are executed as the next conventional instruction in the pipeline, no special treatment required.
             Instruction::BranchTableTarget { results, offset } => {
-                self.execute_copy_span_non_overlapping_impl(results, values, len);
+                self.execute_copy_span_impl(results, values, len);
                 self.execute_branch(offset)
             }
             Instruction::BranchTableTargetNonOverlapping { results, offset } => {
-                self.execute_copy_span_non_overlapping_impl(results, values, len);
+                self.execute_copy_span_impl(results, values, len);
                 self.execute_branch(offset)
             }
             _ => {}

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -152,7 +152,7 @@ impl Executor<'_> {
             // Note: we explicitly do _not_ handle branch table returns here for technical reasons.
             //       They are executed as the next conventional instruction in the pipeline, no special treatment required.
             Instruction::BranchTableTarget { results, offset } => {
-                self.execute_copy_span_impl(results, values, len);
+                self.execute_copy_span_non_overlapping_impl(results, values, len);
                 self.execute_branch(offset)
             }
             Instruction::BranchTableTargetNonOverlapping { results, offset } => {
@@ -173,7 +173,7 @@ impl Executor<'_> {
             // Note: we explicitly do _not_ handle branch table returns here for technical reasons.
             //       They are executed as the next conventional instruction in the pipeline, no special treatment required.
             Instruction::BranchTableTarget { results, offset } => {
-                self.execute_copy_many_impl(ip_list, results, &[]);
+                self.execute_copy_many_non_overlapping_impl(ip_list, results, &[]);
                 self.execute_branch(offset)
             }
             Instruction::BranchTableTargetNonOverlapping { results, offset } => {

--- a/crates/wasmi/src/engine/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/executor/instrs/copy.rs
@@ -82,15 +82,15 @@ impl Executor<'_> {
         }
     }
 
-    /// Executes an [`Instruction::CopyManyNonOverlapping`].
-    pub fn execute_copy_many_non_overlapping(&mut self, results: RegSpan, values: [Reg; 2]) {
+    /// Executes an [`Instruction::CopyMany`].
+    pub fn execute_copy_many(&mut self, results: RegSpan, values: [Reg; 2]) {
         self.ip.add(1);
-        self.ip = self.execute_copy_many_non_overlapping_impl(self.ip, results, &values);
+        self.ip = self.execute_copy_many_impl(self.ip, results, &values);
         self.next_instr()
     }
 
-    /// Internal implementation of [`Instruction::CopyManyNonOverlapping`] execution.
-    pub fn execute_copy_many_non_overlapping_impl(
+    /// Internal implementation of [`Instruction::CopyMany`] execution.
+    pub fn execute_copy_many_impl(
         &mut self,
         ip: InstructionPtr,
         results: RegSpan,

--- a/crates/wasmi/src/engine/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/executor/instrs/copy.rs
@@ -50,30 +50,20 @@ impl Executor<'_> {
         self.execute_copy_impl(result, value, |_, value| UntypedVal::from(f64::from(value)))
     }
 
-    /// Executes an [`Instruction::CopySpanNonOverlapping`].
+    /// Executes an [`Instruction::CopySpan`].
     ///
     /// # Note
     ///
     /// - This instruction assumes that `results` and `values` do _not_ overlap
     ///   and thus can copy all the elements without a costly temporary buffer.
     /// - If `results` and `values` _do_ overlap [`Instruction::CopySpan`] is used.
-    pub fn execute_copy_span_non_overlapping(
-        &mut self,
-        results: RegSpan,
-        values: RegSpan,
-        len: u16,
-    ) {
-        self.execute_copy_span_non_overlapping_impl(results, values, len);
+    pub fn execute_copy_span(&mut self, results: RegSpan, values: RegSpan, len: u16) {
+        self.execute_copy_span_impl(results, values, len);
         self.next_instr();
     }
 
-    /// Internal implementation of [`Instruction::CopySpanNonOverlapping`] execution.
-    pub fn execute_copy_span_non_overlapping_impl(
-        &mut self,
-        results: RegSpan,
-        values: RegSpan,
-        len: u16,
-    ) {
+    /// Internal implementation of [`Instruction::CopySpan`] execution.
+    pub fn execute_copy_span_impl(&mut self, results: RegSpan, values: RegSpan, len: u16) {
         let results = results.iter(len);
         let values = values.iter(len);
         for (result, value) in results.into_iter().zip(values.into_iter()) {

--- a/crates/wasmi/src/engine/translator/func/instrs.rs
+++ b/crates/wasmi/src/engine/translator/func/instrs.rs
@@ -317,7 +317,7 @@ impl InstrEncoder {
     /// This is used for the following n-ary instructions:
     ///
     /// - [`Instruction::ReturnMany`]
-    /// - [`Instruction::CopyManyNonOverlapping`]
+    /// - [`Instruction::CopyMany`]
     /// - [`Instruction::CallInternal`]
     /// - [`Instruction::CallImported`]
     /// - [`Instruction::CallIndirect`]

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -510,7 +510,7 @@ impl FuncTranslator {
         let fused_copy = match last_copy {
             Instruction::Copy { .. } => Self::try_merge_copy_instr(last_copy, result, value),
             Instruction::Copy2 { .. } => Self::try_merge_copy2_instr(last_copy, result, value),
-            Instruction::CopySpanNonOverlapping { .. } => {
+            Instruction::CopySpan { .. } => {
                 Self::try_merge_copy_span_instr(last_copy, result, value)
             }
             _ => return Ok(None),
@@ -592,7 +592,7 @@ impl FuncTranslator {
             let values = RegSpan::new(last_value0);
             let len = 3_u16;
             debug_assert!(!RegSpan::has_overlapping_copies(results, values, len));
-            return Some(Instruction::copy_span_non_overlapping(results, values, len));
+            return Some(Instruction::copy_span(results, values, len));
         }
         if result == last_result0.prev() && value == last_value0.prev() {
             // Case: we can prepend `copy_instr`.
@@ -604,7 +604,7 @@ impl FuncTranslator {
             let values = RegSpan::new(value);
             let len = 3_u16;
             debug_assert!(!RegSpan::has_overlapping_copies(results, values, len));
-            return Some(Instruction::copy_span_non_overlapping(results, values, len));
+            return Some(Instruction::copy_span(results, values, len));
         }
         None
     }
@@ -617,7 +617,7 @@ impl FuncTranslator {
         result: Reg,
         value: Reg,
     ) -> Option<Instruction> {
-        let Instruction::CopySpanNonOverlapping {
+        let Instruction::CopySpan {
             results,
             values,
             len,
@@ -636,9 +636,7 @@ impl FuncTranslator {
                 // Case: cannot merge since resulting `copy_span` has overlapping copies.
                 return None;
             }
-            return Some(Instruction::copy_span_non_overlapping(
-                results, values, new_len,
-            ));
+            return Some(Instruction::copy_span(results, values, new_len));
         }
         if result == last_result0.prev() && value == last_value0.prev() {
             // Case: we can prepend `copy_instr`.
@@ -647,7 +645,7 @@ impl FuncTranslator {
                 // Case: cannot merge since resulting `copy_span` has overlapping copies.
                 return None;
             }
-            return Some(Instruction::copy_span_non_overlapping(
+            return Some(Instruction::copy_span(
                 RegSpan::new(result),
                 RegSpan::new(value),
                 new_len,
@@ -769,7 +767,7 @@ impl FuncTranslator {
         }
         debug_assert!(!RegSpan::has_overlapping_copies(results, values, len));
         self.instrs.push_instr(
-            Instruction::copy_span_non_overlapping(results, values, len),
+            Instruction::copy_span(results, values, len),
             consume_fuel_instr,
             |costs| costs.fuel_for_copying_values(u64::from(len)),
         )?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -815,7 +815,7 @@ impl FuncTranslator {
                 let val0 = self.layout.operand_to_reg(*val0)?;
                 let val1 = self.layout.operand_to_reg(*val1)?;
                 self.instrs.push_instr(
-                    Instruction::copy_many_non_overlapping_ext(results, val0, val1),
+                    Instruction::copy_many_ext(results, val0, val1),
                     consume_fuel_instr,
                     |costs| costs.fuel_for_copying_values(u64::from(len)),
                 )?;


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1607.