### PR TITLE
Fix `simd` usage in Wasmi's C-API

### DIFF
--- a/crates/c_api/src/types/val.rs
+++ b/crates/c_api/src/types/val.rs
@@ -34,10 +34,6 @@ pub enum wasm_valkind_t {
     ///
     /// Wraps [`ValType::F64`].
     WASM_F64 = 3,
-    /// A Wasm `v128` value type.
-    ///
-    /// Wraps [`ValType::V128`].
-    WASM_V128 = 4,
     /// A Wasm external reference type.
     ///
     /// Wraps [`ValType::ExternRef`].
@@ -71,7 +67,6 @@ pub(crate) fn into_valtype(kind: wasm_valkind_t) -> ValType {
         wasm_valkind_t::WASM_I64 => ValType::I64,
         wasm_valkind_t::WASM_F32 => ValType::F32,
         wasm_valkind_t::WASM_F64 => ValType::F64,
-        wasm_valkind_t::WASM_V128 => ValType::V128,
         wasm_valkind_t::WASM_EXTERNREF => ValType::ExternRef,
         wasm_valkind_t::WASM_FUNCREF => ValType::FuncRef,
     }
@@ -84,8 +79,8 @@ pub(crate) fn from_valtype(ty: &ValType) -> wasm_valkind_t {
         ValType::I64 => wasm_valkind_t::WASM_I64,
         ValType::F32 => wasm_valkind_t::WASM_F32,
         ValType::F64 => wasm_valkind_t::WASM_F64,
-        ValType::V128 => wasm_valkind_t::WASM_V128,
         ValType::ExternRef => wasm_valkind_t::WASM_EXTERNREF,
         ValType::FuncRef => wasm_valkind_t::WASM_FUNCREF,
+        unsupported => ::core::panic!("c-api: unsupported `valtype` found: {unsupported:?}"),
     }
 }


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1672.

Wasmi implemented `simd` support superficially while the official C-API does not. This caused `wasm_val_t` and `wasm_valtype_t` types to be misaligned which caused issues.

@haroel can you confirm that this PR fixes the underlying issue?