### PR TITLE
Remove `smallvec` usage from `ConstExpr::new` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,6 @@ version = "0.49.1"
 dependencies = [
  "assert_matches",
  "criterion",
- "smallvec",
  "spin",
  "wasmi_collections 0.49.1",
  "wasmi_core 0.49.1",

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -29,7 +29,6 @@ spin = { version = "0.9", default-features = false, features = [
     "spin_mutex",
     "rwlock",
 ] }
-smallvec = { version = "1.13.1", features = ["union"] }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/crates/wasmi/src/module/init_expr.rs
+++ b/crates/wasmi/src/module/init_expr.rs
@@ -216,7 +216,7 @@ macro_rules! def_expr {
 #[derive(Debug, Default)]
 pub struct ConstExprStack {
     /// The top-most [`Op`] on the stack.
-    /// 
+    ///
     /// # Note
     /// This is an optimization so that the [`ConstExprStack`] does not
     /// require heap allocations for the common case where only a single

--- a/crates/wasmi/src/module/init_expr.rs
+++ b/crates/wasmi/src/module/init_expr.rs
@@ -243,8 +243,8 @@ impl ConstExprStack {
 
     /// Pops the 2 top-most [`Op`]s from the [`ConstExprStack`] if any.
     pub fn pop2(&mut self) -> Option<(Op, Op)> {
-        let rhs = self.ops.pop()?;
-        let lhs = self.ops.pop()?;
+        let rhs = self.pop()?;
+        let lhs = self.pop()?;
         Some((lhs, rhs))
     }
 }

--- a/crates/wasmi/src/module/init_expr.rs
+++ b/crates/wasmi/src/module/init_expr.rs
@@ -216,6 +216,11 @@ macro_rules! def_expr {
 #[derive(Debug, Default)]
 pub struct ConstExprStack {
     /// The top-most [`Op`] on the stack.
+    /// 
+    /// # Note
+    /// This is an optimization so that the [`ConstExprStack`] does not
+    /// require heap allocations for the common case where only a single
+    /// stack slot is needed.
     top: Option<Op>,
     /// The remaining ops on the stack.
     ops: Vec<Op>,


### PR DESCRIPTION
This allows us to finally drop the `smallvec` dependency altogether, closing https://github.com/wasmi-labs/wasmi/issues/1622 and https://github.com/wasmi-labs/wasmi/issues/1609.

Closes #1622.
Closes #1609.