### PR TITLE
Redesign `StackLimits` API for `Engine`'s config

### DIFF
--- a/crates/fuzz/src/oracle/wasmi.rs
+++ b/crates/fuzz/src/oracle/wasmi.rs
@@ -11,7 +11,6 @@ use wasmi::{
     Instance,
     Linker,
     Module,
-    StackLimits,
     Store,
     StoreLimits,
     StoreLimitsBuilder,
@@ -62,14 +61,9 @@ impl DifferentialOracleMeta for WasmiOracle {
         //
         // We increase the maximum stack space for Wasmi (register) to avoid
         // common stack overflows in certain generated fuzz test cases this way.
-        config.set_stack_limits(
-            StackLimits::new(
-                1024,             // 1 kiB
-                1024 * 1024 * 10, // 10 MiB
-                1024,
-            )
-            .unwrap(),
-        );
+        config.set_min_stack_height(1024); // 1 kiB
+        config.set_min_stack_height(1024 * 1024 * 10); // 10 MiB
+        config.set_max_recursion_depth(1024);
         config.wasm_custom_page_sizes(true);
         config.wasm_wide_arithmetic(true);
         let engine = Engine::new(&config);

--- a/crates/wasmi/benches/bench/mod.rs
+++ b/crates/wasmi/benches/bench/mod.rs
@@ -1,5 +1,5 @@
 use std::{fs::File, io::Read as _};
-use wasmi::{Config, StackLimits};
+use wasmi::Config;
 
 /// Returns the Wasm binary at the given `file_name` as `Vec<u8>`.
 ///
@@ -24,7 +24,9 @@ pub fn load_wasm_from_file(file_name: &str) -> Vec<u8> {
 pub fn bench_config() -> Config {
     let mut config = Config::default();
     config.wasm_tail_call(true);
-    config.set_stack_limits(StackLimits::new(1024, 1024 * 1024, 64 * 1024).unwrap());
+    config.set_min_stack_height(1024);
+    config.set_max_stack_height(1024 * 1024);
+    config.set_max_recursion_depth(64 * 1024);
     config
 }
 

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -24,9 +24,6 @@ use crate::{
     StoreContextMut,
 };
 
-#[cfg(doc)]
-use crate::engine::StackLimits;
-
 use super::{code_map::CodeMap, ResumableError};
 
 mod cache;
@@ -226,7 +223,7 @@ pub struct EngineExecutor<'engine> {
 fn do_nothing<T>(_: &mut T) {}
 
 impl<'engine> EngineExecutor<'engine> {
-    /// Creates a new [`EngineExecutor`] with the given [`StackLimits`].
+    /// Creates a new [`EngineExecutor`] for the given [`Stack`].
     fn new(code_map: &'engine CodeMap, stack: &'engine mut Stack) -> Self {
         Self { code_map, stack }
     }

--- a/crates/wasmi/src/engine/executor/stack/mod.rs
+++ b/crates/wasmi/src/engine/executor/stack/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
         ValueStack,
     },
 };
-use crate::{Instance, StackLimits, TrapCode};
+use crate::{engine::StackConfig, Instance, TrapCode};
 
 /// Returns a [`TrapCode`] signalling a stack overflow.
 #[cold]
@@ -32,12 +32,9 @@ impl Stack {
     /// Creates a new [`Stack`] given the [`Config`].
     ///
     /// [`Config`]: [`crate::Config`]
-    pub fn new(limits: StackLimits) -> Self {
-        let calls = CallStack::new(limits.maximum_recursion_depth);
-        let values = ValueStack::new(
-            limits.initial_value_stack_height,
-            limits.maximum_value_stack_height,
-        );
+    pub fn new(config: &StackConfig) -> Self {
+        let calls = CallStack::new(config.max_recursion_depth());
+        let values = ValueStack::new(config.min_stack_height(), config.max_stack_height());
         Self { calls, values }
     }
 

--- a/crates/wasmi/src/engine/limits/mod.rs
+++ b/crates/wasmi/src/engine/limits/mod.rs
@@ -6,5 +6,5 @@ mod tests;
 
 pub use self::{
     engine::{EnforcedLimits, EnforcedLimitsError},
-    stack::StackLimits,
+    stack::StackConfig,
 };

--- a/crates/wasmi/src/engine/limits/stack.rs
+++ b/crates/wasmi/src/engine/limits/stack.rs
@@ -1,80 +1,102 @@
-use crate::core::UntypedVal;
-use core::{
-    error::Error,
-    fmt::{self, Display},
-    mem::size_of,
-};
+/// Default value for maximum recursion depth.
+const DEFAULT_MAX_RECURSION_DEPTH: usize = 1000;
 
-/// Default value for initial value stack height in bytes.
-const DEFAULT_MIN_VALUE_STACK_HEIGHT: usize = 1024;
+/// Default value for minimum value stack height in bytes.
+const DEFAULT_MIN_STACK_HEIGHT: usize = 1_000;
 
 /// Default value for maximum value stack height in bytes.
-const DEFAULT_MAX_VALUE_STACK_HEIGHT: usize = 1024 * DEFAULT_MIN_VALUE_STACK_HEIGHT;
+const DEFAULT_MAX_STACK_HEIGHT: usize = 1_000_000;
 
-/// Default value for maximum recursion depth.
-const DEFAULT_MAX_RECURSION_DEPTH: usize = 1024;
+/// The default maximum number of cached stacks for reuse.
+const DEFAULT_MAX_CACHED_STACKS: usize = 2;
 
-/// The configured limits of the Wasm stack.
-#[derive(Debug, Copy, Clone)]
-pub struct StackLimits {
-    /// The initial value stack height that the Wasm stack prepares.
-    pub initial_value_stack_height: usize,
-    /// The maximum value stack height in use that the Wasm stack allows.
-    pub maximum_value_stack_height: usize,
-    /// The maximum number of nested calls that the Wasm stack allows.
-    pub maximum_recursion_depth: usize,
-}
-
-/// An error that may occur when configuring [`StackLimits`].
+/// An error returned by some [`StackConfig`] methods.
 #[derive(Debug)]
-pub enum LimitsError {
-    /// The initial value stack height exceeds the maximum value stack height.
-    InitialValueStackExceedsMaximum,
+pub enum StackConfigError {
+    /// The given minimum stack height exceeds the maximum stack height.
+    MinStackHeightExceedsMax,
 }
 
-impl Error for LimitsError {}
+/// The Wasmi [`Engine`]'s stack configuration.
+///
+/// [`Engine`]: crate::Engine
+#[derive(Debug, Copy, Clone)]
+pub struct StackConfig {
+    /// The maximum recursion depth.
+    max_recursion_depth: usize,
+    /// The minimum (or initial) value stack height.
+    min_stack_height: usize,
+    /// The maximum value stack height.
+    max_stack_height: usize,
+    /// The maximum number of cached stacks kept for reuse.
+    max_cached_stacks: usize,
+}
 
-impl Display for LimitsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            LimitsError::InitialValueStackExceedsMaximum => {
-                write!(f, "initial value stack height exceeds maximum stack height")
-            }
+impl Default for StackConfig {
+    fn default() -> Self {
+        Self {
+            max_recursion_depth: DEFAULT_MAX_RECURSION_DEPTH,
+            min_stack_height: DEFAULT_MIN_STACK_HEIGHT,
+            max_stack_height: DEFAULT_MAX_STACK_HEIGHT,
+            max_cached_stacks: DEFAULT_MAX_CACHED_STACKS,
         }
     }
 }
 
-impl StackLimits {
-    /// Creates a new [`StackLimits`] configuration.
+impl StackConfig {
+    /// Sets the new maximum recursion depth.
+    pub fn set_max_recursion_depth(&mut self, value: usize) {
+        self.max_recursion_depth = value;
+    }
+
+    /// Sets the new minimum (or initial) value stack height.
     ///
     /// # Errors
     ///
-    /// If the `initial_value_stack_height` exceeds `maximum_value_stack_height`.
-    pub fn new(
-        initial_value_stack_height: usize,
-        maximum_value_stack_height: usize,
-        maximum_recursion_depth: usize,
-    ) -> Result<Self, LimitsError> {
-        if initial_value_stack_height > maximum_value_stack_height {
-            return Err(LimitsError::InitialValueStackExceedsMaximum);
+    /// If `value` is greater than the current maximum value stack heihgt.
+    pub fn set_min_stack_height(&mut self, value: usize) -> Result<(), StackConfigError> {
+        if value > self.max_stack_height {
+            return Err(StackConfigError::MinStackHeightExceedsMax);
         }
-        Ok(Self {
-            initial_value_stack_height,
-            maximum_value_stack_height,
-            maximum_recursion_depth,
-        })
+        self.min_stack_height = value;
+        Ok(())
     }
-}
 
-impl Default for StackLimits {
-    fn default() -> Self {
-        let register_len = size_of::<UntypedVal>();
-        let initial_value_stack_height = DEFAULT_MIN_VALUE_STACK_HEIGHT / register_len;
-        let maximum_value_stack_height = DEFAULT_MAX_VALUE_STACK_HEIGHT / register_len;
-        Self {
-            initial_value_stack_height,
-            maximum_value_stack_height,
-            maximum_recursion_depth: DEFAULT_MAX_RECURSION_DEPTH,
+    /// Sets the new maximum value stack height.
+    ///
+    /// # Errors
+    ///
+    /// If `value` is less than the current minimum (or initial) value stack heihgt.
+    pub fn set_max_stack_height(&mut self, value: usize) -> Result<(), StackConfigError> {
+        if value < self.max_stack_height {
+            return Err(StackConfigError::MinStackHeightExceedsMax);
         }
+        self.max_stack_height = value;
+        Ok(())
+    }
+
+    /// Sets the maximum number of stacks that the [`Engine`] keeps for reuse.
+    pub fn set_max_cached_stacks(&mut self, value: usize) {
+        self.max_recursion_depth = value;
+    }
+
+    /// Returns the maximum recursion depth.
+    pub fn max_recursion_depth(&self) -> usize {
+        self.max_recursion_depth
+    }
+
+    /// Returns the minimum (or initial) value stack height.
+    pub fn min_stack_height(&self) -> usize {
+        self.min_stack_height
+    }
+
+    /// Returns the maximum value stack height.
+    pub fn max_stack_height(&self) -> usize {
+        self.max_stack_height
+    }
+
+    /// Returns the maximum number of stacks that the [`Engine`] keeps for reuse.
+    pub fn max_cached_stacks(&mut self) -> usize {
+        self.max_cached_stacks
     }
 }

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -32,7 +32,7 @@ use self::{
 pub use self::{
     code_map::{EngineFunc, EngineFuncSpan, EngineFuncSpanIter},
     config::{CompilationMode, Config},
-    limits::{EnforcedLimits, EnforcedLimitsError, StackLimits},
+    limits::{EnforcedLimits, EnforcedLimitsError, StackConfig},
     resumable::{
         ResumableCall,
         ResumableCallHostTrap,
@@ -514,19 +514,16 @@ impl ReusableAllocationStack {
 pub struct EngineStacks {
     /// Stacks to be (re)used.
     stacks: Vec<Stack>,
-    /// Stack limits for newly constructed engine stacks.
-    limits: StackLimits,
-    /// How many stacks should be kept for reuse at most.
-    keep: usize,
+    /// The stack configuration.
+    config: StackConfig,
 }
 
 impl EngineStacks {
     /// Creates new [`EngineStacks`] with the given [`StackLimits`].
-    pub fn new(config: &Config) -> Self {
+    pub fn new(config: &StackConfig) -> Self {
         Self {
             stacks: Vec::new(),
-            limits: config.stack_limits(),
-            keep: config.cached_stacks(),
+            config: *config,
         }
     }
 
@@ -534,13 +531,13 @@ impl EngineStacks {
     pub fn reuse_or_new(&mut self) -> Stack {
         match self.stacks.pop() {
             Some(stack) => stack,
-            None => Stack::new(self.limits),
+            None => Stack::new(&self.config),
         }
     }
 
     /// Disose and recycle the `stack`.
     pub fn recycle(&mut self, stack: Stack) {
-        if stack.capacity() > 0 && self.stacks.len() < self.keep {
+        if stack.capacity() > 0 && self.stacks.len() < self.config.max_cached_stacks() {
             self.stacks.push(stack);
         }
     }
@@ -555,7 +552,7 @@ impl EngineInner {
             code_map: CodeMap::new(config),
             func_types: RwLock::new(FuncTypeRegistry::new(engine_idx)),
             allocs: Mutex::new(ReusableAllocationStack::default()),
-            stacks: Mutex::new(EngineStacks::new(config)),
+            stacks: Mutex::new(EngineStacks::new(&config.stack)),
         }
     }
 

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -184,7 +184,6 @@ pub use self::{
         ResumableCall,
         ResumableCallHostTrap,
         ResumableCallOutOfFuel,
-        StackLimits,
         TypedResumableCall,
         TypedResumableCallHostTrap,
         TypedResumableCallOutOfFuel,


### PR DESCRIPTION
- Removed `StackLimits`
- Removed `Config::set_stack_limits` method
- Add `Config::set_{min_stack_height,max_stack_height,max_cached_stacks}`
- Add and use `StackConfig` internally