### PR TITLE
Update CodeCov CI Action to v5.5.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -369,10 +369,12 @@ jobs:
         run: |
           cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v5.4.3
+        uses: codecov/codecov-action@v5.5.0
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
https://github.com/wasmi-labs/wasmi/pull/1644 done right. Closes https://github.com/wasmi-labs/wasmi/pull/1644.