### PR TITLE
Improve `wasmi_ir` compile times

### DIFF
--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -79,6 +79,21 @@ macro_rules! define_enum {
                     }
                 }
             )*
+
+            /// Returns the result [`Reg`] for `self`.
+            ///
+            /// Returns `None` if `self` does not statically return a single [`Reg`].
+            pub fn result(&self) -> Option<$crate::Reg> {
+                match *self {
+                    $(
+                        Self::$name { $( $( $result_name, )? )* .. } => {
+                            IntoReg::into_reg((
+                                $( $( $result_name )? )*
+                            ))
+                        }
+                    )*
+                }
+            }
         }
     };
 }
@@ -108,46 +123,6 @@ impl IntoReg for [Reg; 2] {}
 impl IntoReg for RegSpan {}
 impl<const N: u16> IntoReg for FixedRegSpan<N> {}
 impl IntoReg for () {}
-
-macro_rules! define_result {
-    (
-        $(
-            $( #[doc = $doc:literal] )*
-            #[snake_name($snake_name:ident)]
-            $name:ident
-            $(
-                {
-                    $(
-                        @ $result_name:ident: $result_ty:ty,
-                    )?
-                    $(
-                        $( #[$field_docs:meta] )*
-                        $field_name:ident: $field_ty:ty
-                    ),*
-                    $(,)?
-                }
-            )?
-        ),* $(,)?
-    ) => {
-        impl Instruction {
-            /// Returns the result [`Reg`] for `self`.
-            ///
-            /// Returns `None` if `self` does not statically return a single [`Reg`].
-            pub fn result(&self) -> Option<$crate::Reg> {
-                match *self {
-                    $(
-                        Self::$name { $( $( $result_name, )? )* .. } => {
-                            IntoReg::into_reg((
-                                $( $( $result_name )? )*
-                            ))
-                        }
-                    )*
-                }
-            }
-        }
-    };
-}
-for_each_op::for_each_op!(define_result);
 
 impl Instruction {
     /// Creates a new [`Instruction::ReturnReg2`] for the given [`Reg`] indices.

--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -95,6 +95,21 @@ macro_rules! define_enum {
                 }
             }
         }
+
+        impl<'a> $crate::visit_regs::HostVisitor for &'a mut Instruction {
+            fn host_visitor<V: VisitRegs>(self, visitor: &mut V) {
+                match self {
+                    $(
+                        Instruction::$name { $( $( $result_name, )? $( $field_name, )* )? } => {
+                            $(
+                                $( $crate::visit_regs::Res($result_name).host_visitor(visitor); )?
+                                $( $field_name.host_visitor(visitor); )*
+                            )?
+                        }
+                    )*
+                }
+            }
+        }
     };
 }
 for_each_op::for_each_op!(define_enum);

--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -40,7 +40,7 @@ macro_rules! define_enum {
         /// The documentation of each [`Instruction`] describes its encoding in the
         /// `#Encoding` section of its documentation if it requires more than a single
         /// instruction for its encoding.
-        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+        #[derive(Debug)]
         #[non_exhaustive]
         #[repr(u16)]
         pub enum Instruction {
@@ -83,6 +83,13 @@ macro_rules! define_enum {
     };
 }
 for_each_op::for_each_op!(define_enum);
+
+impl Copy for Instruction {}
+impl Clone for Instruction {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
 /// Helper trait for [`Instruction::result`] method implementation.
 trait IntoReg: Sized {


### PR DESCRIPTION
- Removed `PartialEq` and `Eq` derives from `Instruction` enum.
- Made `Copy` and `Clone` impls on `Instruction` non derives.
- Moved `Instruction::result` definition into `define_enum` macro.
- Moved `HostVisitor` trait impl for `Instruction` into `define_enum` macro.

All above changes combined improve `wasmi_ir` compile times (`--dev`) from 2.2s -> 1.3s improving `wasmi` compile times from 5.8s -> 4.8s.