### PR TITLE
chore: fix typo in comment

### DIFF
--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -149,7 +149,7 @@ impl EngineFuncSpan {
 
     /// Returns the n-th [`EngineFunc`] in `self`, if any.
     ///
-    /// # Pancis
+    /// # Panics
     ///
     /// If `n` is out of bounds.
     #[track_caller]


### PR DESCRIPTION
fix typo in comment