### PR TITLE
Remove `bulk-ops` immediate `Instruction` variants

### DIFF
--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -5129,27 +5129,6 @@ macro_rules! for_each_op_grouped {
                     /// The number of copied elements.
                     len: Reg,
                 },
-                /// Variant of [`Instruction::TableCopy`] with a constant 16-bit `len` field.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the tables.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the `dst` Wasm table instance
-                /// 2. [`Instruction::TableIndex`]: the `src` Wasm table instance
-                #[snake_name(table_copy_imm)]
-                TableCopyImm {
-                    /// The start index of the `dst` table.
-                    dst: Reg,
-                    /// The start index of the `src` table.
-                    src: Reg,
-                    /// The number of copied elements.
-                    len: Const16<u64>,
-                },
 
                 /// Wasm `table.init <table> <elem>` instruction.
                 ///
@@ -5170,27 +5149,6 @@ macro_rules! for_each_op_grouped {
                     /// The number of copied elements.
                     len: Reg,
                 },
-                /// Variant of [`Instruction::TableInit`] with a constant 16-bit `len` field.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the tables.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::TableIndex`]: the Wasm `table` instance
-                /// 2. [`Instruction::ElemIndex`]: the Wasm `element` segment instance
-                #[snake_name(table_init_imm)]
-                TableInitImm {
-                    /// The start index of the `dst` table.
-                    dst: Reg,
-                    /// The start index of the `src` table.
-                    src: Reg,
-                    /// The number of copied elements.
-                    len: Const16<u32>,
-                },
 
                 /// Wasm `table.fill <table>` instruction: `table[dst..dst+len] = value`
                 ///
@@ -5206,20 +5164,6 @@ macro_rules! for_each_op_grouped {
                     /// The value of the filled elements.
                     value: Reg,
                 },
-                /// Variant of [`Instruction::TableFill`] with 16-bit constant `len` index.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::TableIndex`] encoding the Wasm `table` instance.
-                #[snake_name(table_fill_imm)]
-                TableFillImm {
-                    /// The start index of the table to fill.
-                    dst: Reg,
-                    /// The number of elements to fill.
-                    len: Const16<u64>,
-                    /// The value of the filled elements.
-                    value: Reg,
-                },
 
                 /// Wasm `table.grow <table>` instruction.
                 ///
@@ -5231,19 +5175,6 @@ macro_rules! for_each_op_grouped {
                     @result: Reg,
                     /// The number of elements to add to the table.
                     delta: Reg,
-                    /// The value that is used to fill up the new cells.
-                    value: Reg,
-                },
-                /// Variant of [`Instruction::TableGrow`] with 16-bit constant `delta`.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::TableIndex`] encoding the Wasm `table` instance.
-                #[snake_name(table_grow_imm)]
-                TableGrowImm {
-                    @result: Reg,
-                    /// The number of elements to add to the table.
-                    delta: Const16<u64>,
                     /// The value that is used to fill up the new cells.
                     value: Reg,
                 },
@@ -5278,17 +5209,6 @@ macro_rules! for_each_op_grouped {
                     /// The number of pages to add to the memory.
                     delta: Reg,
                 },
-                /// Variant of [`Instruction::MemoryGrow`] with 16-bit constant `delta`.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::MemoryIndex`] encoding the Wasm `memory` instance.
-                #[snake_name(memory_grow_imm)]
-                MemoryGrowImm {
-                    @result: Reg,
-                    /// The number of pages to add to the memory.
-                    delta: Const32<u64>,
-                },
 
                 /// Wasm `memory.copy` instruction.
                 ///
@@ -5308,27 +5228,6 @@ macro_rules! for_each_op_grouped {
                     src: Reg,
                     /// The number of copied bytes.
                     len: Reg,
-                },
-                /// Variant of [`Instruction::MemoryCopy`] with a constant 16-bit `len` field.
-                ///
-                /// # Note
-                ///
-                /// This instruction copies _exactly_ `len` elements between the memories.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the `dst` Wasm linear memory instance
-                /// 2. [`Instruction::MemoryIndex`]: the `src` Wasm linear memory instance
-                #[snake_name(memory_copy_imm)]
-                MemoryCopyImm {
-                    /// The start index of the `dst` memory.
-                    dst: Reg,
-                    /// The start index of the `src` memory.
-                    src: Reg,
-                    /// The number of copied bytes.
-                    len: Const16<u64>,
                 },
 
                 /// Wasm `memory.fill` instruction.
@@ -5361,34 +5260,6 @@ macro_rules! for_each_op_grouped {
                     /// The number of bytes to fill.
                     len: Reg,
                 },
-                /// Variant of [`Instruction::MemoryFill`] with 16-bit constant `len` value.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::MemoryIndex`] encoding the Wasm `memory` instance.
-                #[snake_name(memory_fill_exact)]
-                MemoryFillExact {
-                    /// The start index of the memory to fill.
-                    dst: Reg,
-                    /// The byte value used to fill the memory.
-                    value: Reg,
-                    /// The number of bytes to fill.
-                    len: Const16<u64>,
-                },
-                /// Variant of [`Instruction::MemoryFill`] with constant fill `value` and `len`.
-                ///
-                /// # Encoding
-                ///
-                /// Followed by [`Instruction::MemoryIndex`] encoding the Wasm `memory` instance.
-                #[snake_name(memory_fill_imm_exact)]
-                MemoryFillImmExact {
-                    /// The start index of the memory to fill.
-                    dst: Reg,
-                    /// The byte value used to fill the memory.
-                    value: u8,
-                    /// The number of bytes to fill.
-                    len: Const16<u64>,
-                },
 
                 /// Wasm `memory.init <data>` instruction.
                 ///
@@ -5408,23 +5279,6 @@ macro_rules! for_each_op_grouped {
                     src: Reg,
                     /// The number of bytes to initialize.
                     len: Reg,
-                },
-                /// Variant of [`Instruction::MemoryInit`] with a constant 16-bit `len` field.
-                ///
-                /// # Encoding
-                ///
-                /// This [`Instruction`] must be followed by
-                ///
-                /// 1. [`Instruction::MemoryIndex`]: the Wasm `memory` instance
-                /// 1. [`Instruction::DataIndex`]: the `data` segment to initialize the memory
-                #[snake_name(memory_init_imm)]
-                MemoryInitImm {
-                    /// The start index of the `dst` memory.
-                    dst: Reg,
-                    /// The start index of the `src` data segment.
-                    src: Reg,
-                    /// The number of initialized bytes.
-                    len: Const16<u32>,
                 },
 
                 /// A [`Table`] instruction parameter.

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -1219,31 +1219,17 @@ impl<'engine> Executor<'engine> {
                 Instr::TableCopy { dst, src, len } => {
                     self.execute_table_copy(store.inner_mut(), dst, src, len)?
                 }
-                Instr::TableCopyImm { dst, src, len } => {
-                    self.execute_table_copy_imm(store.inner_mut(), dst, src, len)?
-                }
                 Instr::TableInit { dst, src, len } => {
                     self.execute_table_init(store.inner_mut(), dst, src, len)?
                 }
-                Instr::TableInitImm { dst, src, len } => {
-                    self.execute_table_init_imm(store.inner_mut(), dst, src, len)?
-                }
                 Instr::TableFill { dst, len, value } => {
                     self.execute_table_fill(store.inner_mut(), dst, len, value)?
-                }
-                Instr::TableFillImm { dst, len, value } => {
-                    self.execute_table_fill_imm(store.inner_mut(), dst, len, value)?
                 }
                 Instr::TableGrow {
                     result,
                     delta,
                     value,
                 } => self.execute_table_grow(store, result, delta, value)?,
-                Instr::TableGrowImm {
-                    result,
-                    delta,
-                    value,
-                } => self.execute_table_grow_imm(store, result, delta, value)?,
                 Instr::ElemDrop { index } => self.execute_element_drop(store.inner_mut(), index),
                 Instr::DataDrop { index } => self.execute_data_drop(store.inner_mut(), index),
                 Instr::MemorySize { result, memory } => {
@@ -1252,14 +1238,8 @@ impl<'engine> Executor<'engine> {
                 Instr::MemoryGrow { result, delta } => {
                     self.execute_memory_grow(store, result, delta)?
                 }
-                Instr::MemoryGrowImm { result, delta } => {
-                    self.execute_memory_grow_imm(store, result, delta)?
-                }
                 Instr::MemoryCopy { dst, src, len } => {
                     self.execute_memory_copy(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryCopyImm { dst, src, len } => {
-                    self.execute_memory_copy_imm(store.inner_mut(), dst, src, len)?
                 }
                 Instr::MemoryFill { dst, value, len } => {
                     self.execute_memory_fill(store.inner_mut(), dst, value, len)?
@@ -1267,17 +1247,8 @@ impl<'engine> Executor<'engine> {
                 Instr::MemoryFillImm { dst, value, len } => {
                     self.execute_memory_fill_imm(store.inner_mut(), dst, value, len)?
                 }
-                Instr::MemoryFillExact { dst, value, len } => {
-                    self.execute_memory_fill_exact(store.inner_mut(), dst, value, len)?
-                }
-                Instr::MemoryFillImmExact { dst, value, len } => {
-                    self.execute_memory_fill_imm_exact(store.inner_mut(), dst, value, len)?
-                }
                 Instr::MemoryInit { dst, src, len } => {
                     self.execute_memory_init(store.inner_mut(), dst, src, len)?
-                }
-                Instr::MemoryInitImm { dst, src, len } => {
-                    self.execute_memory_init_imm(store.inner_mut(), dst, src, len)?
                 }
                 Instr::TableIndex { .. }
                 | Instr::MemoryIndex { .. }

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -75,16 +75,6 @@ impl Executor<'_> {
         delta: Reg,
     ) -> Result<(), Error> {
         let delta: u64 = self.get_register_as(delta);
-        self.execute_memory_grow_impl(store, result, delta)
-    }
-
-    /// Executes a generic `memory.grow` instruction.
-    fn execute_memory_grow_impl(
-        &mut self,
-        store: &mut PrunedStore,
-        result: Reg,
-        delta: u64,
-    ) -> Result<(), Error> {
         let memory = self.fetch_memory_index(1);
         if delta == 0 {
             // Case: growing by 0 pages means there is nothing to do
@@ -132,21 +122,10 @@ impl Executor<'_> {
         let dst: u64 = self.get_register_as(dst);
         let src: u64 = self.get_register_as(src);
         let len: u64 = self.get_register_as(len);
-        self.execute_memory_copy_impl(store, dst, src, len)
-    }
-
-    /// Executes a generic `memory.copy` instruction.
-    fn execute_memory_copy_impl(
-        &mut self,
-        store: &mut StoreInner,
-        dst_index: u64,
-        src_index: u64,
-        len: u64,
-    ) -> Result<(), Error> {
-        let Ok(dst_index) = usize::try_from(dst_index) else {
+        let Ok(dst_index) = usize::try_from(dst) else {
             return Err(Error::from(TrapCode::MemoryOutOfBounds));
         };
-        let Ok(src_index) = usize::try_from(src_index) else {
+        let Ok(src_index) = usize::try_from(src) else {
             return Err(Error::from(TrapCode::MemoryOutOfBounds));
         };
         let Ok(len) = usize::try_from(len) else {
@@ -270,17 +249,6 @@ impl Executor<'_> {
         let dst: u64 = self.get_register_as(dst);
         let src: u32 = self.get_register_as(src);
         let len: u32 = self.get_register_as(len);
-        self.execute_memory_init_impl(store, dst, src, len)
-    }
-
-    /// Executes a generic `memory.init` instruction.
-    fn execute_memory_init_impl(
-        &mut self,
-        store: &mut StoreInner,
-        dst: u64,
-        src: u32,
-        len: u32,
-    ) -> Result<(), Error> {
         let Ok(dst_index) = usize::try_from(dst) else {
             return Err(Error::from(TrapCode::MemoryOutOfBounds));
         };

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -4,8 +4,6 @@ use crate::{
     errors::MemoryError,
     ir::{
         index::{Data, Memory},
-        Const16,
-        Const32,
         Instruction,
         Reg,
     },
@@ -80,19 +78,7 @@ impl Executor<'_> {
         self.execute_memory_grow_impl(store, result, delta)
     }
 
-    /// Executes an [`Instruction::MemoryGrowImm`].
-    pub fn execute_memory_grow_imm(
-        &mut self,
-        store: &mut PrunedStore,
-        result: Reg,
-        delta: Const32<u64>,
-    ) -> Result<(), Error> {
-        let delta = u64::from(delta);
-        self.execute_memory_grow_impl(store, result, delta)
-    }
-
     /// Executes a generic `memory.grow` instruction.
-    #[inline(never)]
     fn execute_memory_grow_impl(
         &mut self,
         store: &mut PrunedStore,
@@ -149,22 +135,7 @@ impl Executor<'_> {
         self.execute_memory_copy_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::MemoryCopyImm`].
-    pub fn execute_memory_copy_imm(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Reg,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u64 = self.get_register_as(src);
-        let len: u64 = len.into();
-        self.execute_memory_copy_impl(store, dst, src, len)
-    }
-
     /// Executes a generic `memory.copy` instruction.
-    #[inline(never)]
     fn execute_memory_copy_impl(
         &mut self,
         store: &mut StoreInner,
@@ -260,33 +231,6 @@ impl Executor<'_> {
         self.execute_memory_fill_impl(store, dst, value, len)
     }
 
-    /// Executes an [`Instruction::MemoryFillExact`].
-    pub fn execute_memory_fill_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        value: Reg,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let value: u8 = self.get_register_as(value);
-        let len: u64 = len.into();
-        self.execute_memory_fill_impl(store, dst, value, len)
-    }
-
-    /// Executes an [`Instruction::MemoryFillImmExact`].
-    pub fn execute_memory_fill_imm_exact(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        value: u8,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let len: u64 = len.into();
-        self.execute_memory_fill_impl(store, dst, value, len)
-    }
-
     /// Executes a generic `memory.fill` instruction.
     #[inline(never)]
     fn execute_memory_fill_impl(
@@ -329,22 +273,7 @@ impl Executor<'_> {
         self.execute_memory_init_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::MemoryInitImm`].
-    pub fn execute_memory_init_imm(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Reg,
-        len: Const16<u32>,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u32 = self.get_register_as(src);
-        let len: u32 = len.into();
-        self.execute_memory_init_impl(store, dst, src, len)
-    }
-
     /// Executes a generic `memory.init` instruction.
-    #[inline(never)]
     fn execute_memory_init_impl(
         &mut self,
         store: &mut StoreInner,

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -5,7 +5,6 @@ use crate::{
     errors::TableError,
     ir::{
         index::{Elem, Table},
-        Const16,
         Const32,
         Instruction,
         Reg,
@@ -155,22 +154,7 @@ impl Executor<'_> {
         self.execute_table_copy_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::TableCopyImm`].
-    pub fn execute_table_copy_imm(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Reg,
-        len: Const16<u64>,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u64 = self.get_register_as(src);
-        let len: u64 = len.into();
-        self.execute_table_copy_impl(store, dst, src, len)
-    }
-
     /// Executes a generic `table.copy` instruction.
-    #[inline(never)]
     fn execute_table_copy_impl(
         &mut self,
         store: &mut StoreInner,
@@ -211,22 +195,7 @@ impl Executor<'_> {
         self.execute_table_init_impl(store, dst, src, len)
     }
 
-    /// Executes an [`Instruction::TableInitImm`].
-    pub fn execute_table_init_imm(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        src: Reg,
-        len: Const16<u32>,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let src: u32 = self.get_register_as(src);
-        let len: u32 = len.into();
-        self.execute_table_init_impl(store, dst, src, len)
-    }
-
     /// Executes a generic `table.init` instruction.
-    #[inline(never)]
     fn execute_table_init_impl(
         &mut self,
         store: &mut StoreInner,
@@ -257,21 +226,7 @@ impl Executor<'_> {
         self.execute_table_fill_impl(store, dst, len, value)
     }
 
-    /// Executes an [`Instruction::TableFillImm`].
-    pub fn execute_table_fill_imm(
-        &mut self,
-        store: &mut StoreInner,
-        dst: Reg,
-        len: Const16<u64>,
-        value: Reg,
-    ) -> Result<(), Error> {
-        let dst: u64 = self.get_register_as(dst);
-        let len: u64 = len.into();
-        self.execute_table_fill_impl(store, dst, len, value)
-    }
-
     /// Executes a generic `table.fill` instruction.
-    #[inline(never)]
     fn execute_table_fill_impl(
         &mut self,
         store: &mut StoreInner,
@@ -299,20 +254,7 @@ impl Executor<'_> {
         self.execute_table_grow_impl(store, result, delta, value)
     }
 
-    /// Executes an [`Instruction::TableGrowImm`].
-    pub fn execute_table_grow_imm(
-        &mut self,
-        store: &mut PrunedStore,
-        result: Reg,
-        delta: Const16<u64>,
-        value: Reg,
-    ) -> Result<(), Error> {
-        let delta: u64 = delta.into();
-        self.execute_table_grow_impl(store, result, delta, value)
-    }
-
     /// Executes a generic `table.grow` instruction.
-    #[inline(never)]
     fn execute_table_grow_impl(
         &mut self,
         store: &mut PrunedStore,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1843,23 +1843,6 @@ impl FuncTranslator {
         }
     }
 
-    /// Creates a new 16-bit encoded [`Input16`] from the given `operand`.
-    pub fn make_input16<T>(&mut self, operand: Operand) -> Result<Input16<T>, Error>
-    where
-        T: From<TypedVal> + Into<UntypedVal> + TryInto<Const16<T>> + Copy,
-    {
-        self.make_input(operand, |this, imm| {
-            let opd16 = match T::from(imm).try_into() {
-                Ok(rhs) => Input::Immediate(rhs),
-                Err(_) => {
-                    let rhs = this.layout.const_to_reg(imm)?;
-                    Input::Reg(rhs)
-                }
-            };
-            Ok(opd16)
-        })
-    }
-
     /// Create a new generic [`Input`] from the given `operand`.
     fn make_input<R>(
         &mut self,

--- a/crates/wasmi/tests/integration/fuel_consumption.rs
+++ b/crates/wasmi/tests/integration/fuel_consumption.rs
@@ -74,5 +74,5 @@ fn check_fuel_consumption(given_fuel: u64, consumed_fuel: u64) {
 
 #[test]
 fn fuel_consumption_01() {
-    check_fuel_consumption(3, 3);
+    check_fuel_consumption(4, 4);
 }


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1641.

Removes 9 `Instruction`s in total, all of which are costly to execute and thus usually not part of the hot-path of a Wasm program.