### PR TITLE
Rename `wasmi_ir::Reg` types to `Slot`

### DIFF
--- a/crates/ir/src/enum.rs
+++ b/crates/ir/src/enum.rs
@@ -106,98 +106,106 @@ impl Clone for Op {
 }
 
 impl Op {
-    /// Creates a new [`Op::ReturnReg2`] for the given [`Reg`] indices.
-    pub fn return_reg2_ext(reg0: impl Into<Reg>, reg1: impl Into<Reg>) -> Self {
+    /// Creates a new [`Op::ReturnSlot2`] for the given [`Slot`] indices.
+    pub fn return_reg2_ext(reg0: impl Into<Slot>, reg1: impl Into<Slot>) -> Self {
         Self::return_reg2([reg0.into(), reg1.into()])
     }
 
-    /// Creates a new [`Op::ReturnReg3`] for the given [`Reg`] indices.
+    /// Creates a new [`Op::ReturnSlot3`] for the given [`Slot`] indices.
     pub fn return_reg3_ext(
-        reg0: impl Into<Reg>,
-        reg1: impl Into<Reg>,
-        reg2: impl Into<Reg>,
+        reg0: impl Into<Slot>,
+        reg1: impl Into<Slot>,
+        reg2: impl Into<Slot>,
     ) -> Self {
         Self::return_reg3([reg0.into(), reg1.into(), reg2.into()])
     }
 
-    /// Creates a new [`Op::ReturnMany`] for the given [`Reg`] indices.
+    /// Creates a new [`Op::ReturnMany`] for the given [`Slot`] indices.
     pub fn return_many_ext(
-        reg0: impl Into<Reg>,
-        reg1: impl Into<Reg>,
-        reg2: impl Into<Reg>,
+        reg0: impl Into<Slot>,
+        reg1: impl Into<Slot>,
+        reg2: impl Into<Slot>,
     ) -> Self {
         Self::return_many([reg0.into(), reg1.into(), reg2.into()])
     }
 
     /// Creates a new [`Op::Copy2`].
-    pub fn copy2_ext(results: RegSpan, value0: impl Into<Reg>, value1: impl Into<Reg>) -> Self {
-        let span = FixedRegSpan::new(results).unwrap_or_else(|_| {
-            panic!("encountered invalid `results` `RegSpan` for `Copy2`: {results:?}")
+    pub fn copy2_ext(results: SlotSpan, value0: impl Into<Slot>, value1: impl Into<Slot>) -> Self {
+        let span = FixedSlotSpan::new(results).unwrap_or_else(|_| {
+            panic!("encountered invalid `results` `SlotSpan` for `Copy2`: {results:?}")
         });
         Self::copy2(span, [value0.into(), value1.into()])
     }
 
     /// Creates a new [`Op::CopyMany`].
-    pub fn copy_many_ext(results: RegSpan, head0: impl Into<Reg>, head1: impl Into<Reg>) -> Self {
+    pub fn copy_many_ext(
+        results: SlotSpan,
+        head0: impl Into<Slot>,
+        head1: impl Into<Slot>,
+    ) -> Self {
         Self::copy_many(results, [head0.into(), head1.into()])
     }
 
-    /// Creates a new [`Op::Register2`] instruction parameter.
-    pub fn register2_ext(reg0: impl Into<Reg>, reg1: impl Into<Reg>) -> Self {
+    /// Creates a new [`Op::Slot2`] instruction parameter.
+    pub fn register2_ext(reg0: impl Into<Slot>, reg1: impl Into<Slot>) -> Self {
         Self::register2([reg0.into(), reg1.into()])
     }
 
-    /// Creates a new [`Op::Register3`] instruction parameter.
-    pub fn register3_ext(reg0: impl Into<Reg>, reg1: impl Into<Reg>, reg2: impl Into<Reg>) -> Self {
+    /// Creates a new [`Op::Slot3`] instruction parameter.
+    pub fn register3_ext(
+        reg0: impl Into<Slot>,
+        reg1: impl Into<Slot>,
+        reg2: impl Into<Slot>,
+    ) -> Self {
         Self::register3([reg0.into(), reg1.into(), reg2.into()])
     }
 
-    /// Creates a new [`Op::RegisterList`] instruction parameter.
+    /// Creates a new [`Op::SlotList`] instruction parameter.
     pub fn register_list_ext(
-        reg0: impl Into<Reg>,
-        reg1: impl Into<Reg>,
-        reg2: impl Into<Reg>,
+        reg0: impl Into<Slot>,
+        reg1: impl Into<Slot>,
+        reg2: impl Into<Slot>,
     ) -> Self {
         Self::register_list([reg0.into(), reg1.into(), reg2.into()])
     }
 
-    /// Creates a new [`Op::RegisterAndImm32`] from the given `reg` and `offset_hi`.
-    pub fn register_and_offset_hi(reg: impl Into<Reg>, offset_hi: Offset64Hi) -> Self {
+    /// Creates a new [`Op::SlotAndImm32`] from the given `reg` and `offset_hi`.
+    pub fn register_and_offset_hi(reg: impl Into<Slot>, offset_hi: Offset64Hi) -> Self {
         Self::register_and_imm32(reg, offset_hi.0)
     }
 
-    /// Returns `Some` [`Reg`] and [`Offset64Hi`] if encoded properly.
+    /// Returns `Some` [`Slot`] and [`Offset64Hi`] if encoded properly.
     ///
     /// # Errors
     ///
     /// Returns back `self` if it was an incorrect [`Op`].
     /// This allows for a better error message to inform the user.
-    pub fn filter_register_and_offset_hi(self) -> Result<(Reg, Offset64Hi), Self> {
-        if let Op::RegisterAndImm32 { reg, imm } = self {
+    pub fn filter_register_and_offset_hi(self) -> Result<(Slot, Offset64Hi), Self> {
+        if let Op::SlotAndImm32 { reg, imm } = self {
             return Ok((reg, Offset64Hi(u32::from(imm))));
         }
         Err(self)
     }
 
-    /// Creates a new [`Op::RegisterAndImm32`] from the given `reg` and `offset_hi`.
-    pub fn register_and_lane<LaneType>(reg: impl Into<Reg>, lane: LaneType) -> Self
+    /// Creates a new [`Op::SlotAndImm32`] from the given `reg` and `offset_hi`.
+    pub fn register_and_lane<LaneType>(reg: impl Into<Slot>, lane: LaneType) -> Self
     where
         LaneType: Into<u8>,
     {
         Self::register_and_imm32(reg, u32::from(lane.into()))
     }
 
-    /// Returns `Some` [`Reg`] and a `lane` index if encoded properly.
+    /// Returns `Some` [`Slot`] and a `lane` index if encoded properly.
     ///
     /// # Errors
     ///
     /// Returns back `self` if it was an incorrect [`Op`].
     /// This allows for a better error message to inform the user.
-    pub fn filter_register_and_lane<LaneType>(self) -> Result<(Reg, LaneType), Self>
+    pub fn filter_register_and_lane<LaneType>(self) -> Result<(Slot, LaneType), Self>
     where
         LaneType: TryFrom<u8>,
     {
-        if let Op::RegisterAndImm32 { reg, imm } = self {
+        if let Op::SlotAndImm32 { reg, imm } = self {
             let lane_index = u32::from(imm) as u8;
             let Ok(lane) = LaneType::try_from(lane_index) else {
                 panic!("encountered out of bounds lane index: {}", lane_index)
@@ -212,7 +220,7 @@ impl Op {
         Self::imm16_and_imm32(value, offset_hi.0)
     }
 
-    /// Returns `Some` [`Reg`] and [`Offset64Hi`] if encoded properly.
+    /// Returns `Some` [`Slot`] and [`Offset64Hi`] if encoded properly.
     ///
     /// # Errors
     ///

--- a/crates/ir/src/error.rs
+++ b/crates/ir/src/error.rs
@@ -3,8 +3,8 @@ use core::fmt;
 /// An error that may be occurred when operating with some Wasmi IR primitives.
 #[derive(Debug)]
 pub enum Error {
-    /// Encountered when trying to create a [`Reg`](crate::Reg) from an out of bounds integer.
-    RegisterOutOfBounds,
+    /// Encountered when trying to create a [`Slot`](crate::Slot) from an out of bounds integer.
+    StackSlotOutOfBounds,
     /// Encountered when trying to create a [`BranchOffset`](crate::BranchOffset) from an out of bounds integer.
     BranchOffsetOutOfBounds,
     /// Encountered when trying to create a [`Comparator`](crate::Comparator) from an out of bounds integer.
@@ -16,7 +16,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::RegisterOutOfBounds => write!(f, "register out of bounds"),
+            Self::StackSlotOutOfBounds => write!(f, "stack slot index out of bounds"),
             Self::BranchOffsetOutOfBounds => write!(f, "branch offset out of bounds"),
             Self::ComparatorOutOfBounds => write!(f, "comparator out of bounds"),
             Self::BlockFuelOutOfBounds => write!(f, "block fuel out of bounds"),

--- a/crates/ir/src/for_each_op.rs
+++ b/crates/ir/src/for_each_op.rs
@@ -37,9 +37,9 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Returns a single value stored in a register.
                 #[snake_name(return_reg)]
-                ReturnReg {
+                ReturnSlot {
                     /// The returned value.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// A Wasm `return` instruction.
                 ///
@@ -47,9 +47,9 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Returns two values stored in registers.
                 #[snake_name(return_reg2)]
-                ReturnReg2 {
+                ReturnSlot2 {
                     /// The returned values.
-                    values: [Reg; 2],
+                    values: [Slot; 2],
                 },
                 /// A Wasm `return` instruction.
                 ///
@@ -57,9 +57,9 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Returns three values stored in registers.
                 #[snake_name(return_reg3)]
-                ReturnReg3 {
+                ReturnSlot3 {
                     /// The returned values.
-                    values: [Reg; 3],
+                    values: [Slot; 3],
                 },
                 /// A Wasm `return` instruction.
                 ///
@@ -95,11 +95,11 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Note
                 ///
-                /// Returns values as stored in the bounded [`RegSpan`].
+                /// Returns values as stored in the bounded [`SlotSpan`].
                 #[snake_name(return_span)]
                 ReturnSpan {
-                    /// The [`RegSpan`] that represents the registers that store the returned values.
-                    values: BoundedRegSpan,
+                    /// The [`SlotSpan`] that represents the registers that store the returned values.
+                    values: BoundedSlotSpan,
                 },
                 /// A Wasm `return` instruction.
                 ///
@@ -111,15 +111,15 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Must be followed by
                 ///
-                /// 1. Zero or more [`Op::RegisterList`]
+                /// 1. Zero or more [`Op::SlotList`]
                 /// 2. Followed by one of
-                ///     - [`Op::Register`]
-                ///     - [`Op::Register2`]
-                ///     - [`Op::Register3`]
+                ///     - [`Op::Slot`]
+                ///     - [`Op::Slot2`]
+                ///     - [`Op::Slot3`]
                 #[snake_name(return_many)]
                 ReturnMany {
                     /// The first three returned values.
-                    values: [Reg; 3],
+                    values: [Slot; 3],
                 },
 
                 /// A Wasm `br` instruction.
@@ -139,14 +139,14 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_cmp_fallback)]
                 BranchCmpFallback {
                     /// The left-hand side value for the comparison.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side value for the comparison.
                     ///
                     /// # Note
                     ///
                     /// We allocate constant values as function local constant values and use
                     /// their register to only require a single fallback instruction variant.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The register that stores the [`ComparatorAndOffset`] of this instruction.
                     ///
                     /// # Note
@@ -156,16 +156,16 @@ macro_rules! for_each_op_grouped {
                     /// and 32-bit branch offset fields.
                     ///
                     /// [`ComparatorAndOffset`]: crate::ComparatorAndOffset
-                    params: Reg,
+                    params: Slot,
                 },
 
                 /// A fused `i32.and` and branch instruction.
                 #[snake_name(branch_i32_and)]
                 BranchI32And {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -173,7 +173,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_and_imm16)]
                 BranchI32AndImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                     /// The 16-bit encoded branch offset.
@@ -183,9 +183,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_or)]
                 BranchI32Or {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -193,7 +193,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_or_imm16)]
                 BranchI32OrImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                     /// The 16-bit encoded branch offset.
@@ -203,9 +203,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_nand)]
                 BranchI32Nand {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -213,7 +213,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_nand_imm16)]
                 BranchI32NandImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                     /// The 16-bit encoded branch offset.
@@ -223,9 +223,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_nor)]
                 BranchI32Nor {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -233,7 +233,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_nor_imm16)]
                 BranchI32NorImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                     /// The 16-bit encoded branch offset.
@@ -244,9 +244,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_eq)]
                 BranchI32Eq {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -254,7 +254,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_eq_imm16)]
                 BranchI32EqImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                     /// The 16-bit encoded branch offset.
@@ -264,9 +264,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_ne)]
                 BranchI32Ne {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -274,7 +274,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_ne_imm16)]
                 BranchI32NeImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                     /// The 16-bit encoded branch offset.
@@ -285,9 +285,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_lt_s)]
                 BranchI32LtS {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -297,7 +297,7 @@ macro_rules! for_each_op_grouped {
                     /// The right-hand side operand to the conditional operator.
                     lhs: Const16<i32>,
                     /// The left-hand side operand to the conditional operator.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -305,7 +305,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_lt_s_imm16_rhs)]
                 BranchI32LtSImm16Rhs {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                     /// The 16-bit encoded branch offset.
@@ -315,9 +315,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_lt_u)]
                 BranchI32LtU {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -327,7 +327,7 @@ macro_rules! for_each_op_grouped {
                     /// The right-hand side operand to the conditional operator.
                     lhs: Const16<u32>,
                     /// The left-hand side operand to the conditional operator.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -335,7 +335,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_lt_u_imm16_rhs)]
                 BranchI32LtUImm16Rhs {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<u32>,
                     /// The 16-bit encoded branch offset.
@@ -345,9 +345,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_le_s)]
                 BranchI32LeS {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -357,7 +357,7 @@ macro_rules! for_each_op_grouped {
                     /// The right-hand side operand to the conditional operator.
                     lhs: Const16<i32>,
                     /// The left-hand side operand to the conditional operator.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -365,7 +365,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_le_s_imm16_rhs)]
                 BranchI32LeSImm16Rhs {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                     /// The 16-bit encoded branch offset.
@@ -375,9 +375,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_le_u)]
                 BranchI32LeU {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -387,7 +387,7 @@ macro_rules! for_each_op_grouped {
                     /// The right-hand side operand to the conditional operator.
                     lhs: Const16<u32>,
                     /// The left-hand side operand to the conditional operator.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -395,7 +395,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i32_le_u_imm16_rhs)]
                 BranchI32LeUImm16Rhs {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<u32>,
                     /// The 16-bit encoded branch offset.
@@ -406,9 +406,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_and)]
                 BranchI64And {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -416,7 +416,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_and_imm16)]
                 BranchI64AndImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                     /// The 16-bit encoded branch offset.
@@ -426,9 +426,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_or)]
                 BranchI64Or {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -436,7 +436,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_or_imm16)]
                 BranchI64OrImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                     /// The 16-bit encoded branch offset.
@@ -446,9 +446,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_nand)]
                 BranchI64Nand {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -456,7 +456,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_nand_imm16)]
                 BranchI64NandImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                     /// The 16-bit encoded branch offset.
@@ -466,9 +466,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_nor)]
                 BranchI64Nor {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -476,7 +476,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_nor_imm16)]
                 BranchI64NorImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                     /// The 16-bit encoded branch offset.
@@ -487,9 +487,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_eq)]
                 BranchI64Eq {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -497,7 +497,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_eq_imm16)]
                 BranchI64EqImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                     /// The 16-bit encoded branch offset.
@@ -507,9 +507,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_ne)]
                 BranchI64Ne {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -517,7 +517,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_ne_imm16)]
                 BranchI64NeImm16 {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                     /// The 16-bit encoded branch offset.
@@ -528,9 +528,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_lt_s)]
                 BranchI64LtS {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -540,7 +540,7 @@ macro_rules! for_each_op_grouped {
                     /// The right-hand side operand to the conditional operator.
                     lhs: Const16<i64>,
                     /// The left-hand side operand to the conditional operator.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -548,7 +548,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_lt_s_imm16_rhs)]
                 BranchI64LtSImm16Rhs {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                     /// The 16-bit encoded branch offset.
@@ -558,9 +558,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_lt_u)]
                 BranchI64LtU {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -570,7 +570,7 @@ macro_rules! for_each_op_grouped {
                     /// The right-hand side operand to the conditional operator.
                     lhs: Const16<u64>,
                     /// The left-hand side operand to the conditional operator.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -578,7 +578,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_lt_u_imm16_rhs)]
                 BranchI64LtUImm16Rhs {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<u64>,
                     /// The 16-bit encoded branch offset.
@@ -588,9 +588,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_le_s)]
                 BranchI64LeS {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -600,7 +600,7 @@ macro_rules! for_each_op_grouped {
                     /// The right-hand side operand to the conditional operator.
                     lhs: Const16<i64>,
                     /// The left-hand side operand to the conditional operator.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -608,7 +608,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_le_s_imm16_rhs)]
                 BranchI64LeSImm16Rhs {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                     /// The 16-bit encoded branch offset.
@@ -618,9 +618,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_le_u)]
                 BranchI64LeU {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -630,7 +630,7 @@ macro_rules! for_each_op_grouped {
                     /// The right-hand side operand to the conditional operator.
                     lhs: Const16<u64>,
                     /// The left-hand side operand to the conditional operator.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -638,7 +638,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_i64_le_u_imm16_rhs)]
                 BranchI64LeUImm16Rhs {
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<u64>,
                     /// The 16-bit encoded branch offset.
@@ -649,9 +649,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f32_eq)]
                 BranchF32Eq {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -659,9 +659,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f32_ne)]
                 BranchF32Ne {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -670,9 +670,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f32_lt)]
                 BranchF32Lt {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -680,9 +680,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f32_le)]
                 BranchF32Le {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -691,9 +691,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f32_not_lt)]
                 BranchF32NotLt {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -701,9 +701,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f32_not_le)]
                 BranchF32NotLe {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -712,9 +712,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f64_eq)]
                 BranchF64Eq {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -722,9 +722,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f64_ne)]
                 BranchF64Ne {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -733,9 +733,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f64_lt)]
                 BranchF64Lt {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -743,9 +743,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f64_le)]
                 BranchF64Le {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -754,9 +754,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f64_not_lt)]
                 BranchF64NotLt {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -764,9 +764,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_f64_not_le)]
                 BranchF64NotLe {
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                     /// The 16-bit encoded branch offset.
                     offset: BranchOffset16,
                 },
@@ -779,7 +779,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_table_0)]
                 BranchTable0 {
                     /// The register holding the index of the instruction.
-                    index: Reg,
+                    index: Slot,
                     /// The number of branch table targets including the default target.
                     len_targets: u32,
                 },
@@ -791,14 +791,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// 1. Followed by one of [`Op::RegisterSpan`].
+                /// 1. Followed by one of [`Op::SlotSpan`].
                 /// 2. Followed `len_target` times by
                 ///
                 /// - [`Op::BranchTableTarget`]
                 #[snake_name(branch_table_span)]
                 BranchTableSpan {
                     /// The register holding the index of the instruction.
-                    index: Reg,
+                    index: Slot,
                     /// The number of branch table targets including the default target.
                     len_targets: u32,
                 },
@@ -810,20 +810,20 @@ macro_rules! for_each_op_grouped {
                 /// This is a Wasmi utility instruction used to translate Wasm control flow.
                 #[snake_name(copy)]
                 Copy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the value to copy.
-                    value: Reg,
+                    value: Slot,
                 },
-                /// Copies two [`Reg`] values to `results`.
+                /// Copies two [`Slot`] values to `results`.
                 ///
                 /// # Note
                 ///
                 /// This is a Wasmi utility instruction used to translate Wasm control flow.
                 #[snake_name(copy2)]
                 Copy2 {
-                    @results: FixedRegSpan<2>,
+                    @results: FixedSlotSpan<2>,
                     /// The registers holding the values to copy.
-                    values: [Reg; 2],
+                    values: [Slot; 2],
                 },
                 /// Copies the 32-bit immediate `value` to `result`.
                 ///
@@ -833,7 +833,7 @@ macro_rules! for_each_op_grouped {
                 /// Read [`Op::Copy`] for more information about this instruction.
                 #[snake_name(copy_imm32)]
                 CopyImm32 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 32-bit encoded immediate value to copy.
                     value: AnyConst32,
                 },
@@ -846,7 +846,7 @@ macro_rules! for_each_op_grouped {
                 /// - Read [`Op::Copy`] for more information about this instruction.
                 #[snake_name(copy_i64imm32)]
                 CopyI64Imm32 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 32-bit encoded `i64` immediate value to copy.
                     value: Const32<i64>,
                 },
@@ -859,16 +859,16 @@ macro_rules! for_each_op_grouped {
                 /// - Read [`Op::Copy`] for more information about this instruction.
                 #[snake_name(copy_f64imm32)]
                 CopyF64Imm32 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 32-bit encoded `i64` immediate value to copy.
                     value: Const32<f64>,
                 },
                 /// Variant of [`Op::CopySpan`] that assumes that `results` and `values` span do not overlap.
                 #[snake_name(copy_span)]
                 CopySpan {
-                    @results: RegSpan,
+                    @results: SlotSpan,
                     /// The contiguous registers holding the inputs of this instruction.
-                    values: RegSpan,
+                    values: SlotSpan,
                     /// The amount of copied registers.
                     len: u16,
                 },
@@ -876,16 +876,16 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Must be followed by
                 ///
-                /// 1. Zero or more [`Op::RegisterList`]
+                /// 1. Zero or more [`Op::SlotList`]
                 /// 2. Followed by one of
-                ///     - [`Op::Register`]
-                ///     - [`Op::Register2`]
-                ///     - [`Op::Register3`]
+                ///     - [`Op::Slot`]
+                ///     - [`Op::Slot2`]
+                ///     - [`Op::Slot3`]
                 #[snake_name(copy_many)]
                 CopyMany {
-                    @results: RegSpan,
+                    @results: SlotSpan,
                     /// The first two input registers to copy.
-                    values: [Reg; 2],
+                    values: [Slot; 2],
                 },
 
                 /// Wasm `return_call` equivalent Wasmi instruction.
@@ -908,11 +908,11 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Must be followed by
                 ///
-                /// 1. Zero or more [`Op::RegisterList`]
+                /// 1. Zero or more [`Op::SlotList`]
                 /// 2. Followed by one of
-                ///     - [`Op::Register`]
-                ///     - [`Op::Register2`]
-                ///     - [`Op::Register3`]
+                ///     - [`Op::Slot`]
+                ///     - [`Op::Slot2`]
+                ///     - [`Op::Slot3`]
                 #[snake_name(return_call_internal)]
                 ReturnCallInternal {
                     /// The called internal function.
@@ -939,11 +939,11 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Must be followed by
                 ///
-                /// 1. Zero or more [`Op::RegisterList`]
+                /// 1. Zero or more [`Op::SlotList`]
                 /// 2. Followed by one of
-                ///     - [`Op::Register`]
-                ///     - [`Op::Register2`]
-                ///     - [`Op::Register3`]
+                ///     - [`Op::Slot`]
+                ///     - [`Op::Slot2`]
+                ///     - [`Op::Slot3`]
                 #[snake_name(return_call_imported)]
                 ReturnCallImported {
                     /// The called imported function.
@@ -989,11 +989,11 @@ macro_rules! for_each_op_grouped {
                 /// Must be followed by
                 ///
                 /// 1. [`Op::CallIndirectParams`]: encoding `table` and `index`
-                /// 2. Zero or more [`Op::RegisterList`]
+                /// 2. Zero or more [`Op::SlotList`]
                 /// 3. Followed by one of
-                ///     - [`Op::Register`]
-                ///     - [`Op::Register2`]
-                ///     - [`Op::Register3`]
+                ///     - [`Op::Slot`]
+                ///     - [`Op::Slot2`]
+                ///     - [`Op::Slot3`]
                 #[snake_name(return_call_indirect)]
                 ReturnCallIndirect {
                     /// The called internal function.
@@ -1010,11 +1010,11 @@ macro_rules! for_each_op_grouped {
                 /// Must be followed by
                 ///
                 /// 1. [`Op::CallIndirectParamsImm16`]: encoding `table` and `index`
-                /// 2. Zero or more [`Op::RegisterList`]
+                /// 2. Zero or more [`Op::SlotList`]
                 /// 3. Followed by one of
-                ///     - [`Op::Register`]
-                ///     - [`Op::Register2`]
-                ///     - [`Op::Register3`]
+                ///     - [`Op::Slot`]
+                ///     - [`Op::Slot2`]
+                ///     - [`Op::Slot3`]
                 #[snake_name(return_call_indirect_imm16)]
                 ReturnCallIndirectImm16 {
                     /// The called internal function.
@@ -1028,7 +1028,7 @@ macro_rules! for_each_op_grouped {
                 /// Used for calling internally compiled Wasm functions without parameters.
                 #[snake_name(call_internal_0)]
                 CallInternal0 {
-                    @results: RegSpan,
+                    @results: SlotSpan,
                     /// The called internal function.
                     func: InternalFunc,
                 },
@@ -1042,14 +1042,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Must be followed by
                 ///
-                /// 1. Zero or more [`Op::RegisterList`]
+                /// 1. Zero or more [`Op::SlotList`]
                 /// 2. Followed by one of
-                ///     - [`Op::Register`]
-                ///     - [`Op::Register2`]
-                ///     - [`Op::Register3`]
+                ///     - [`Op::Slot`]
+                ///     - [`Op::Slot2`]
+                ///     - [`Op::Slot3`]
                 #[snake_name(call_internal)]
                 CallInternal {
-                    @results: RegSpan,
+                    @results: SlotSpan,
                     /// The called internal function.
                     func: InternalFunc,
                 },
@@ -1061,7 +1061,7 @@ macro_rules! for_each_op_grouped {
                 /// Used for calling imported Wasm functions without parameters.
                 #[snake_name(call_imported_0)]
                 CallImported0 {
-                    @results: RegSpan,
+                    @results: SlotSpan,
                     /// The called imported function.
                     func: Func,
                 },
@@ -1075,14 +1075,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Must be followed by
                 ///
-                /// 1. Zero or more [`Op::RegisterList`]
+                /// 1. Zero or more [`Op::SlotList`]
                 /// 2. Followed by one of
-                ///     - [`Op::Register`]
-                ///     - [`Op::Register2`]
-                ///     - [`Op::Register3`]
+                ///     - [`Op::Slot`]
+                ///     - [`Op::Slot2`]
+                ///     - [`Op::Slot3`]
                 #[snake_name(call_imported)]
                 CallImported {
-                    @results: RegSpan,
+                    @results: SlotSpan,
                     /// The called imported function.
                     func: Func,
                 },
@@ -1098,7 +1098,7 @@ macro_rules! for_each_op_grouped {
                 /// Must be followed by [`Op::CallIndirectParams`] encoding `table` and `index`.
                 #[snake_name(call_indirect_0)]
                 CallIndirect0 {
-                    @results: RegSpan,
+                    @results: SlotSpan,
                     /// The called internal function.
                     func_type: FuncType,
                 },
@@ -1113,7 +1113,7 @@ macro_rules! for_each_op_grouped {
                 /// Must be followed by [`Op::CallIndirectParamsImm16`] encoding `table` and `index`.
                 #[snake_name(call_indirect_0_imm16)]
                 CallIndirect0Imm16 {
-                    @results: RegSpan,
+                    @results: SlotSpan,
                     /// The called internal function.
                     func_type: FuncType,
                 },
@@ -1128,14 +1128,14 @@ macro_rules! for_each_op_grouped {
                 /// Must be followed by
                 ///
                 /// 1. [`Op::CallIndirectParams`]: encoding `table` and `index`
-                /// 2. Zero or more [`Op::RegisterList`]
+                /// 2. Zero or more [`Op::SlotList`]
                 /// 3. Followed by one of
-                ///     - [`Op::Register`]
-                ///     - [`Op::Register2`]
-                ///     - [`Op::Register3`]
+                ///     - [`Op::Slot`]
+                ///     - [`Op::Slot2`]
+                ///     - [`Op::Slot3`]
                 #[snake_name(call_indirect)]
                 CallIndirect {
-                    @results: RegSpan,
+                    @results: SlotSpan,
                     /// The called internal function.
                     func_type: FuncType,
                 },
@@ -1150,14 +1150,14 @@ macro_rules! for_each_op_grouped {
                 /// Must be followed by
                 ///
                 /// 1. [`Op::CallIndirectParamsImm16`]: encoding `table` and `index`
-                /// 2. Zero or more [`Op::RegisterList`]
+                /// 2. Zero or more [`Op::SlotList`]
                 /// 3. Followed by one of
-                ///     - [`Op::Register`]
-                ///     - [`Op::Register2`]
-                ///     - [`Op::Register3`]
+                ///     - [`Op::Slot`]
+                ///     - [`Op::Slot2`]
+                ///     - [`Op::Slot3`]
                 #[snake_name(call_indirect_imm16)]
                 CallIndirectImm16 {
-                    @results: RegSpan,
+                    @results: SlotSpan,
                     /// The called internal function.
                     func_type: FuncType,
                 },
@@ -1166,25 +1166,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_and)]
                 SelectI32And {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i32.and` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_and_imm16)]
                 SelectI32AndImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                 },
@@ -1192,25 +1192,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_or)]
                 SelectI32Or {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i32.or` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_or_imm16)]
                 SelectI32OrImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                 },
@@ -1218,25 +1218,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_eq)]
                 SelectI32Eq {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i32.eq` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_eq_imm16)]
                 SelectI32EqImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                 },
@@ -1244,25 +1244,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_lt_s)]
                 SelectI32LtS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i32.lt_s` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_lt_s_imm16_rhs)]
                 SelectI32LtSImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                 },
@@ -1270,25 +1270,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_lt_u)]
                 SelectI32LtU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i32.lt_u` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_lt_u_imm16_rhs)]
                 SelectI32LtUImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<u32>,
                 },
@@ -1296,25 +1296,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_le_s)]
                 SelectI32LeS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i32.le_s` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_le_s_imm16_rhs)]
                 SelectI32LeSImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i32>,
                 },
@@ -1322,25 +1322,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_le_u)]
                 SelectI32LeU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i32.le_u` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i32_le_u_imm16_rhs)]
                 SelectI32LeUImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<u32>,
                 },
@@ -1348,25 +1348,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_and)]
                 SelectI64And {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i64.and` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_and_imm16)]
                 SelectI64AndImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                 },
@@ -1374,25 +1374,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_or)]
                 SelectI64Or {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i64.or` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_or_imm16)]
                 SelectI64OrImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                 },
@@ -1400,25 +1400,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_eq)]
                 SelectI64Eq {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i64.eq` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_eq_imm16)]
                 SelectI64EqImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                 },
@@ -1426,25 +1426,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_lt_s)]
                 SelectI64LtS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i64.lt_s` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_lt_s_imm16_rhs)]
                 SelectI64LtSImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                 },
@@ -1452,25 +1452,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_lt_u)]
                 SelectI64LtU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i64.lt_u` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_lt_u_imm16_rhs)]
                 SelectI64LtUImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<u64>,
                 },
@@ -1478,25 +1478,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_le_s)]
                 SelectI64LeS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i64.le_s` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_le_s_imm16_rhs)]
                 SelectI64LeSImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<i64>,
                 },
@@ -1504,25 +1504,25 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_le_u)]
                 SelectI64LeU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `i64.le_u` and `select` instruction with 16-bit immediate `rhs` value.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_i64_le_u_imm16_rhs)]
                 SelectI64LeUImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the conditional operator.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the conditional operator.
                     rhs: Const16<u64>,
                 },
@@ -1530,86 +1530,86 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_f32_eq)]
                 SelectF32Eq {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `f32.lt` and `select` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_f32_lt)]
                 SelectF32Lt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `f32.le` and `select` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_f32_le)]
                 SelectF32Le {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// A fused `f64.eq` and `select` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_f64_eq)]
                 SelectF64Eq {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `f64.lt` and `select` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_f64_lt)]
                 SelectF64Lt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A fused `f64.le` and `select` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register2`] encoding `true_val` and `false_val`.`
+                /// Followed by [`Op::Slot2`] encoding `true_val` and `false_val`.`
                 #[snake_name(select_f64_le)]
                 SelectF64Le {
-                    @result: Reg,
+                    @result: Slot,
                     /// The left-hand side operand to the branch conditional.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The right-hand side operand to the branch conditional.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// A Wasm `ref.func` equivalent Wasmi instruction.
                 #[snake_name(ref_func)]
                 RefFunc {
-                    @result: Reg,
+                    @result: Slot,
                     /// The index of the referenced function.
                     func: Func,
                 },
@@ -1617,7 +1617,7 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `global.get` equivalent Wasmi instruction.
                 #[snake_name(global_get)]
                 GlobalGet {
-                    @result: Reg,
+                    @result: Slot,
                     /// The index identifying the global variable for the `global.get` instruction.
                     global: Global,
                 },
@@ -1625,7 +1625,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(global_set)]
                 GlobalSet {
                     /// The register holding the value to be stored in the global variable.
-                    input: Reg,
+                    input: Slot,
                     /// The index identifying the global variable for the `global.set` instruction.
                     global: Global,
                 },
@@ -1664,13 +1664,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(load32)]
                 Load32 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -1687,7 +1687,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(load32_at)]
                 Load32At {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -1699,9 +1699,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(load32_offset16)]
                 Load32Offset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -1716,13 +1716,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(load64)]
                 Load64 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -1739,7 +1739,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(load64_at)]
                 Load64At {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -1751,9 +1751,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(load64_offset16)]
                 Load64Offset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -1764,13 +1764,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i32_load8_s)]
                 I32Load8s {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -1787,7 +1787,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(i32_load8_s_at)]
                 I32Load8sAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -1799,9 +1799,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(i32_load8_s_offset16)]
                 I32Load8sOffset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -1812,13 +1812,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i32_load8_u)]
                 I32Load8u {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -1835,7 +1835,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(i32_load8_u_at)]
                 I32Load8uAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -1847,9 +1847,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(i32_load8_u_offset16)]
                 I32Load8uOffset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -1860,13 +1860,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i32_load16_s)]
                 I32Load16s {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -1883,7 +1883,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(i32_load16_s_at)]
                 I32Load16sAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -1895,9 +1895,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(i32_load16_s_offset16)]
                 I32Load16sOffset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -1908,13 +1908,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i32_load16_u)]
                 I32Load16u {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -1931,7 +1931,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(i32_load16_u_at)]
                 I32Load16uAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -1943,9 +1943,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(i32_load16_u_offset16)]
                 I32Load16uOffset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -1956,13 +1956,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_load8_s)]
                 I64Load8s {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -1979,7 +1979,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(i64_load8_s_at)]
                 I64Load8sAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -1991,9 +1991,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(i64_load8_s_offset16)]
                 I64Load8sOffset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -2004,13 +2004,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_load8_u)]
                 I64Load8u {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2027,7 +2027,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(i64_load8_u_at)]
                 I64Load8uAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -2039,9 +2039,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(i64_load8_u_offset16)]
                 I64Load8uOffset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -2052,13 +2052,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_load16_s)]
                 I64Load16s {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2075,7 +2075,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(i64_load16_s_at)]
                 I64Load16sAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -2087,9 +2087,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(i64_load16_s_offset16)]
                 I64Load16sOffset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -2100,13 +2100,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_load16_u)]
                 I64Load16u {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2123,7 +2123,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(i64_load16_u_at)]
                 I64Load16uAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -2135,9 +2135,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(i64_load16_u_offset16)]
                 I64Load16uOffset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -2148,13 +2148,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_load32_s)]
                 I64Load32s {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2171,7 +2171,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(i64_load32_s_at)]
                 I64Load32sAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -2183,9 +2183,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(i64_load32_s_offset16)]
                 I64Load32sOffset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -2196,13 +2196,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `ptr` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `ptr` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_load32_u)]
                 I64Load32u {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2219,7 +2219,7 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance if missing.
                 #[snake_name(i64_load32_u_at)]
                 I64Load32uAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the `load` instruction.
                     address: Address32,
                 },
@@ -2231,9 +2231,9 @@ macro_rules! for_each_op_grouped {
                 /// - Operates on the default Wasm memory instance.
                 #[snake_name(i64_load32_u_offset16)]
                 I64Load32uOffset16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the pointer of the `load` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -2248,14 +2248,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(store32)]
                 Store32 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2268,11 +2268,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(store32_offset16)]
                 Store32Offset16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Store instruction for 32-bit values.
                 ///
@@ -2288,7 +2288,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(store32_at)]
                 Store32At {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The constant address to store the value.
                     address: Address32,
                 },
@@ -2303,14 +2303,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(store64)]
                 Store64 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2323,11 +2323,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(store64_offset16)]
                 Store64Offset16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Store instruction for 64-bit values.
                 ///
@@ -2343,7 +2343,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(store64_at)]
                 Store64At {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The constant address to store the value.
                     address: Address32,
                 },
@@ -2358,14 +2358,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i32_store_imm16)]
                 I32StoreImm16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2378,7 +2378,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i32_store_offset16_imm16)]
                 I32StoreOffset16Imm16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
@@ -2409,14 +2409,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i32_store8)]
                 I32Store8 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2430,14 +2430,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i32_store8_imm)]
                 I32Store8Imm {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2450,11 +2450,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i32_store8_offset16)]
                 I32Store8Offset16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Wasm `i32.store8` equivalent Wasmi instruction.
                 ///
@@ -2465,7 +2465,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i32_store8_offset16_imm)]
                 I32Store8Offset16Imm {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
@@ -2485,7 +2485,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i32_store8_at)]
                 I32Store8At {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The constant address to store the value.
                     address: Address32,
                 },
@@ -2514,14 +2514,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i32_store16)]
                 I32Store16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2535,14 +2535,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i32_store16_imm)]
                 I32Store16Imm {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2555,11 +2555,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i32_store16_offset16)]
                 I32Store16Offset16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Wasm `i32.store16` equivalent Wasmi instruction.
                 ///
@@ -2570,7 +2570,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i32_store16_offset16_imm)]
                 I32Store16Offset16Imm {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
@@ -2590,7 +2590,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i32_store16_at)]
                 I32Store16At {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The constant address to store the value.
                     address: Address32,
                 },
@@ -2623,14 +2623,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_store_imm16)]
                 I64StoreImm16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2643,7 +2643,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i64_store_offset16_imm16)]
                 I64StoreOffset16Imm16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
@@ -2674,14 +2674,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_store8)]
                 I64Store8 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2695,14 +2695,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_store8_imm)]
                 I64Store8Imm {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2715,11 +2715,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i64_store8_offset16)]
                 I64Store8Offset16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Wasm `i64.store8` equivalent Wasmi instruction.
                 ///
@@ -2730,7 +2730,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i64_store8_offset16_imm)]
                 I64Store8Offset16Imm {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
@@ -2750,7 +2750,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i64_store8_at)]
                 I64Store8At {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The constant address to store the value.
                     address: Address32,
                 },
@@ -2779,14 +2779,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_store16)]
                 I64Store16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2800,14 +2800,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_store16_imm)]
                 I64Store16Imm {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2820,11 +2820,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i64_store16_offset16)]
                 I64Store16Offset16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Wasm `i64.store16` equivalent Wasmi instruction.
                 ///
@@ -2835,7 +2835,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i64_store16_offset16_imm)]
                 I64Store16Offset16Imm {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
@@ -2855,7 +2855,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i64_store16_at)]
                 I64Store16At {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The constant address to store the value.
                     address: Address32,
                 },
@@ -2884,14 +2884,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_store32)]
                 I64Store32 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2905,14 +2905,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// 1. [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// 2. Optional [`Op::MemoryIndex`]: encoding `memory` index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(i64_store32_imm16)]
                 I64Store32Imm16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load offset.
                     offset_lo: Offset64Lo,
                 },
@@ -2925,11 +2925,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i64_store32_offset16)]
                 I64Store32Offset16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Wasm `i64.store32` equivalent Wasmi instruction.
                 ///
@@ -2940,7 +2940,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i64_store32_offset16_imm16)]
                 I64Store32Offset16Imm16 {
                     /// The register storing the pointer of the `store` instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The register storing the pointer offset of the `store` instruction.
                     offset: Offset16,
                     /// The value to be stored.
@@ -2960,7 +2960,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(i64_store32_at)]
                 I64Store32At {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The constant address to store the value.
                     address: Address32,
                 },
@@ -2986,18 +2986,18 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i32.eq` equivalent Wasmi instruction.
                 #[snake_name(i32_eq)]
                 I32Eq{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32.eq` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i32_eq_imm16)]
                 I32EqImm16{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
@@ -3005,18 +3005,18 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i32.ne` equivalent Wasmi instruction.
                 #[snake_name(i32_ne)]
                 I32Ne{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32.ne` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i32_ne_imm16)]
                 I32NeImm16{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
@@ -3024,54 +3024,54 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i32.lt_s` equivalent Wasmi instruction.
                 #[snake_name(i32_lt_s)]
                 I32LtS{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32.lt_s` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i32_lt_s_imm16_lhs)]
                 I32LtSImm16Lhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32.lt_s` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i32_lt_s_imm16_rhs)]
                 I32LtSImm16Rhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
                 /// Wasm `i32.lt_u` equivalent Wasmi instruction.
                 #[snake_name(i32_lt_u)]
                 I32LtU{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32.lt_u` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i32_lt_u_imm16_lhs)]
                 I32LtUImm16Lhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<u32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32.lt_u` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i32_lt_u_imm16_rhs)]
                 I32LtUImm16Rhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<u32>,
                 },
@@ -3079,54 +3079,54 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i32.le_s` equivalent Wasmi instruction.
                 #[snake_name(i32_le_s)]
                 I32LeS{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32.le_s` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i32_le_s_imm16_lhs)]
                 I32LeSImm16Lhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32.le_s` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i32_le_s_imm16_rhs)]
                 I32LeSImm16Rhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
                 /// Wasm `i32.le_u` equivalent Wasmi instruction.
                 #[snake_name(i32_le_u)]
                 I32LeU{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32.le_u` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i32_le_u_imm16_lhs)]
                 I32LeUImm16Lhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<u32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32.le_u` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i32_le_u_imm16_rhs)]
                 I32LeUImm16Rhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<u32>,
                 },
@@ -3134,18 +3134,18 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i64.eq` equivalent Wasmi instruction.
                 #[snake_name(i64_eq)]
                 I64Eq{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.eq` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_eq_imm16)]
                 I64EqImm16{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -3153,18 +3153,18 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i64.ne` equivalent Wasmi instruction.
                 #[snake_name(i64_ne)]
                 I64Ne{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.ne` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_ne_imm16)]
                 I64NeImm16{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -3172,27 +3172,27 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i64.lt_s` equivalent Wasmi instruction.
                 #[snake_name(i64_lt_s)]
                 I64LtS{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.lt_s` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i64_lt_s_imm16_lhs)]
                 I64LtSImm16Lhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.lt_s` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_lt_s_imm16_rhs)]
                 I64LtSImm16Rhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -3200,27 +3200,27 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i64.lt_u` equivalent Wasmi instruction.
                 #[snake_name(i64_lt_u)]
                 I64LtU{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.lt_u` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i64_lt_u_imm16_lhs)]
                 I64LtUImm16Lhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<u64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.lt_u` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_lt_u_imm16_rhs)]
                 I64LtUImm16Rhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<u64>,
                 },
@@ -3228,27 +3228,27 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i64.le_s` equivalent Wasmi instruction.
                 #[snake_name(i64_le_s)]
                 I64LeS{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.le_s` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i64_le_s_imm16_lhs)]
                 I64LeSImm16Lhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.le_s` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_le_s_imm16_rhs)]
                 I64LeSImm16Rhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -3256,27 +3256,27 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i64.le_u` equivalent Wasmi instruction.
                 #[snake_name(i64_le_u)]
                 I64LeU{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.le_u` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i64_le_u_imm16_lhs)]
                 I64LeUImm16Lhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<u64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.le_u` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_le_u_imm16_rhs)]
                 I64LeUImm16Rhs{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<u64>,
                 },
@@ -3284,143 +3284,143 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `f32.eq` equivalent Wasmi instruction.
                 #[snake_name(f32_eq)]
                 F32Eq{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f32.ne` equivalent Wasmi instruction.
                 #[snake_name(f32_ne)]
                 F32Ne{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f32.lt` equivalent Wasmi instruction.
                 #[snake_name(f32_lt)]
                 F32Lt{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f32.le` equivalent Wasmi instruction.
                 #[snake_name(f32_le)]
                 F32Le{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Negated Wasm `f32.lt` equivalent Wasmi instruction.
                 #[snake_name(f32_not_lt)]
                 F32NotLt{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Negated Wasm `f32.le` equivalent Wasmi instruction.
                 #[snake_name(f32_not_le)]
                 F32NotLe{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// Wasm `f64.eq` equivalent Wasmi instruction.
                 #[snake_name(f64_eq)]
                 F64Eq{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f64.ne` equivalent Wasmi instruction.
                 #[snake_name(f64_ne)]
                 F64Ne{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f64.lt` equivalent Wasmi instruction.
                 #[snake_name(f64_lt)]
                 F64Lt{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f64.le` equivalent Wasmi instruction.
                 #[snake_name(f64_le)]
                 F64Le{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Negated Wasm `f64.lt` equivalent Wasmi instruction.
                 #[snake_name(f64_not_lt)]
                 F64NotLt{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Negated Wasm `f64.le` equivalent Wasmi instruction.
                 #[snake_name(f64_not_le)]
                 F64NotLe{
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i32` count-leading-zeros (clz) instruction.
                 #[snake_name(i32_clz)]
                 I32Clz {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// `i32` count-trailing-zeros (ctz) instruction.
                 #[snake_name(i32_ctz)]
                 I32Ctz {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// `i32` pop-count instruction.
                 #[snake_name(i32_popcnt)]
                 I32Popcnt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
 
                 /// `i32` add instruction: `r0 = r1 + r2`
                 #[snake_name(i32_add)]
                 I32Add {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i32` add (small) immediate instruction: `r0 = r1 + c0`
                 ///
@@ -3429,9 +3429,9 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I32Add`] for 16-bit constant values.
                 #[snake_name(i32_add_imm16)]
                 I32AddImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
@@ -3439,11 +3439,11 @@ macro_rules! for_each_op_grouped {
                 /// `i32` subtract instruction: `r0 = r1 - r2`
                 #[snake_name(i32_sub)]
                 I32Sub {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i32` subtract immediate instruction: `r0 = c0 - r1`
                 ///
@@ -3453,21 +3453,21 @@ macro_rules! for_each_op_grouped {
                 /// - Required instruction since subtraction is not commutative.
                 #[snake_name(i32_sub_imm16_lhs)]
                 I32SubImm16Lhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i32` multiply instruction: `r0 = r1 * r2`
                 #[snake_name(i32_mul)]
                 I32Mul {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i32` multiply immediate instruction: `r0 = r1 * c0`
                 ///
@@ -3476,9 +3476,9 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I32Mul`] for 16-bit constant values.
                 #[snake_name(i32_mul_imm16)]
                 I32MulImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
@@ -3486,11 +3486,11 @@ macro_rules! for_each_op_grouped {
                 /// `i32` signed-division instruction: `r0 = r1 / r2`
                 #[snake_name(i32_div_s)]
                 I32DivS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i32` signed-division immediate instruction: `r0 = r1 / c0`
                 ///
@@ -3500,9 +3500,9 @@ macro_rules! for_each_op_grouped {
                 /// - Guarantees that the right-hand side operand is not zero.
                 #[snake_name(i32_div_s_imm16_rhs)]
                 I32DivSImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<NonZeroI32>,
                 },
@@ -3515,21 +3515,21 @@ macro_rules! for_each_op_grouped {
                 /// - Required instruction since signed-division is not commutative.
                 #[snake_name(i32_div_s_imm16_lhs)]
                 I32DivSImm16Lhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i32` unsigned-division instruction: `r0 = r1 / r2`
                 #[snake_name(i32_div_u)]
                 I32DivU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i32` unsigned-division immediate instruction: `r0 = r1 / c0`
                 ///
@@ -3542,9 +3542,9 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I32DivU`] for 16-bit constant values.
                 #[snake_name(i32_div_u_imm16_rhs)]
                 I32DivUImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<NonZeroU32>,
                 },
@@ -3557,21 +3557,21 @@ macro_rules! for_each_op_grouped {
                 /// - Required instruction since `i32` unsigned-division is not commutative.
                 #[snake_name(i32_div_u_imm16_lhs)]
                 I32DivUImm16Lhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<u32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i32` signed-remainder instruction: `r0 = r1 % r2`
                 #[snake_name(i32_rem_s)]
                 I32RemS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i32` signed-remainder immediate instruction: `r0 = r1 % c0`
                 ///
@@ -3581,9 +3581,9 @@ macro_rules! for_each_op_grouped {
                 /// - Guarantees that the right-hand side operand is not zero.
                 #[snake_name(i32_rem_s_imm16_rhs)]
                 I32RemSImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<NonZeroI32>,
                 },
@@ -3596,21 +3596,21 @@ macro_rules! for_each_op_grouped {
                 /// - Required instruction since `i32` signed-remainder is not commutative.
                 #[snake_name(i32_rem_s_imm16_lhs)]
                 I32RemSImm16Lhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i32` unsigned-remainder instruction: `r0 = r1 % r2`
                 #[snake_name(i32_rem_u)]
                 I32RemU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i32` signed-remainder immediate instruction: `r0 = r1 % c0`
                 ///
@@ -3620,9 +3620,9 @@ macro_rules! for_each_op_grouped {
                 /// - Guarantees that the right-hand side operand is not zero.
                 #[snake_name(i32_rem_u_imm16_rhs)]
                 I32RemUImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<NonZeroU32>,
                 },
@@ -3635,21 +3635,21 @@ macro_rules! for_each_op_grouped {
                 /// - Required instruction since unsigned-remainder is not commutative.
                 #[snake_name(i32_rem_u_imm16_lhs)]
                 I32RemUImm16Lhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<u32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i32` bitwise-and instruction: `r0 = r1 & r2`
                 #[snake_name(i32_bitand)]
                 I32BitAnd {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i32` bitwise-and (small) immediate instruction: `r0 = r1 & c0`
                 ///
@@ -3658,20 +3658,20 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I32BitAnd`] for 16-bit constant values.
                 #[snake_name(i32_bitand_imm16)]
                 I32BitAndImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
                 /// `i32` bitwise-or instruction: `r0 = r1 & r2`
                 #[snake_name(i32_bitor)]
                 I32BitOr {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i32` bitwise-or (small) immediate instruction: `r0 = r1 & c0`
                 ///
@@ -3680,20 +3680,20 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I32BitOr`] for 16-bit constant values.
                 #[snake_name(i32_bitor_imm16)]
                 I32BitOrImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
                 /// `i32` bitwise-or instruction: `r0 = r1 ^ r2`
                 #[snake_name(i32_bitxor)]
                 I32BitXor {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i32` bitwise-or (small) immediate instruction: `r0 = r1 ^ c0`
                 ///
@@ -3702,9 +3702,9 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I32BitXor`] for 16-bit constant values.
                 #[snake_name(i32_bitxor_imm16)]
                 I32BitXorImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
@@ -3712,36 +3712,36 @@ macro_rules! for_each_op_grouped {
                 /// Logical `i32.and` instruction.
                 #[snake_name(i32_and)]
                 I32And {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Variant of [`Op::I32And`] with 16-bit `rhs` immediate.
                 #[snake_name(i32_and_imm16)]
                 I32AndImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
                 /// Logical `i32.or` instruction.
                 #[snake_name(i32_or)]
                 I32Or {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Variant of [`Op::I32Or`] with 16-bit `rhs` immediate.
                 #[snake_name(i32_or_imm16)]
                 I32OrImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
@@ -3751,18 +3751,18 @@ macro_rules! for_each_op_grouped {
                 /// This usually is the result of fusing `i32.and` + `i32.eqz`.
                 #[snake_name(i32_nand)]
                 I32Nand {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Variant of [`Op::I32Nand`] with 16-bit `rhs` immediate.
                 #[snake_name(i32_nand_imm16)]
                 I32NandImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
@@ -3771,18 +3771,18 @@ macro_rules! for_each_op_grouped {
                 /// This usually is the result of fusing `i32.or` + `i32.eqz`.
                 #[snake_name(i32_nor)]
                 I32Nor {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Variant of [`Op::I32Nor`] with 16-bit `rhs` immediate.
                 #[snake_name(i32_nor_imm16)]
                 I32NorImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i32>,
                 },
@@ -3790,173 +3790,173 @@ macro_rules! for_each_op_grouped {
                 /// A Wasm `i32.shl` equivalent Wasmi instruction.
                 #[snake_name(i32_shl)]
                 I32Shl {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A Wasm `i32.shl` equivalent Wasmi instruction with 16-bit immediate `rhs` operand.
                 #[snake_name(i32_shl_by)]
                 I32ShlBy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: ShiftAmount<i32>,
                 },
                 /// A Wasm `i32.shl` equivalent Wasmi instruction with 16-bit immediate `lhs` operand.
                 #[snake_name(i32_shl_imm16)]
                 I32ShlImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// A Wasm `i32.shr_u` equivalent Wasmi instruction.
                 #[snake_name(i32_shr_u)]
                 I32ShrU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A Wasm `i32.shr_u` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i32_shr_u_by)]
                 I32ShrUBy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: ShiftAmount<i32>,
                 },
                 /// A Wasm `i32.shr_u` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i32_shr_u_imm16)]
                 I32ShrUImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// A Wasm `i32.shr_s` equivalent Wasmi instruction.
                 #[snake_name(i32_shr_s)]
                 I32ShrS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A Wasm `i32.shr_s` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i32_shr_s_by)]
                 I32ShrSBy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: ShiftAmount<i32>,
                 },
                 /// A Wasm `i32.shr_s` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i32_shr_s_imm16)]
                 I32ShrSImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// A Wasm `i32.rotl` equivalent Wasmi instruction.
                 #[snake_name(i32_rotl)]
                 I32Rotl {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A Wasm `i32.rotl` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i32_rotl_by)]
                 I32RotlBy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: ShiftAmount<i32>,
                 },
                 /// A Wasm `i32.rotl` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i32_rotl_imm16)]
                 I32RotlImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// A Wasm `i32.rotr` equivalent Wasmi instruction.
                 #[snake_name(i32_rotr)]
                 I32Rotr {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A Wasm `i32.rotr` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i32_rotr_by)]
                 I32RotrBy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: ShiftAmount<i32>,
                 },
                 /// A Wasm `i32.rotr` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i32_rotr_imm16)]
                 I32RotrImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i32>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i64` count-leading-zeros (clz) instruction.
                 #[snake_name(i64_clz)]
                 I64Clz {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// `i64` count-trailing-zeros (ctz) instruction.
                 #[snake_name(i64_ctz)]
                 I64Ctz {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// `i64` pop-count instruction.
                 #[snake_name(i64_popcnt)]
                 I64Popcnt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
 
                 /// `i64` add instruction: `r0 = r1 + r2`
                 #[snake_name(i64_add)]
                 I64Add {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i64` add (small) immediate instruction: `r0 = r1 + c0`
                 ///
@@ -3965,9 +3965,9 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I64Add`] for 16-bit constant values.
                 #[snake_name(i64_add_imm16)]
                 I64AddImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -3975,11 +3975,11 @@ macro_rules! for_each_op_grouped {
                 /// `i64` subtract instruction: `r0 = r1 - r2`
                 #[snake_name(i64_sub)]
                 I64Sub {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i64` subtract immediate instruction: `r0 = c0 - r1`
                 ///
@@ -3989,21 +3989,21 @@ macro_rules! for_each_op_grouped {
                 /// - Required instruction since subtraction is not commutative.
                 #[snake_name(i64_sub_imm16_lhs)]
                 I64SubImm16Lhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i64` multiply instruction: `r0 = r1 * r2`
                 #[snake_name(i64_mul)]
                 I64Mul {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i64` multiply immediate instruction: `r0 = r1 * c0`
                 ///
@@ -4012,9 +4012,9 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I64Mul`] for 16-bit constant values.
                 #[snake_name(i64_mul_imm16)]
                 I64MulImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -4022,11 +4022,11 @@ macro_rules! for_each_op_grouped {
                 /// `i64` signed-division instruction: `r0 = r1 / r2`
                 #[snake_name(i64_div_s)]
                 I64DivS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i64` signed-division immediate instruction: `r0 = r1 / c0`
                 ///
@@ -4036,9 +4036,9 @@ macro_rules! for_each_op_grouped {
                 /// - Guarantees that the right-hand side operand is not zero.
                 #[snake_name(i64_div_s_imm16_rhs)]
                 I64DivSImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<NonZeroI64>,
                 },
@@ -4051,21 +4051,21 @@ macro_rules! for_each_op_grouped {
                 /// - Optimized variant of [`Op::I64DivU`] for 16-bit constant values.
                 #[snake_name(i64_div_s_imm16_lhs)]
                 I64DivSImm16Lhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i64` unsigned-division instruction: `r0 = r1 / r2`
                 #[snake_name(i64_div_u)]
                 I64DivU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i64` unsigned-division immediate instruction: `r0 = r1 / c0`
                 ///
@@ -4078,9 +4078,9 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I64DivU`] for 16-bit constant values.
                 #[snake_name(i64_div_u_imm16_rhs)]
                 I64DivUImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<NonZeroU64>,
                 },
@@ -4093,21 +4093,21 @@ macro_rules! for_each_op_grouped {
                 /// - Required instruction since unsigned-division is not commutative.
                 #[snake_name(i64_div_u_imm16_lhs)]
                 I64DivUImm16Lhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<u64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i64` signed-remainder instruction: `r0 = r1 % r2`
                 #[snake_name(i64_rem_s)]
                 I64RemS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i64` signed-remainder immediate instruction: `r0 = r1 % c0`
                 ///
@@ -4117,9 +4117,9 @@ macro_rules! for_each_op_grouped {
                 /// - Guarantees that the right-hand side operand is not zero.
                 #[snake_name(i64_rem_s_imm16_rhs)]
                 I64RemSImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<NonZeroI64>,
                 },
@@ -4132,21 +4132,21 @@ macro_rules! for_each_op_grouped {
                 /// - Required instruction since signed-remainder is not commutative.
                 #[snake_name(i64_rem_s_imm16_lhs)]
                 I64RemSImm16Lhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i64` unsigned-remainder instruction: `r0 = r1 % r2`
                 #[snake_name(i64_rem_u)]
                 I64RemU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i64` signed-remainder immediate instruction: `r0 = r1 % c0`
                 ///
@@ -4156,9 +4156,9 @@ macro_rules! for_each_op_grouped {
                 /// - Guarantees that the right-hand side operand is not zero.
                 #[snake_name(i64_rem_u_imm16_rhs)]
                 I64RemUImm16Rhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<NonZeroU64>,
                 },
@@ -4171,21 +4171,21 @@ macro_rules! for_each_op_grouped {
                 /// - Required instruction since unsigned-remainder is not commutative.
                 #[snake_name(i64_rem_u_imm16_lhs)]
                 I64RemUImm16Lhs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<u64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// `i64` bitwise-and instruction: `r0 = r1 & r2`
                 #[snake_name(i64_bitand)]
                 I64BitAnd {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i64` bitwise-and (small) immediate instruction: `r0 = r1 & c0`
                 ///
@@ -4194,9 +4194,9 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I64BitAnd`] for 16-bit constant values.
                 #[snake_name(i64_bitand_imm16)]
                 I64BitAndImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -4204,11 +4204,11 @@ macro_rules! for_each_op_grouped {
                 /// `i64` bitwise-or instruction: `r0 = r1 & r2`
                 #[snake_name(i64_bitor)]
                 I64BitOr {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i64` bitwise-or (small) immediate instruction: `r0 = r1 & c0`
                 ///
@@ -4217,9 +4217,9 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I64BitOr`] for 16-bit constant values.
                 #[snake_name(i64_bitor_imm16)]
                 I64BitOrImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -4227,11 +4227,11 @@ macro_rules! for_each_op_grouped {
                 /// `i64` bitwise-or instruction: `r0 = r1 ^ r2`
                 #[snake_name(i64_bitxor)]
                 I64BitXor {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// `i64` bitwise-or (small) immediate instruction: `r0 = r1 ^ c0`
                 ///
@@ -4240,9 +4240,9 @@ macro_rules! for_each_op_grouped {
                 /// Optimized variant of [`Op::I64BitXor`] for 16-bit constant values.
                 #[snake_name(i64_bitxor_imm16)]
                 I64BitXorImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -4250,36 +4250,36 @@ macro_rules! for_each_op_grouped {
                 /// Logical `i64.and` instruction.
                 #[snake_name(i64_and)]
                 I64And {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Variant of [`Op::I64And`] with 16-bit `rhs` immediate.
                 #[snake_name(i64_and_imm16)]
                 I64AndImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
                 /// Logical `i64.or` instruction.
                 #[snake_name(i64_or)]
                 I64Or {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Variant of [`Op::I64Or`] with 16-bit `rhs` immediate.
                 #[snake_name(i64_or_imm16)]
                 I64OrImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -4289,18 +4289,18 @@ macro_rules! for_each_op_grouped {
                 /// This usually is the result of fusing `i64.and` + `i64.eqz`.
                 #[snake_name(i64_nand)]
                 I64Nand {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Variant of [`Op::I64Nand`] with 16-bit `rhs` immediate.
                 #[snake_name(i64_nand_imm16)]
                 I64NandImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -4309,18 +4309,18 @@ macro_rules! for_each_op_grouped {
                 /// This usually is the result of fusing `i64.or` + `i64.eqz`.
                 #[snake_name(i64_nor)]
                 I64Nor {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Variant of [`Op::I64Nor`] with 16-bit `rhs` immediate.
                 #[snake_name(i64_nor_imm16)]
                 I64NorImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: Const16<i64>,
                 },
@@ -4328,149 +4328,149 @@ macro_rules! for_each_op_grouped {
                 /// A Wasm `i64.shl` equivalent Wasmi instruction.
                 #[snake_name(i64_shl)]
                 I64Shl {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A Wasm `i64.shl` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_shl_by)]
                 I64ShlBy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: ShiftAmount<i64>,
                 },
                 /// A Wasm `i64.shl` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i64_shl_imm16)]
                 I64ShlImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// A Wasm `i64.shr_u` equivalent Wasmi instruction.
                 #[snake_name(i64_shr_u)]
                 I64ShrU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A Wasm `i64.shr_u` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_shr_u_by)]
                 I64ShrUBy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: ShiftAmount<i64>,
                 },
                 /// A Wasm `i64.shr_u` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i64_shr_u_imm16)]
                 I64ShrUImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// A Wasm `i64.shr_s` equivalent Wasmi instruction.
                 #[snake_name(i64_shr_s)]
                 I64ShrS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A Wasm `i64.shr_s` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_shr_s_by)]
                 I64ShrSBy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: ShiftAmount<i64>,
                 },
                 /// A Wasm `i64.shr_s` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i64_shr_s_imm16)]
                 I64ShrSImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// A Wasm `i64.rotl` equivalent Wasmi instruction.
                 #[snake_name(i64_rotl)]
                 I64Rotl {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A Wasm `i64.rotl` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_rotl_by)]
                 I64RotlBy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: ShiftAmount<i64>,
                 },
                 /// A Wasm `i64.rotl` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i64_rotl_imm16)]
                 I64RotlImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// A Wasm `i64.rotr` equivalent Wasmi instruction.
                 #[snake_name(i64_rotr)]
                 I64Rotr {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// A Wasm `i64.rotr` equivalent Wasmi instruction with 16-bit immediate `rhs` value.
                 #[snake_name(i64_rotr_by)]
                 I64RotrBy {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding one of the operands.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The 16-bit immediate value.
                     rhs: ShiftAmount<i64>,
                 },
                 /// A Wasm `i64.rotr` equivalent Wasmi instruction with 16-bit immediate `lhs` value.
                 #[snake_name(i64_rotr_imm16)]
                 I64RotrImm16 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The 16-bit immediate value.
                     lhs: Const16<i64>,
                     /// The register holding one of the operands.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// Wasm `i32.wrap_i64` instruction.
                 #[snake_name(i32_wrap_i64)]
                 I32WrapI64 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
 
                 /// Wasm `i64.add128` instruction.
@@ -4481,15 +4481,15 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register3`] encoding `lhs_hi`, `rhs_lo` and `rhs_hi`
+                /// Followed by [`Op::Slot3`] encoding `lhs_hi`, `rhs_lo` and `rhs_hi`
                 #[snake_name(i64_add128)]
                 I64Add128 {
                     // Note:
-                    // - We are not using `FixedRegSpan` to be able to change both results independently.
+                    // - We are not using `FixedSlotSpan` to be able to change both results independently.
                     // - This allows for more `local.set` optimizations.
-                    @results: [Reg; 2],
+                    @results: [Slot; 2],
                     /// The 64 hi-bits of the `lhs` input parameter.
-                    lhs_lo: Reg,
+                    lhs_lo: Slot,
                 },
                 /// Wasm `i64.sub128` instruction.
                 ///
@@ -4499,15 +4499,15 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register3`] encoding `lhs_hi`, `rhs_lo` and `rhs_hi`
+                /// Followed by [`Op::Slot3`] encoding `lhs_hi`, `rhs_lo` and `rhs_hi`
                 #[snake_name(i64_sub128)]
                 I64Sub128 {
                     // Note:
-                    // - We are not using `FixedRegSpan` to be able to change both results independently.
+                    // - We are not using `FixedSlotSpan` to be able to change both results independently.
                     // - This allows for more `local.set` optimizations.
-                    @results: [Reg; 2],
+                    @results: [Slot; 2],
                     /// The low 64-bits of the `lhs` input parameter.
-                    lhs_lo: Reg,
+                    lhs_lo: Slot,
                 },
                 /// Wasm `i64.mul_wide_s` instruction.
                 ///
@@ -4516,11 +4516,11 @@ macro_rules! for_each_op_grouped {
                 /// This instruction is part of the Wasm `wide-arithmetic` proposal.
                 #[snake_name(i64_mul_wide_s)]
                 I64MulWideS {
-                    @results: FixedRegSpan<2>,
+                    @results: FixedSlotSpan<2>,
                     /// The `lhs` input value for the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The `rhs` input value for the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64.mul_wide_u` instruction.
                 ///
@@ -4529,11 +4529,11 @@ macro_rules! for_each_op_grouped {
                 /// This instruction is part of the Wasm `wide-arithmetic` proposal.
                 #[snake_name(i64_mul_wide_u)]
                 I64MulWideU {
-                    @results: FixedRegSpan<2>,
+                    @results: FixedSlotSpan<2>,
                     /// The `lhs` input value for the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The `rhs` input value for the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// Wasm `i32.extend8_s` instruction.
@@ -4543,9 +4543,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `sign-extension` proposal.
                 #[snake_name(i32_extend8_s)]
                 I32Extend8S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i32.extend16_s` instruction.
                 ///
@@ -4554,9 +4554,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `sign-extension` proposal.
                 #[snake_name(i32_extend16_s)]
                 I32Extend16S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i64.extend8_s` instruction.
                 ///
@@ -4565,9 +4565,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `sign-extension` proposal.
                 #[snake_name(i64_extend8_s)]
                 I64Extend8S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm(UnaryInstr) `i64.extend16_s` instruction.
                 ///
@@ -4576,9 +4576,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `sign-extension` proposal.
                 #[snake_name(i64_extend16_s)]
                 I64Extend16S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i64.extend32_s` instruction.
                 ///
@@ -4587,129 +4587,129 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `sign-extension` proposal.
                 #[snake_name(i64_extend32_s)]
                 I64Extend32S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
 
                 /// Wasm `f32.abs` equivalent Wasmi instruction.
                 #[snake_name(f32_abs)]
                 F32Abs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f32.neg` equivalent Wasmi instruction.
                 #[snake_name(f32_neg)]
                 F32Neg {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f32.ceil` equivalent Wasmi instruction.
                 #[snake_name(f32_ceil)]
                 F32Ceil {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f32.floor` equivalent Wasmi instruction.
                 #[snake_name(f32_floor)]
                 F32Floor {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f32.trunc` equivalent Wasmi instruction.
                 #[snake_name(f32_trunc)]
                 F32Trunc {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f32.nearest` equivalent Wasmi instruction.
                 #[snake_name(f32_nearest)]
                 F32Nearest {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f32.sqrt` equivalent Wasmi instruction.
                 #[snake_name(f32_sqrt)]
                 F32Sqrt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f32.add` equivalent Wasmi instruction.
                 #[snake_name(f32_add)]
                 F32Add {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f32.sub` equivalent Wasmi instruction.
                 #[snake_name(f32_sub)]
                 F32Sub {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f32.mul` equivalent Wasmi instruction.
                 #[snake_name(f32_mul)]
                 F32Mul {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f32.div` equivalent Wasmi instruction.
                 #[snake_name(f32_div)]
                 F32Div {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f32.min` equivalent Wasmi instruction.
                 #[snake_name(f32_min)]
                 F32Min {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f32.max` equivalent Wasmi instruction.
                 #[snake_name(f32_max)]
                 F32Max {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f32.copysign` equivalent Wasmi instruction.
                 #[snake_name(f32_copysign)]
                 F32Copysign {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f32.copysign` equivalent Wasmi instruction with NaN canonicalization.
                 #[snake_name(f32_copysign_imm)]
                 F32CopysignImm {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
                     rhs: Sign<f32>,
                 },
@@ -4717,121 +4717,121 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `f64.abs` equivalent Wasmi instruction.
                 #[snake_name(f64_abs)]
                 F64Abs {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.neg` equivalent Wasmi instruction.
                 #[snake_name(f64_neg)]
                 F64Neg {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.ceil` equivalent Wasmi instruction.
                 #[snake_name(f64_ceil)]
                 F64Ceil {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.floor` equivalent Wasmi instruction.
                 #[snake_name(f64_floor)]
                 F64Floor {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.trunc` equivalent Wasmi instruction.
                 #[snake_name(f64_trunc)]
                 F64Trunc {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.nearest` equivalent Wasmi instruction.
                 #[snake_name(f64_nearest)]
                 F64Nearest {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.sqrt` equivalent Wasmi instruction.
                 #[snake_name(f64_sqrt)]
                 F64Sqrt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.add` equivalent Wasmi instruction.
                 #[snake_name(f64_add)]
                 F64Add {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f64.sub` equivalent Wasmi instruction.
                 #[snake_name(f64_sub)]
                 F64Sub {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f64.mul` equivalent Wasmi instruction.
                 #[snake_name(f64_mul)]
                 F64Mul {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f64.div` equivalent Wasmi instruction.
                 #[snake_name(f64_div)]
                 F64Div {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f64.min` equivalent Wasmi instruction.
                 #[snake_name(f64_min)]
                 F64Min {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f64.max` equivalent Wasmi instruction.
                 #[snake_name(f64_max)]
                 F64Max {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f64.copysign` equivalent Wasmi instruction.
                 #[snake_name(f64_copysign)]
                 F64Copysign {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `f64.copysign` equivalent Wasmi instruction with imediate `rhs` value.
                 #[snake_name(f64_copysign_imm)]
                 F64CopysignImm {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the left-hand side value.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the right-hand side value.
                     rhs: Sign<f64>,
                 },
@@ -4839,58 +4839,58 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i32.trunc_f32_s` instruction.
                 #[snake_name(i32_trunc_f32_s)]
                 I32TruncF32S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i32.trunc_f32_u` instruction.
                 #[snake_name(i32_trunc_f32_u)]
                 I32TruncF32U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i32.trunc_f64_s` instruction.
                 #[snake_name(i32_trunc_f64_s)]
                 I32TruncF64S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i32.trunc_f64_u` instruction.
                 #[snake_name(i32_trunc_f64_u)]
                 I32TruncF64U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i64.trunc_f32_s` instruction.
                 #[snake_name(i64_trunc_f32_s)]
                 I64TruncF32S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i64.trunc_f32_u` instruction.
                 #[snake_name(i64_trunc_f32_u)]
                 I64TruncF32U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i64.trunc_f64_s` instruction.
                 #[snake_name(i64_trunc_f64_s)]
                 I64TruncF64S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i64.trunc_f64_u` instruction.
                 #[snake_name(i64_trunc_f64_u)]
                 I64TruncF64U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
 
                 /// Wasm `i32.trunc_sat_f32_s` instruction.
@@ -4900,9 +4900,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `non-trapping float-to-int conversions` proposal.
                 #[snake_name(i32_trunc_sat_f32_s)]
                 I32TruncSatF32S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i32.trunc_sat_f32_u` instruction.
                 ///
@@ -4911,9 +4911,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `non-trapping float-to-int conversions` proposal.
                 #[snake_name(i32_trunc_sat_f32_u)]
                 I32TruncSatF32U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i32.trunc_sat_f64_s` instruction.
                 ///
@@ -4922,9 +4922,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `non-trapping float-to-int conversions` proposal.
                 #[snake_name(i32_trunc_sat_f64_s)]
                 I32TruncSatF64S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i32.trunc_sat_f64_u` instruction.
                 ///
@@ -4933,9 +4933,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `non-trapping float-to-int conversions` proposal.
                 #[snake_name(i32_trunc_sat_f64_u)]
                 I32TruncSatF64U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i64.trunc_sat_f32_s` instruction.
                 ///
@@ -4944,9 +4944,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `non-trapping float-to-int conversions` proposal.
                 #[snake_name(i64_trunc_sat_f32_s)]
                 I64TruncSatF32S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i64.trunc_sat_f32_u` instruction.
                 ///
@@ -4955,9 +4955,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `non-trapping float-to-int conversions` proposal.
                 #[snake_name(i64_trunc_sat_f32_u)]
                 I64TruncSatF32U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i64.trunc_sat_f64_s` instruction.
                 ///
@@ -4966,9 +4966,9 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `non-trapping float-to-int conversions` proposal.
                 #[snake_name(i64_trunc_sat_f64_s)]
                 I64TruncSatF64S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `i64.trunc_sat_f64_u` instruction.
                 ///
@@ -4977,81 +4977,81 @@ macro_rules! for_each_op_grouped {
                 /// Instruction from the Wasm `non-trapping float-to-int conversions` proposal.
                 #[snake_name(i64_trunc_sat_f64_u)]
                 I64TruncSatF64U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
 
                 /// Wasm `f32.demote_f64` instruction.
                 #[snake_name(f32_demote_f64)]
                 F32DemoteF64 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.promote_f32` instruction.
                 #[snake_name(f64_promote_f32)]
                 F64PromoteF32 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
 
                 /// Wasm `f32.convert_i32_s` instruction.
                 #[snake_name(f32_convert_i32_s)]
                 F32ConvertI32S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f32.convert_i32_u` instruction.
                 #[snake_name(f32_convert_i32_u)]
                 F32ConvertI32U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f32.convert_i64_s` instruction.
                 #[snake_name(f32_convert_i64_s)]
                 F32ConvertI64S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f32.convert_i64_u` instruction.
                 #[snake_name(f32_convert_i64_u)]
                 F32ConvertI64U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.convert_i32_s` instruction.
                 #[snake_name(f64_convert_i32_s)]
                 F64ConvertI32S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.convert_i32_u` instruction.
                 #[snake_name(f64_convert_i32_u)]
                 F64ConvertI32U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.convert_i64_s` instruction.
                 #[snake_name(f64_convert_i64_s)]
                 F64ConvertI64S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
                 /// Wasm `f64.convert_i64_u` instruction.
                 #[snake_name(f64_convert_i64_u)]
                 F64ConvertI64U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the input of the instruction.
-                    input: Reg,
+                    input: Slot,
                 },
 
                 /// A Wasm `table.get` instruction: `result = table[index]`
@@ -5061,9 +5061,9 @@ macro_rules! for_each_op_grouped {
                 /// This [`Op`] must be followed by an [`Op::TableIndex`].
                 #[snake_name(table_get)]
                 TableGet {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the index of the table element to get.
-                    index: Reg,
+                    index: Slot,
                 },
                 /// Variant of [`Op::TableGet`] with constant `index` value.
                 ///
@@ -5072,7 +5072,7 @@ macro_rules! for_each_op_grouped {
                 /// This [`Op`] must be followed by an [`Op::TableIndex`].
                 #[snake_name(table_get_imm)]
                 TableGetImm {
-                    @result: Reg,
+                    @result: Slot,
                     /// The constant `index` value of the table element to get.
                     index: Const32<u64>,
                 },
@@ -5080,7 +5080,7 @@ macro_rules! for_each_op_grouped {
                 /// A Wasm `table.size` instruction.
                 #[snake_name(table_size)]
                 TableSize {
-                    @result: Reg,
+                    @result: Slot,
                     /// The index identifying the table for the instruction.
                     table: Table,
                 },
@@ -5093,9 +5093,9 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(table_set)]
                 TableSet {
                     /// The register holding the `index` of the instruction.
-                    index: Reg,
+                    index: Slot,
                     /// The register holding the `value` of the instruction.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Variant of [`Op::TableSet`] with constant `index` value.
                 ///
@@ -5105,7 +5105,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(table_set_at)]
                 TableSetAt {
                     /// The register holding the `value` of the instruction.
-                    value: Reg,
+                    value: Slot,
                     /// The constant `index` of the instruction.
                     index: Const32<u64>,
                 },
@@ -5123,11 +5123,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(table_copy)]
                 TableCopy {
                     /// The start index of the `dst` table.
-                    dst: Reg,
+                    dst: Slot,
                     /// The start index of the `src` table.
-                    src: Reg,
+                    src: Slot,
                     /// The number of copied elements.
-                    len: Reg,
+                    len: Slot,
                 },
 
                 /// Wasm `table.init <table> <elem>` instruction.
@@ -5143,11 +5143,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(table_init)]
                 TableInit {
                     /// The start index of the `dst` table.
-                    dst: Reg,
+                    dst: Slot,
                     /// The start index of the `src` table.
-                    src: Reg,
+                    src: Slot,
                     /// The number of copied elements.
-                    len: Reg,
+                    len: Slot,
                 },
 
                 /// Wasm `table.fill <table>` instruction: `table[dst..dst+len] = value`
@@ -5158,11 +5158,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(table_fill)]
                 TableFill {
                     /// The start index of the table to fill.
-                    dst: Reg,
+                    dst: Slot,
                     /// The number of elements to fill.
-                    len: Reg,
+                    len: Slot,
                     /// The value of the filled elements.
-                    value: Reg,
+                    value: Slot,
                 },
 
                 /// Wasm `table.grow <table>` instruction.
@@ -5172,11 +5172,11 @@ macro_rules! for_each_op_grouped {
                 /// Followed by [`Op::TableIndex`] encoding the Wasm `table` instance.
                 #[snake_name(table_grow)]
                 TableGrow {
-                    @result: Reg,
+                    @result: Slot,
                     /// The number of elements to add to the table.
-                    delta: Reg,
+                    delta: Slot,
                     /// The value that is used to fill up the new cells.
-                    value: Reg,
+                    value: Slot,
                 },
 
                 /// A Wasm `elem.drop` equalivalent Wasmi instruction.
@@ -5193,7 +5193,7 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `memory.size` instruction.
                 #[snake_name(memory_size)]
                 MemorySize {
-                    @result: Reg,
+                    @result: Slot,
                     /// The index identifying the Wasm linear memory for the instruction.
                     memory: Memory,
                 },
@@ -5205,9 +5205,9 @@ macro_rules! for_each_op_grouped {
                 /// Followed by [`Op::MemoryIndex`] encoding the Wasm `memory` instance.
                 #[snake_name(memory_grow)]
                 MemoryGrow {
-                    @result: Reg,
+                    @result: Slot,
                     /// The number of pages to add to the memory.
-                    delta: Reg,
+                    delta: Slot,
                 },
 
                 /// Wasm `memory.copy` instruction.
@@ -5223,11 +5223,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(memory_copy)]
                 MemoryCopy {
                     /// The start index of the `dst` memory.
-                    dst: Reg,
+                    dst: Slot,
                     /// The start index of the `src` memory.
-                    src: Reg,
+                    src: Slot,
                     /// The number of copied bytes.
-                    len: Reg,
+                    len: Slot,
                 },
 
                 /// Wasm `memory.fill` instruction.
@@ -5240,11 +5240,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(memory_fill)]
                 MemoryFill {
                     /// The start index of the memory to fill.
-                    dst: Reg,
+                    dst: Slot,
                     /// The byte value used to fill the memory.
-                    value: Reg,
+                    value: Slot,
                     /// The number of bytes to fill.
-                    len: Reg,
+                    len: Slot,
                 },
                 /// Variant of [`Op::MemoryFill`] with constant fill `value`.
                 ///
@@ -5254,11 +5254,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(memory_fill_imm)]
                 MemoryFillImm {
                     /// The start index of the memory to fill.
-                    dst: Reg,
+                    dst: Slot,
                     /// The byte value used to fill the memory.
                     value: u8,
                     /// The number of bytes to fill.
-                    len: Reg,
+                    len: Slot,
                 },
 
                 /// Wasm `memory.init <data>` instruction.
@@ -5274,11 +5274,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(memory_init)]
                 MemoryInit {
                     /// The start index of the `dst` memory.
-                    dst: Reg,
+                    dst: Slot,
                     /// The start index of the `src` data segment.
-                    src: Reg,
+                    src: Slot,
                     /// The number of bytes to initialize.
-                    len: Reg,
+                    len: Slot,
                 },
 
                 /// A [`Table`] instruction parameter.
@@ -5359,7 +5359,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(branch_table_target)]
                 BranchTableTarget {
                     /// The registers where the values are going to be copied.
-                    results: RegSpan,
+                    results: SlotSpan,
                     /// The branching offset of the branch table target.
                     offset: BranchOffset,
                 },
@@ -5371,48 +5371,48 @@ macro_rules! for_each_op_grouped {
                     /// The 32-bit immediate value.
                     imm32: AnyConst32,
                 },
-                /// An instruction parameter with a [`Reg`] and a 32-bit immediate value.
+                /// An instruction parameter with a [`Slot`] and a 32-bit immediate value.
                 #[snake_name(register_and_imm32)]
-                RegisterAndImm32 {
-                    /// The [`Reg`] parameter value.
-                    reg: Reg,
+                SlotAndImm32 {
+                    /// The [`Slot`] parameter value.
+                    reg: Slot,
                     /// The 32-bit immediate value.
                     imm: AnyConst32,
                 },
-                /// A bounded [`RegSpan`] instruction parameter.
+                /// A bounded [`SlotSpan`] instruction parameter.
                 #[snake_name(register_span)]
-                RegisterSpan { span: BoundedRegSpan },
-                /// A [`Reg`] instruction parameter.
+                SlotSpan { span: BoundedSlotSpan },
+                /// A [`Slot`] instruction parameter.
                 ///
                 /// # Note
                 ///
                 /// This [`Op`] only acts as a parameter to another
                 /// one and will never be executed itself directly.
                 #[snake_name(register)]
-                Register {
-                    reg: Reg
+                Slot {
+                    reg: Slot
                 },
-                /// Two [`Reg`] instruction parameters.
+                /// Two [`Slot`] instruction parameters.
                 ///
                 /// # Note
                 ///
                 /// This [`Op`] only acts as a parameter to another
                 /// one and will never be executed itself directly.
                 #[snake_name(register2)]
-                Register2 {
-                    regs: [Reg; 2]
+                Slot2 {
+                    regs: [Slot; 2]
                 },
-                /// Three [`Reg`] instruction parameters.
+                /// Three [`Slot`] instruction parameters.
                 ///
                 /// # Note
                 ///
                 /// This [`Op`] only acts as a parameter to another
                 /// one and will never be executed itself directly.
                 #[snake_name(register3)]
-                Register3 {
-                    regs: [Reg; 3]
+                Slot3 {
+                    regs: [Slot; 3]
                 },
-                /// [`Reg`] slice parameters.
+                /// [`Slot`] slice parameters.
                 ///
                 /// # Note
                 ///
@@ -5423,18 +5423,18 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// This must always be followed by one of
                 ///
-                /// - [`Op::Register`]
-                /// - [`Op::Register2`]
-                /// - [`Op::Register3`]
+                /// - [`Op::Slot`]
+                /// - [`Op::Slot2`]
+                /// - [`Op::Slot3`]
                 #[snake_name(register_list)]
-                RegisterList {
-                    regs: [Reg; 3]
+                SlotList {
+                    regs: [Slot; 3]
                 },
                 /// Auxiliary [`Op`] to encode table access information for indirect call instructions.
                 #[snake_name(call_indirect_params)]
                 CallIndirectParams {
                     /// The index of the called function in the table.
-                    index: Reg,
+                    index: Slot,
                     /// The table which holds the called function at the index.
                     table: Table,
                 },
@@ -5452,115 +5452,115 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `i8x16.splat` instruction.
                 #[snake_name(i8x16_splat)]
                 I8x16Splat {
-                    @result: Reg,
+                    @result: Slot,
                     /// The value to be splatted.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Wasm `i16x8.splat` instruction.
                 #[snake_name(i16x8_splat)]
                 I16x8Splat {
-                    @result: Reg,
+                    @result: Slot,
                     /// The value to be splatted.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Wasm `i32x4.splat` instruction.
                 #[snake_name(i32x4_splat)]
                 I32x4Splat {
-                    @result: Reg,
+                    @result: Slot,
                     /// The value to be splatted.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Wasm `i64x2.splat` instruction.
                 #[snake_name(i64x2_splat)]
                 I64x2Splat {
-                    @result: Reg,
+                    @result: Slot,
                     /// The value to be splatted.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Wasm `f32x4.splat` instruction.
                 #[snake_name(f32x4_splat)]
                 F32x4Splat {
-                    @result: Reg,
+                    @result: Slot,
                     /// The value to be splatted.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Wasm `f64x2.splat` instruction.
                 #[snake_name(f64x2_splat)]
                 F64x2Splat {
-                    @result: Reg,
+                    @result: Slot,
                     /// The value to be splatted.
-                    value: Reg,
+                    value: Slot,
                 },
 
                 /// Wasm `i8x16.extract_lane_s` instruction.
                 #[snake_name(i8x16_extract_lane_s)]
                 I8x16ExtractLaneS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`].
-                    value: Reg,
+                    value: Slot,
                     /// The lane to extract the value.
                     lane: ImmLaneIdx16,
                 },
                 /// Wasm `i8x16.extract_lane_u` instruction.
                 #[snake_name(i8x16_extract_lane_u)]
                 I8x16ExtractLaneU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`].
-                    value: Reg,
+                    value: Slot,
                     /// The lane to extract the value.
                     lane: ImmLaneIdx16,
                 },
                 /// Wasm `i16x8.extract_lane_s` instruction.
                 #[snake_name(i16x8_extract_lane_s)]
                 I16x8ExtractLaneS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`].
-                    value: Reg,
+                    value: Slot,
                     /// The lane to extract the value.
                     lane: ImmLaneIdx8,
                 },
                 /// Wasm `i16x8.extract_lane_u` instruction.
                 #[snake_name(i16x8_extract_lane_u)]
                 I16x8ExtractLaneU {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`].
-                    value: Reg,
+                    value: Slot,
                     /// The lane to extract the value.
                     lane: ImmLaneIdx8,
                 },
                 /// Wasm `i32x4.extract_lane` instruction.
                 #[snake_name(i32x4_extract_lane)]
                 I32x4ExtractLane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`].
-                    value: Reg,
+                    value: Slot,
                     /// The lane to extract the value.
                     lane: ImmLaneIdx4,
                 },
                 /// Wasm `i64x2.extract_lane` instruction.
                 #[snake_name(i64x2_extract_lane)]
                 I64x2ExtractLane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`].
-                    value: Reg,
+                    value: Slot,
                     /// The lane to extract the value.
                     lane: ImmLaneIdx2,
                 },
                 /// Wasm `f32x4.extract_lane` instruction.
                 #[snake_name(f32x4_extract_lane)]
                 F32x4ExtractLane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`].
-                    value: Reg,
+                    value: Slot,
                     /// The lane to extract the value.
                     lane: ImmLaneIdx4,
                 },
                 /// Wasm `f64x2.extract_lane` instruction.
                 #[snake_name(f64x2_extract_lane)]
                 F64x2ExtractLane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`].
-                    value: Reg,
+                    value: Slot,
                     /// The lane to extract the value.
                     lane: ImmLaneIdx2,
                 },
@@ -5569,21 +5569,21 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register`] encoding `value`.
+                /// Followed by [`Op::Slot`] encoding `value`.
                 #[snake_name(i8x16_replace_lane)]
                 I8x16ReplaceLane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx16,
                 },
                 /// Variant of [`Op::I8x16ReplaceLane`] with imediate `value`.
                 #[snake_name(i8x16_replace_lane_imm)]
                 I8x16ReplaceLaneImm {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx16,
                     /// The value replacing the `lane` in `input`.
@@ -5593,12 +5593,12 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register`] encoding `value`.
+                /// Followed by [`Op::Slot`] encoding `value`.
                 #[snake_name(i16x8_replace_lane)]
                 I16x8ReplaceLane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx8,
                 },
@@ -5609,9 +5609,9 @@ macro_rules! for_each_op_grouped {
                 /// Followed by [`Op::Const32`] encoding the immediate `value` of type `i16`.
                 #[snake_name(i16x8_replace_lane_imm)]
                 I16x8ReplaceLaneImm {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx8,
                 },
@@ -5619,12 +5619,12 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register`] encoding `value`.
+                /// Followed by [`Op::Slot`] encoding `value`.
                 #[snake_name(i32x4_replace_lane)]
                 I32x4ReplaceLane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx4,
                 },
@@ -5632,12 +5632,12 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register`] encoding the immediate `value` of type `i32`.
+                /// Followed by [`Op::Slot`] encoding the immediate `value` of type `i32`.
                 #[snake_name(i32x4_replace_lane_imm)]
                 I32x4ReplaceLaneImm {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx4,
                 },
@@ -5645,12 +5645,12 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register`] encoding `value`.
+                /// Followed by [`Op::Slot`] encoding `value`.
                 #[snake_name(i64x2_replace_lane)]
                 I64x2ReplaceLane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx2,
                 },
@@ -5661,9 +5661,9 @@ macro_rules! for_each_op_grouped {
                 /// Followed by [`Op::I64Const32`] encoding the 32-bit `value`.
                 #[snake_name(i64x2_replace_lane_imm32)]
                 I64x2ReplaceLaneImm32 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx2,
                 },
@@ -5671,12 +5671,12 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register`] encoding `value`.
+                /// Followed by [`Op::Slot`] encoding `value`.
                 #[snake_name(f32x4_replace_lane)]
                 F32x4ReplaceLane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx4,
                 },
@@ -5687,9 +5687,9 @@ macro_rules! for_each_op_grouped {
                 /// Followed by [`Op::Const32`] encoding `value` of type `f32`.
                 #[snake_name(f32x4_replace_lane_imm)]
                 F32x4ReplaceLaneImm {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx4,
                 },
@@ -5697,12 +5697,12 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register`] encoding `value`.
+                /// Followed by [`Op::Slot`] encoding `value`.
                 #[snake_name(f64x2_replace_lane)]
                 F64x2ReplaceLane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx2,
                 },
@@ -5713,9 +5713,9 @@ macro_rules! for_each_op_grouped {
                 /// Followed by [`Op::F64Const32`] encoding the 32-bit immediate `value`.
                 #[snake_name(f64x2_replace_lane_imm32)]
                 F64x2ReplaceLaneImm32 {
-                    @result: Reg,
+                    @result: Slot,
                     /// The input [`V128`] that gets a value replaced.
-                    input: Reg,
+                    input: Slot,
                     /// The lane of the replaced value.
                     lane: ImmLaneIdx2,
                 },
@@ -5724,830 +5724,830 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register`] encoding the `selector` of type [`V128`].
+                /// Followed by [`Op::Slot`] encoding the `selector` of type [`V128`].
                 #[snake_name(i8x16_shuffle)]
                 I8x16Shuffle {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.swizzle` instruction.
                 #[snake_name(i8x16_swizzle)]
                 I8x16Swizzle {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register holding the `input` of the instruction.
-                    input: Reg,
+                    input: Slot,
                     /// The register holding the `selector` of the instruction.
-                    selector: Reg,
+                    selector: Slot,
                 },
 
                 /// Wasm `i8x16.add` instruction.
                 #[snake_name(i8x16_add)]
                 I8x16Add {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.add` instruction.
                 #[snake_name(i16x8_add)]
                 I16x8Add {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.add` instruction.
                 #[snake_name(i32x4_add)]
                 I32x4Add {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.add` instruction.
                 #[snake_name(i64x2_add)]
                 I64x2Add {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.sub` instruction.
                 #[snake_name(i8x16_sub)]
                 I8x16Sub {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.sub` instruction.
                 #[snake_name(i16x8_sub)]
                 I16x8Sub {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.sub` instruction.
                 #[snake_name(i32x4_sub)]
                 I32x4Sub {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.sub` instruction.
                 #[snake_name(i64x2_sub)]
                 I64x2Sub {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.mul` instruction.
                 #[snake_name(i16x8_mul)]
                 I16x8Mul {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.mul` instruction.
                 #[snake_name(i32x4_mul)]
                 I32x4Mul {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.mul` instruction.
                 #[snake_name(i64x2_mul)]
                 I64x2Mul {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// Wasm `i32x4.dot_i16x8_s` instruction.
                 #[snake_name(i32x4_dot_i16x8_s)]
                 I32x4DotI16x8S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.relaxed_dot_i8x16_i7x8_s` instruction.
                 #[snake_name(i16x8_relaxed_dot_i8x16_i7x16_s)]
                 I16x8RelaxedDotI8x16I7x16S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.relaxed_dot_i8x16_i7x16_add_s` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by an [`Op::Register`] encoding `c`.
+                /// Followed by an [`Op::Slot`] encoding `c`.
                 #[snake_name(i32x4_relaxed_dot_i8x16_i7x16_add_s)]
                 I32x4RelaxedDotI8x16I7x16AddS {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `lhs` of the instruction.
-                    lhs: Reg,
+                    lhs: Slot,
                     /// The register storing the `rhs` of the instruction.
-                    rhs: Reg,
+                    rhs: Slot,
                 },
 
                 /// Wasm `f32x4.relaxed_madd` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by an [`Op::Register`] encoding `c`.
+                /// Followed by an [`Op::Slot`] encoding `c`.
                 #[snake_name(f32x4_relaxed_madd)]
                 F32x4RelaxedMadd {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `a` of the instruction.
-                    a: Reg,
+                    a: Slot,
                     /// The register storing the `b` of the instruction.
-                    b: Reg,
+                    b: Slot,
                 },
                 /// Wasm `f32x4.relaxed_nmadd` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by an [`Op::Register`] encoding `c`.
+                /// Followed by an [`Op::Slot`] encoding `c`.
                 #[snake_name(f32x4_relaxed_nmadd)]
                 F32x4RelaxedNmadd {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `a` of the instruction.
-                    a: Reg,
+                    a: Slot,
                     /// The register storing the `b` of the instruction.
-                    b: Reg,
+                    b: Slot,
                 },
                 /// Wasm `f64x2.relaxed_madd` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by an [`Op::Register`] encoding `c`.
+                /// Followed by an [`Op::Slot`] encoding `c`.
                 #[snake_name(f64x2_relaxed_madd)]
                 F64x2RelaxedMadd {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `a` of the instruction.
-                    a: Reg,
+                    a: Slot,
                     /// The register storing the `b` of the instruction.
-                    b: Reg,
+                    b: Slot,
                 },
                 /// Wasm `f64x2.relaxed_nmadd` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by an [`Op::Register`] encoding `c`.
+                /// Followed by an [`Op::Slot`] encoding `c`.
                 #[snake_name(f64x2_relaxed_nmadd)]
                 F64x2RelaxedNmadd {
-                    @result: Reg,
+                    @result: Slot,
                     /// The register storing the `a` of the instruction.
-                    a: Reg,
+                    a: Slot,
                     /// The register storing the `b` of the instruction.
-                    b: Reg,
+                    b: Slot,
                 },
 
                 /// Wasm `i8x16.neg` instruction.
                 #[snake_name(i8x16_neg)]
                 I8x16Neg {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i16x8.neg` instruction.
                 #[snake_name(i16x8_neg)]
                 I16x8Neg {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.neg` instruction.
                 #[snake_name(i32x4_neg)]
                 I32x4Neg {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i64x2.neg` instruction.
                 #[snake_name(i64x2_neg)]
                 I64x2Neg {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
 
                 /// Wasm `i16x8.extmul_low_i8x16_s` instruction.
                 #[snake_name(i16x8_extmul_low_i8x16_s)]
                 I16x8ExtmulLowI8x16S {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.extmul_high_i8x16_s` instruction.
                 #[snake_name(i16x8_extmul_high_i8x16_s)]
                 I16x8ExtmulHighI8x16S {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.extmul_low_i8x16_u` instruction.
                 #[snake_name(i16x8_extmul_low_i8x16_u)]
                 I16x8ExtmulLowI8x16U {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.extmul_high_i8x16_u` instruction.
                 #[snake_name(i16x8_extmul_high_i8x16_u)]
                 I16x8ExtmulHighI8x16U {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.extmul_low_i16x8_s` instruction.
                 #[snake_name(i32x4_extmul_low_i16x8_s)]
                 I32x4ExtmulLowI16x8S {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.extmul_high_i16x8_s` instruction.
                 #[snake_name(i32x4_extmul_high_i16x8_s)]
                 I32x4ExtmulHighI16x8S {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.extmul_low_i16x8_u` instruction.
                 #[snake_name(i32x4_extmul_low_i16x8_u)]
                 I32x4ExtmulLowI16x8U {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.extmul_high_i16x8_u` instruction.
                 #[snake_name(i32x4_extmul_high_i16x8_u)]
                 I32x4ExtmulHighI16x8U {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.extmul_low_i32x4_s` instruction.
                 #[snake_name(i64x2_extmul_low_i32x4_s)]
                 I64x2ExtmulLowI32x4S {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.extmul_high_i32x4_s` instruction.
                 #[snake_name(i64x2_extmul_high_i32x4_s)]
                 I64x2ExtmulHighI32x4S {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.extmul_low_i32x4_u` instruction.
                 #[snake_name(i64x2_extmul_low_i32x4_u)]
                 I64x2ExtmulLowI32x4U {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.extmul_high_i32x4_u` instruction.
                 #[snake_name(i64x2_extmul_high_i32x4_u)]
                 I64x2ExtmulHighI32x4U {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
 
                 /// Wasm `i16x8.extadd_pairwise_i8x16_s` instruction.
                 #[snake_name(i16x8_extadd_pairwise_i8x16_s)]
                 I16x8ExtaddPairwiseI8x16S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i16x8.extadd_pairwise_i8x16_u` instruction.
                 #[snake_name(i16x8_extadd_pairwise_i8x16_u)]
                 I16x8ExtaddPairwiseI8x16U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.extadd_pairwise_i16x8_s` instruction.
                 #[snake_name(i32x4_extadd_pairwise_i16x8_s)]
                 I32x4ExtaddPairwiseI16x8S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.extadd_pairwise_i16x8_u` instruction.
                 #[snake_name(i32x4_extadd_pairwise_i16x8_u)]
                 I32x4ExtaddPairwiseI16x8U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
 
                 /// Wasm `i8x16.add_sat_s` instruction.
                 #[snake_name(i8x16_add_sat_s)]
                 I8x16AddSatS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.add_sat_u` instruction.
                 #[snake_name(i8x16_add_sat_u)]
                 I8x16AddSatU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.add_sat_s` instruction.
                 #[snake_name(i16x8_add_sat_s)]
                 I16x8AddSatS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.add_sat_u` instruction.
                 #[snake_name(i16x8_add_sat_u)]
                 I16x8AddSatU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.sub_sat_s` instruction.
                 #[snake_name(i8x16_sub_sat_s)]
                 I8x16SubSatS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.sub_sat_u` instruction.
                 #[snake_name(i8x16_sub_sat_u)]
                 I8x16SubSatU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.sub_sat_s` instruction.
                 #[snake_name(i16x8_sub_sat_s)]
                 I16x8SubSatS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.sub_sat_u` instruction.
                 #[snake_name(i16x8_sub_sat_u)]
                 I16x8SubSatU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
 
                 /// Wasm `i16x8.q15mulr_sat_s` instruction.
                 #[snake_name(i16x8_q15mulr_sat_s)]
                 I16x8Q15MulrSatS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
 
                 /// Wasm `i8x16.min_s` instruction.
                 #[snake_name(i8x16_min_s)]
                 I8x16MinS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.min_u` instruction.
                 #[snake_name(i8x16_min_u)]
                 I8x16MinU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.min_s` instruction.
                 #[snake_name(i16x8_min_s)]
                 I16x8MinS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.min_u` instruction.
                 #[snake_name(i16x8_min_u)]
                 I16x8MinU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.min_s` instruction.
                 #[snake_name(i32x4_min_s)]
                 I32x4MinS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.min_u` instruction.
                 #[snake_name(i32x4_min_u)]
                 I32x4MinU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.max_s` instruction.
                 #[snake_name(i8x16_max_s)]
                 I8x16MaxS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.max_u` instruction.
                 #[snake_name(i8x16_max_u)]
                 I8x16MaxU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.max_s` instruction.
                 #[snake_name(i16x8_max_s)]
                 I16x8MaxS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.max_u` instruction.
                 #[snake_name(i16x8_max_u)]
                 I16x8MaxU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.max_s` instruction.
                 #[snake_name(i32x4_max_s)]
                 I32x4MaxS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.max_u` instruction.
                 #[snake_name(i32x4_max_u)]
                 I32x4MaxU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
 
                 /// Wasm `i8x16.avgr_u` instruction.
                 #[snake_name(i8x16_avgr_u)]
                 I8x16AvgrU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.avgr_u` instruction.
                 #[snake_name(i16x8_avgr_u)]
                 I16x8AvgrU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
 
                 /// Wasm `i8x16.abs` instruction.
                 #[snake_name(i8x16_abs)]
                 I8x16Abs {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i16x8.abs` instruction.
                 #[snake_name(i16x8_abs)]
                 I16x8Abs {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.abs` instruction.
                 #[snake_name(i32x4_abs)]
                 I32x4Abs {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i64x2.abs` instruction.
                 #[snake_name(i64x2_abs)]
                 I64x2Abs {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
 
                 /// Wasm `i8x16.shl` instruction.
                 #[snake_name(i8x16_shl)]
                 I8x16Shl {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I8x16Shl`] with immediate shift amount.
                 #[snake_name(i8x16_shl_by)]
                 I8x16ShlBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i16x8.shl` instruction.
                 #[snake_name(i16x8_shl)]
                 I16x8Shl {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I16x8Shl`] with immediate shift amount.
                 #[snake_name(i16x8_shl_by)]
                 I16x8ShlBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i32x4.shl` instruction.
                 #[snake_name(i32x4_shl)]
                 I32x4Shl {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I32x4Shl`] with immediate shift amount.
                 #[snake_name(i32x4_shl_by)]
                 I32x4ShlBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i64x2.shl` instruction.
                 #[snake_name(i64x2_shl)]
                 I64x2Shl {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I64x2Shl`] with immediate shift amount.
                 #[snake_name(i64x2_shl_by)]
                 I64x2ShlBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i8x16.shr_s` instruction.
                 #[snake_name(i8x16_shr_s)]
                 I8x16ShrS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I8x16ShrS`] with immediate shift amount.
                 #[snake_name(i8x16_shr_s_by)]
                 I8x16ShrSBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i8x16.shr_u` instruction.
                 #[snake_name(i8x16_shr_u)]
                 I8x16ShrU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I8x16ShrU`] with immediate shift amount.
                 #[snake_name(i8x16_shr_u_by)]
                 I8x16ShrUBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i16x8.shr_s` instruction.
                 #[snake_name(i16x8_shr_s)]
                 I16x8ShrS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I16x8ShrS`] with immediate shift amount.
                 #[snake_name(i16x8_shr_s_by)]
                 I16x8ShrSBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i16x8.shr_u` instruction.
                 #[snake_name(i16x8_shr_u)]
                 I16x8ShrU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I16x8ShrU`] with immediate shift amount.
                 #[snake_name(i16x8_shr_u_by)]
                 I16x8ShrUBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i32x4.shr_s` instruction.
                 #[snake_name(i32x4_shr_s)]
                 I32x4ShrS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I32x4ShrS`] with immediate shift amount.
                 #[snake_name(i32x4_shr_s_by)]
                 I32x4ShrSBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i32x4.shr_u` instruction.
                 #[snake_name(i32x4_shr_u)]
                 I32x4ShrU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I32x4ShrU`] with immediate shift amount.
                 #[snake_name(i32x4_shr_u_by)]
                 I32x4ShrUBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i64x2.shr_s` instruction.
                 #[snake_name(i64x2_shr_s)]
                 I64x2ShrS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I64x2ShrS`] with immediate shift amount.
                 #[snake_name(i64x2_shr_s_by)]
                 I64x2ShrSBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
                 /// Wasm `i64x2.shr_u` instruction.
                 #[snake_name(i64x2_shr_u)]
                 I64x2ShrU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Variants of [`Op::I64x2ShrU`] with immediate shift amount.
                 #[snake_name(i64x2_shr_u_by)]
                 I64x2ShrUBy {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
                     /// The 16-bit encoded shift amount.
                     rhs: ShiftAmount<u32>,
                 },
@@ -6555,839 +6555,839 @@ macro_rules! for_each_op_grouped {
                 /// Wasm `v128.and` instruction.
                 #[snake_name(v128_and)]
                 V128And {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `v128.or` instruction.
                 #[snake_name(v128_or)]
                 V128Or {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `v128.xor` instruction.
                 #[snake_name(v128_xor)]
                 V128Xor {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `v128.andnot` instruction.
                 #[snake_name(v128_andnot)]
                 V128Andnot {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `v128.not` instruction.
                 #[snake_name(v128_not)]
                 V128Not {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
 
                 /// Wasm `v128.bitselect` instruction.
                 ///
                 /// # Encoding
                 ///
-                /// Followed by [`Op::Register`] encoding the `selector`.
+                /// Followed by [`Op::Slot`] encoding the `selector`.
                 #[snake_name(v128_bitselect)]
                 V128Bitselect {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
 
                 /// Wasm `i8x16.popcnt` instruction.
                 #[snake_name(i8x16_popcnt)]
                 I8x16Popcnt {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `v128.any_true` instruction.
                 #[snake_name(v128_any_true)]
                 V128AnyTrue {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i8x16.all_true` instruction.
                 #[snake_name(i8x16_all_true)]
                 I8x16AllTrue {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i16x8.all_true` instruction.
                 #[snake_name(i16x8_all_true)]
                 I16x8AllTrue {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.all_true` instruction.
                 #[snake_name(i32x4_all_true)]
                 I32x4AllTrue {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i64x2.all_true` instruction.
                 #[snake_name(i64x2_all_true)]
                 I64x2AllTrue {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i8x16.bitmask` instruction.
                 #[snake_name(i8x16_bitmask)]
                 I8x16Bitmask {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i16x8.bitmask` instruction.
                 #[snake_name(i16x8_bitmask)]
                 I16x8Bitmask {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.bitmask` instruction.
                 #[snake_name(i32x4_bitmask)]
                 I32x4Bitmask {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i64x2.bitmask` instruction.
                 #[snake_name(i64x2_bitmask)]
                 I64x2Bitmask {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
 
                 /// Wasm `i8x16.eq` instruction.
                 #[snake_name(i8x16_eq)]
                 I8x16Eq {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.eq` instruction.
                 #[snake_name(i16x8_eq)]
                 I16x8Eq {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.eq` instruction.
                 #[snake_name(i32x4_eq)]
                 I32x4Eq {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.eq` instruction.
                 #[snake_name(i64x2_eq)]
                 I64x2Eq {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.eq` instruction.
                 #[snake_name(f32x4_eq)]
                 F32x4Eq {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.eq` instruction.
                 #[snake_name(f64x2_eq)]
                 F64x2Eq {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.ne` instruction.
                 #[snake_name(i8x16_ne)]
                 I8x16Ne {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.ne` instruction.
                 #[snake_name(i16x8_ne)]
                 I16x8Ne {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.ne` instruction.
                 #[snake_name(i32x4_ne)]
                 I32x4Ne {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.ne` instruction.
                 #[snake_name(i64x2_ne)]
                 I64x2Ne {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.ne` instruction.
                 #[snake_name(f32x4_ne)]
                 F32x4Ne {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.ne` instruction.
                 #[snake_name(f64x2_ne)]
                 F64x2Ne {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.lt_s` instruction.
                 #[snake_name(i8x16_lt_s)]
                 I8x16LtS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.lt_u` instruction.
                 #[snake_name(i8x16_lt_u)]
                 I8x16LtU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.lt_s` instruction.
                 #[snake_name(i16x8_lt_s)]
                 I16x8LtS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.lt_u` instruction.
                 #[snake_name(i16x8_lt_u)]
                 I16x8LtU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.lt_s` instruction.
                 #[snake_name(i32x4_lt_s)]
                 I32x4LtS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.lt_u` instruction.
                 #[snake_name(i32x4_lt_u)]
                 I32x4LtU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.lt_s` instruction.
                 #[snake_name(i64x2_lt_s)]
                 I64x2LtS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.lt` instruction.
                 #[snake_name(f32x4_lt)]
                 F32x4Lt {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.lt` instruction.
                 #[snake_name(f64x2_lt)]
                 F64x2Lt {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.le_s` instruction.
                 #[snake_name(i8x16_le_s)]
                 I8x16LeS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.le_u` instruction.
                 #[snake_name(i8x16_le_u)]
                 I8x16LeU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.le_s` instruction.
                 #[snake_name(i16x8_le_s)]
                 I16x8LeS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.le_u` instruction.
                 #[snake_name(i16x8_le_u)]
                 I16x8LeU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.le_s` instruction.
                 #[snake_name(i32x4_le_s)]
                 I32x4LeS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i32x4.le_u` instruction.
                 #[snake_name(i32x4_le_u)]
                 I32x4LeU {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i64x2.le_s` instruction.
                 #[snake_name(i64x2_le_s)]
                 I64x2LeS {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.le` instruction.
                 #[snake_name(f32x4_le)]
                 F32x4Le {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.le` instruction.
                 #[snake_name(f64x2_le)]
                 F64x2Le {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
 
                 /// Wasm `f32x4.neg` instruction.
                 #[snake_name(f32x4_neg)]
                 F32x4Neg {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f64x2.neg` instruction.
                 #[snake_name(f64x2_neg)]
                 F64x2Neg {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f32x4.abs` instruction.
                 #[snake_name(f32x4_abs)]
                 F32x4Abs {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f64x2.abs` instruction.
                 #[snake_name(f64x2_abs)]
                 F64x2Abs {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
 
                 /// Wasm `f32x4.min` instruction.
                 #[snake_name(f32x4_min)]
                 F32x4Min {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.min` instruction.
                 #[snake_name(f64x2_min)]
                 F64x2Min {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.max` instruction.
                 #[snake_name(f32x4_max)]
                 F32x4Max {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.max` instruction.
                 #[snake_name(f64x2_max)]
                 F64x2Max {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.pmin` instruction.
                 #[snake_name(f32x4_pmin)]
                 F32x4Pmin {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.pmin` instruction.
                 #[snake_name(f64x2_pmin)]
                 F64x2Pmin {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.pmax` instruction.
                 #[snake_name(f32x4_pmax)]
                 F32x4Pmax {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.pmax` instruction.
                 #[snake_name(f64x2_pmax)]
                 F64x2Pmax {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.add` instruction.
                 #[snake_name(f32x4_add)]
                 F32x4Add {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.add` instruction.
                 #[snake_name(f64x2_add)]
                 F64x2Add {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.sub` instruction.
                 #[snake_name(f32x4_sub)]
                 F32x4Sub {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.sub` instruction.
                 #[snake_name(f64x2_sub)]
                 F64x2Sub {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.div` instruction.
                 #[snake_name(f32x4_div)]
                 F32x4Div {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.div` instruction.
                 #[snake_name(f64x2_div)]
                 F64x2Div {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f32x4.mul` instruction.
                 #[snake_name(f32x4_mul)]
                 F32x4Mul {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `f64x2.mul` instruction.
                 #[snake_name(f64x2_mul)]
                 F64x2Mul {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Register holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slot holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
 
                 /// Wasm `f32x4.sqrt` instruction.
                 #[snake_name(f32x4_sqrt)]
                 F32x4Sqrt {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f64x2.sqrt` instruction.
                 #[snake_name(f64x2_sqrt)]
                 F64x2Sqrt {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f32x4.ceil` instruction.
                 #[snake_name(f32x4_ceil)]
                 F32x4Ceil {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f64x2.ceil` instruction.
                 #[snake_name(f64x2_ceil)]
                 F64x2Ceil {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f32x4.floor` instruction.
                 #[snake_name(f32x4_floor)]
                 F32x4Floor {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f64x2.floor` instruction.
                 #[snake_name(f64x2_floor)]
                 F64x2Floor {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f32x4.trunc` instruction.
                 #[snake_name(f32x4_trunc)]
                 F32x4Trunc {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f64x2.trunc` instruction.
                 #[snake_name(f64x2_trunc)]
                 F64x2Trunc {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f32x4.nearest` instruction.
                 #[snake_name(f32x4_nearest)]
                 F32x4Nearest {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f64x2.nearest` instruction.
                 #[snake_name(f64x2_nearest)]
                 F64x2Nearest {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
 
                 /// Wasm `f32x4.convert_i32x4_s` instruction.
                 #[snake_name(f32x4_convert_i32x4_s)]
                 F32x4ConvertI32x4S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f32x4.convert_i32x4_u` instruction.
                 #[snake_name(f32x4_convert_i32x4_u)]
                 F32x4ConvertI32x4U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f64x2.convert_low_i32x4_s` instruction.
                 #[snake_name(f64x2_convert_low_i32x4_s)]
                 F64x2ConvertLowI32x4S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f64x2.convert_low_i32x4_u` instruction.
                 #[snake_name(f64x2_convert_low_i32x4_u)]
                 F64x2ConvertLowI32x4U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.trunc_sat_f32x4_s` instruction.
                 #[snake_name(i32x4_trunc_sat_f32x4_s)]
                 I32x4TruncSatF32x4S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.trunc_sat_f32x4_u` instruction.
                 #[snake_name(i32x4_trunc_sat_f32x4_u)]
                 I32x4TruncSatF32x4U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.trunc_sat_f64x2_s_zero` instruction.
                 #[snake_name(i32x4_trunc_sat_f64x2_s_zero)]
                 I32x4TruncSatF64x2SZero {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.trunc_sat_f64x2_u_zero` instruction.
                 #[snake_name(i32x4_trunc_sat_f64x2_u_zero)]
                 I32x4TruncSatF64x2UZero {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f32x4.demote_f64x2_zero` instruction.
                 #[snake_name(f32x4_demote_f64x2_zero)]
                 F32x4DemoteF64x2Zero {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `f64x2.promote_low_f32x4` instruction.
                 #[snake_name(f64x2_promote_low_f32x4)]
                 F64x2PromoteLowF32x4 {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
 
                 /// Wasm `i8x16.narrow_i16x8_s` instruction.
                 #[snake_name(i8x16_narrow_i16x8_s)]
                 I8x16NarrowI16x8S {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Regstier holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slotstier holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i8x16.narrow_i16x8_u` instruction.
                 #[snake_name(i8x16_narrow_i16x8_u)]
                 I8x16NarrowI16x8U {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Regstier holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slotstier holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.narrow_i32x4_s` instruction.
                 #[snake_name(i16x8_narrow_i32x4_s)]
                 I16x8NarrowI32x4S {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Regstier holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slotstier holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
                 /// Wasm `i16x8.narrow_i32x4_u` instruction.
                 #[snake_name(i16x8_narrow_i32x4_u)]
                 I16x8NarrowI32x4U {
-                    @result: Reg,
-                    /// Register holding the `lhs` of the instruction.
-                    lhs: Reg,
-                    /// Regstier holding the `rhs` of the instruction.
-                    rhs: Reg,
+                    @result: Slot,
+                    /// Slot holding the `lhs` of the instruction.
+                    lhs: Slot,
+                    /// Slotstier holding the `rhs` of the instruction.
+                    rhs: Slot,
                 },
 
                 /// Wasm `i16x8.extend_low_i8x16_s` instruction.
                 #[snake_name(i16x8_extend_low_i8x16_s)]
                 I16x8ExtendLowI8x16S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i16x8.extend_high_i8x16_s` instruction.
                 #[snake_name(i16x8_extend_high_i8x16_s)]
                 I16x8ExtendHighI8x16S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i16x8.extend_low_i8x16_u` instruction.
                 #[snake_name(i16x8_extend_low_i8x16_u)]
                 I16x8ExtendLowI8x16U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i16x8.extend_high_i8x16_u` instruction.
                 #[snake_name(i16x8_extend_high_i8x16_u)]
                 I16x8ExtendHighI8x16U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.extend_low_i16x8_s` instruction.
                 #[snake_name(i32x4_extend_low_i16x8_s)]
                 I32x4ExtendLowI16x8S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.extend_high_i16x8_s` instruction.
                 #[snake_name(i32x4_extend_high_i16x8_s)]
                 I32x4ExtendHighI16x8S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.extend_low_i16x8_u` instruction.
                 #[snake_name(i32x4_extend_low_i16x8_u)]
                 I32x4ExtendLowI16x8U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i32x4.extend_high_i16x8_u` instruction.
                 #[snake_name(i32x4_extend_high_i16x8_u)]
                 I32x4ExtendHighI16x8U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i64x2.extend_low_i32x4_s` instruction.
                 #[snake_name(i64x2_extend_low_i32x4_s)]
                 I64x2ExtendLowI32x4S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i64x2.extend_high_i32x4_s` instruction.
                 #[snake_name(i64x2_extend_high_i32x4_s)]
                 I64x2ExtendHighI32x4S {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i64x2.extend_low_i32x4_u` instruction.
                 #[snake_name(i64x2_extend_low_i32x4_u)]
                 I64x2ExtendLowI32x4U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
                 /// Wasm `i64x2.extend_high_i32x4_u` instruction.
                 #[snake_name(i64x2_extend_high_i32x4_u)]
                 I64x2ExtendHighI32x4U {
-                    @result: Reg,
-                    /// Register holding the `input` of the instruction.
-                    input: Reg,
+                    @result: Slot,
+                    /// Slot holding the `input` of the instruction.
+                    input: Slot,
                 },
 
                 /// Wasm `v128.store` instruction.
@@ -7396,14 +7396,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// - [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// - [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// - Optional [`Op::MemoryIndex`]: encoding memory index used
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_store)]
                 V128Store {
                     /// The register storing the `pointer` of the store instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7415,11 +7415,11 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(v128_store_offset16)]
                 V128StoreOffset16 {
                     /// The register storing the `pointer` of the store instruction.
-                    ptr: Reg,
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                     /// The register storing the `value` of the store instruction.
-                    value: Reg,
+                    value: Slot,
                 },
                 /// Variant of [`Op::V128Store`] with 32-bit immediate address.
                 ///
@@ -7431,7 +7431,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(v128_store_at)]
                 V128StoreAt {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The 32-bit constant address to store the value.
                     address: Address32,
                 },
@@ -7442,14 +7442,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// - [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// - [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// - [`Op::Imm16AndImm32`]: encoding `lane_index` and `memory_index` respectively
                 ///
                 /// The `lane_index` is of type [`ImmLaneIdx16`].
                 #[snake_name(v128_store8_lane)]
                 V128Store8Lane {
-                    /// Register storing the `ptr` of the instruction.
-                    ptr: Reg,
+                    /// Slot storing the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit store `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7460,10 +7460,10 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_store8_lane_offset8)]
                 V128Store8LaneOffset8 {
-                    /// Register storing the `ptr` of the instruction.
-                    ptr: Reg,
-                    /// Register storing the `value` of the instruction.
-                    value: Reg,
+                    /// Slot storing the `ptr` of the instruction.
+                    ptr: Slot,
+                    /// Slot storing the `value` of the instruction.
+                    value: Slot,
                     /// The 8-bit store `offset`.
                     offset: Offset8,
                     /// The lane of the stored [`V128`] `value`.
@@ -7477,7 +7477,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(v128_store8_lane_at)]
                 V128Store8LaneAt {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The 32-bit constant address to store the value.
                     address: Address32,
                 },
@@ -7488,14 +7488,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// - [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// - [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// - [`Op::Imm16AndImm32`]: encoding `lane_index` and `memory_index` respectively
                 ///
                 /// The `lane_index` is of type [`ImmLaneIdx8`].
                 #[snake_name(v128_store16_lane)]
                 V128Store16Lane {
-                    /// Register storing the `ptr` of the instruction.
-                    ptr: Reg,
+                    /// Slot storing the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit store `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7506,10 +7506,10 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_store16_lane_offset8)]
                 V128Store16LaneOffset8 {
-                    /// Register storing the `ptr` of the instruction.
-                    ptr: Reg,
-                    /// Register storing the `value` of the instruction.
-                    value: Reg,
+                    /// Slot storing the `ptr` of the instruction.
+                    ptr: Slot,
+                    /// Slot storing the `value` of the instruction.
+                    value: Slot,
                     /// The 8-bit store `offset`.
                     offset: Offset8,
                     /// The lane of the stored [`V128`] `value`.
@@ -7523,7 +7523,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(v128_store16_lane_at)]
                 V128Store16LaneAt {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The 32-bit constant address to store the value.
                     address: Address32,
                 },
@@ -7534,14 +7534,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// - [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// - [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// - [`Op::Imm16AndImm32`]: encoding `lane_index` and `memory_index` respectively
                 ///
                 /// The `lane_index` is of type [`ImmLaneIdx4`].
                 #[snake_name(v128_store32_lane)]
                 V128Store32Lane {
-                    /// Register storing the `ptr` of the instruction.
-                    ptr: Reg,
+                    /// Slot storing the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit store `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7552,10 +7552,10 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_store32_lane_offset8)]
                 V128Store32LaneOffset8 {
-                    /// Register storing the `ptr` of the instruction.
-                    ptr: Reg,
-                    /// Register storing the `value` of the instruction.
-                    value: Reg,
+                    /// Slot storing the `ptr` of the instruction.
+                    ptr: Slot,
+                    /// Slot storing the `value` of the instruction.
+                    value: Slot,
                     /// The 8-bit store `offset`.
                     offset: Offset8,
                     /// The lane of the stored [`V128`] `value`.
@@ -7569,7 +7569,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(v128_store32_lane_at)]
                 V128Store32LaneAt {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The 32-bit constant address to store the value.
                     address: Address32,
                 },
@@ -7580,14 +7580,14 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// - [`Op::RegisterAndImm32`]: encoding `value` and `offset_hi`
+                /// - [`Op::SlotAndImm32`]: encoding `value` and `offset_hi`
                 /// - [`Op::Imm16AndImm32`]: encoding `lane_index` and `memory_index` respectively
                 ///
                 /// The `lane_index` is of type [`ImmLaneIdx2`].
                 #[snake_name(v128_store64_lane)]
                 V128Store64Lane {
-                    /// Register storing the `ptr` of the instruction.
-                    ptr: Reg,
+                    /// Slot storing the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The lower 32-bit of the 64-bit store `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7598,10 +7598,10 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_store64_lane_offset8)]
                 V128Store64LaneOffset8 {
-                    /// Register storing the `ptr` of the instruction.
-                    ptr: Reg,
-                    /// Register storing the `value` of the instruction.
-                    value: Reg,
+                    /// Slot storing the `ptr` of the instruction.
+                    ptr: Slot,
+                    /// Slot storing the `value` of the instruction.
+                    value: Slot,
                     /// The 8-bit store `offset`.
                     offset: Offset8,
                     /// The lane of the stored [`V128`] `value`.
@@ -7615,7 +7615,7 @@ macro_rules! for_each_op_grouped {
                 #[snake_name(v128_store64_lane_at)]
                 V128Store64LaneAt {
                     /// The value to be stored.
-                    value: Reg,
+                    value: Slot,
                     /// The 32-bit constant address to store the value.
                     address: Address32,
                 },
@@ -7626,13 +7626,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load)]
                 V128Load {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7645,7 +7645,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load_at)]
                 V128LoadAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -7656,9 +7656,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load_offset16)]
                 V128LoadOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -7669,13 +7669,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load32_zero)]
                 V128Load32Zero {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7688,7 +7688,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load32_zero_at)]
                 V128Load32ZeroAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -7699,9 +7699,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load32_zero_offset16)]
                 V128Load32ZeroOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -7712,13 +7712,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load64_zero)]
                 V128Load64Zero {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7731,7 +7731,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load64_zero_at)]
                 V128Load64ZeroAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -7742,9 +7742,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load64_zero_offset16)]
                 V128Load64ZeroOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -7755,13 +7755,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load8_splat)]
                 V128Load8Splat {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7774,7 +7774,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load8_splat_at)]
                 V128Load8SplatAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -7785,9 +7785,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load8_splat_offset16)]
                 V128Load8SplatOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -7798,13 +7798,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load16_splat)]
                 V128Load16Splat {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7817,7 +7817,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load16_splat_at)]
                 V128Load16SplatAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -7828,9 +7828,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load16_splat_offset16)]
                 V128Load16SplatOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -7841,13 +7841,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load32_splat)]
                 V128Load32Splat {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7860,7 +7860,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load32_splat_at)]
                 V128Load32SplatAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -7871,9 +7871,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load32_splat_offset16)]
                 V128Load32SplatOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -7884,13 +7884,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load64_splat)]
                 V128Load64Splat {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7903,7 +7903,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load64_splat_at)]
                 V128Load64SplatAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -7914,9 +7914,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load64_splat_offset16)]
                 V128Load64SplatOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -7927,13 +7927,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load8x8_s)]
                 V128Load8x8S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7946,7 +7946,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load8x8_s_at)]
                 V128Load8x8SAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -7957,9 +7957,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load8x8_s_offset16)]
                 V128Load8x8SOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -7970,13 +7970,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load8x8_u)]
                 V128Load8x8U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -7989,7 +7989,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load8x8_u_at)]
                 V128Load8x8UAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -8000,9 +8000,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load8x8_u_offset16)]
                 V128Load8x8UOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -8013,13 +8013,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load16x4_s)]
                 V128Load16x4S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -8032,7 +8032,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load16x4_s_at)]
                 V128Load16x4SAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -8043,9 +8043,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load16x4_s_offset16)]
                 V128Load16x4SOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -8056,13 +8056,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load16x4_u)]
                 V128Load16x4U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -8075,7 +8075,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load16x4_u_at)]
                 V128Load16x4UAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -8086,9 +8086,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load16x4_u_offset16)]
                 V128Load16x4UOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -8099,13 +8099,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load32x2_s)]
                 V128Load32x2S {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -8118,7 +8118,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load32x2_s_at)]
                 V128Load32x2SAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -8129,9 +8129,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load32x2_s_offset16)]
                 V128Load32x2SOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -8142,13 +8142,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load32x2_u)]
                 V128Load32x2U {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -8161,7 +8161,7 @@ macro_rules! for_each_op_grouped {
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load32x2_u_at)]
                 V128Load32x2UAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -8172,9 +8172,9 @@ macro_rules! for_each_op_grouped {
                 /// Operates on the default Wasm memory instance.
                 #[snake_name(v128_load32x2_u_offset16)]
                 V128Load32x2UOffset16 {
-                    @result: Reg,
-                    /// Register holding the `ptr` of the instruction.
-                    ptr: Reg,
+                    @result: Slot,
+                    /// Slot holding the `ptr` of the instruction.
+                    ptr: Slot,
                     /// The 16-bit encoded offset of the `load` instruction.
                     offset: Offset16,
                 },
@@ -8185,8 +8185,8 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
-                /// 2. [`Op::RegisterAndImm32`] encoding `input` and `lane` index.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 2. [`Op::SlotAndImm32`] encoding `input` and `lane` index.
                 /// 3. Optional [`Op::MemoryIndex`] encoding the `memory` index used.
                 ///
                 /// # Note
@@ -8196,7 +8196,7 @@ macro_rules! for_each_op_grouped {
                 /// The `lane_index` is of type [`ImmLaneIdx16`].
                 #[snake_name(v128_load8_lane)]
                 V128Load8Lane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -8206,13 +8206,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `input` and `lane_index`.
+                /// 1. [`Op::SlotAndImm32`] encoding `input` and `lane_index`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding the `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load8_lane_at)]
                 V128Load8LaneAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -8223,8 +8223,8 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
-                /// 2. [`Op::RegisterAndImm32`] encoding `input` and `lane` index.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 2. [`Op::SlotAndImm32`] encoding `input` and `lane` index.
                 /// 3. Optional [`Op::MemoryIndex`] encoding the `memory` index used.
                 ///
                 /// # Note
@@ -8234,7 +8234,7 @@ macro_rules! for_each_op_grouped {
                 /// The `lane_index` is of type [`ImmLaneIdx8`].
                 #[snake_name(v128_load16_lane)]
                 V128Load16Lane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -8244,13 +8244,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `input` and `lane_index`.
+                /// 1. [`Op::SlotAndImm32`] encoding `input` and `lane_index`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding the `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load16_lane_at)]
                 V128Load16LaneAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -8261,8 +8261,8 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
-                /// 2. [`Op::RegisterAndImm32`] encoding `input` and `lane` index.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 2. [`Op::SlotAndImm32`] encoding `input` and `lane` index.
                 /// 3. Optional [`Op::MemoryIndex`] encoding the `memory` index used.
                 ///
                 /// # Note
@@ -8272,7 +8272,7 @@ macro_rules! for_each_op_grouped {
                 /// The `lane_index` is of type [`ImmLaneIdx4`].
                 #[snake_name(v128_load32_lane)]
                 V128Load32Lane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -8282,13 +8282,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `input` and `lane_index`.
+                /// 1. [`Op::SlotAndImm32`] encoding `input` and `lane_index`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding the `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load32_lane_at)]
                 V128Load32LaneAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },
@@ -8299,8 +8299,8 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `ptr` and `offset_hi`.
-                /// 2. [`Op::RegisterAndImm32`] encoding `input` and `lane` index.
+                /// 1. [`Op::SlotAndImm32`] encoding `ptr` and `offset_hi`.
+                /// 2. [`Op::SlotAndImm32`] encoding `input` and `lane` index.
                 /// 3. Optional [`Op::MemoryIndex`] encoding the `memory` index used.
                 ///
                 /// # Note
@@ -8310,7 +8310,7 @@ macro_rules! for_each_op_grouped {
                 /// The `lane_index` is of type [`ImmLaneIdx2`].
                 #[snake_name(v128_load64_lane)]
                 V128Load64Lane {
-                    @result: Reg,
+                    @result: Slot,
                     /// The lower 32-bit of the 64-bit load `offset`.
                     offset_lo: Offset64Lo,
                 },
@@ -8320,13 +8320,13 @@ macro_rules! for_each_op_grouped {
                 ///
                 /// Followed by
                 ///
-                /// 1. [`Op::RegisterAndImm32`] encoding `input` and `lane_index`.
+                /// 1. [`Op::SlotAndImm32`] encoding `input` and `lane_index`.
                 /// 2. Optional [`Op::MemoryIndex`] encoding the `memory_index` used.
                 ///
                 /// If [`Op::MemoryIndex`] is missing the default memory is used.
                 #[snake_name(v128_load64_lane_at)]
                 V128Load64LaneAt {
-                    @result: Reg,
+                    @result: Slot,
                     /// The `ptr+offset` address of the load instruction.
                     address: Address32,
                 },

--- a/crates/ir/src/index.rs
+++ b/crates/ir/src/index.rs
@@ -5,8 +5,8 @@ use crate::Error;
 macro_rules! for_each_index {
     ($mac:ident) => {
         $mac! {
-            /// A Wasmi register.
-            Reg(pub(crate) i16);
+            /// A Wasmi stack slot.
+            Slot(pub(crate) i16);
             /// A Wasm function index.
             Func(pub(crate) u32);
             /// A Wasm function type index.
@@ -62,18 +62,18 @@ macro_rules! define_index {
 }
 for_each_index!(define_index);
 
-impl TryFrom<u32> for Reg {
+impl TryFrom<u32> for Slot {
     type Error = Error;
 
     fn try_from(local_index: u32) -> Result<Self, Self::Error> {
         i16::try_from(local_index)
-            .map_err(|_| Error::RegisterOutOfBounds)
+            .map_err(|_| Error::StackSlotOutOfBounds)
             .map(Self::from)
     }
 }
 
-impl Reg {
-    /// Returns the n-th next [`Reg`] from `self` with contiguous index.
+impl Slot {
+    /// Returns the n-th next [`Slot`] from `self` with contiguous index.
     ///
     /// # Note
     ///
@@ -83,7 +83,7 @@ impl Reg {
         Self(self.0.wrapping_add_unsigned(n))
     }
 
-    /// Returns the n-th previous [`Reg`] from `self` with contiguous index.
+    /// Returns the n-th previous [`Slot`] from `self` with contiguous index.
     ///
     /// # Note
     ///
@@ -93,12 +93,12 @@ impl Reg {
         Self(self.0.wrapping_sub_unsigned(n))
     }
 
-    /// Returns the [`Reg`] with the next contiguous index.
+    /// Returns the [`Slot`] with the next contiguous index.
     pub fn next(self) -> Self {
         self.next_n(1)
     }
 
-    /// Returns the [`Reg`] with the previous contiguous index.
+    /// Returns the [`Slot`] with the previous contiguous index.
     pub fn prev(self) -> Self {
         self.prev_n(1)
     }

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -23,7 +23,7 @@ use wasmi_core as core;
 pub use self::{
     error::Error,
     immeditate::{AnyConst16, AnyConst32, Const16, Const32},
-    index::Reg,
+    index::Slot,
     primitive::{
         Address,
         Address32,
@@ -42,6 +42,6 @@ pub use self::{
         Sign,
     },
     r#enum::Op,
-    span::{BoundedRegSpan, FixedRegSpan, RegSpan, RegSpanIter},
+    span::{BoundedSlotSpan, FixedSlotSpan, SlotSpan, SlotSpanIter},
     visit_results::VisitResults,
 };

--- a/crates/ir/src/span.rs
+++ b/crates/ir/src/span.rs
@@ -1,45 +1,45 @@
-use crate::{Error, Reg};
+use crate::{Error, Slot};
 
-/// A [`RegSpan`] of contiguous [`Reg`] indices.
+/// A [`SlotSpan`] of contiguous [`Slot`] indices.
 ///
 /// # Note
 ///
-/// - Represents an amount of contiguous [`Reg`] indices.
-/// - For the sake of space efficiency the actual number of [`Reg`]
-///   of the [`RegSpan`] is stored externally and provided in
-///   [`RegSpan::iter`] when there is a need to iterate over
-///   the [`Reg`] of the [`RegSpan`].
+/// - Represents an amount of contiguous [`Slot`] indices.
+/// - For the sake of space efficiency the actual number of [`Slot`]
+///   of the [`SlotSpan`] is stored externally and provided in
+///   [`SlotSpan::iter`] when there is a need to iterate over
+///   the [`Slot`] of the [`SlotSpan`].
 ///
 /// The caller is responsible for providing the correct length.
 /// Due to Wasm validation guided bytecode construction we assert
 /// that the externally stored length is valid.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
-pub struct RegSpan(Reg);
+pub struct SlotSpan(Slot);
 
-impl RegSpan {
-    /// Creates a new [`RegSpan`] starting with the given `start` [`Reg`].
-    pub fn new(head: Reg) -> Self {
+impl SlotSpan {
+    /// Creates a new [`SlotSpan`] starting with the given `start` [`Slot`].
+    pub fn new(head: Slot) -> Self {
         Self(head)
     }
 
-    /// Returns a [`RegSpanIter`] yielding `len` [`Reg`]s.
-    pub fn iter_sized(self, len: usize) -> RegSpanIter {
-        RegSpanIter::new(self.0, len)
+    /// Returns a [`SlotSpanIter`] yielding `len` [`Slot`]s.
+    pub fn iter_sized(self, len: usize) -> SlotSpanIter {
+        SlotSpanIter::new(self.0, len)
     }
 
-    /// Returns a [`RegSpanIter`] yielding `len` [`Reg`]s.
-    pub fn iter(self, len: u16) -> RegSpanIter {
-        RegSpanIter::new_u16(self.0, len)
+    /// Returns a [`SlotSpanIter`] yielding `len` [`Slot`]s.
+    pub fn iter(self, len: u16) -> SlotSpanIter {
+        SlotSpanIter::new_u16(self.0, len)
     }
 
-    /// Returns the head [`Reg`] of the [`RegSpan`].
-    pub fn head(self) -> Reg {
+    /// Returns the head [`Slot`] of the [`SlotSpan`].
+    pub fn head(self) -> Slot {
         self.0
     }
 
-    /// Returns an exclusive reference to the head [`Reg`] of the [`RegSpan`].
-    pub fn head_mut(&mut self) -> &mut Reg {
+    /// Returns an exclusive reference to the head [`Slot`] of the [`SlotSpan`].
+    pub fn head_mut(&mut self) -> &mut Slot {
         &mut self.0
     }
 
@@ -52,21 +52,21 @@ impl RegSpan {
     /// - `[ 0 <- 1, 1 <- 2, 2 <- 3 ]`: no overlap
     /// - `[ 1 <- 0, 2 <- 1 ]`: overlaps!
     pub fn has_overlapping_copies(results: Self, values: Self, len: u16) -> bool {
-        RegSpanIter::has_overlapping_copies(results.iter(len), values.iter(len))
+        SlotSpanIter::has_overlapping_copies(results.iter(len), values.iter(len))
     }
 }
 
-/// A [`RegSpan`] with a statically known number of [`Reg`].
+/// A [`SlotSpan`] with a statically known number of [`Slot`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
-pub struct FixedRegSpan<const N: u16> {
-    /// The underlying [`RegSpan`] without the known length.
-    span: RegSpan,
+pub struct FixedSlotSpan<const N: u16> {
+    /// The underlying [`SlotSpan`] without the known length.
+    span: SlotSpan,
 }
 
-impl FixedRegSpan<2> {
+impl FixedSlotSpan<2> {
     /// Returns an array of the results represented by `self`.
-    pub fn to_array(self) -> [Reg; 2] {
+    pub fn to_array(self) -> [Slot; 2] {
         let span = self.span();
         let fst = span.head();
         let snd = fst.next();
@@ -74,41 +74,41 @@ impl FixedRegSpan<2> {
     }
 }
 
-impl<const N: u16> FixedRegSpan<N> {
-    /// Creates a new [`RegSpan`] starting with the given `start` [`Reg`].
-    pub fn new(span: RegSpan) -> Result<Self, Error> {
+impl<const N: u16> FixedSlotSpan<N> {
+    /// Creates a new [`SlotSpan`] starting with the given `start` [`Slot`].
+    pub fn new(span: SlotSpan) -> Result<Self, Error> {
         let head = span.head();
         if head >= head.next_n(N) {
-            return Err(Error::RegisterOutOfBounds);
+            return Err(Error::StackSlotOutOfBounds);
         }
         Ok(Self { span })
     }
 
-    /// Returns a [`RegSpanIter`] yielding `N` [`Reg`]s.
-    pub fn iter(&self) -> RegSpanIter {
+    /// Returns a [`SlotSpanIter`] yielding `N` [`Slot`]s.
+    pub fn iter(&self) -> SlotSpanIter {
         self.span.iter(self.len())
     }
 
-    /// Creates a new [`BoundedRegSpan`] from `self`.
-    pub fn bounded(self) -> BoundedRegSpan {
-        BoundedRegSpan {
+    /// Creates a new [`BoundedSlotSpan`] from `self`.
+    pub fn bounded(self) -> BoundedSlotSpan {
+        BoundedSlotSpan {
             span: self.span,
             len: N,
         }
     }
 
-    /// Returns the underlying [`RegSpan`] of `self`.
-    pub fn span(self) -> RegSpan {
+    /// Returns the underlying [`SlotSpan`] of `self`.
+    pub fn span(self) -> SlotSpan {
         self.span
     }
 
-    /// Returns an exclusive reference to the underlying [`RegSpan`] of `self`.
-    pub fn span_mut(&mut self) -> &mut RegSpan {
+    /// Returns an exclusive reference to the underlying [`SlotSpan`] of `self`.
+    pub fn span_mut(&mut self) -> &mut SlotSpan {
         &mut self.span
     }
 
-    /// Returns `true` if the [`Reg`] is contained in `self`.
-    pub fn contains(self, reg: Reg) -> bool {
+    /// Returns `true` if the [`Slot`] is contained in `self`.
+    pub fn contains(self, reg: Slot) -> bool {
         if self.is_empty() {
             return false;
         }
@@ -117,7 +117,7 @@ impl<const N: u16> FixedRegSpan<N> {
         min <= reg && reg < max
     }
 
-    /// Returns the number of [`Reg`]s in `self`.
+    /// Returns the number of [`Slot`]s in `self`.
     pub fn len(self) -> u16 {
         N
     }
@@ -128,56 +128,56 @@ impl<const N: u16> FixedRegSpan<N> {
     }
 }
 
-impl<const N: u16> IntoIterator for &FixedRegSpan<N> {
-    type Item = Reg;
-    type IntoIter = RegSpanIter;
+impl<const N: u16> IntoIterator for &FixedSlotSpan<N> {
+    type Item = Slot;
+    type IntoIter = SlotSpanIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-impl<const N: u16> IntoIterator for FixedRegSpan<N> {
-    type Item = Reg;
-    type IntoIter = RegSpanIter;
+impl<const N: u16> IntoIterator for FixedSlotSpan<N> {
+    type Item = Slot;
+    type IntoIter = SlotSpanIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-/// A [`RegSpan`] with a known number of [`Reg`].
+/// A [`SlotSpan`] with a known number of [`Slot`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct BoundedRegSpan {
-    /// The first [`Reg`] in `self`.
-    span: RegSpan,
-    /// The number of [`Reg`] in `self`.
+pub struct BoundedSlotSpan {
+    /// The first [`Slot`] in `self`.
+    span: SlotSpan,
+    /// The number of [`Slot`] in `self`.
     len: u16,
 }
 
-impl BoundedRegSpan {
-    /// Creates a new [`BoundedRegSpan`] from the given `span` and `len`.
-    pub fn new(span: RegSpan, len: u16) -> Self {
+impl BoundedSlotSpan {
+    /// Creates a new [`BoundedSlotSpan`] from the given `span` and `len`.
+    pub fn new(span: SlotSpan, len: u16) -> Self {
         Self { span, len }
     }
 
-    /// Returns a [`RegSpanIter`] yielding `len` [`Reg`]s.
-    pub fn iter(&self) -> RegSpanIter {
+    /// Returns a [`SlotSpanIter`] yielding `len` [`Slot`]s.
+    pub fn iter(&self) -> SlotSpanIter {
         self.span.iter(self.len())
     }
 
-    /// Returns `self` as unbounded [`RegSpan`].
-    pub fn span(&self) -> RegSpan {
+    /// Returns `self` as unbounded [`SlotSpan`].
+    pub fn span(&self) -> SlotSpan {
         self.span
     }
 
-    /// Returns a mutable reference to the underlying [`RegSpan`].
-    pub fn span_mut(&mut self) -> &mut RegSpan {
+    /// Returns a mutable reference to the underlying [`SlotSpan`].
+    pub fn span_mut(&mut self) -> &mut SlotSpan {
         &mut self.span
     }
 
-    /// Returns `true` if the [`Reg`] is contained in `self`.
-    pub fn contains(self, reg: Reg) -> bool {
+    /// Returns `true` if the [`Slot`] is contained in `self`.
+    pub fn contains(self, reg: Slot) -> bool {
         if self.is_empty() {
             return false;
         }
@@ -186,7 +186,7 @@ impl BoundedRegSpan {
         min <= reg && reg < max
     }
 
-    /// Returns the number of [`Reg`] in `self`.
+    /// Returns the number of [`Slot`] in `self`.
     pub fn len(&self) -> u16 {
         self.len
     }
@@ -197,36 +197,36 @@ impl BoundedRegSpan {
     }
 }
 
-impl IntoIterator for &BoundedRegSpan {
-    type Item = Reg;
-    type IntoIter = RegSpanIter;
+impl IntoIterator for &BoundedSlotSpan {
+    type Item = Slot;
+    type IntoIter = SlotSpanIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-impl IntoIterator for BoundedRegSpan {
-    type Item = Reg;
-    type IntoIter = RegSpanIter;
+impl IntoIterator for BoundedSlotSpan {
+    type Item = Slot;
+    type IntoIter = SlotSpanIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-/// A [`RegSpanIter`] iterator yielding contiguous [`Reg`].
+/// A [`SlotSpanIter`] iterator yielding contiguous [`Slot`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RegSpanIter {
-    /// The next [`Reg`] in the [`RegSpanIter`].
-    next: Reg,
-    /// The last [`Reg`] in the [`RegSpanIter`].
-    last: Reg,
+pub struct SlotSpanIter {
+    /// The next [`Slot`] in the [`SlotSpanIter`].
+    next: Slot,
+    /// The last [`Slot`] in the [`SlotSpanIter`].
+    last: Slot,
 }
 
-impl RegSpanIter {
-    /// Creates a [`RegSpanIter`] from then given raw `start` and `end` [`Reg`].
-    pub fn from_raw_parts(start: Reg, end: Reg) -> Self {
+impl SlotSpanIter {
+    /// Creates a [`SlotSpanIter`] from then given raw `start` and `end` [`Slot`].
+    pub fn from_raw_parts(start: Slot, end: Slot) -> Self {
         debug_assert!(i16::from(start) <= i16::from(end));
         Self {
             next: start,
@@ -234,43 +234,43 @@ impl RegSpanIter {
         }
     }
 
-    /// Creates a new [`RegSpanIter`] for the given `start` [`Reg`] and length `len`.
+    /// Creates a new [`SlotSpanIter`] for the given `start` [`Slot`] and length `len`.
     ///
     /// # Panics
     ///
-    /// If the `start..end` [`Reg`] span indices are out of bounds.
-    fn new(start: Reg, len: usize) -> Self {
+    /// If the `start..end` [`Slot`] span indices are out of bounds.
+    fn new(start: Slot, len: usize) -> Self {
         let len = u16::try_from(len)
             .unwrap_or_else(|_| panic!("out of bounds length for register span: {len}"));
         Self::new_u16(start, len)
     }
 
-    /// Creates a new [`RegSpanIter`] for the given `start` [`Reg`] and length `len`.
+    /// Creates a new [`SlotSpanIter`] for the given `start` [`Slot`] and length `len`.
     ///
     /// # Panics
     ///
-    /// If the `start..end` [`Reg`] span indices are out of bounds.
-    fn new_u16(start: Reg, len: u16) -> Self {
+    /// If the `start..end` [`Slot`] span indices are out of bounds.
+    fn new_u16(start: Slot, len: u16) -> Self {
         let next = start;
         let last = start
             .0
             .checked_add_unsigned(len)
-            .map(Reg)
+            .map(Slot)
             .expect("overflowing register index for register span");
         Self::from_raw_parts(next, last)
     }
 
-    /// Creates a [`RegSpan`] from this [`RegSpanIter`].
-    pub fn span(self) -> RegSpan {
-        RegSpan(self.next)
+    /// Creates a [`SlotSpan`] from this [`SlotSpanIter`].
+    pub fn span(self) -> SlotSpan {
+        SlotSpan(self.next)
     }
 
-    /// Returns the remaining number of [`Reg`]s yielded by the [`RegSpanIter`].
+    /// Returns the remaining number of [`Slot`]s yielded by the [`SlotSpanIter`].
     pub fn len_as_u16(&self) -> u16 {
         self.last.0.abs_diff(self.next.0)
     }
 
-    /// Returns `true` if `self` yields no more [`Reg`]s.
+    /// Returns `true` if `self` yields no more [`Slot`]s.
     pub fn is_empty(&self) -> bool {
         self.len_as_u16() == 0
     }
@@ -308,8 +308,8 @@ impl RegSpanIter {
     }
 }
 
-impl Iterator for RegSpanIter {
-    type Item = Reg;
+impl Iterator for SlotSpanIter {
+    type Item = Slot;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.next == self.last {
@@ -321,7 +321,7 @@ impl Iterator for RegSpanIter {
     }
 }
 
-impl DoubleEndedIterator for RegSpanIter {
+impl DoubleEndedIterator for SlotSpanIter {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.next == self.last {
             return None;
@@ -331,8 +331,8 @@ impl DoubleEndedIterator for RegSpanIter {
     }
 }
 
-impl ExactSizeIterator for RegSpanIter {
+impl ExactSizeIterator for SlotSpanIter {
     fn len(&self) -> usize {
-        usize::from(RegSpanIter::len_as_u16(self))
+        usize::from(SlotSpanIter::len_as_u16(self))
     }
 }

--- a/crates/ir/src/tests.rs
+++ b/crates/ir/src/tests.rs
@@ -1,13 +1,13 @@
-use crate::{Reg, RegSpan, RegSpanIter};
+use crate::{Slot, SlotSpan, SlotSpanIter};
 
 #[test]
 fn has_overlapping_copy_spans_works() {
-    fn span(reg: impl Into<Reg>) -> RegSpan {
-        RegSpan::new(reg.into())
+    fn span(reg: impl Into<Slot>) -> SlotSpan {
+        SlotSpan::new(reg.into())
     }
 
-    fn has_overlapping_copy_spans(results: RegSpan, values: RegSpan, len: u16) -> bool {
-        RegSpanIter::has_overlapping_copies(results.iter(len), values.iter(len))
+    fn has_overlapping_copy_spans(results: SlotSpan, values: SlotSpan, len: u16) -> bool {
+        SlotSpanIter::has_overlapping_copies(results.iter(len), values.iter(len))
     }
 
     // len == 0

--- a/crates/ir/src/visit_results.rs
+++ b/crates/ir/src/visit_results.rs
@@ -1,18 +1,18 @@
 use crate::{index::*, *};
 
 impl Op {
-    /// Visit result [`Reg`]s of `self` via the `visitor`.
+    /// Visit result [`Slot`]s of `self` via the `visitor`.
     pub fn visit_results<V: VisitResults>(&mut self, visitor: &mut V) {
         ResultsVisitor::host_visitor(self, visitor)
     }
 }
 
-/// Implemented by [`Reg`] visitors to visit result [`Reg`]s of an [`Op`] via [`Op::visit_results`].
+/// Implemented by [`Slot`] visitors to visit result [`Slot`]s of an [`Op`] via [`Op::visit_results`].
 pub trait VisitResults {
-    /// Visits a [`Reg`] storing the result of an [`Op`].
-    fn visit_result_reg(&mut self, reg: &mut Reg);
-    /// Visits a [`RegSpan`] storing the results of an [`Op`].
-    fn visit_result_regs(&mut self, reg: &mut RegSpan, len: Option<u16>);
+    /// Visits a [`Slot`] storing the result of an [`Op`].
+    fn visit_result_reg(&mut self, reg: &mut Slot);
+    /// Visits a [`SlotSpan`] storing the results of an [`Op`].
+    fn visit_result_regs(&mut self, reg: &mut SlotSpan, len: Option<u16>);
 }
 
 /// Internal trait used to dispatch to a [`VisitResults`] visitor.
@@ -21,33 +21,33 @@ pub trait ResultsVisitor {
     fn host_visitor<V: VisitResults>(self, visitor: &mut V);
 }
 
-impl ResultsVisitor for &'_ mut Reg {
+impl ResultsVisitor for &'_ mut Slot {
     fn host_visitor<V: VisitResults>(self, visitor: &mut V) {
         visitor.visit_result_reg(self);
     }
 }
 
-impl ResultsVisitor for &'_ mut [Reg; 2] {
+impl ResultsVisitor for &'_ mut [Slot; 2] {
     fn host_visitor<V: VisitResults>(self, visitor: &mut V) {
         visitor.visit_result_reg(&mut self[0]);
         visitor.visit_result_reg(&mut self[1]);
     }
 }
 
-impl ResultsVisitor for &'_ mut RegSpan {
+impl ResultsVisitor for &'_ mut SlotSpan {
     fn host_visitor<V: VisitResults>(self, visitor: &mut V) {
         visitor.visit_result_regs(self, None);
     }
 }
 
-impl ResultsVisitor for &'_ mut BoundedRegSpan {
+impl ResultsVisitor for &'_ mut BoundedSlotSpan {
     fn host_visitor<V: VisitResults>(self, visitor: &mut V) {
         let len = self.len();
         visitor.visit_result_regs(self.span_mut(), Some(len));
     }
 }
 
-impl<const N: u16> ResultsVisitor for &'_ mut FixedRegSpan<N> {
+impl<const N: u16> ResultsVisitor for &'_ mut FixedSlotSpan<N> {
     fn host_visitor<V: VisitResults>(self, visitor: &mut V) {
         visitor.visit_result_regs(self.span_mut(), Some(N));
     }

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -4,12 +4,12 @@ use crate::{
     core::{hint, wasm, ReadAs, UntypedVal, WriteAs},
     engine::{
         code_map::CodeMap,
-        executor::stack::{CallFrame, FrameRegisters, ValueStack},
+        executor::stack::{CallFrame, FrameSlots, ValueStack},
         utils::unreachable_unchecked,
         DedupFuncType,
         EngineFunc,
     },
-    ir::{index, BlockFuel, Const16, Offset64Hi, Op, Reg, ShiftAmount},
+    ir::{index, BlockFuel, Const16, Offset64Hi, Op, ShiftAmount, Slot},
     memory::DataSegment,
     store::{PrunedStore, StoreInner},
     table::ElementSegment,
@@ -89,7 +89,7 @@ pub fn execute_instrs<'engine>(
 #[derive(Debug)]
 struct Executor<'engine> {
     /// Stores the value stack of live values on the Wasm stack.
-    sp: FrameRegisters,
+    sp: FrameSlots,
     /// The pointer to the currently executed instruction.
     ip: InstructionPtr,
     /// The cached instance and instance related data.
@@ -141,13 +141,13 @@ impl<'engine> Executor<'engine> {
                 Instr::Return => {
                     forward_return!(self.execute_return(store.inner_mut()))
                 }
-                Instr::ReturnReg { value } => {
+                Instr::ReturnSlot { value } => {
                     forward_return!(self.execute_return_reg(store.inner_mut(), value))
                 }
-                Instr::ReturnReg2 { values } => {
+                Instr::ReturnSlot2 { values } => {
                     forward_return!(self.execute_return_reg2(store.inner_mut(), values))
                 }
-                Instr::ReturnReg3 { values } => {
+                Instr::ReturnSlot3 { values } => {
                     forward_return!(self.execute_return_reg3(store.inner_mut(), values))
                 }
                 Instr::ReturnImm32 { value } => {
@@ -1258,13 +1258,13 @@ impl<'engine> Executor<'engine> {
                 | Instr::I64Const32 { .. }
                 | Instr::F64Const32 { .. }
                 | Instr::BranchTableTarget { .. }
-                | Instr::Register { .. }
-                | Instr::Register2 { .. }
-                | Instr::Register3 { .. }
-                | Instr::RegisterAndImm32 { .. }
+                | Instr::Slot { .. }
+                | Instr::Slot2 { .. }
+                | Instr::Slot3 { .. }
+                | Instr::SlotAndImm32 { .. }
                 | Instr::Imm16AndImm32 { .. }
-                | Instr::RegisterSpan { .. }
-                | Instr::RegisterList { .. }
+                | Instr::SlotSpan { .. }
+                | Instr::SlotList { .. }
                 | Instr::CallIndirectParams { .. }
                 | Instr::CallIndirectParamsImm16 { .. } => self.invalid_instruction_word()?,
                 #[cfg(feature = "simd")]
@@ -2278,8 +2278,8 @@ impl Executor<'_> {
         fn get_element_segment(&self, index: index::Elem) -> ElementSegment;
     }
 
-    /// Returns the [`Reg`] value.
-    fn get_register(&self, register: Reg) -> UntypedVal {
+    /// Returns the [`Slot`] value.
+    fn get_register(&self, register: Slot) -> UntypedVal {
         // Safety: - It is the responsibility of the `Executor`
         //           implementation to keep the `sp` pointer valid
         //           whenever this method is accessed.
@@ -2288,8 +2288,8 @@ impl Executor<'_> {
         unsafe { self.sp.get(register) }
     }
 
-    /// Returns the [`Reg`] value.
-    fn get_register_as<T>(&self, register: Reg) -> T
+    /// Returns the [`Slot`] value.
+    fn get_register_as<T>(&self, register: Slot) -> T
     where
         UntypedVal: ReadAs<T>,
     {
@@ -2301,8 +2301,8 @@ impl Executor<'_> {
         unsafe { self.sp.read_as::<T>(register) }
     }
 
-    /// Sets the [`Reg`] value to `value`.
-    fn set_register(&mut self, register: Reg, value: impl Into<UntypedVal>) {
+    /// Sets the [`Slot`] value to `value`.
+    fn set_register(&mut self, register: Slot, value: impl Into<UntypedVal>) {
         // Safety: - It is the responsibility of the `Executor`
         //           implementation to keep the `sp` pointer valid
         //           whenever this method is accessed.
@@ -2311,8 +2311,8 @@ impl Executor<'_> {
         unsafe { self.sp.set(register, value.into()) };
     }
 
-    /// Sets the [`Reg`] value to `value`.
-    fn set_register_as<T>(&mut self, register: Reg, value: T)
+    /// Sets the [`Slot`] value to `value`.
+    fn set_register_as<T>(&mut self, register: Slot, value: T)
     where
         UntypedVal: WriteAs<T>,
     {
@@ -2368,8 +2368,8 @@ impl Executor<'_> {
         Ok(())
     }
 
-    /// Returns the [`FrameRegisters`] of the [`CallFrame`].
-    fn frame_stack_ptr_impl(value_stack: &mut ValueStack, frame: &CallFrame) -> FrameRegisters {
+    /// Returns the [`FrameSlots`] of the [`CallFrame`].
+    fn frame_stack_ptr_impl(value_stack: &mut ValueStack, frame: &CallFrame) -> FrameSlots {
         // Safety: We are using the frame's own base offset as input because it is
         //         guaranteed by the Wasm validation and translation phase to be
         //         valid for all register indices used by the associated function body.
@@ -2392,7 +2392,7 @@ impl Executor<'_> {
     /// The initialization of the [`Executor`] allows for efficient execution.
     fn init_call_frame_impl(
         value_stack: &mut ValueStack,
-        sp: &mut FrameRegisters,
+        sp: &mut FrameSlots,
         ip: &mut InstructionPtr,
         frame: &CallFrame,
     ) {
@@ -2402,7 +2402,7 @@ impl Executor<'_> {
 
     /// Executes a generic unary [`Op`].
     #[inline(always)]
-    fn execute_unary<P, R>(&mut self, result: Reg, input: Reg, op: fn(P) -> R)
+    fn execute_unary<P, R>(&mut self, result: Slot, input: Slot, op: fn(P) -> R)
     where
         UntypedVal: ReadAs<P> + WriteAs<R>,
     {
@@ -2415,8 +2415,8 @@ impl Executor<'_> {
     #[inline(always)]
     fn try_execute_unary<P, R>(
         &mut self,
-        result: Reg,
-        input: Reg,
+        result: Slot,
+        input: Slot,
         op: fn(P) -> Result<R, TrapCode>,
     ) -> Result<(), Error>
     where
@@ -2431,9 +2431,9 @@ impl Executor<'_> {
     #[inline(always)]
     fn execute_binary<Lhs, Rhs, Result>(
         &mut self,
-        result: Reg,
-        lhs: Reg,
-        rhs: Reg,
+        result: Slot,
+        lhs: Slot,
+        rhs: Slot,
         op: fn(Lhs, Rhs) -> Result,
     ) where
         UntypedVal: ReadAs<Lhs> + ReadAs<Rhs> + WriteAs<Result>,
@@ -2448,8 +2448,8 @@ impl Executor<'_> {
     #[inline(always)]
     fn execute_binary_imm16_rhs<Lhs, Rhs, T>(
         &mut self,
-        result: Reg,
-        lhs: Reg,
+        result: Slot,
+        lhs: Slot,
         rhs: Const16<Rhs>,
         op: fn(Lhs, Rhs) -> T,
     ) where
@@ -2466,9 +2466,9 @@ impl Executor<'_> {
     #[inline(always)]
     fn execute_binary_imm16_lhs<Lhs, Rhs, T>(
         &mut self,
-        result: Reg,
+        result: Slot,
         lhs: Const16<Lhs>,
-        rhs: Reg,
+        rhs: Slot,
         op: fn(Lhs, Rhs) -> T,
     ) where
         Lhs: From<Const16<Lhs>>,
@@ -2484,8 +2484,8 @@ impl Executor<'_> {
     #[inline(always)]
     fn execute_shift_by<Lhs, Rhs, T>(
         &mut self,
-        result: Reg,
-        lhs: Reg,
+        result: Slot,
+        lhs: Slot,
         rhs: ShiftAmount<Rhs>,
         op: fn(Lhs, Rhs) -> T,
     ) where
@@ -2502,9 +2502,9 @@ impl Executor<'_> {
     #[inline(always)]
     fn try_execute_binary<Lhs, Rhs, T>(
         &mut self,
-        result: Reg,
-        lhs: Reg,
-        rhs: Reg,
+        result: Slot,
+        lhs: Slot,
+        rhs: Slot,
         op: fn(Lhs, Rhs) -> Result<T, TrapCode>,
     ) -> Result<(), Error>
     where
@@ -2520,8 +2520,8 @@ impl Executor<'_> {
     #[inline(always)]
     fn try_execute_divrem_imm16_rhs<Lhs, Rhs, T>(
         &mut self,
-        result: Reg,
-        lhs: Reg,
+        result: Slot,
+        lhs: Slot,
         rhs: Const16<Rhs>,
         op: fn(Lhs, Rhs) -> Result<T, Error>,
     ) -> Result<(), Error>
@@ -2539,8 +2539,8 @@ impl Executor<'_> {
     #[inline(always)]
     fn execute_divrem_imm16_rhs<Lhs, NonZeroT, T>(
         &mut self,
-        result: Reg,
-        lhs: Reg,
+        result: Slot,
+        lhs: Slot,
         rhs: Const16<NonZeroT>,
         op: fn(Lhs, NonZeroT) -> T,
     ) where
@@ -2557,9 +2557,9 @@ impl Executor<'_> {
     #[inline(always)]
     fn try_execute_binary_imm16_lhs<Lhs, Rhs, T>(
         &mut self,
-        result: Reg,
+        result: Slot,
         lhs: Const16<Lhs>,
-        rhs: Reg,
+        rhs: Slot,
         op: fn(Lhs, Rhs) -> Result<T, TrapCode>,
     ) -> Result<(), Error>
     where
@@ -2592,14 +2592,14 @@ impl Executor<'_> {
         }
     }
 
-    /// Fetches the [`Reg`] and [`Offset64Hi`] parameters for a load or store [`Op`].
-    unsafe fn fetch_reg_and_offset_hi(&self) -> (Reg, Offset64Hi) {
+    /// Fetches the [`Slot`] and [`Offset64Hi`] parameters for a load or store [`Op`].
+    unsafe fn fetch_reg_and_offset_hi(&self) -> (Slot, Offset64Hi) {
         let mut addr: InstructionPtr = self.ip;
         addr.add(1);
         match addr.get().filter_register_and_offset_hi() {
             Ok(value) => value,
             Err(instr) => unsafe {
-                unreachable_unchecked!("expected an `Op::RegisterAndImm32` but found: {instr:?}")
+                unreachable_unchecked!("expected an `Op::SlotAndImm32` but found: {instr:?}")
             },
         }
     }
@@ -2643,7 +2643,7 @@ impl Executor<'_> {
     }
 
     /// Executes an [`Op::RefFunc`].
-    fn execute_ref_func(&mut self, result: Reg, func_index: index::Func) {
+    fn execute_ref_func(&mut self, result: Slot, func_index: index::Func) {
         let func = self.get_func(func_index);
         let funcref = <Ref<Func>>::from(func);
         self.set_register(result, funcref);

--- a/crates/wasmi/src/engine/executor/instrs/binary.rs
+++ b/crates/wasmi/src/engine/executor/instrs/binary.rs
@@ -1,7 +1,7 @@
 use super::{Executor, UntypedValueExt};
 use crate::{
     core::wasm,
-    ir::{Const16, Reg, ShiftAmount, Sign},
+    ir::{Const16, ShiftAmount, Sign, Slot},
     Error,
     TrapCode,
 };
@@ -68,7 +68,7 @@ macro_rules! impl_binary_imm16 {
     ( $( ($ty:ty, Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Const16<$ty>) {
+            pub fn $fn_name(&mut self, result: Slot, lhs: Slot, rhs: Const16<$ty>) {
                 self.execute_binary_imm16_rhs(result, lhs, rhs, $op)
             }
         )*
@@ -102,7 +102,7 @@ macro_rules! impl_shift_by {
     ( $( ($ty:ty, Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: ShiftAmount<$ty>) {
+            pub fn $fn_name(&mut self, result: Slot, lhs: Slot, rhs: ShiftAmount<$ty>) {
                 self.execute_shift_by(result, lhs, rhs, $op)
             }
         )*
@@ -128,7 +128,7 @@ macro_rules! impl_binary_imm16_lhs {
     ( $( ($ty:ty, Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, lhs: Const16<$ty>, rhs: Reg) {
+            pub fn $fn_name(&mut self, result: Slot, lhs: Const16<$ty>, rhs: Slot) {
                 self.execute_binary_imm16_lhs(result, lhs, rhs, $op)
             }
         )*
@@ -157,7 +157,7 @@ macro_rules! impl_fallible_binary {
     ( $( (Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Reg) -> Result<(), Error> {
+            pub fn $fn_name(&mut self, result: Slot, lhs: Slot, rhs: Slot) -> Result<(), Error> {
                 self.try_execute_binary(result, lhs, rhs, $op).map_err(Error::from)
             }
         )*
@@ -244,7 +244,7 @@ macro_rules! impl_divrem_s_imm16_rhs {
     ( $( ($ty:ty, Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Const16<$ty>) -> Result<(), Error> {
+            pub fn $fn_name(&mut self, result: Slot, lhs: Slot, rhs: Const16<$ty>) -> Result<(), Error> {
                 self.try_execute_divrem_imm16_rhs(result, lhs, rhs, $op)
             }
         )*
@@ -264,7 +264,7 @@ macro_rules! impl_divrem_u_imm16_rhs {
     ( $( ($ty:ty, Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Const16<$ty>) {
+            pub fn $fn_name(&mut self, result: Slot, lhs: Slot, rhs: Const16<$ty>) {
                 self.execute_divrem_imm16_rhs(result, lhs, rhs, $op)
             }
         )*
@@ -284,7 +284,7 @@ macro_rules! impl_fallible_binary_imm16_lhs {
     ( $( ($ty:ty, Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, lhs: Const16<$ty>, rhs: Reg) -> Result<(), Error> {
+            pub fn $fn_name(&mut self, result: Slot, lhs: Const16<$ty>, rhs: Slot) -> Result<(), Error> {
                 self.try_execute_binary_imm16_lhs(result, lhs, rhs, $op).map_err(Error::from)
             }
         )*
@@ -306,7 +306,7 @@ impl Executor<'_> {
 
 impl Executor<'_> {
     /// Executes an [`Op::F32CopysignImm`].
-    pub fn execute_f32_copysign_imm(&mut self, result: Reg, lhs: Reg, rhs: Sign<f32>) {
+    pub fn execute_f32_copysign_imm(&mut self, result: Slot, lhs: Slot, rhs: Sign<f32>) {
         let lhs = self.get_register_as::<f32>(lhs);
         let rhs = f32::from(rhs);
         self.set_register_as::<f32>(result, wasm::f32_copysign(lhs, rhs));
@@ -314,7 +314,7 @@ impl Executor<'_> {
     }
 
     /// Executes an [`Op::F64CopysignImm`].
-    pub fn execute_f64_copysign_imm(&mut self, result: Reg, lhs: Reg, rhs: Sign<f64>) {
+    pub fn execute_f64_copysign_imm(&mut self, result: Slot, lhs: Slot, rhs: Sign<f64>) {
         let lhs = self.get_register_as::<f64>(lhs);
         let rhs = f64::from(rhs);
         self.set_register_as::<f64>(result, wasm::f64_copysign(lhs, rhs));

--- a/crates/wasmi/src/engine/executor/instrs/branch.rs
+++ b/crates/wasmi/src/engine/executor/instrs/branch.rs
@@ -2,7 +2,7 @@ use super::{Executor, UntypedValueCmpExt, UntypedValueExt};
 use crate::{
     core::{ReadAs, UntypedVal},
     engine::utils::unreachable_unchecked,
-    ir::{BranchOffset, BranchOffset16, Comparator, ComparatorAndOffset, Const16, Op, Reg},
+    ir::{BranchOffset, BranchOffset16, Comparator, ComparatorAndOffset, Const16, Op, Slot},
 };
 use core::cmp;
 
@@ -30,7 +30,7 @@ impl Executor<'_> {
     }
 
     /// Fetches the branch table index value and normalizes it to clamp between `0..len_targets`.
-    fn fetch_branch_table_offset(&self, index: Reg, len_targets: u32) -> usize {
+    fn fetch_branch_table_offset(&self, index: Slot, len_targets: u32) -> usize {
         let index: u32 = self.get_register_as::<u32>(index);
         // The index of the default target which is the last target of the slice.
         let max_index = len_targets - 1;
@@ -38,20 +38,20 @@ impl Executor<'_> {
         cmp::min(index, max_index) as usize + 1
     }
 
-    pub fn execute_branch_table_0(&mut self, index: Reg, len_targets: u32) {
+    pub fn execute_branch_table_0(&mut self, index: Slot, len_targets: u32) {
         let offset = self.fetch_branch_table_offset(index, len_targets);
         self.ip.add(offset);
     }
 
-    pub fn execute_branch_table_span(&mut self, index: Reg, len_targets: u32) {
+    pub fn execute_branch_table_span(&mut self, index: Slot, len_targets: u32) {
         let offset = self.fetch_branch_table_offset(index, len_targets);
         self.ip.add(1);
         let values = match *self.ip.get() {
-            Op::RegisterSpan { span } => span,
+            Op::SlotSpan { span } => span,
             unexpected => {
-                // Safety: Wasmi translation guarantees that `Op::RegisterSpan` follows.
+                // Safety: Wasmi translation guarantees that `Op::SlotSpan` follows.
                 unsafe {
-                    unreachable_unchecked!("expected `Op::RegisterSpan` but found: {unexpected:?}")
+                    unreachable_unchecked!("expected `Op::SlotSpan` but found: {unexpected:?}")
                 }
             }
         };
@@ -80,8 +80,8 @@ impl Executor<'_> {
     #[inline(always)]
     fn execute_branch_binop<T>(
         &mut self,
-        lhs: Reg,
-        rhs: Reg,
+        lhs: Slot,
+        rhs: Slot,
         offset: impl Into<BranchOffset>,
         f: fn(T, T) -> bool,
     ) where
@@ -98,7 +98,7 @@ impl Executor<'_> {
     /// Executes a generic fused compare and branch instruction with immediate `rhs` operand.
     fn execute_branch_binop_imm16_rhs<T>(
         &mut self,
-        lhs: Reg,
+        lhs: Slot,
         rhs: Const16<T>,
         offset: BranchOffset16,
         f: fn(T, T) -> bool,
@@ -118,7 +118,7 @@ impl Executor<'_> {
     fn execute_branch_binop_imm16_lhs<T>(
         &mut self,
         lhs: Const16<T>,
-        rhs: Reg,
+        rhs: Slot,
         offset: BranchOffset16,
         f: fn(T, T) -> bool,
     ) where
@@ -168,7 +168,7 @@ macro_rules! impl_execute_branch_binop {
             $(
                 #[doc = concat!("Executes an [`Op::", stringify!($op_name), "`].")]
                 #[inline(always)]
-                pub fn $fn_name(&mut self, lhs: Reg, rhs: Reg, offset: BranchOffset16) {
+                pub fn $fn_name(&mut self, lhs: Slot, rhs: Slot, offset: BranchOffset16) {
                     self.execute_branch_binop::<$ty>(lhs, rhs, offset, $op)
                 }
             )*
@@ -218,7 +218,7 @@ macro_rules! impl_execute_branch_binop_imm16_rhs {
         impl<'engine> Executor<'engine> {
             $(
                 #[doc = concat!("Executes an [`Op::", stringify!($op_name), "`].")]
-                pub fn $fn_name(&mut self, lhs: Reg, rhs: Const16<$ty>, offset: BranchOffset16) {
+                pub fn $fn_name(&mut self, lhs: Slot, rhs: Const16<$ty>, offset: BranchOffset16) {
                     self.execute_branch_binop_imm16_rhs::<$ty>(lhs, rhs, offset, $op)
                 }
             )*
@@ -254,7 +254,7 @@ macro_rules! impl_execute_branch_binop_imm16_lhs {
         impl<'engine> Executor<'engine> {
             $(
                 #[doc = concat!("Executes an [`Op::", stringify!($op_name), "`].")]
-                pub fn $fn_name(&mut self, lhs: Const16<$ty>, rhs: Reg, offset: BranchOffset16) {
+                pub fn $fn_name(&mut self, lhs: Const16<$ty>, rhs: Slot, offset: BranchOffset16) {
                     self.execute_branch_binop_imm16_lhs::<$ty>(lhs, rhs, offset, $op)
                 }
             )*
@@ -275,7 +275,7 @@ impl_execute_branch_binop_imm16_lhs! {
 
 impl Executor<'_> {
     /// Executes an [`Op::BranchCmpFallback`].
-    pub fn execute_branch_cmp_fallback(&mut self, lhs: Reg, rhs: Reg, params: Reg) {
+    pub fn execute_branch_cmp_fallback(&mut self, lhs: Slot, rhs: Slot, params: Slot) {
         use Comparator as C;
         let params: u64 = self.get_register_as(params);
         let Some(params) = ComparatorAndOffset::from_u64(params) else {

--- a/crates/wasmi/src/engine/executor/instrs/call.rs
+++ b/crates/wasmi/src/engine/executor/instrs/call.rs
@@ -9,7 +9,7 @@ use crate::{
         ResumableHostTrapError,
     },
     func::{FuncEntity, HostFuncEntity},
-    ir::{index, Op, Reg, RegSpan},
+    ir::{index, Op, Slot, SlotSpan},
     store::{CallHooks, PrunedStore, StoreInner},
     Error,
     Func,
@@ -181,11 +181,11 @@ impl Executor<'_> {
     #[inline(always)]
     fn dispatch_compiled_func<C: CallContext>(
         &mut self,
-        results: RegSpan,
+        results: SlotSpan,
         func: CompiledFuncRef,
     ) -> Result<CallFrame, Error> {
-        // We have to reinstantiate the `self.sp` [`FrameRegisters`] since we just called
-        // [`ValueStack::alloc_call_frame`] which might invalidate all live [`FrameRegisters`].
+        // We have to reinstantiate the `self.sp` [`FrameSlots`] since we just called
+        // [`ValueStack::alloc_call_frame`] which might invalidate all live [`FrameSlots`].
         let caller = self
             .stack
             .calls
@@ -210,17 +210,17 @@ impl Executor<'_> {
     /// last call parameter [`Op`] if any.
     fn copy_call_params(&mut self, uninit_params: &mut FrameParams) {
         self.ip.add(1);
-        if let Op::RegisterList { .. } = self.ip.get() {
+        if let Op::SlotList { .. } = self.ip.get() {
             self.copy_call_params_list(uninit_params);
         }
         match self.ip.get() {
-            Op::Register { reg } => {
+            Op::Slot { reg } => {
                 self.copy_regs(uninit_params, array::from_ref(reg));
             }
-            Op::Register2 { regs } => {
+            Op::Slot2 { regs } => {
                 self.copy_regs(uninit_params, regs);
             }
-            Op::Register3 { regs } => {
+            Op::Slot3 { regs } => {
                 self.copy_regs(uninit_params, regs);
             }
             unexpected => {
@@ -234,8 +234,8 @@ impl Executor<'_> {
         }
     }
 
-    /// Copies an array of [`Reg`] to the `dst` [`Reg`] span.
-    fn copy_regs<const N: usize>(&self, uninit_params: &mut FrameParams, regs: &[Reg; N]) {
+    /// Copies an array of [`Slot`] to the `dst` [`Slot`] span.
+    fn copy_regs<const N: usize>(&self, uninit_params: &mut FrameParams, regs: &[Slot; N]) {
         for value in regs {
             let value = self.get_register(*value);
             // Safety: The `callee.results()` always refer to a span of valid
@@ -246,14 +246,14 @@ impl Executor<'_> {
         }
     }
 
-    /// Copies a list of [`Op::RegisterList`] to the `dst` [`Reg`] span.
+    /// Copies a list of [`Op::SlotList`] to the `dst` [`Slot`] span.
     /// Copies the parameters from `src` for the called [`CallFrame`].
     ///
     /// This will make the [`InstructionPtr`] point to the [`Op`] following the
-    /// last [`Op::RegisterList`] if any.
+    /// last [`Op::SlotList`] if any.
     #[cold]
     fn copy_call_params_list(&mut self, uninit_params: &mut FrameParams) {
-        while let Op::RegisterList { regs } = self.ip.get() {
+        while let Op::SlotList { regs } = self.ip.get() {
             self.copy_regs(uninit_params, regs);
             self.ip.add(1);
         }
@@ -264,7 +264,7 @@ impl Executor<'_> {
     fn prepare_compiled_func_call<C: CallContext>(
         &mut self,
         store: &mut StoreInner,
-        results: RegSpan,
+        results: SlotSpan,
         func: EngineFunc,
         mut instance: Option<Instance>,
     ) -> Result<(), Error> {
@@ -328,7 +328,7 @@ impl Executor<'_> {
         self.prepare_compiled_func_call::<C>(store, results, func, None)
     }
 
-    /// Returns the `results` [`RegSpan`] of the top-most [`CallFrame`] on the [`CallStack`].
+    /// Returns the `results` [`SlotSpan`] of the top-most [`CallFrame`] on the [`CallStack`].
     ///
     /// # Note
     ///
@@ -337,7 +337,7 @@ impl Executor<'_> {
     ///
     /// [`CallStack`]: crate::engine::executor::stack::CallStack
     #[inline(always)]
-    fn caller_results(&self) -> RegSpan {
+    fn caller_results(&self) -> SlotSpan {
         self.stack
             .calls
             .peek()
@@ -350,7 +350,7 @@ impl Executor<'_> {
     pub fn execute_call_internal_0(
         &mut self,
         store: &mut StoreInner,
-        results: RegSpan,
+        results: SlotSpan,
         func: EngineFunc,
     ) -> Result<(), Error> {
         self.prepare_compiled_func_call::<marker::NestedCall0>(store, results, func, None)
@@ -361,7 +361,7 @@ impl Executor<'_> {
     pub fn execute_call_internal(
         &mut self,
         store: &mut StoreInner,
-        results: RegSpan,
+        results: SlotSpan,
         func: EngineFunc,
     ) -> Result<(), Error> {
         self.prepare_compiled_func_call::<marker::NestedCall>(store, results, func, None)
@@ -399,7 +399,7 @@ impl Executor<'_> {
     pub fn execute_call_imported_0(
         &mut self,
         store: &mut PrunedStore,
-        results: RegSpan,
+        results: SlotSpan,
         func: index::Func,
     ) -> Result<(), Error> {
         let func = self.get_func(func);
@@ -411,7 +411,7 @@ impl Executor<'_> {
     pub fn execute_call_imported(
         &mut self,
         store: &mut PrunedStore,
-        results: RegSpan,
+        results: SlotSpan,
         func: index::Func,
     ) -> Result<(), Error> {
         let func = self.get_func(func);
@@ -423,7 +423,7 @@ impl Executor<'_> {
     fn execute_call_imported_impl<C: CallContext>(
         &mut self,
         store: &mut PrunedStore,
-        results: Option<RegSpan>,
+        results: Option<SlotSpan>,
         func: &Func,
     ) -> Result<ControlFlow, Error> {
         match store.inner().resolve_func(func) {
@@ -460,7 +460,7 @@ impl Executor<'_> {
     fn execute_host_func<C: CallContext>(
         &mut self,
         store: &mut PrunedStore,
-        results: Option<RegSpan>,
+        results: Option<SlotSpan>,
         func: &Func,
         host_func: HostFuncEntity,
     ) -> Result<ControlFlow, Error> {
@@ -468,8 +468,8 @@ impl Executor<'_> {
         let len_results = host_func.len_results();
         let max_inout = usize::from(len_params.max(len_results));
         let instance = *self.stack.calls.instance_expect();
-        // We have to reinstantiate the `self.sp` [`FrameRegisters`] since we just called
-        // [`ValueStack::reserve`] which might invalidate all live [`FrameRegisters`].
+        // We have to reinstantiate the `self.sp` [`FrameSlots`] since we just called
+        // [`ValueStack::reserve`] which might invalidate all live [`FrameSlots`].
         let (caller, popped_instance) = match <C as CallContext>::KIND {
             CallKind::Nested => self.stack.calls.peek().copied().map(|frame| (frame, None)),
             CallKind::Tail => self.stack.calls.pop(),
@@ -613,7 +613,7 @@ impl Executor<'_> {
     pub fn execute_call_indirect_0(
         &mut self,
         store: &mut PrunedStore,
-        results: RegSpan,
+        results: SlotSpan,
         func_type: index::FuncType,
     ) -> Result<(), Error> {
         let (index, table) = self.pull_call_indirect_params();
@@ -631,7 +631,7 @@ impl Executor<'_> {
     pub fn execute_call_indirect_0_imm16(
         &mut self,
         store: &mut PrunedStore,
-        results: RegSpan,
+        results: SlotSpan,
         func_type: index::FuncType,
     ) -> Result<(), Error> {
         let (index, table) = self.pull_call_indirect_params_imm16();
@@ -649,7 +649,7 @@ impl Executor<'_> {
     pub fn execute_call_indirect(
         &mut self,
         store: &mut PrunedStore,
-        results: RegSpan,
+        results: SlotSpan,
         func_type: index::FuncType,
     ) -> Result<(), Error> {
         let (index, table) = self.pull_call_indirect_params();
@@ -667,7 +667,7 @@ impl Executor<'_> {
     pub fn execute_call_indirect_imm16(
         &mut self,
         store: &mut PrunedStore,
-        results: RegSpan,
+        results: SlotSpan,
         func_type: index::FuncType,
     ) -> Result<(), Error> {
         let (index, table) = self.pull_call_indirect_params_imm16();
@@ -685,7 +685,7 @@ impl Executor<'_> {
     fn execute_call_indirect_impl<C: CallContext>(
         &mut self,
         store: &mut PrunedStore,
-        results: Option<RegSpan>,
+        results: Option<SlotSpan>,
         func_type: index::FuncType,
         index: u64,
         table: index::Table,

--- a/crates/wasmi/src/engine/executor/instrs/comparison.rs
+++ b/crates/wasmi/src/engine/executor/instrs/comparison.rs
@@ -1,7 +1,7 @@
 use super::{Executor, UntypedValueCmpExt};
 use crate::{
     core::wasm,
-    ir::{Const16, Reg},
+    ir::{Const16, Slot},
 };
 
 #[cfg(doc)]
@@ -43,7 +43,7 @@ macro_rules! impl_comparison_imm16_rhs {
     ( $( ($ty:ty, Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Const16<$ty>) {
+            pub fn $fn_name(&mut self, result: Slot, lhs: Slot, rhs: Const16<$ty>) {
                 self.execute_binary_imm16_rhs(result, lhs, rhs, $op)
             }
         )*
@@ -72,7 +72,7 @@ macro_rules! impl_comparison_imm16_lhs {
     ( $( ($ty:ty, Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, lhs: Const16<$ty>, rhs: Reg) {
+            pub fn $fn_name(&mut self, result: Slot, lhs: Const16<$ty>, rhs: Slot) {
                 self.execute_binary_imm16_lhs(result, lhs, rhs, $op)
             }
         )*

--- a/crates/wasmi/src/engine/executor/instrs/conversion.rs
+++ b/crates/wasmi/src/engine/executor/instrs/conversion.rs
@@ -1,5 +1,5 @@
 use super::Executor;
-use crate::{core::wasm, ir::Reg, Error};
+use crate::{core::wasm, ir::Slot, Error};
 
 #[cfg(doc)]
 use crate::ir::Op;
@@ -8,7 +8,7 @@ macro_rules! impl_fallible_conversion_impls {
     ( $( (Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, input: Reg) -> Result<(), Error> {
+            pub fn $fn_name(&mut self, result: Slot, input: Slot) -> Result<(), Error> {
                 self.try_execute_unary(result, input, $op)
             }
         )*

--- a/crates/wasmi/src/engine/executor/instrs/copy.rs
+++ b/crates/wasmi/src/engine/executor/instrs/copy.rs
@@ -2,31 +2,31 @@ use super::{Executor, InstructionPtr};
 use crate::{
     core::UntypedVal,
     engine::utils::unreachable_unchecked,
-    ir::{AnyConst32, Const32, FixedRegSpan, Op, Reg, RegSpan},
+    ir::{AnyConst32, Const32, FixedSlotSpan, Op, Slot, SlotSpan},
 };
 use core::slice;
 
 impl Executor<'_> {
     /// Executes a generic `copy` [`Op`].
-    fn execute_copy_impl<T>(&mut self, result: Reg, value: T, f: fn(&mut Self, T) -> UntypedVal) {
+    fn execute_copy_impl<T>(&mut self, result: Slot, value: T, f: fn(&mut Self, T) -> UntypedVal) {
         let value = f(self, value);
         self.set_register(result, value);
         self.next_instr()
     }
 
     /// Executes an [`Op::Copy`].
-    pub fn execute_copy(&mut self, result: Reg, value: Reg) {
+    pub fn execute_copy(&mut self, result: Slot, value: Slot) {
         self.execute_copy_impl(result, value, |this, value| this.get_register(value))
     }
 
     /// Executes an [`Op::Copy2`].
-    pub fn execute_copy_2(&mut self, results: FixedRegSpan<2>, values: [Reg; 2]) {
+    pub fn execute_copy_2(&mut self, results: FixedSlotSpan<2>, values: [Slot; 2]) {
         self.execute_copy_2_impl(results, values);
         self.next_instr()
     }
 
     /// Internal implementation of [`Op::Copy2`] execution.
-    fn execute_copy_2_impl(&mut self, results: FixedRegSpan<2>, values: [Reg; 2]) {
+    fn execute_copy_2_impl(&mut self, results: FixedSlotSpan<2>, values: [Slot; 2]) {
         let result0 = results.span().head();
         let result1 = result0.next();
         // We need `tmp` in case `results[0] == values[1]` to avoid overwriting `values[1]` before reading it.
@@ -36,17 +36,17 @@ impl Executor<'_> {
     }
 
     /// Executes an [`Op::CopyImm32`].
-    pub fn execute_copy_imm32(&mut self, result: Reg, value: AnyConst32) {
+    pub fn execute_copy_imm32(&mut self, result: Slot, value: AnyConst32) {
         self.execute_copy_impl(result, value, |_, value| UntypedVal::from(u32::from(value)))
     }
 
     /// Executes an [`Op::CopyI64Imm32`].
-    pub fn execute_copy_i64imm32(&mut self, result: Reg, value: Const32<i64>) {
+    pub fn execute_copy_i64imm32(&mut self, result: Slot, value: Const32<i64>) {
         self.execute_copy_impl(result, value, |_, value| UntypedVal::from(i64::from(value)))
     }
 
     /// Executes an [`Op::CopyF64Imm32`].
-    pub fn execute_copy_f64imm32(&mut self, result: Reg, value: Const32<f64>) {
+    pub fn execute_copy_f64imm32(&mut self, result: Slot, value: Const32<f64>) {
         self.execute_copy_impl(result, value, |_, value| UntypedVal::from(f64::from(value)))
     }
 
@@ -57,13 +57,13 @@ impl Executor<'_> {
     /// - This instruction assumes that `results` and `values` do _not_ overlap
     ///   and thus can copy all the elements without a costly temporary buffer.
     /// - If `results` and `values` _do_ overlap [`Op::CopySpan`] is used.
-    pub fn execute_copy_span(&mut self, results: RegSpan, values: RegSpan, len: u16) {
+    pub fn execute_copy_span(&mut self, results: SlotSpan, values: SlotSpan, len: u16) {
         self.execute_copy_span_impl(results, values, len);
         self.next_instr();
     }
 
     /// Internal implementation of [`Op::CopySpan`] execution.
-    pub fn execute_copy_span_impl(&mut self, results: RegSpan, values: RegSpan, len: u16) {
+    pub fn execute_copy_span_impl(&mut self, results: SlotSpan, values: SlotSpan, len: u16) {
         let results = results.iter(len);
         let values = values.iter(len);
         for (result, value) in results.into_iter().zip(values.into_iter()) {
@@ -73,7 +73,7 @@ impl Executor<'_> {
     }
 
     /// Executes an [`Op::CopyMany`].
-    pub fn execute_copy_many(&mut self, results: RegSpan, values: [Reg; 2]) {
+    pub fn execute_copy_many(&mut self, results: SlotSpan, values: [Slot; 2]) {
         self.ip.add(1);
         self.ip = self.execute_copy_many_impl(self.ip, results, &values);
         self.next_instr()
@@ -83,12 +83,12 @@ impl Executor<'_> {
     pub fn execute_copy_many_impl(
         &mut self,
         ip: InstructionPtr,
-        results: RegSpan,
-        values: &[Reg],
+        results: SlotSpan,
+        values: &[Slot],
     ) -> InstructionPtr {
         let mut ip = ip;
         let mut result = results.head();
-        let mut copy_values = |values: &[Reg]| {
+        let mut copy_values = |values: &[Slot]| {
             for &value in values {
                 let value = self.get_register(value);
                 self.set_register(result, value);
@@ -96,14 +96,14 @@ impl Executor<'_> {
             }
         };
         copy_values(values);
-        while let Op::RegisterList { regs } = ip.get() {
+        while let Op::SlotList { regs } = ip.get() {
             copy_values(regs);
             ip.add(1);
         }
         let values = match ip.get() {
-            Op::Register { reg } => slice::from_ref(reg),
-            Op::Register2 { regs } => regs,
-            Op::Register3 { regs } => regs,
+            Op::Slot { reg } => slice::from_ref(reg),
+            Op::Slot2 { regs } => regs,
+            Op::Slot3 { regs } => regs,
             unexpected => {
                 // Safety: Wasmi translator guarantees that register-list finalizer exists.
                 unsafe {

--- a/crates/wasmi/src/engine/executor/instrs/global.rs
+++ b/crates/wasmi/src/engine/executor/instrs/global.rs
@@ -1,7 +1,7 @@
 use super::Executor;
 use crate::{
     core::{hint, UntypedVal},
-    ir::{index, Const16, Reg},
+    ir::{index, Const16, Slot},
     store::StoreInner,
 };
 
@@ -10,7 +10,7 @@ use crate::ir::Op;
 
 impl Executor<'_> {
     /// Executes an [`Op::GlobalGet`].
-    pub fn execute_global_get(&mut self, store: &StoreInner, result: Reg, global: index::Global) {
+    pub fn execute_global_get(&mut self, store: &StoreInner, result: Slot, global: index::Global) {
         let value = match u32::from(global) {
             0 => unsafe { self.cache.global.get() },
             _ => {
@@ -28,7 +28,7 @@ impl Executor<'_> {
         &mut self,
         store: &mut StoreInner,
         global: index::Global,
-        input: Reg,
+        input: Slot,
     ) {
         let input = self.get_register(input);
         self.execute_global_set_impl(store, global, input)

--- a/crates/wasmi/src/engine/executor/instrs/load.rs
+++ b/crates/wasmi/src/engine/executor/instrs/load.rs
@@ -1,7 +1,7 @@
 use super::Executor;
 use crate::{
     core::{wasm, UntypedVal, WriteAs},
-    ir::{index::Memory, Address32, Offset16, Offset64, Offset64Hi, Offset64Lo, Reg},
+    ir::{index::Memory, Address32, Offset16, Offset64, Offset64Hi, Offset64Lo, Slot},
     store::StoreInner,
     Error,
     TrapCode,
@@ -21,8 +21,8 @@ type WasmLoadAtOp<T> = fn(memory: &[u8], address: usize) -> Result<T, TrapCode>;
 
 impl Executor<'_> {
     /// Returns the register `value` and `offset` parameters for a `load` [`Op`].
-    fn fetch_ptr_and_offset_hi(&self) -> (Reg, Offset64Hi) {
-        // Safety: Wasmi translation guarantees that `Op::RegisterAndImm32` exists.
+    fn fetch_ptr_and_offset_hi(&self) -> (Slot, Offset64Hi) {
+        // Safety: Wasmi translation guarantees that `Op::SlotAndImm32` exists.
         unsafe { self.fetch_reg_and_offset_hi() }
     }
 
@@ -43,7 +43,7 @@ impl Executor<'_> {
         &mut self,
         store: &StoreInner,
         memory: Memory,
-        result: Reg,
+        result: Slot,
         address: u64,
         offset: Offset64,
         load_extend: WasmLoadOp<T>,
@@ -74,7 +74,7 @@ impl Executor<'_> {
         &mut self,
         store: &StoreInner,
         memory: Memory,
-        result: Reg,
+        result: Slot,
         address: Address32,
         load_extend_at: WasmLoadAtOp<T>,
     ) -> Result<(), Error>
@@ -102,7 +102,7 @@ impl Executor<'_> {
     /// - `i64.load32_u`
     fn execute_load_extend_mem0<T>(
         &mut self,
-        result: Reg,
+        result: Slot,
         address: u64,
         offset: Offset64,
         load_extend: WasmLoadOp<T>,
@@ -120,7 +120,7 @@ impl Executor<'_> {
     fn execute_load_impl<T>(
         &mut self,
         store: &StoreInner,
-        result: Reg,
+        result: Slot,
         offset_lo: Offset64Lo,
         load_extend: WasmLoadOp<T>,
     ) -> Result<(), Error>
@@ -139,7 +139,7 @@ impl Executor<'_> {
     fn execute_load_at_impl<T>(
         &mut self,
         store: &StoreInner,
-        result: Reg,
+        result: Slot,
         address: Address32,
         load_extend_at: WasmLoadAtOp<T>,
     ) -> Result<(), Error>
@@ -154,8 +154,8 @@ impl Executor<'_> {
     /// Executes a generic `load_offset16` [`Op`].
     fn execute_load_offset16_impl<T>(
         &mut self,
-        result: Reg,
-        ptr: Reg,
+        result: Slot,
+        ptr: Slot,
         offset: Offset16,
         load_extend: WasmLoadOp<T>,
     ) -> Result<(), Error>
@@ -182,17 +182,17 @@ macro_rules! impl_execute_load {
     ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_load), "`].")]
-            pub fn $fn_load(&mut self, store: &StoreInner, result: Reg, offset_lo: Offset64Lo) -> Result<(), Error> {
+            pub fn $fn_load(&mut self, store: &StoreInner, result: Slot, offset_lo: Offset64Lo) -> Result<(), Error> {
                 self.execute_load_impl(store, result, offset_lo, $load_fn)
             }
 
             #[doc = concat!("Executes an [`Op::", stringify!($var_load_at), "`].")]
-            pub fn $fn_load_at(&mut self, store: &StoreInner, result: Reg, address: Address32) -> Result<(), Error> {
+            pub fn $fn_load_at(&mut self, store: &StoreInner, result: Slot, address: Address32) -> Result<(), Error> {
                 self.execute_load_at_impl(store, result, address, $load_at_fn)
             }
 
             #[doc = concat!("Executes an [`Op::", stringify!($var_load_off16), "`].")]
-            pub fn $fn_load_off16(&mut self, result: Reg, ptr: Reg, offset: Offset16) -> Result<(), Error> {
+            pub fn $fn_load_off16(&mut self, result: Slot, ptr: Slot, offset: Offset16) -> Result<(), Error> {
                 self.execute_load_offset16_impl::<$ty>(result, ptr, offset, $load_fn)
             }
         )*

--- a/crates/wasmi/src/engine/executor/instrs/memory.rs
+++ b/crates/wasmi/src/engine/executor/instrs/memory.rs
@@ -5,7 +5,7 @@ use crate::{
     ir::{
         index::{Data, Memory},
         Op,
-        Reg,
+        Slot,
     },
     store::{PrunedStore, StoreInner},
     Error,
@@ -51,13 +51,13 @@ impl Executor<'_> {
     }
 
     /// Executes an [`Op::MemorySize`].
-    pub fn execute_memory_size(&mut self, store: &StoreInner, result: Reg, memory: Memory) {
+    pub fn execute_memory_size(&mut self, store: &StoreInner, result: Slot, memory: Memory) {
         self.execute_memory_size_impl(store, result, memory);
         self.next_instr()
     }
 
     /// Underlying implementation of [`Op::MemorySize`].
-    fn execute_memory_size_impl(&mut self, store: &StoreInner, result: Reg, memory: Memory) {
+    fn execute_memory_size_impl(&mut self, store: &StoreInner, result: Slot, memory: Memory) {
         let memory = self.get_memory(memory);
         let size = store.resolve_memory(&memory).size();
         self.set_register(result, size);
@@ -67,8 +67,8 @@ impl Executor<'_> {
     pub fn execute_memory_grow(
         &mut self,
         store: &mut PrunedStore,
-        result: Reg,
-        delta: Reg,
+        result: Slot,
+        delta: Slot,
     ) -> Result<(), Error> {
         let delta: u64 = self.get_register_as(delta);
         let memory = self.fetch_memory_index(1);
@@ -111,9 +111,9 @@ impl Executor<'_> {
     pub fn execute_memory_copy(
         &mut self,
         store: &mut StoreInner,
-        dst: Reg,
-        src: Reg,
-        len: Reg,
+        dst: Slot,
+        src: Slot,
+        len: Slot,
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let src: u64 = self.get_register_as(src);
@@ -183,9 +183,9 @@ impl Executor<'_> {
     pub fn execute_memory_fill(
         &mut self,
         store: &mut StoreInner,
-        dst: Reg,
-        value: Reg,
-        len: Reg,
+        dst: Slot,
+        value: Slot,
+        len: Slot,
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let value: u8 = self.get_register_as(value);
@@ -197,9 +197,9 @@ impl Executor<'_> {
     pub fn execute_memory_fill_imm(
         &mut self,
         store: &mut StoreInner,
-        dst: Reg,
+        dst: Slot,
         value: u8,
-        len: Reg,
+        len: Slot,
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let len: u64 = self.get_register_as(len);
@@ -238,9 +238,9 @@ impl Executor<'_> {
     pub fn execute_memory_init(
         &mut self,
         store: &mut StoreInner,
-        dst: Reg,
-        src: Reg,
-        len: Reg,
+        dst: Slot,
+        src: Slot,
+        len: Slot,
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let src: u32 = self.get_register_as(src);

--- a/crates/wasmi/src/engine/executor/instrs/return_.rs
+++ b/crates/wasmi/src/engine/executor/instrs/return_.rs
@@ -1,8 +1,8 @@
 use super::{ControlFlow, Executor, InstructionPtr};
 use crate::{
     core::UntypedVal,
-    engine::{executor::stack::FrameRegisters, utils::unreachable_unchecked},
-    ir::{AnyConst32, BoundedRegSpan, Const32, Op, Reg, RegSpan},
+    engine::{executor::stack::FrameSlots, utils::unreachable_unchecked},
+    ir::{AnyConst32, BoundedSlotSpan, Const32, Op, Slot, SlotSpan},
     store::StoreInner,
 };
 use core::slice;
@@ -42,10 +42,10 @@ impl Executor<'_> {
         self.return_impl(store)
     }
 
-    /// Returns the [`FrameRegisters`] of the caller and the [`RegSpan`] of the results.
+    /// Returns the [`FrameSlots`] of the caller and the [`SlotSpan`] of the results.
     ///
-    /// The returned [`FrameRegisters`] is valid for all [`Reg`] in the returned [`RegSpan`].
-    fn return_caller_results(&mut self) -> (FrameRegisters, RegSpan) {
+    /// The returned [`FrameSlots`] is valid for all [`Slot`] in the returned [`SlotSpan`].
+    fn return_caller_results(&mut self) -> (FrameSlots, SlotSpan) {
         let (callee, caller) = self
             .stack
             .calls
@@ -70,7 +70,7 @@ impl Executor<'_> {
                 // In this case we transfer the single return `value` to the root
                 // register span of the entire value stack which is simply its zero index.
                 let dst_sp = self.stack.values.root_stack_ptr();
-                let results = RegSpan::new(Reg::from(0));
+                let results = SlotSpan::new(Slot::from(0));
                 (dst_sp, results)
             }
         }
@@ -93,26 +93,34 @@ impl Executor<'_> {
         self.return_impl(store)
     }
 
-    /// Execute an [`Op::ReturnReg`] returning a single [`Reg`] value.
-    pub fn execute_return_reg(&mut self, store: &mut StoreInner, value: Reg) -> ControlFlow {
+    /// Execute an [`Op::ReturnSlot`] returning a single [`Slot`] value.
+    pub fn execute_return_reg(&mut self, store: &mut StoreInner, value: Slot) -> ControlFlow {
         self.execute_return_value(store, value, Self::get_register)
     }
 
-    /// Execute an [`Op::ReturnReg2`] returning two [`Reg`] values.
-    pub fn execute_return_reg2(&mut self, store: &mut StoreInner, values: [Reg; 2]) -> ControlFlow {
+    /// Execute an [`Op::ReturnSlot2`] returning two [`Slot`] values.
+    pub fn execute_return_reg2(
+        &mut self,
+        store: &mut StoreInner,
+        values: [Slot; 2],
+    ) -> ControlFlow {
         self.execute_return_reg_n_impl::<2>(store, values)
     }
 
-    /// Execute an [`Op::ReturnReg3`] returning three [`Reg`] values.
-    pub fn execute_return_reg3(&mut self, store: &mut StoreInner, values: [Reg; 3]) -> ControlFlow {
+    /// Execute an [`Op::ReturnSlot3`] returning three [`Slot`] values.
+    pub fn execute_return_reg3(
+        &mut self,
+        store: &mut StoreInner,
+        values: [Slot; 3],
+    ) -> ControlFlow {
         self.execute_return_reg_n_impl::<3>(store, values)
     }
 
-    /// Executes an [`Op::ReturnReg2`] or [`Op::ReturnReg3`] generically.
+    /// Executes an [`Op::ReturnSlot2`] or [`Op::ReturnSlot3`] generically.
     fn execute_return_reg_n_impl<const N: usize>(
         &mut self,
         store: &mut StoreInner,
-        values: [Reg; N],
+        values: [Slot; N],
     ) -> ControlFlow {
         let (mut caller_sp, results) = self.return_caller_results();
         debug_assert!(u16::try_from(N).is_ok());
@@ -158,7 +166,7 @@ impl Executor<'_> {
     pub fn execute_return_span(
         &mut self,
         store: &mut StoreInner,
-        values: BoundedRegSpan,
+        values: BoundedSlotSpan,
     ) -> ControlFlow {
         let (mut caller_sp, results) = self.return_caller_results();
         let results = results.iter(values.len());
@@ -174,7 +182,11 @@ impl Executor<'_> {
     }
 
     /// Execute an [`Op::ReturnMany`] returning many values.
-    pub fn execute_return_many(&mut self, store: &mut StoreInner, values: [Reg; 3]) -> ControlFlow {
+    pub fn execute_return_many(
+        &mut self,
+        store: &mut StoreInner,
+        values: [Slot; 3],
+    ) -> ControlFlow {
         self.ip.add(1);
         self.copy_many_return_values(self.ip, &values);
         self.return_impl(store)
@@ -187,10 +199,10 @@ impl Executor<'_> {
     /// Used by the execution logic for
     ///
     /// - [`Op::ReturnMany`]
-    pub fn copy_many_return_values(&mut self, ip: InstructionPtr, values: &[Reg]) {
+    pub fn copy_many_return_values(&mut self, ip: InstructionPtr, values: &[Slot]) {
         let (mut caller_sp, results) = self.return_caller_results();
         let mut result = results.head();
-        let mut copy_results = |values: &[Reg]| {
+        let mut copy_results = |values: &[Slot]| {
             for value in values {
                 let value = self.get_register(*value);
                 // Safety: The `callee.results()` always refer to a span of valid
@@ -203,14 +215,14 @@ impl Executor<'_> {
         };
         copy_results(values);
         let mut ip = ip;
-        while let Op::RegisterList { regs } = ip.get() {
+        while let Op::SlotList { regs } = ip.get() {
             copy_results(regs);
             ip.add(1);
         }
         let values = match ip.get() {
-            Op::Register { reg } => slice::from_ref(reg),
-            Op::Register2 { regs } => regs,
-            Op::Register3 { regs } => regs,
+            Op::Slot { reg } => slice::from_ref(reg),
+            Op::Slot2 { regs } => regs,
+            Op::Slot3 { regs } => regs,
             unexpected => {
                 // Safety: Wasmi translation guarantees that a register-list finalizer exists.
                 unsafe {

--- a/crates/wasmi/src/engine/executor/instrs/store.rs
+++ b/crates/wasmi/src/engine/executor/instrs/store.rs
@@ -11,7 +11,7 @@ use crate::{
         Offset64,
         Offset64Hi,
         Offset64Lo,
-        Reg,
+        Slot,
     },
     store::StoreInner,
     Error,
@@ -42,7 +42,7 @@ impl Executor<'_> {
         match addr.get().filter_imm16_and_offset_hi::<T>() {
             Ok(value) => value,
             Err(instr) => unsafe {
-                unreachable_unchecked!("expected an `Op::RegisterAndImm32` but found: {instr:?}")
+                unreachable_unchecked!("expected an `Op::SlotAndImm32` but found: {instr:?}")
             },
         }
     }
@@ -125,7 +125,7 @@ impl Executor<'_> {
     fn execute_store<T>(
         &mut self,
         store: &mut StoreInner,
-        ptr: Reg,
+        ptr: Slot,
         offset_lo: Offset64Lo,
         store_op: WasmStoreOp<T>,
     ) -> Result<(), Error>
@@ -144,7 +144,7 @@ impl Executor<'_> {
     fn execute_store_imm<T>(
         &mut self,
         store: &mut StoreInner,
-        ptr: Reg,
+        ptr: Slot,
         offset_lo: Offset64Lo,
         offset_hi: Offset64Hi,
         value: T,
@@ -162,9 +162,9 @@ impl Executor<'_> {
 
     fn execute_store_offset16<T>(
         &mut self,
-        ptr: Reg,
+        ptr: Slot,
         offset: Offset16,
-        value: Reg,
+        value: Slot,
         store_op: WasmStoreOp<T>,
     ) -> Result<(), Error>
     where
@@ -178,7 +178,7 @@ impl Executor<'_> {
 
     fn execute_store_offset16_imm16<T>(
         &mut self,
-        ptr: Reg,
+        ptr: Slot,
         offset: Offset16,
         value: T,
         store_op: WasmStoreOp<T>,
@@ -195,7 +195,7 @@ impl Executor<'_> {
         &mut self,
         store: &mut StoreInner,
         address: Address32,
-        value: Reg,
+        value: Slot,
         store_at_op: WasmStoreAtOp<T>,
     ) -> Result<(), Error>
     where
@@ -243,7 +243,7 @@ macro_rules! impl_execute_istore {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_store_imm), "`].")]
             #[allow(clippy::cast_lossless)]
-            pub fn $fn_store_imm(&mut self, store: &mut StoreInner, ptr: Reg, offset_lo: Offset64Lo) -> Result<(), Error> {
+            pub fn $fn_store_imm(&mut self, store: &mut StoreInner, ptr: Slot, offset_lo: Offset64Lo) -> Result<(), Error> {
                 let (value, offset_hi) = self.fetch_value_and_offset_imm::<$to_ty>();
                 self.execute_store_imm::<$ty>(store, ptr, offset_lo, offset_hi, value as $ty, $store_fn)
             }
@@ -252,7 +252,7 @@ macro_rules! impl_execute_istore {
             #[allow(clippy::cast_lossless)]
             pub fn $fn_store_off16_imm16(
                 &mut self,
-                ptr: Reg,
+                ptr: Slot,
                 offset: Offset16,
                 value: $from_ty,
             ) -> Result<(), Error> {
@@ -325,22 +325,22 @@ macro_rules! impl_execute_istore_trunc {
             }
 
             #[doc = concat!("Executes an [`Op::", stringify!($var_store), "`].")]
-            pub fn $fn_store(&mut self, store: &mut StoreInner, ptr: Reg, offset_lo: Offset64Lo) -> Result<(), Error> {
+            pub fn $fn_store(&mut self, store: &mut StoreInner, ptr: Slot, offset_lo: Offset64Lo) -> Result<(), Error> {
                 self.execute_store::<$ty>(store, ptr, offset_lo, $store_fn)
             }
 
             #[doc = concat!("Executes an [`Op::", stringify!($var_store_off16), "`].")]
             pub fn $fn_store_off16(
                 &mut self,
-                ptr: Reg,
+                ptr: Slot,
                 offset: Offset16,
-                value: Reg,
+                value: Slot,
             ) -> Result<(), Error> {
                 self.execute_store_offset16::<$ty>(ptr, offset, value, $store_fn)
             }
 
             #[doc = concat!("Executes an [`Op::", stringify!($var_store_at), "`].")]
-            pub fn $fn_store_at(&mut self, store: &mut StoreInner, address: Address32, value: Reg) -> Result<(), Error> {
+            pub fn $fn_store_at(&mut self, store: &mut StoreInner, address: Address32, value: Slot) -> Result<(), Error> {
                 self.execute_store_at::<$ty>(store, address, value, $store_at_fn)
             }
         )*
@@ -424,22 +424,22 @@ macro_rules! impl_execute_store {
     ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_store), "`].")]
-            pub fn $fn_store(&mut self, store: &mut StoreInner, ptr: Reg, offset_lo: Offset64Lo) -> Result<(), Error> {
+            pub fn $fn_store(&mut self, store: &mut StoreInner, ptr: Slot, offset_lo: Offset64Lo) -> Result<(), Error> {
                 self.execute_store::<$ty>(store, ptr, offset_lo, $store_fn)
             }
 
             #[doc = concat!("Executes an [`Op::", stringify!($var_store_off16), "`].")]
             pub fn $fn_store_off16(
                 &mut self,
-                ptr: Reg,
+                ptr: Slot,
                 offset: Offset16,
-                value: Reg,
+                value: Slot,
             ) -> Result<(), Error> {
                 self.execute_store_offset16::<$ty>(ptr, offset, value, $store_fn)
             }
 
             #[doc = concat!("Executes an [`Op::", stringify!($var_store_at), "`].")]
-            pub fn $fn_store_at(&mut self, store: &mut StoreInner, address: Address32, value: Reg) -> Result<(), Error> {
+            pub fn $fn_store_at(&mut self, store: &mut StoreInner, address: Address32, value: Slot) -> Result<(), Error> {
                 self.execute_store_at::<$ty>(store, address, value, $store_at_fn)
             }
         )*

--- a/crates/wasmi/src/engine/executor/instrs/table.rs
+++ b/crates/wasmi/src/engine/executor/instrs/table.rs
@@ -7,7 +7,7 @@ use crate::{
         index::{Elem, Table},
         Const32,
         Op,
-        Reg,
+        Slot,
     },
     store::{PrunedStore, StoreInner},
     Error,
@@ -49,8 +49,8 @@ impl Executor<'_> {
     pub fn execute_table_get(
         &mut self,
         store: &StoreInner,
-        result: Reg,
-        index: Reg,
+        result: Slot,
+        index: Slot,
     ) -> Result<(), Error> {
         let index: u64 = self.get_register_as(index);
         self.execute_table_get_impl(store, result, index)
@@ -60,7 +60,7 @@ impl Executor<'_> {
     pub fn execute_table_get_imm(
         &mut self,
         store: &StoreInner,
-        result: Reg,
+        result: Slot,
         index: Const32<u64>,
     ) -> Result<(), Error> {
         let index: u64 = index.into();
@@ -71,7 +71,7 @@ impl Executor<'_> {
     fn execute_table_get_impl(
         &mut self,
         store: &StoreInner,
-        result: Reg,
+        result: Slot,
         index: u64,
     ) -> Result<(), Error> {
         let table_index = self.fetch_table_index(1);
@@ -85,13 +85,13 @@ impl Executor<'_> {
     }
 
     /// Executes an [`Op::TableSize`].
-    pub fn execute_table_size(&mut self, store: &StoreInner, result: Reg, table_index: Table) {
+    pub fn execute_table_size(&mut self, store: &StoreInner, result: Slot, table_index: Table) {
         self.execute_table_size_impl(store, result, table_index);
         self.next_instr();
     }
 
     /// Executes a generic `table.size` instruction.
-    fn execute_table_size_impl(&mut self, store: &StoreInner, result: Reg, table_index: Table) {
+    fn execute_table_size_impl(&mut self, store: &StoreInner, result: Slot, table_index: Table) {
         let table = self.get_table(table_index);
         let size = store.resolve_table(&table).size();
         self.set_register(result, size);
@@ -101,8 +101,8 @@ impl Executor<'_> {
     pub fn execute_table_set(
         &mut self,
         store: &mut StoreInner,
-        index: Reg,
-        value: Reg,
+        index: Slot,
+        value: Slot,
     ) -> Result<(), Error> {
         let index: u64 = self.get_register_as(index);
         self.execute_table_set_impl(store, index, value)
@@ -113,7 +113,7 @@ impl Executor<'_> {
         &mut self,
         store: &mut StoreInner,
         index: Const32<u64>,
-        value: Reg,
+        value: Slot,
     ) -> Result<(), Error> {
         let index: u64 = index.into();
         self.execute_table_set_impl(store, index, value)
@@ -124,7 +124,7 @@ impl Executor<'_> {
         &mut self,
         store: &mut StoreInner,
         index: u64,
-        value: Reg,
+        value: Slot,
     ) -> Result<(), Error> {
         let table_index = self.fetch_table_index(1);
         let table = self.get_table(table_index);
@@ -140,9 +140,9 @@ impl Executor<'_> {
     pub fn execute_table_copy(
         &mut self,
         store: &mut StoreInner,
-        dst: Reg,
-        src: Reg,
-        len: Reg,
+        dst: Slot,
+        src: Slot,
+        len: Slot,
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let src: u64 = self.get_register_as(src);
@@ -170,9 +170,9 @@ impl Executor<'_> {
     pub fn execute_table_init(
         &mut self,
         store: &mut StoreInner,
-        dst: Reg,
-        src: Reg,
-        len: Reg,
+        dst: Slot,
+        src: Slot,
+        len: Slot,
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let src: u32 = self.get_register_as(src);
@@ -191,9 +191,9 @@ impl Executor<'_> {
     pub fn execute_table_fill(
         &mut self,
         store: &mut StoreInner,
-        dst: Reg,
-        len: Reg,
-        value: Reg,
+        dst: Slot,
+        len: Slot,
+        value: Slot,
     ) -> Result<(), Error> {
         let dst: u64 = self.get_register_as(dst);
         let len: u64 = self.get_register_as(len);
@@ -209,9 +209,9 @@ impl Executor<'_> {
     pub fn execute_table_grow(
         &mut self,
         store: &mut PrunedStore,
-        result: Reg,
-        delta: Reg,
-        value: Reg,
+        result: Slot,
+        delta: Slot,
+        value: Slot,
     ) -> Result<(), Error> {
         let delta: u64 = self.get_register_as(delta);
         let table_index = self.fetch_table_index(1);

--- a/crates/wasmi/src/engine/executor/instrs/unary.rs
+++ b/crates/wasmi/src/engine/executor/instrs/unary.rs
@@ -1,5 +1,5 @@
 use super::Executor;
-use crate::{core::wasm, ir::Reg};
+use crate::{core::wasm, ir::Slot};
 
 #[cfg(doc)]
 use crate::ir::Op;

--- a/crates/wasmi/src/engine/executor/instrs/utils.rs
+++ b/crates/wasmi/src/engine/executor/instrs/utils.rs
@@ -1,6 +1,6 @@
 use super::Executor;
 use crate::{
-    ir::{index::Memory, Offset64Hi, Reg},
+    ir::{index::Memory, Offset64Hi, Slot},
     store::StoreInner,
 };
 
@@ -11,7 +11,7 @@ macro_rules! impl_unary_executors {
     ( $( (Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, input: Reg) {
+            pub fn $fn_name(&mut self, result: Slot, input: Slot) {
                 self.execute_unary(result, input, $op)
             }
         )*
@@ -22,7 +22,7 @@ macro_rules! impl_binary_executors {
     ( $( (Op::$var_name:ident, $fn_name:ident, $op:expr) ),* $(,)? ) => {
         $(
             #[doc = concat!("Executes an [`Op::", stringify!($var_name), "`].")]
-            pub fn $fn_name(&mut self, result: Reg, lhs: Reg, rhs: Reg) {
+            pub fn $fn_name(&mut self, result: Slot, lhs: Slot, rhs: Slot) {
                 self.execute_binary(result, lhs, rhs, $op)
             }
         )*
@@ -31,8 +31,8 @@ macro_rules! impl_binary_executors {
 
 impl Executor<'_> {
     /// Returns the register `value` and `offset` parameters for a `load` [`Op`].
-    pub fn fetch_value_and_offset_hi(&self) -> (Reg, Offset64Hi) {
-        // Safety: Wasmi translation guarantees that `Op::RegisterAndImm32` exists.
+    pub fn fetch_value_and_offset_hi(&self) -> (Slot, Offset64Hi) {
+        // Safety: Wasmi translation guarantees that `Op::SlotAndImm32` exists.
         unsafe { self.fetch_reg_and_offset_hi() }
     }
 

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         ResumableCallOutOfFuel,
     },
     func::HostFuncEntity,
-    ir::{Reg, RegSpan},
+    ir::{Slot, SlotSpan},
     store::CallHooks,
     CallHook,
     Error,
@@ -270,7 +270,7 @@ impl<'engine> EngineExecutor<'engine> {
                     CallFrame::new(
                         InstructionPtr::new(compiled_func.instrs().as_ptr()),
                         offsets,
-                        RegSpan::new(Reg::from(0)),
+                        SlotSpan::new(Slot::from(0)),
                     ),
                     Some(instance),
                 )?;
@@ -314,7 +314,7 @@ impl<'engine> EngineExecutor<'engine> {
         &mut self,
         store: &mut Store<T>,
         params: impl CallParams,
-        caller_results: RegSpan,
+        caller_results: SlotSpan,
         results: Results,
     ) -> Result<<Results as CallResults>::Results, Error>
     where

--- a/crates/wasmi/src/engine/executor/stack/calls.rs
+++ b/crates/wasmi/src/engine/executor/stack/calls.rs
@@ -2,7 +2,7 @@ use super::{err_stack_overflow, BaseValueStackOffset, FrameValueStackOffset};
 use crate::{
     collections::HeadVec,
     engine::executor::InstructionPtr,
-    ir::RegSpan,
+    ir::SlotSpan,
     Instance,
     TrapCode,
 };
@@ -13,7 +13,7 @@ use crate::{
     engine::executor::stack::ValueStack,
     engine::EngineFunc,
     ir::Op,
-    ir::Reg,
+    ir::Slot,
     Global,
     Memory,
     Table,
@@ -199,7 +199,7 @@ pub struct CallFrame {
     /// Offsets of the [`CallFrame`] into the [`ValueStack`].
     offsets: StackOffsets,
     /// Span of registers were the caller expects them in its [`CallFrame`].
-    results: RegSpan,
+    results: SlotSpan,
     /// Is `true` if this [`CallFrame`] changed the currently used [`Instance`].
     ///
     /// - This flag is an optimization to reduce the amount of accesses on the
@@ -212,7 +212,7 @@ pub struct CallFrame {
 
 impl CallFrame {
     /// Creates a new [`CallFrame`].
-    pub fn new(instr_ptr: InstructionPtr, offsets: StackOffsets, results: RegSpan) -> Self {
+    pub fn new(instr_ptr: InstructionPtr, offsets: StackOffsets, results: SlotSpan) -> Self {
         Self {
             instr_ptr,
             offsets,
@@ -254,13 +254,13 @@ impl CallFrame {
         self.offsets.base
     }
 
-    /// Returns the [`RegSpan`] of the [`CallFrame`].
+    /// Returns the [`SlotSpan`] of the [`CallFrame`].
     ///
     /// # Note
     ///
-    /// The registers yielded by the returned [`RegSpan`]
+    /// The registers yielded by the returned [`SlotSpan`]
     /// refer to the [`CallFrame`] of the caller of this [`CallFrame`].
-    pub fn results(&self) -> RegSpan {
+    pub fn results(&self) -> SlotSpan {
         self.results
     }
 }

--- a/crates/wasmi/src/engine/executor/stack/mod.rs
+++ b/crates/wasmi/src/engine/executor/stack/mod.rs
@@ -3,13 +3,7 @@ mod values;
 
 pub use self::{
     calls::{CallFrame, CallStack, StackOffsets},
-    values::{
-        BaseValueStackOffset,
-        FrameParams,
-        FrameRegisters,
-        FrameValueStackOffset,
-        ValueStack,
-    },
+    values::{BaseValueStackOffset, FrameParams, FrameSlots, FrameValueStackOffset, ValueStack},
 };
 use crate::{engine::StackConfig, Instance, TrapCode};
 
@@ -70,9 +64,9 @@ impl Stack {
     ///
     /// # Safety
     ///
-    /// Any [`FrameRegisters`] allocated within the range `from..to` on the [`ValueStack`]
+    /// Any [`FrameSlots`] allocated within the range `from..to` on the [`ValueStack`]
     /// may be invalidated by this operation. It is the caller's responsibility to reinstantiate
-    /// all [`FrameRegisters`] affected by this.
+    /// all [`FrameSlots`] affected by this.
     #[inline]
     #[must_use]
     pub unsafe fn merge_call_frames(&mut self, callee: &mut CallFrame) -> Option<Instance> {

--- a/crates/wasmi/src/engine/executor/stack/values.rs
+++ b/crates/wasmi/src/engine/executor/stack/values.rs
@@ -2,7 +2,7 @@ use super::{err_stack_overflow, StackOffsets};
 use crate::{
     core::{ReadAs, UntypedVal, WriteAs},
     engine::code_map::CompiledFuncRef,
-    ir::Reg,
+    ir::Slot,
     TrapCode,
 };
 use alloc::vec::Vec;
@@ -110,15 +110,15 @@ impl ValueStack {
         self.values.clear();
     }
 
-    /// Returns the root [`FrameRegisters`] pointing to the first value on the [`ValueStack`].
-    pub fn root_stack_ptr(&mut self) -> FrameRegisters {
-        FrameRegisters::new(self.values.as_mut_ptr())
+    /// Returns the root [`FrameSlots`] pointing to the first value on the [`ValueStack`].
+    pub fn root_stack_ptr(&mut self) -> FrameSlots {
+        FrameSlots::new(self.values.as_mut_ptr())
     }
 
-    /// Returns the [`FrameRegisters`] at the given `offset`.
-    pub unsafe fn stack_ptr_at(&mut self, offset: impl Into<ValueStackOffset>) -> FrameRegisters {
+    /// Returns the [`FrameSlots`] at the given `offset`.
+    pub unsafe fn stack_ptr_at(&mut self, offset: impl Into<ValueStackOffset>) -> FrameSlots {
         let ptr = self.values.as_mut_ptr().add(offset.into().0);
-        FrameRegisters::new(ptr)
+        FrameSlots::new(ptr)
     }
 
     /// Returns the capacity of the [`ValueStack`].
@@ -211,7 +211,7 @@ impl ValueStack {
     ///
     /// # Note
     ///
-    /// - All live [`FrameRegisters`] might be invalidated and need to be reinstantiated.
+    /// - All live [`FrameSlots`] might be invalidated and need to be reinstantiated.
     /// - The parameters of the allocated [`EngineFunc`] are set to zero
     ///   and require proper initialization after this call.
     ///
@@ -264,7 +264,7 @@ impl ValueStack {
     ///
     /// # Safety
     ///
-    /// - This invalidates all [`FrameRegisters`] within the range `from..` and the caller has to
+    /// - This invalidates all [`FrameSlots`] within the range `from..` and the caller has to
     ///   make sure to properly reinstantiate all those pointers after this operation.
     /// - This also invalidates all [`FrameValueStackOffset`] and [`BaseValueStackOffset`] indices
     ///   within the range `from..`.
@@ -281,7 +281,7 @@ impl ValueStack {
     }
 }
 
-/// The offset of the [`FrameRegisters`].
+/// The offset of the [`FrameSlots`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ValueStackOffset(usize);
 
@@ -329,9 +329,9 @@ impl From<ValueStackOffset> for FrameValueStackOffset {
 /// # Note
 ///
 /// This points to the first mutable cell of the allocated [`CallFrame`].
-/// The first mutable cell of a [`CallFrame`] is accessed by [`Register(0)`].
+/// The first mutable cell of a [`CallFrame`] is accessed by [`Slot(0)`].
 ///
-/// [`Register(0)`]: [`Reg`]
+/// [`Slot(0)`]: [`Slot`]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BaseValueStackOffset(ValueStackOffset);
 
@@ -354,7 +354,7 @@ pub struct FrameParams {
 }
 
 impl FrameParams {
-    /// Creates a new [`FrameRegisters`].
+    /// Creates a new [`FrameSlots`].
     pub fn new(ptr: &mut [MaybeUninit<UntypedVal>]) -> Self {
         Self {
             range: ptr.as_mut_ptr_range(),
@@ -365,7 +365,7 @@ impl FrameParams {
     ///
     /// # Safety
     ///
-    /// It is the callers responsibility to provide a [`Reg`] that
+    /// It is the callers responsibility to provide a [`Slot`] that
     /// does not access the underlying [`ValueStack`] out of bounds.
     pub unsafe fn init_next(&mut self, value: UntypedVal) {
         self.range.start.write(MaybeUninit::new(value));
@@ -382,43 +382,43 @@ impl FrameParams {
     }
 }
 
-/// Accessor to the [`Reg`] values of a [`CallFrame`] on the [`CallStack`].
+/// Accessor to the [`Slot`] values of a [`CallFrame`] on the [`CallStack`].
 ///
 /// [`CallStack`]: [`super::CallStack`]
-pub struct FrameRegisters {
+pub struct FrameSlots {
     /// The underlying raw pointer to a [`CallFrame`] on the [`ValueStack`].
     ptr: *mut UntypedVal,
 }
 
-impl Debug for FrameRegisters {
+impl Debug for FrameSlots {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", &self.ptr)
     }
 }
 
-impl FrameRegisters {
-    /// Creates a new [`FrameRegisters`].
+impl FrameSlots {
+    /// Creates a new [`FrameSlots`].
     fn new(ptr: *mut UntypedVal) -> Self {
         Self { ptr }
     }
 
-    /// Returns the [`UntypedVal`] at the given [`Reg`].
+    /// Returns the [`UntypedVal`] at the given [`Slot`].
     ///
     /// # Safety
     ///
-    /// It is the callers responsibility to provide a [`Reg`] that
+    /// It is the callers responsibility to provide a [`Slot`] that
     /// does not access the underlying [`ValueStack`] out of bounds.
-    pub unsafe fn get(&self, register: Reg) -> UntypedVal {
+    pub unsafe fn get(&self, register: Slot) -> UntypedVal {
         ptr::read(self.register_offset(register))
     }
 
-    /// Returns the [`UntypedVal`] at the given [`Reg`].
+    /// Returns the [`UntypedVal`] at the given [`Slot`].
     ///
     /// # Safety
     ///
-    /// It is the callers responsibility to provide a [`Reg`] that
+    /// It is the callers responsibility to provide a [`Slot`] that
     /// does not access the underlying [`ValueStack`] out of bounds.
-    pub unsafe fn read_as<T>(&self, register: Reg) -> T
+    pub unsafe fn read_as<T>(&self, register: Slot) -> T
     where
         UntypedVal: ReadAs<T>,
     {
@@ -429,9 +429,9 @@ impl FrameRegisters {
     ///
     /// # Safety
     ///
-    /// It is the callers responsibility to provide a [`Reg`] that
+    /// It is the callers responsibility to provide a [`Slot`] that
     /// does not access the underlying [`ValueStack`] out of bounds.
-    pub unsafe fn set(&mut self, register: Reg, value: UntypedVal) {
+    pub unsafe fn set(&mut self, register: Slot, value: UntypedVal) {
         ptr::write(self.register_offset(register), value)
     }
 
@@ -439,9 +439,9 @@ impl FrameRegisters {
     ///
     /// # Safety
     ///
-    /// It is the callers responsibility to provide a [`Reg`] that
+    /// It is the callers responsibility to provide a [`Slot`] that
     /// does not access the underlying [`ValueStack`] out of bounds.
-    pub unsafe fn write_as<T>(&mut self, register: Reg, value: T)
+    pub unsafe fn write_as<T>(&mut self, register: Slot, value: T)
     where
         UntypedVal: WriteAs<T>,
     {
@@ -449,8 +449,8 @@ impl FrameRegisters {
         val.write_as(value);
     }
 
-    /// Returns the underlying pointer offset by the [`Reg`] index.
-    unsafe fn register_offset(&self, register: Reg) -> *mut UntypedVal {
+    /// Returns the underlying pointer offset by the [`Slot`] index.
+    unsafe fn register_offset(&self, register: Slot) -> *mut UntypedVal {
         unsafe { self.ptr.offset(isize::from(i16::from(register))) }
     }
 }

--- a/crates/wasmi/src/engine/resumable.rs
+++ b/crates/wasmi/src/engine/resumable.rs
@@ -2,7 +2,7 @@ use super::Func;
 use crate::{
     engine::Stack,
     func::{CallResultsTuple, FuncError},
-    ir::RegSpan,
+    ir::SlotSpan,
     AsContext,
     AsContextMut,
     Engine,
@@ -57,7 +57,7 @@ pub struct ResumableHostTrapError {
     /// The host function that returned the error.
     host_func: Func,
     /// The result registers of the caller of the host function.
-    caller_results: RegSpan,
+    caller_results: SlotSpan,
 }
 
 impl core::error::Error for ResumableHostTrapError {}
@@ -71,7 +71,7 @@ impl fmt::Display for ResumableHostTrapError {
 impl ResumableHostTrapError {
     /// Creates a new [`ResumableHostTrapError`].
     #[cold]
-    pub(crate) fn new(host_error: Error, host_func: Func, caller_results: RegSpan) -> Self {
+    pub(crate) fn new(host_error: Error, host_func: Func, caller_results: SlotSpan) -> Self {
         Self {
             host_error,
             host_func,
@@ -89,8 +89,8 @@ impl ResumableHostTrapError {
         &self.host_func
     }
 
-    /// Returns the caller results [`RegSpan`] of the [`ResumableHostTrapError`].
-    pub(crate) fn caller_results(&self) -> &RegSpan {
+    /// Returns the caller results [`SlotSpan`] of the [`ResumableHostTrapError`].
+    pub(crate) fn caller_results(&self) -> &SlotSpan {
         &self.caller_results
     }
 }
@@ -276,7 +276,7 @@ pub struct ResumableCallHostTrap {
     /// # Note
     ///
     /// This is only needed for the register-machine Wasmi engine backend.
-    caller_results: RegSpan,
+    caller_results: SlotSpan,
 }
 
 impl ResumableCallHostTrap {
@@ -286,7 +286,7 @@ impl ResumableCallHostTrap {
         func: Func,
         host_func: Func,
         host_error: Error,
-        caller_results: RegSpan,
+        caller_results: SlotSpan,
         stack: Stack,
     ) -> Self {
         Self {
@@ -302,7 +302,7 @@ impl ResumableCallHostTrap {
     /// # Note
     ///
     /// This should only be called from the register-machine Wasmi engine backend.
-    pub(super) fn update(&mut self, host_func: Func, host_error: Error, caller_results: RegSpan) {
+    pub(super) fn update(&mut self, host_func: Func, host_error: Error, caller_results: SlotSpan) {
         self.host_func = host_func;
         self.host_error = host_error;
         self.caller_results = caller_results;
@@ -346,12 +346,12 @@ impl ResumableCallHostTrap {
         self.host_error
     }
 
-    /// Returns the caller results [`RegSpan`].
+    /// Returns the caller results [`SlotSpan`].
     ///
     /// # Note
     ///
     /// This is `Some` only for [`ResumableCallHostTrap`] originating from the register-machine Wasmi engine.
-    pub(crate) fn caller_results(&self) -> RegSpan {
+    pub(crate) fn caller_results(&self) -> SlotSpan {
         self.caller_results
     }
 
@@ -435,7 +435,7 @@ impl ResumableCallOutOfFuel {
         self,
         host_func: Func,
         host_error: Error,
-        caller_results: RegSpan,
+        caller_results: SlotSpan,
     ) -> ResumableCallHostTrap {
         ResumableCallHostTrap {
             common: self.common,

--- a/crates/wasmi/src/engine/translator/error.rs
+++ b/crates/wasmi/src/engine/translator/error.rs
@@ -17,9 +17,9 @@ pub enum TranslationError {
     /// Fuel required for a block is out of bounds.
     BlockFuelOutOfBounds,
     /// Tried to allocate more registers than possible.
-    AllocatedTooManyRegisters,
+    AllocatedTooManySlots,
     /// Tried to use an out of bounds register index.
-    RegisterOutOfBounds,
+    SlotOutOfBounds,
     /// Pushed too many values on the emulated value stack during translation.
     EmulatedValueStackOverflow,
     /// Tried to allocate too many or large provider slices.
@@ -74,13 +74,13 @@ impl Display for TranslationError {
                     "fuel required to execute a block is out of bounds for wasmi bytecode"
                 )
             }
-            Self::AllocatedTooManyRegisters => {
+            Self::AllocatedTooManySlots => {
                 write!(
                     f,
                     "translation requires more registers for a function than available"
                 )
             }
-            Self::RegisterOutOfBounds => {
+            Self::SlotOutOfBounds => {
                 write!(f, "tried to access out of bounds register index")
             }
             Self::EmulatedValueStackOverflow => {

--- a/crates/wasmi/src/engine/translator/func/instrs.rs
+++ b/crates/wasmi/src/engine/translator/func/instrs.rs
@@ -12,7 +12,7 @@ use crate::{
         relink_result::RelinkResult,
         utils::{BumpFuelConsumption as _, Instr, IsInstructionParameter as _},
     },
-    ir::{BranchOffset, Op, Reg},
+    ir::{BranchOffset, Op, Slot},
     module::ModuleHeader,
     Engine,
     Error,
@@ -155,8 +155,8 @@ impl InstrEncoder {
     ///   the new result which shall replace the `old_result`.
     pub fn try_replace_result(
         &mut self,
-        new_result: Reg,
-        old_result: Reg,
+        new_result: Slot,
+        old_result: Slot,
         layout: &StackLayout,
         module: &ModuleHeader,
     ) -> Result<bool, Error> {
@@ -187,7 +187,7 @@ impl InstrEncoder {
     pub fn try_fuse_select(
         &mut self,
         ty: ValType,
-        select_condition: Reg,
+        select_condition: Slot,
         layout: &StackLayout,
         stack: &mut Stack,
     ) -> Result<Option<bool>, Error> {
@@ -327,7 +327,7 @@ impl InstrEncoder {
     ) -> Result<(), Error> {
         let mut remaining = operands;
         let mut operand_to_reg =
-            |operand: &Operand| -> Result<Reg, Error> { layout.operand_to_reg(*operand) };
+            |operand: &Operand| -> Result<Slot, Error> { layout.operand_to_reg(*operand) };
         let instr = loop {
             match remaining {
                 [] => return Ok(()),

--- a/crates/wasmi/src/engine/translator/func/layout/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/layout/mod.rs
@@ -5,7 +5,7 @@ use super::{LocalIdx, Operand, OperandIdx, Reset};
 use crate::{
     core::UntypedVal,
     engine::{translator::comparator::AllocConst, TranslationError},
-    ir::Reg,
+    ir::Slot,
     Error,
 };
 
@@ -29,7 +29,7 @@ impl Reset for StackLayout {
 }
 
 impl StackLayout {
-    /// Register `amount` local variables of common type `ty`.
+    /// Slot `amount` local variables of common type `ty`.
     ///
     /// # Errors
     ///
@@ -39,11 +39,11 @@ impl StackLayout {
         Ok(())
     }
 
-    /// Returns the [`StackSpace`] of the [`Reg`].
+    /// Returns the [`StackSpace`] of the [`Slot`].
     ///
-    /// Returns `None` if the [`Reg`] is unknown to the [`Stack`].
+    /// Returns `None` if the [`Slot`] is unknown to the [`Stack`].
     #[must_use]
-    pub fn stack_space(&self, reg: Reg) -> StackSpace {
+    pub fn stack_space(&self, reg: Slot) -> StackSpace {
         let index = i16::from(reg);
         if index.is_negative() {
             return StackSpace::Const;
@@ -55,7 +55,7 @@ impl StackLayout {
         StackSpace::Temp
     }
 
-    /// Converts the `operand` into the associated [`Reg`].
+    /// Converts the `operand` into the associated [`Slot`].
     ///
     /// # Note
     ///
@@ -68,7 +68,7 @@ impl StackLayout {
     /// # Errors
     ///
     /// If the forwarded method returned an error.
-    pub fn operand_to_reg(&mut self, operand: Operand) -> Result<Reg, Error> {
+    pub fn operand_to_reg(&mut self, operand: Operand) -> Result<Slot, Error> {
         match operand {
             Operand::Local(operand) => self.local_to_reg(operand.local_index()),
             Operand::Temp(operand) => self.temp_to_reg(operand.operand_index()),
@@ -76,38 +76,38 @@ impl StackLayout {
         }
     }
 
-    /// Converts the local `index` into the associated [`Reg`].
+    /// Converts the local `index` into the associated [`Slot`].
     ///
     /// # Errors
     ///
-    /// If `index` cannot be converted into a [`Reg`].
+    /// If `index` cannot be converted into a [`Slot`].
     #[inline]
-    pub fn local_to_reg(&self, index: LocalIdx) -> Result<Reg, Error> {
+    pub fn local_to_reg(&self, index: LocalIdx) -> Result<Slot, Error> {
         debug_assert!(
             (u32::from(index) as usize) < self.len_locals,
             "out of bounds local operand index: {index:?}"
         );
         let Ok(index) = i16::try_from(u32::from(index)) else {
-            return Err(Error::from(TranslationError::AllocatedTooManyRegisters));
+            return Err(Error::from(TranslationError::AllocatedTooManySlots));
         };
-        Ok(Reg::from(index))
+        Ok(Slot::from(index))
     }
 
-    /// Converts the operand `index` into the associated [`Reg`].
+    /// Converts the operand `index` into the associated [`Slot`].
     ///
     /// # Errors
     ///
-    /// If `index` cannot be converted into a [`Reg`].
+    /// If `index` cannot be converted into a [`Slot`].
     #[inline]
-    pub fn temp_to_reg(&self, index: OperandIdx) -> Result<Reg, Error> {
+    pub fn temp_to_reg(&self, index: OperandIdx) -> Result<Slot, Error> {
         let index = usize::from(index);
         let Some(index) = index.checked_add(self.len_locals) else {
-            return Err(Error::from(TranslationError::AllocatedTooManyRegisters));
+            return Err(Error::from(TranslationError::AllocatedTooManySlots));
         };
         let Ok(index) = i16::try_from(index) else {
-            return Err(Error::from(TranslationError::AllocatedTooManyRegisters));
+            return Err(Error::from(TranslationError::AllocatedTooManySlots));
         };
-        Ok(Reg::from(index))
+        Ok(Slot::from(index))
     }
 
     /// Allocates a function local constant `value`.
@@ -116,7 +116,7 @@ impl StackLayout {
     ///
     /// If too many function local constants have been allocated already.
     #[inline]
-    pub fn const_to_reg(&mut self, value: impl Into<UntypedVal>) -> Result<Reg, Error> {
+    pub fn const_to_reg(&mut self, value: impl Into<UntypedVal>) -> Result<Slot, Error> {
         self.consts.alloc(value.into())
     }
 
@@ -131,12 +131,12 @@ impl StackLayout {
 }
 
 impl AllocConst for StackLayout {
-    fn alloc_const<T: Into<UntypedVal>>(&mut self, value: T) -> Result<Reg, Error> {
+    fn alloc_const<T: Into<UntypedVal>>(&mut self, value: T) -> Result<Slot, Error> {
         self.const_to_reg(value)
     }
 }
 
-/// The [`StackSpace`] of a [`Reg`].
+/// The [`StackSpace`] of a [`Slot`].
 #[derive(Debug, Copy, Clone)]
 pub enum StackSpace {
     /// Stack slot referring to a local variable.

--- a/crates/wasmi/src/engine/translator/func/locals.rs
+++ b/crates/wasmi/src/engine/translator/func/locals.rs
@@ -50,7 +50,7 @@ impl LocalsRegistry {
     /// The maximum number of local variables in the fast `tys_first` vector.
     const FIRST_TYS_MAX: usize = 100;
 
-    /// Registers `amount` of locals of type `ty` for `self`.
+    /// Slots `amount` of locals of type `ty` for `self`.
     ///
     /// # Errors
     ///

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -56,22 +56,22 @@ use crate::{
         Address,
         Address32,
         AnyConst16,
-        BoundedRegSpan,
+        BoundedSlotSpan,
         BranchOffset,
         BranchOffset16,
         Comparator,
         ComparatorAndOffset,
         Const16,
         Const32,
-        FixedRegSpan,
+        FixedSlotSpan,
         IntoShiftAmount,
         Offset16,
         Offset64,
         Offset64Lo,
         Op,
-        Reg,
-        RegSpan,
         Sign,
+        Slot,
+        SlotSpan,
     },
     module::{FuncIdx, FuncTypeIdx, MemoryIdx, ModuleHeader, TableIdx, WasmiValueType},
     Engine,
@@ -115,7 +115,7 @@ pub struct FuncTranslator {
     locals: LocalsRegistry,
     /// Wasm layout to map stack slots to Wasmi registers.
     layout: StackLayout,
-    /// Registers and pins labels and tracks their users.
+    /// Slots and pins labels and tracks their users.
     labels: LabelRegistry,
     /// Constructs and encodes function instructions.
     instrs: InstrEncoder,
@@ -134,7 +134,7 @@ pub struct FuncTranslatorAllocations {
     locals: LocalsRegistry,
     /// Wasm layout to map stack slots to Wasmi registers.
     layout: StackLayout,
-    /// Registers and pins labels and tracks their users.
+    /// Slots and pins labels and tracks their users.
     labels: LabelRegistry,
     /// Constructs and encodes function instructions.
     instrs: InstrEncoderAllocations,
@@ -188,7 +188,7 @@ impl WasmTranslator<'_> for FuncTranslator {
         finalize: impl FnOnce(CompiledFuncEntity),
     ) -> Result<Self::Allocations, Error> {
         let Some(frame_size) = self.frame_size() else {
-            return Err(Error::from(TranslationError::AllocatedTooManyRegisters));
+            return Err(Error::from(TranslationError::AllocatedTooManySlots));
         };
         self.update_branch_offsets()?;
         finalize(CompiledFuncEntity::new(
@@ -277,7 +277,7 @@ impl FuncTranslator {
         Ok(())
     }
 
-    /// Registers an `amount` of local variables of type `ty`.
+    /// Slots an `amount` of local variables of type `ty`.
     fn register_locals(&mut self, amount: u32, ty: ValType) -> Result<(), Error> {
         let Ok(amount) = usize::try_from(amount) else {
             panic!(
@@ -344,24 +344,24 @@ impl FuncTranslator {
             .resolve_func_type(dedup_func_type, Clone::clone)
     }
 
-    /// Returns the [`RegSpan`] of a call instruction before manipulating the operand stack.
-    fn call_regspan(&self, len_params: usize) -> Result<RegSpan, Error> {
+    /// Returns the [`SlotSpan`] of a call instruction before manipulating the operand stack.
+    fn call_regspan(&self, len_params: usize) -> Result<SlotSpan, Error> {
         let height = self.stack.height();
         let Some(start) = height.checked_sub(len_params) else {
-            panic!("operand stack underflow while evaluating call `RegSpan`");
+            panic!("operand stack underflow while evaluating call `SlotSpan`");
         };
         let start = self.layout.temp_to_reg(OperandIdx::from(start))?;
-        Ok(RegSpan::new(start))
+        Ok(SlotSpan::new(start))
     }
 
     /// Push `results` as [`TempOperand`] onto the [`Stack`] tagged to `instr`.
     ///
-    /// Returns the [`RegSpan`] identifying the pushed operands if any.
+    /// Returns the [`SlotSpan`] identifying the pushed operands if any.
     fn push_results(
         &mut self,
         instr: Instr,
         results: &[ValType],
-    ) -> Result<Option<RegSpan>, Error> {
+    ) -> Result<Option<SlotSpan>, Error> {
         let (first, rest) = match results.split_first() {
             Some((first, rest)) => (first, rest),
             None => return Ok(None),
@@ -371,7 +371,7 @@ impl FuncTranslator {
             self.stack.push_temp(*result, Some(instr))?;
         }
         let start = self.layout.temp_to_reg(first)?;
-        Ok(Some(RegSpan::new(start)))
+        Ok(Some(SlotSpan::new(start)))
     }
 
     /// Returns the [`Engine`] for which the function is compiled.
@@ -447,7 +447,7 @@ impl FuncTranslator {
     /// - This does _not_ encode a copy if the copy is a no-op.
     fn encode_copies(
         &mut self,
-        results: RegSpan,
+        results: SlotSpan,
         len_values: u16,
         consume_fuel_instr: Option<Instr>,
     ) -> Result<(), Error> {
@@ -475,7 +475,7 @@ impl FuncTranslator {
     /// This won't encode a copy if `result` and `value` yields a no-op copy.
     fn encode_copy(
         &mut self,
-        result: Reg,
+        result: Slot,
         value: Operand,
         consume_fuel_instr: Option<Instr>,
     ) -> Result<Option<Instr>, Error> {
@@ -524,7 +524,7 @@ impl FuncTranslator {
     /// Tries to merge two [`Op::Copy`] instructions and returns the result.
     ///
     /// Returns `None` if merging was not possible.
-    fn try_merge_copy_instr(last_copy: Op, result: Reg, value: Reg) -> Option<Op> {
+    fn try_merge_copy_instr(last_copy: Op, result: Slot, value: Slot) -> Option<Op> {
         let Op::Copy {
             result: last_result,
             value: last_value,
@@ -540,11 +540,11 @@ impl FuncTranslator {
         }
         if result == last_result.next() {
             // Case: we can append `copy_instrs`.
-            return Some(Op::copy2_ext(RegSpan::new(last_result), last_value, value));
+            return Some(Op::copy2_ext(SlotSpan::new(last_result), last_value, value));
         }
         if result == last_result.prev() {
             // Case: we can prepend `copy_instr`.
-            return Some(Op::copy2_ext(RegSpan::new(result), value, last_value));
+            return Some(Op::copy2_ext(SlotSpan::new(result), value, last_value));
         }
         None
     }
@@ -552,7 +552,7 @@ impl FuncTranslator {
     /// Tries to merge an [`Op::Copy2`] and an [`Op::Copy`] and returns the result.
     ///
     /// Returns `None` if merging was not possible.
-    fn try_merge_copy2_instr(last_copy: Op, result: Reg, value: Reg) -> Option<Op> {
+    fn try_merge_copy2_instr(last_copy: Op, result: Slot, value: Slot) -> Option<Op> {
         let Op::Copy2 { results, values } = last_copy else {
             // Case: `last_copy` does not refer to a mergable copy instruction.
             return None;
@@ -570,10 +570,10 @@ impl FuncTranslator {
                 // Case: cannot merge since `value` is overwritten by `last_copy`.
                 return None;
             }
-            let results = RegSpan::new(last_result0);
-            let values = RegSpan::new(last_value0);
+            let results = SlotSpan::new(last_result0);
+            let values = SlotSpan::new(last_value0);
             let len = 3_u16;
-            debug_assert!(!RegSpan::has_overlapping_copies(results, values, len));
+            debug_assert!(!SlotSpan::has_overlapping_copies(results, values, len));
             return Some(Op::copy_span(results, values, len));
         }
         if result == last_result0.prev() && value == last_value0.prev() {
@@ -582,10 +582,10 @@ impl FuncTranslator {
                 // Case: cannot merge since `result` overwrites results of `last_copy`.
                 return None;
             }
-            let results = RegSpan::new(result);
-            let values = RegSpan::new(value);
+            let results = SlotSpan::new(result);
+            let values = SlotSpan::new(value);
             let len = 3_u16;
-            debug_assert!(!RegSpan::has_overlapping_copies(results, values, len));
+            debug_assert!(!SlotSpan::has_overlapping_copies(results, values, len));
             return Some(Op::copy_span(results, values, len));
         }
         None
@@ -594,7 +594,7 @@ impl FuncTranslator {
     /// Tries to merge an [`Op::CopySpan`] and an [`Op::Copy`] and returns the result.
     ///
     /// Returns `None` if merging was not possible.
-    fn try_merge_copy_span_instr(last_copy: Op, result: Reg, value: Reg) -> Option<Op> {
+    fn try_merge_copy_span_instr(last_copy: Op, result: Slot, value: Slot) -> Option<Op> {
         let Op::CopySpan {
             results,
             values,
@@ -610,7 +610,7 @@ impl FuncTranslator {
         if result == last_result0.next_n(len) && value == last_value0.next_n(len) {
             // Case: we can append `copy_instr`.
             let new_len = len + 1;
-            if RegSpan::has_overlapping_copies(results, values, new_len) {
+            if SlotSpan::has_overlapping_copies(results, values, new_len) {
                 // Case: cannot merge since resulting `copy_span` has overlapping copies.
                 return None;
             }
@@ -619,13 +619,13 @@ impl FuncTranslator {
         if result == last_result0.prev() && value == last_value0.prev() {
             // Case: we can prepend `copy_instr`.
             let new_len = len + 1;
-            if RegSpan::has_overlapping_copies(results, values, new_len) {
+            if SlotSpan::has_overlapping_copies(results, values, new_len) {
                 // Case: cannot merge since resulting `copy_span` has overlapping copies.
                 return None;
             }
             return Some(Op::copy_span(
-                RegSpan::new(result),
-                RegSpan::new(value),
+                SlotSpan::new(result),
+                SlotSpan::new(value),
                 new_len,
             ));
         }
@@ -636,7 +636,7 @@ impl FuncTranslator {
     ///
     /// Returns `None` if the resulting copy instruction is a no-op.
     fn make_copy_instr(
-        result: Reg,
+        result: Slot,
         value: Operand,
         layout: &mut StackLayout,
     ) -> Result<Option<Op>, Error> {
@@ -664,7 +664,7 @@ impl FuncTranslator {
 
     /// Returns the copy instruction to copy the given immediate `value` to `result`.
     fn make_copy_imm_instr(
-        result: Reg,
+        result: Slot,
         value: TypedVal,
         layout: &mut StackLayout,
     ) -> Result<Op, Error> {
@@ -706,7 +706,7 @@ impl FuncTranslator {
     /// This won't encode a copy if the resulting copy instruction is a no-op.
     fn encode_copy2(
         &mut self,
-        results: RegSpan,
+        results: SlotSpan,
         val0: Operand,
         val1: Operand,
         consume_fuel_instr: Option<Instr>,
@@ -734,8 +734,8 @@ impl FuncTranslator {
     /// This won't encode a copy if the resulting copy instruction is a no-op.
     fn encode_copy_span(
         &mut self,
-        results: RegSpan,
-        values: RegSpan,
+        results: SlotSpan,
+        values: SlotSpan,
         len: u16,
         consume_fuel_instr: Option<Instr>,
     ) -> Result<(), Error> {
@@ -743,7 +743,7 @@ impl FuncTranslator {
             // Case: results and values are equal and therefore the copy is a no-op
             return Ok(());
         }
-        debug_assert!(!RegSpan::has_overlapping_copies(results, values, len));
+        debug_assert!(!SlotSpan::has_overlapping_copies(results, values, len));
         self.instrs.push_instr(
             Op::copy_span(results, values, len),
             consume_fuel_instr,
@@ -761,7 +761,7 @@ impl FuncTranslator {
     ///   of noop copies between `results` and `values`.
     fn encode_copy_many(
         &mut self,
-        results: RegSpan,
+        results: SlotSpan,
         len: u16,
         consume_fuel_instr: Option<Instr>,
     ) -> Result<(), Error> {
@@ -803,12 +803,12 @@ impl FuncTranslator {
 
     /// Tries to strip noop copies from the start of the `copy_many`.
     ///
-    /// Returns the stripped `results` [`RegSpan`] and `values` slice of [`Operand`]s.
+    /// Returns the stripped `results` [`SlotSpan`] and `values` slice of [`Operand`]s.
     fn copy_many_strip_noop_start<'a>(
-        results: RegSpan,
+        results: SlotSpan,
         values: &'a [Operand],
         layout: &StackLayout,
-    ) -> Result<(RegSpan, &'a [Operand]), Error> {
+    ) -> Result<(SlotSpan, &'a [Operand]), Error> {
         let mut result = results.head();
         let mut values = values;
         while let Some((value, rest)) = values.split_first() {
@@ -827,14 +827,14 @@ impl FuncTranslator {
             result = result.next();
             values = rest;
         }
-        Ok((RegSpan::new(result), values))
+        Ok((SlotSpan::new(result), values))
     }
 
     /// Tries to strip noop copies from the end of the `copy_many`.
     ///
     /// Returns the stripped `values` slice of [`Operand`]s.
     fn copy_many_strip_noop_end<'a>(
-        results: RegSpan,
+        results: SlotSpan,
         values: &'a [Operand],
         layout: &StackLayout,
     ) -> Result<&'a [Operand], Error> {
@@ -872,7 +872,7 @@ impl FuncTranslator {
     /// - `[ 3 <- 1, 4 <- 2, 5 <- 3 ]` has overlapping copies since register `3`
     ///   is written to in the first copy but read from in the third.
     fn has_overlapping_copies(
-        results: RegSpan,
+        results: SlotSpan,
         values: &[Operand],
         layout: &StackLayout,
     ) -> Result<bool, Error> {
@@ -907,23 +907,23 @@ impl FuncTranslator {
         Ok(false)
     }
 
-    /// Returns the results [`RegSpan`] of the `frame` if any.
-    fn frame_results(&self, frame: &impl ControlFrameBase) -> Result<Option<RegSpan>, Error> {
+    /// Returns the results [`SlotSpan`] of the `frame` if any.
+    fn frame_results(&self, frame: &impl ControlFrameBase) -> Result<Option<SlotSpan>, Error> {
         Self::frame_results_impl(frame, &self.engine, &self.layout)
     }
 
-    /// Returns the results [`RegSpan`] of the `frame` if any.
+    /// Returns the results [`SlotSpan`] of the `frame` if any.
     fn frame_results_impl(
         frame: &impl ControlFrameBase,
         engine: &Engine,
         layout: &StackLayout,
-    ) -> Result<Option<RegSpan>, Error> {
+    ) -> Result<Option<SlotSpan>, Error> {
         if frame.len_branch_params(engine) == 0 {
             return Ok(None);
         }
         let height = frame.height();
         let start = layout.temp_to_reg(OperandIdx::from(height))?;
-        let span = RegSpan::new(start);
+        let span = SlotSpan::new(start);
         Ok(Some(span))
     }
 
@@ -966,16 +966,16 @@ impl FuncTranslator {
         Ok(())
     }
 
-    /// Efficiently converts the `operand` to a [`Reg`] if it is an immediate.
+    /// Efficiently converts the `operand` to a [`Slot`] if it is an immediate.
     ///
     /// # Note
     ///
     /// - Preferrably, this encodes the immediate `operand` into a `copy` instruction
     ///   with the immediate encoded inline.
     /// - If the immediate `operand` cannot be encoded as `copy` with inline immediate
-    ///   a function local constant [`Reg`] will be allocated and returned.
-    /// - Returns the associated [`Reg`] if `operand` is an [`Operand::Temp`] or [`Operand::Local`].
-    fn immediate_to_reg(&mut self, operand: Operand) -> Result<Reg, Error> {
+    ///   a function local constant [`Slot`] will be allocated and returned.
+    /// - Returns the associated [`Slot`] if `operand` is an [`Operand::Temp`] or [`Operand::Local`].
+    fn immediate_to_reg(&mut self, operand: Operand) -> Result<Slot, Error> {
         match operand {
             Operand::Local(operand) => self.layout.local_to_reg(operand.local_index()),
             Operand::Temp(operand) => self.layout.temp_to_reg(operand.operand_index()),
@@ -986,7 +986,7 @@ impl FuncTranslator {
                     Op::Copy { value, .. } => {
                         // Case: not possible to craft a `copy` instruction
                         //       with an inline immediate, so we can return
-                        //       the allocated function local constant [`Reg`]
+                        //       the allocated function local constant [`Slot`]
                         //       instead.
                         Ok(value)
                     }
@@ -1038,7 +1038,7 @@ impl FuncTranslator {
     fn push_instr_with_result(
         &mut self,
         result_ty: ValType,
-        make_instr: impl FnOnce(Reg) -> Op,
+        make_instr: impl FnOnce(Slot) -> Op,
         fuel_costs: impl FnOnce(&FuelCostsProvider) -> u64,
     ) -> Result<(), Error> {
         let consume_fuel_instr = self.stack.consume_fuel_instr();
@@ -1059,7 +1059,7 @@ impl FuncTranslator {
         result_ty: ValType,
         lhs: Operand,
         rhs: Operand,
-        make_instr: impl FnOnce(Reg, Reg, Reg) -> Op,
+        make_instr: impl FnOnce(Slot, Slot, Slot) -> Op,
         fuel_costs: impl FnOnce(&FuelCostsProvider) -> u64,
     ) -> Result<(), Error> {
         debug_assert_eq!(lhs.ty(), rhs.ty());
@@ -1099,7 +1099,7 @@ impl FuncTranslator {
     /// # Note
     ///
     /// Upon call the `immediates` buffer contains all `br_table` target values.
-    fn encode_br_table_0(&mut self, table: wasmparser::BrTable, index: Reg) -> Result<(), Error> {
+    fn encode_br_table_0(&mut self, table: wasmparser::BrTable, index: Slot) -> Result<(), Error> {
         debug_assert_eq!(self.immediates.len(), (table.len() + 1) as usize);
         self.push_instr(
             Op::branch_table_0(index, table.len() + 1),
@@ -1129,7 +1129,7 @@ impl FuncTranslator {
     fn encode_br_table_n(
         &mut self,
         table: wasmparser::BrTable,
-        index: Reg,
+        index: Slot,
         len_values: u16,
     ) -> Result<(), Error> {
         debug_assert_eq!(self.immediates.len(), (table.len() + 1) as usize);
@@ -1139,7 +1139,7 @@ impl FuncTranslator {
             Op::branch_table_span(index, table.len() + 1),
             FuelCostsProvider::base,
         )?;
-        self.push_param(Op::register_span(BoundedRegSpan::new(values, len_values)))?;
+        self.push_param(Op::register_span(BoundedSlotSpan::new(values, len_values)))?;
         // Encode the `br_table` targets:
         let targets = &self.immediates[..];
         for target in targets {
@@ -1240,7 +1240,7 @@ impl FuncTranslator {
     ) -> Result<Instr, Error> {
         self.peek_operands_into_buffer(usize::from(len));
         if let Some(values) = Self::try_form_regspan_of(&self.operands, &self.layout)? {
-            let values = BoundedRegSpan::new(values, len);
+            let values = BoundedSlotSpan::new(values, len);
             return self.instrs.push_instr(
                 Op::return_span(values),
                 consume_fuel_instr,
@@ -1262,20 +1262,20 @@ impl FuncTranslator {
         Ok(return_instr)
     }
 
-    /// Tries to form a [`RegSpan`] from the top-most `n` operands on the [`Stack`].
+    /// Tries to form a [`SlotSpan`] from the top-most `n` operands on the [`Stack`].
     ///
-    /// Returns `None` if forming a [`RegSpan`] was not possible.
-    fn try_form_regspan(&self, len: usize) -> Result<Option<RegSpan>, Error> {
+    /// Returns `None` if forming a [`SlotSpan`] was not possible.
+    fn try_form_regspan(&self, len: usize) -> Result<Option<SlotSpan>, Error> {
         Self::try_form_regspan_of(self.stack.peek_n(len), &self.layout)
     }
 
-    /// Tries to form a [`RegSpan`] from the `values` slice of [`Operand`]s.
+    /// Tries to form a [`SlotSpan`] from the `values` slice of [`Operand`]s.
     ///
-    /// Returns `None` if forming a [`RegSpan`] was not possible.
+    /// Returns `None` if forming a [`SlotSpan`] was not possible.
     fn try_form_regspan_of<T>(
         values: impl IntoIterator<Item = T>,
         layout: &StackLayout,
-    ) -> Result<Option<RegSpan>, Error>
+    ) -> Result<Option<SlotSpan>, Error>
     where
         T: AsRef<Operand>,
     {
@@ -1300,23 +1300,23 @@ impl FuncTranslator {
             }
             head = cur;
         }
-        Ok(Some(RegSpan::new(start)))
+        Ok(Some(SlotSpan::new(start)))
     }
 
-    /// Tries to form a [`RegSpan`] from the top-most `len` operands on the [`Stack`] or copy to temporaries.
+    /// Tries to form a [`SlotSpan`] from the top-most `len` operands on the [`Stack`] or copy to temporaries.
     ///
-    /// Returns `None` if forming a [`RegSpan`] was not possible.
+    /// Returns `None` if forming a [`SlotSpan`] was not possible.
     fn try_form_regspan_or_move(
         &mut self,
         len: usize,
         consume_fuel_instr: Option<Instr>,
-    ) -> Result<RegSpan, Error> {
+    ) -> Result<SlotSpan, Error> {
         if let Some(span) = self.try_form_regspan(len)? {
             return Ok(span);
         }
         self.move_operands_to_temp(len, consume_fuel_instr)?;
         let Some(span) = self.try_form_regspan(len)? else {
-            unreachable!("the top-most `len` operands are now temporaries thus `RegSpan` forming should succeed")
+            unreachable!("the top-most `len` operands are now temporaries thus `SlotSpan` forming should succeed")
         };
         Ok(span)
     }
@@ -1626,8 +1626,8 @@ impl FuncTranslator {
     fn make_branch_cmp_fallback(
         &mut self,
         cmp: Comparator,
-        lhs: Reg,
-        rhs: Reg,
+        lhs: Slot,
+        rhs: Slot,
         offset: BranchOffset,
     ) -> Result<Op, Error> {
         let params = self
@@ -1723,7 +1723,7 @@ impl FuncTranslator {
     /// Translates a unary Wasm instruction to Wasmi bytecode.
     fn translate_unary<T, R>(
         &mut self,
-        make_instr: fn(result: Reg, input: Reg) -> Op,
+        make_instr: fn(result: Slot, input: Slot) -> Op,
         consteval: fn(input: T) -> R,
     ) -> Result<(), Error>
     where
@@ -1747,7 +1747,7 @@ impl FuncTranslator {
     /// Translates a unary Wasm instruction to Wasmi bytecode.
     fn translate_unary_fallible<T, R>(
         &mut self,
-        make_instr: fn(result: Reg, input: Reg) -> Op,
+        make_instr: fn(result: Slot, input: Slot) -> Op,
         consteval: fn(input: T) -> Result<R, TrapCode>,
     ) -> Result<(), Error>
     where
@@ -1814,7 +1814,7 @@ impl FuncTranslator {
             Ok(rhs) => Ok(Input::Immediate(rhs)),
             Err(_) => {
                 let rhs = self.layout.const_to_reg(value)?;
-                Ok(Input::Reg(rhs))
+                Ok(Input::Slot(rhs))
             }
         }
     }
@@ -1830,7 +1830,7 @@ impl FuncTranslator {
             Operand::Temp(operand) => self.layout.temp_to_reg(operand.operand_index())?,
             Operand::Immediate(operand) => return f(self, operand.val()),
         };
-        Ok(Input::Reg(reg))
+        Ok(Input::Slot(reg))
     }
 
     /// Converts the `provider` to a 16-bit index-type constant value.
@@ -1849,7 +1849,7 @@ impl FuncTranslator {
             operand => {
                 debug_assert_eq!(operand.ty(), index_type.ty());
                 let reg = self.layout.operand_to_reg(operand)?;
-                return Ok(Input::Reg(reg));
+                return Ok(Input::Slot(reg));
             }
         };
         match index_type {
@@ -1865,7 +1865,7 @@ impl FuncTranslator {
             }
         }
         let reg = self.layout.const_to_reg(value)?;
-        Ok(Input::Reg(reg))
+        Ok(Input::Slot(reg))
     }
 
     /// Converts the `provider` to a 32-bit index-type constant value.
@@ -1884,7 +1884,7 @@ impl FuncTranslator {
             operand => {
                 debug_assert_eq!(operand.ty(), index_type.ty());
                 let reg = self.layout.operand_to_reg(operand)?;
-                return Ok(Input::Reg(reg));
+                return Ok(Input::Slot(reg));
             }
         };
         match index_type {
@@ -1899,7 +1899,7 @@ impl FuncTranslator {
             }
         }
         let reg = self.layout.const_to_reg(value)?;
-        Ok(Input::Reg(reg))
+        Ok(Input::Slot(reg))
     }
 
     /// Evaluates `consteval(lhs, rhs)` and pushed either its result or tranlates a `trap`.
@@ -1950,8 +1950,8 @@ impl FuncTranslator {
     /// Translates a commutative binary Wasm operator to Wasmi bytecode.
     fn translate_binary_commutative<T, R>(
         &mut self,
-        make_rr: fn(result: Reg, lhs: Reg, rhs: Reg) -> Op,
-        make_ri: fn(result: Reg, lhs: Reg, rhs: Const16<T>) -> Op,
+        make_rr: fn(result: Slot, lhs: Slot, rhs: Slot) -> Op,
+        make_ri: fn(result: Slot, lhs: Slot, rhs: Const16<T>) -> Op,
         consteval: fn(T, T) -> R,
         opt_ri: fn(this: &mut Self, lhs: Operand, rhs: T) -> Result<bool, Error>,
     ) -> Result<(), Error>
@@ -1975,7 +1975,7 @@ impl FuncTranslator {
                     <R as Typed>::TY,
                     |result| match rhs16 {
                         Input::Immediate(rhs) => make_ri(result, lhs, rhs),
-                        Input::Reg(rhs) => make_rr(result, lhs, rhs),
+                        Input::Slot(rhs) => make_rr(result, lhs, rhs),
                     },
                     FuelCostsProvider::base,
                 )
@@ -1993,13 +1993,13 @@ impl FuncTranslator {
     /// Translates integer division and remainder Wasm operators to Wasmi bytecode.
     fn translate_divrem<T>(
         &mut self,
-        make_instr: fn(result: Reg, lhs: Reg, rhs: Reg) -> Op,
+        make_instr: fn(result: Slot, lhs: Slot, rhs: Slot) -> Op,
         make_instr_imm16_rhs: fn(
-            result: Reg,
-            lhs: Reg,
+            result: Slot,
+            lhs: Slot,
             rhs: Const16<<T as WasmInteger>::NonZero>,
         ) -> Op,
-        make_instr_imm16_lhs: fn(result: Reg, lhs: Const16<T>, rhs: Reg) -> Op,
+        make_instr_imm16_lhs: fn(result: Slot, lhs: Const16<T>, rhs: Slot) -> Op,
         consteval: fn(T, T) -> Result<T, TrapCode>,
     ) -> Result<(), Error>
     where
@@ -2022,7 +2022,7 @@ impl FuncTranslator {
                     <T as Typed>::TY,
                     |result| match rhs16 {
                         Input::Immediate(rhs) => make_instr_imm16_rhs(result, lhs, rhs),
-                        Input::Reg(rhs) => make_instr(result, lhs, rhs),
+                        Input::Slot(rhs) => make_instr(result, lhs, rhs),
                     },
                     FuelCostsProvider::base,
                 )
@@ -2035,7 +2035,7 @@ impl FuncTranslator {
                     <T as Typed>::TY,
                     |result| match lhs16 {
                         Input::Immediate(lhs) => make_instr_imm16_lhs(result, lhs, rhs),
-                        Input::Reg(lhs) => make_instr(result, lhs, rhs),
+                        Input::Slot(lhs) => make_instr(result, lhs, rhs),
                     },
                     FuelCostsProvider::base,
                 )
@@ -2053,9 +2053,9 @@ impl FuncTranslator {
     /// Translates binary non-commutative Wasm operators to Wasmi bytecode.
     fn translate_binary<T, R>(
         &mut self,
-        make_instr: fn(result: Reg, lhs: Reg, rhs: Reg) -> Op,
-        make_instr_imm16_rhs: fn(result: Reg, lhs: Reg, rhs: Const16<T>) -> Op,
-        make_instr_imm16_lhs: fn(result: Reg, lhs: Const16<T>, rhs: Reg) -> Op,
+        make_instr: fn(result: Slot, lhs: Slot, rhs: Slot) -> Op,
+        make_instr_imm16_rhs: fn(result: Slot, lhs: Slot, rhs: Const16<T>) -> Op,
+        make_instr_imm16_lhs: fn(result: Slot, lhs: Const16<T>, rhs: Slot) -> Op,
         consteval: fn(T, T) -> R,
     ) -> Result<(), Error>
     where
@@ -2075,7 +2075,7 @@ impl FuncTranslator {
                     <R as Typed>::TY,
                     |result| match rhs16 {
                         Input::Immediate(rhs) => make_instr_imm16_rhs(result, lhs, rhs),
-                        Input::Reg(rhs) => make_instr(result, lhs, rhs),
+                        Input::Slot(rhs) => make_instr(result, lhs, rhs),
                     },
                     FuelCostsProvider::base,
                 )
@@ -2088,7 +2088,7 @@ impl FuncTranslator {
                     <R as Typed>::TY,
                     |result| match lhs16 {
                         Input::Immediate(lhs) => make_instr_imm16_lhs(result, lhs, rhs),
-                        Input::Reg(lhs) => make_instr(result, lhs, rhs),
+                        Input::Slot(lhs) => make_instr(result, lhs, rhs),
                     },
                     FuelCostsProvider::base,
                 )
@@ -2106,9 +2106,9 @@ impl FuncTranslator {
     /// Translates Wasm `i{32,64}.sub` operators to Wasmi bytecode.
     fn translate_isub<T, R>(
         &mut self,
-        make_sub_rr: fn(result: Reg, lhs: Reg, rhs: Reg) -> Op,
-        make_add_ri: fn(result: Reg, lhs: Reg, rhs: Const16<T>) -> Op,
-        make_sub_ir: fn(result: Reg, lhs: Const16<T>, rhs: Reg) -> Op,
+        make_sub_rr: fn(result: Slot, lhs: Slot, rhs: Slot) -> Op,
+        make_add_ri: fn(result: Slot, lhs: Slot, rhs: Const16<T>) -> Op,
+        make_sub_ir: fn(result: Slot, lhs: Const16<T>, rhs: Slot) -> Op,
         consteval: fn(T, T) -> R,
     ) -> Result<(), Error>
     where
@@ -2127,14 +2127,14 @@ impl FuncTranslator {
                     Ok(rhs) => Input::Immediate(rhs),
                     Err(_) => {
                         let rhs = self.layout.const_to_reg(rhs)?;
-                        Input::Reg(rhs)
+                        Input::Slot(rhs)
                     }
                 };
                 self.push_instr_with_result(
                     <T as Typed>::TY,
                     |result| match rhs16 {
                         Input::Immediate(rhs) => make_add_ri(result, lhs, rhs),
-                        Input::Reg(rhs) => make_sub_rr(result, lhs, rhs),
+                        Input::Slot(rhs) => make_sub_rr(result, lhs, rhs),
                     },
                     FuelCostsProvider::base,
                 )
@@ -2147,7 +2147,7 @@ impl FuncTranslator {
                     <T as Typed>::TY,
                     |result| match lhs16 {
                         Input::Immediate(lhs) => make_sub_ir(result, lhs, rhs),
-                        Input::Reg(lhs) => make_sub_rr(result, lhs, rhs),
+                        Input::Slot(lhs) => make_sub_rr(result, lhs, rhs),
                     },
                     FuelCostsProvider::base,
                 )
@@ -2165,9 +2165,13 @@ impl FuncTranslator {
     /// Translates Wasm shift and rotate operators to Wasmi bytecode.
     fn translate_shift<T>(
         &mut self,
-        make_instr: fn(result: Reg, lhs: Reg, rhs: Reg) -> Op,
-        make_instr_imm16_rhs: fn(result: Reg, lhs: Reg, rhs: <T as IntoShiftAmount>::Output) -> Op,
-        make_instr_imm16_lhs: fn(result: Reg, lhs: Const16<T>, rhs: Reg) -> Op,
+        make_instr: fn(result: Slot, lhs: Slot, rhs: Slot) -> Op,
+        make_instr_imm16_rhs: fn(
+            result: Slot,
+            lhs: Slot,
+            rhs: <T as IntoShiftAmount>::Output,
+        ) -> Op,
+        make_instr_imm16_lhs: fn(result: Slot, lhs: Const16<T>, rhs: Slot) -> Op,
         consteval: fn(T, T) -> T,
     ) -> Result<(), Error>
     where
@@ -2205,7 +2209,7 @@ impl FuncTranslator {
                     <T as Typed>::TY,
                     |result| match lhs16 {
                         Input::Immediate(lhs) => make_instr_imm16_lhs(result, lhs, rhs),
-                        Input::Reg(lhs) => make_instr(result, lhs, rhs),
+                        Input::Slot(lhs) => make_instr(result, lhs, rhs),
                     },
                     FuelCostsProvider::base,
                 )
@@ -2223,7 +2227,7 @@ impl FuncTranslator {
     /// Translate a binary float Wasm operation.
     fn translate_fbinary<T, R>(
         &mut self,
-        make_instr: fn(result: Reg, lhs: Reg, rhs: Reg) -> Op,
+        make_instr: fn(result: Slot, lhs: Slot, rhs: Slot) -> Op,
         consteval: fn(T, T) -> R,
     ) -> Result<(), Error>
     where
@@ -2252,8 +2256,8 @@ impl FuncTranslator {
     /// - Applies constant evaluation if both operands are constant values.
     fn translate_fcopysign<T>(
         &mut self,
-        make_instr: fn(result: Reg, lhs: Reg, rhs: Reg) -> Op,
-        make_instr_imm: fn(result: Reg, lhs: Reg, rhs: Sign<T>) -> Op,
+        make_instr: fn(result: Slot, lhs: Slot, rhs: Slot) -> Op,
+        make_instr_imm: fn(result: Slot, lhs: Slot, rhs: Sign<T>) -> Op,
         consteval: fn(T, T) -> T,
     ) -> Result<(), Error>
     where
@@ -2374,7 +2378,7 @@ impl FuncTranslator {
         let table_type = *self.module.get_type_of_table(TableIdx::from(table_index));
         let index = self.make_index16(index, table_type.index_ty())?;
         let instr = match index {
-            Input::Reg(index) => Op::call_indirect_params(index, table_index),
+            Input::Slot(index) => Op::call_indirect_params(index, table_index),
             Input::Immediate(index) => Op::call_indirect_params_imm16(index, table_index),
         };
         Ok(instr)
@@ -2486,9 +2490,9 @@ impl FuncTranslator {
         &mut self,
         memarg: MemArg,
         loaded_ty: ValType,
-        make_instr: fn(result: Reg, offset_lo: Offset64Lo) -> Op,
-        make_instr_offset16: fn(result: Reg, ptr: Reg, offset: Offset16) -> Op,
-        make_instr_at: fn(result: Reg, address: Address32) -> Op,
+        make_instr: fn(result: Slot, offset_lo: Offset64Lo) -> Op,
+        make_instr_offset16: fn(result: Slot, ptr: Slot, offset: Offset16) -> Op,
+        make_instr_at: fn(result: Slot, address: Address32) -> Op,
     ) -> Result<(), Error> {
         bail_unreachable!(self);
         let (memory, offset) = Self::decode_memarg(memarg);
@@ -2685,7 +2689,7 @@ impl FuncTranslator {
     /// Returns `Some` in case the optimized instructions have been encoded.
     fn encode_istore_wrap_mem0<T: op::StoreWrapOperator>(
         &mut self,
-        ptr: Reg,
+        ptr: Slot,
         offset: u64,
         value: Operand,
     ) -> Result<Option<Instr>, Error>
@@ -2740,9 +2744,9 @@ impl FuncTranslator {
     fn translate_store(
         &mut self,
         memarg: MemArg,
-        store: fn(ptr: Reg, offset_lo: Offset64Lo) -> Op,
-        store_offset16: fn(ptr: Reg, offset: Offset16, value: Reg) -> Op,
-        store_at: fn(value: Reg, address: Address32) -> Op,
+        store: fn(ptr: Slot, offset_lo: Offset64Lo) -> Op,
+        store_offset16: fn(ptr: Slot, offset: Offset16, value: Slot) -> Op,
+        store_at: fn(value: Slot, address: Address32) -> Op,
     ) -> Result<(), Error> {
         bail_unreachable!(self);
         let (memory, offset) = Self::decode_memarg(memarg);
@@ -2789,7 +2793,7 @@ impl FuncTranslator {
         memory: index::Memory,
         address: Address32,
         value: Operand,
-        make_instr_at: fn(value: Reg, address: Address32) -> Op,
+        make_instr_at: fn(value: Slot, address: Address32) -> Op,
     ) -> Result<(), Error> {
         let value = self.layout.operand_to_reg(value)?;
         self.push_instr(make_instr_at(value, address), FuelCostsProvider::store)?;
@@ -2844,7 +2848,7 @@ impl FuncTranslator {
     /// Translates a Wasm `i64.binop128` instruction from the `wide-arithmetic` proposal.
     fn translate_i64_binop128(
         &mut self,
-        make_instr: fn(results: [Reg; 2], lhs_lo: Reg) -> Op,
+        make_instr: fn(results: [Slot; 2], lhs_lo: Slot) -> Op,
         const_eval: fn(lhs_lo: i64, lhs_hi: i64, rhs_lo: i64, rhs_hi: i64) -> (i64, i64),
     ) -> Result<(), Error> {
         bail_unreachable!(self);
@@ -2886,7 +2890,7 @@ impl FuncTranslator {
     /// Translates a Wasm `i64.mul_wide_sx` instruction from the `wide-arithmetic` proposal.
     fn translate_i64_mul_wide_sx(
         &mut self,
-        make_instr: fn(results: FixedRegSpan<2>, lhs: Reg, rhs: Reg) -> Op,
+        make_instr: fn(results: FixedSlotSpan<2>, lhs: Slot, rhs: Slot) -> Op,
         const_eval: fn(lhs: i64, rhs: i64) -> (i64, i64),
         signed: bool,
     ) -> Result<(), Error> {
@@ -2926,14 +2930,14 @@ impl FuncTranslator {
         let result0 = self.stack.push_temp(ValType::I64, None)?;
         let _result1 = self.stack.push_temp(ValType::I64, None)?;
         let result0 = self.layout.temp_to_reg(result0)?;
-        let Ok(results) = <FixedRegSpan<2>>::new(RegSpan::new(result0)) else {
-            return Err(Error::from(TranslationError::AllocatedTooManyRegisters));
+        let Ok(results) = <FixedSlotSpan<2>>::new(SlotSpan::new(result0)) else {
+            return Err(Error::from(TranslationError::AllocatedTooManySlots));
         };
         self.push_instr(make_instr(results, lhs, rhs), FuelCostsProvider::base)?;
         Ok(())
     }
 
-    /// Try to optimize a `i64.mul_wide_sx` instruction with one [`Reg`] and one immediate input.
+    /// Try to optimize a `i64.mul_wide_sx` instruction with one [`Slot`] and one immediate input.
     ///
     /// - Returns `Ok(true)` if the optimiation was applied successfully.
     /// - Returns `Ok(false)` if no optimization was applied.

--- a/crates/wasmi/src/engine/translator/func/op.rs
+++ b/crates/wasmi/src/engine/translator/func/op.rs
@@ -1,4 +1,4 @@
-use crate::ir::{Address32, Offset16, Offset64Lo, Op, Reg};
+use crate::ir::{Address32, Offset16, Offset64Lo, Op, Slot};
 
 /// Trait implemented by all Wasm operators that can be translated as wrapping store instructions.
 pub trait StoreWrapOperator {
@@ -9,11 +9,11 @@ pub trait StoreWrapOperator {
     /// The type of the value as (at most) 16-bit encoded instruction parameter.
     type Param;
 
-    fn store(ptr: Reg, offset_lo: Offset64Lo) -> Op;
-    fn store_imm(ptr: Reg, offset_lo: Offset64Lo) -> Op;
-    fn store_offset16(ptr: Reg, offset: Offset16, value: Reg) -> Op;
-    fn store_offset16_imm(ptr: Reg, offset: Offset16, value: Self::Param) -> Op;
-    fn store_at(value: Reg, address: Address32) -> Op;
+    fn store(ptr: Slot, offset_lo: Offset64Lo) -> Op;
+    fn store_imm(ptr: Slot, offset_lo: Offset64Lo) -> Op;
+    fn store_offset16(ptr: Slot, offset: Offset16, value: Slot) -> Op;
+    fn store_offset16_imm(ptr: Slot, offset: Offset16, value: Self::Param) -> Op;
+    fn store_at(value: Slot, address: Address32) -> Op;
     fn store_at_imm(value: Self::Param, address: Address32) -> Op;
 }
 
@@ -39,23 +39,23 @@ macro_rules! impl_store_wrap {
                 type Wrapped = $wrapped_ty;
                 type Param = $param_ty;
 
-                fn store(ptr: Reg, offset_lo: Offset64Lo) -> Op {
+                fn store(ptr: Slot, offset_lo: Offset64Lo) -> Op {
                     $store(ptr, offset_lo)
                 }
 
-                fn store_imm(ptr: Reg, offset_lo: Offset64Lo) -> Op {
+                fn store_imm(ptr: Slot, offset_lo: Offset64Lo) -> Op {
                     $store_imm(ptr, offset_lo)
                 }
 
-                fn store_offset16(ptr: Reg, offset: Offset16, value: Reg) -> Op {
+                fn store_offset16(ptr: Slot, offset: Offset16, value: Slot) -> Op {
                     $store_offset16(ptr, offset, value)
                 }
 
-                fn store_offset16_imm(ptr: Reg, offset: Offset16, value: Self::Param) -> Op {
+                fn store_offset16_imm(ptr: Slot, offset: Offset16, value: Self::Param) -> Op {
                     $store_offset16_imm(ptr, offset, value)
                 }
 
-                fn store_at(value: Reg, address: Address32) -> Op {
+                fn store_at(value: Slot, address: Address32) -> Op {
                     $store_at(value, address)
                 }
 

--- a/crates/wasmi/src/engine/translator/func/simd/op.rs
+++ b/crates/wasmi/src/engine/translator/func/simd/op.rs
@@ -1,7 +1,7 @@
 use super::IntoLaneIdx;
 use crate::{
     core::{simd, Typed},
-    ir::{Const32, Op, Reg},
+    ir::{Const32, Op, Slot},
     V128,
 };
 
@@ -15,11 +15,11 @@ pub trait SimdReplaceLane {
         value: Self::Item,
     ) -> V128;
 
-    fn replace_lane(result: Reg, input: Reg, lane: <Self::Item as IntoLaneIdx>::LaneIdx) -> Op;
+    fn replace_lane(result: Slot, input: Slot, lane: <Self::Item as IntoLaneIdx>::LaneIdx) -> Op;
 
     fn replace_lane_imm(
-        result: Reg,
-        input: Reg,
+        result: Slot,
+        input: Slot,
         lane: <Self::Item as IntoLaneIdx>::LaneIdx,
         value: Self::Immediate,
     ) -> Op;
@@ -60,16 +60,16 @@ macro_rules! impl_replace_lane {
                 }
 
                 fn replace_lane(
-                    result: Reg,
-                    input: Reg,
+                    result: Slot,
+                    input: Slot,
                     lane: <Self::Item as IntoLaneIdx>::LaneIdx,
                 ) -> Op {
                     $replace_lane(result, input, lane)
                 }
 
                 fn replace_lane_imm(
-                    result: Reg,
-                    input: Reg,
+                    result: Slot,
+                    input: Slot,
                     lane: <Self::Item as IntoLaneIdx>::LaneIdx,
                     value: Self::Immediate,
                 ) -> Op {

--- a/crates/wasmi/src/engine/translator/func/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/simd/visit.rs
@@ -6,7 +6,7 @@ use crate::{
         TypedVal,
     },
     engine::translator::func::{op, simd::op as simd_op, Operand},
-    ir::{Op, Reg},
+    ir::{Op, Slot},
     Error,
     ValType,
     V128,
@@ -25,7 +25,7 @@ impl FuncTranslator {
 /// Used to swap operands of binary [`Op`] constructor.
 macro_rules! swap_ops {
     ($fn_name:path) => {
-        |result: Reg, lhs, rhs| -> Op { $fn_name(result, rhs, lhs) }
+        |result: Slot, lhs, rhs| -> Op { $fn_name(result, rhs, lhs) }
     };
 }
 

--- a/crates/wasmi/src/engine/translator/func/stack/locals.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/locals.rs
@@ -17,7 +17,7 @@ impl Reset for LocalsHead {
 }
 
 impl LocalsHead {
-    /// Registers `amount` of locals.
+    /// Slots `amount` of locals.
     ///
     /// # Errors
     ///

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -93,7 +93,7 @@ impl Stack {
         }
     }
 
-    /// Register `amount` local variables.
+    /// Slot `amount` local variables.
     ///
     /// # Errors
     ///

--- a/crates/wasmi/src/engine/translator/func/stack/operands.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/operands.rs
@@ -93,7 +93,7 @@ impl Reset for OperandStack {
 }
 
 impl OperandStack {
-    /// Register `amount` local variables.
+    /// Slot `amount` local variables.
     ///
     /// # Errors
     ///

--- a/crates/wasmi/src/engine/translator/func/utils.rs
+++ b/crates/wasmi/src/engine/translator/func/utils.rs
@@ -1,4 +1,4 @@
-use crate::ir::{Const16, Const32, Reg};
+use crate::ir::{Const16, Const32, Slot};
 
 /// Bail out early in case the current code is unreachable.
 ///
@@ -22,7 +22,7 @@ macro_rules! bail_unreachable {
 /// [`Op`]: crate::ir::Op
 macro_rules! swap_ops {
     ($make_instr:path) => {{
-        |result: $crate::ir::Reg, lhs, rhs| -> $crate::ir::Op { $make_instr(result, rhs, lhs) }
+        |result: $crate::ir::Slot, lhs, rhs| -> $crate::ir::Op { $make_instr(result, rhs, lhs) }
     }};
 }
 
@@ -57,8 +57,8 @@ pub type Input32<T> = Input<Const32<T>>;
 
 /// A concrete input to a Wasmi instruction.
 pub enum Input<T> {
-    /// A [`Reg`] operand.
-    Reg(Reg),
+    /// A [`Slot`] operand.
+    Slot(Slot),
     /// A 16-bit encoded immediate value operand.
     Immediate(T),
 }

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -1775,7 +1775,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         })?;
         let len = self.immediate_to_reg(len)?;
         let instr: Op = match value {
-            Input::Reg(value) => Op::memory_fill(dst, value, len),
+            Input::Slot(value) => Op::memory_fill(dst, value, len),
             Input::Immediate(value) => Op::memory_fill_imm(dst, value, len),
         };
         self.push_instr(instr, FuelCostsProvider::instance)?;
@@ -1900,7 +1900,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         self.push_instr_with_result(
             item_ty,
             |result| match index {
-                Input::Reg(index) => Op::table_get(result, index),
+                Input::Slot(index) => Op::table_get(result, index),
                 Input::Immediate(index) => Op::table_get_imm(result, index),
             },
             FuelCostsProvider::instance,
@@ -1918,7 +1918,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let index = self.make_index32(index, index_ty)?;
         let value = self.layout.operand_to_reg(value)?;
         let instr = match index {
-            Input::Reg(index) => Op::table_set(index, value),
+            Input::Slot(index) => Op::table_set(index, value),
             Input::Immediate(index) => Op::table_set_at(value, index),
         };
         self.push_instr(instr, FuelCostsProvider::instance)?;

--- a/crates/wasmi/src/engine/translator/utils.rs
+++ b/crates/wasmi/src/engine/translator/utils.rs
@@ -194,12 +194,12 @@ impl IsInstructionParameter for Op {
             | Self::F64Const32 { .. }
             | Self::BranchTableTarget { .. }
             | Self::Imm16AndImm32 { .. }
-            | Self::RegisterAndImm32 { .. }
-            | Self::RegisterSpan { .. }
-            | Self::Register { .. }
-            | Self::Register2 { .. }
-            | Self::Register3 { .. }
-            | Self::RegisterList { .. }
+            | Self::SlotAndImm32 { .. }
+            | Self::SlotSpan { .. }
+            | Self::Slot { .. }
+            | Self::Slot2 { .. }
+            | Self::Slot3 { .. }
+            | Self::SlotList { .. }
             | Self::CallIndirectParams { .. }
             | Self::CallIndirectParamsImm16 { .. }
         )


### PR DESCRIPTION
Affected types are:

- `Reg` -> `Slot`
- `RegSpan` -> `SlotSpan`
- `FixedRegSpan` -> `FixedSlotSpan`
- `BoundedRegSpan` -> `BoundedSlotSpan`

`Slot` refers to a stack slot from now on.
This PR is meant to simplify integration of https://github.com/wasmi-labs/wasmi/pull/1650.