### PR TITLE
Add conversion from `ResumableHostError` to `dyn HostError` via `ErrorKind::as_host`

### DIFF
--- a/crates/wasmi/src/engine/resumable.rs
+++ b/crates/wasmi/src/engine/resumable.rs
@@ -66,6 +66,16 @@ impl ResumableHostTrapError {
         self.host_error
     }
 
+    /// Returns a shared reference to the underlying [`Error`].
+    pub(crate) fn as_error_ref(&self) -> &Error {
+        &self.host_error
+    }
+
+    /// Returns a mutable reference to the underlying [`Error`].
+    pub(crate) fn as_error_mut(&mut self) -> &mut Error {
+        &mut self.host_error
+    }
+
     /// Returns the [`Func`] of the [`ResumableHostTrapError`].
     pub(crate) fn host_func(&self) -> &Func {
         &self.host_func

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -76,6 +76,11 @@ impl Error {
         &self.kind
     }
 
+    /// Returns a mutable reference to [`ErrorKind`] of the [`Error`].
+    pub fn kind_mut(&mut self) -> &mut ErrorKind {
+        &mut self.kind
+    }
+
     /// Returns a reference to [`TrapCode`] if [`Error`] is a [`TrapCode`].
     pub fn as_trap_code(&self) -> Option<TrapCode> {
         self.kind().as_trap_code()
@@ -242,6 +247,7 @@ impl ErrorKind {
     pub fn as_host(&self) -> Option<&dyn HostError> {
         match self {
             Self::Host(error) => Some(error.as_ref()),
+            Self::ResumableHostTrap(error) => error.as_error_ref().kind().as_host(),
             _ => None,
         }
     }
@@ -250,6 +256,7 @@ impl ErrorKind {
     pub fn as_host_mut(&mut self) -> Option<&mut dyn HostError> {
         match self {
             Self::Host(error) => Some(error.as_mut()),
+            Self::ResumableHostTrap(error) => error.as_error_mut().kind_mut().as_host_mut(),
             _ => None,
         }
     }

--- a/crates/wasmi/tests/integration/host_call_error.rs
+++ b/crates/wasmi/tests/integration/host_call_error.rs
@@ -1,0 +1,57 @@
+//! This tests that a host function called from Wasm can return a custom error,
+//! and then catch and handle that error.
+
+use std::fmt;
+use wasmi::{Caller, Engine, Linker, Module, Store};
+
+fn compile_module(engine: &Engine) -> wasmi::Module {
+    let wasm = r#"
+        (module
+            (import "env" "throw_host_error" (func $throw_host_error))
+            (func (export "run")
+                (call $throw_host_error)
+            )
+        )
+    "#;
+    Module::new(engine, wasm).unwrap()
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct CustomHostError {
+    code: u32,
+}
+
+impl fmt::Display for CustomHostError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CustomHostError: code={}", self.code)
+    }
+}
+
+impl core::error::Error for CustomHostError {}
+impl wasmi::errors::HostError for CustomHostError {}
+
+#[test]
+fn test_throw_host_error_in_host_call() {
+    let engine = Engine::default();
+    let mut store = <Store<()>>::new(&engine, ());
+    let module = compile_module(store.engine());
+    let mut linker = <Linker<()>>::new(&engine);
+    linker
+        .func_wrap(
+            "env",
+            "throw_host_error",
+            |_caller: Caller<()>| -> Result<(), wasmi::Error> {
+                Err(wasmi::Error::host(CustomHostError { code: 42 }))
+            },
+        )
+        .unwrap();
+    let instance = linker.instantiate_and_start(&mut store, &module).unwrap();
+    let result = instance
+        .get_typed_func::<(), ()>(&mut store, "run")
+        .unwrap()
+        .call(&mut store, ())
+        .unwrap_err();
+
+    assert!(result.downcast_ref::<CustomHostError>().is_some());
+    assert_eq!(result.downcast_ref::<CustomHostError>().unwrap().code, 42);
+}

--- a/crates/wasmi/tests/integration/mod.rs
+++ b/crates/wasmi/tests/integration/mod.rs
@@ -4,6 +4,7 @@ mod fuel_consumption;
 mod fuel_metering;
 mod func;
 mod host_call_compilation;
+mod host_call_error;
 mod host_call_instantiation;
 mod host_calls_wasm;
 mod instantitation;


### PR DESCRIPTION
In earlier versions of wasmi (I can confirm this worked on 0.36.5, at least), one could use Error::downcast to access a HostError returned from a host function.  On 1.0.3, however, the downcast fails.  It appears that the root cause is that the ErrorKind returned from a host function has changed to a ResumableHostTrap( HostError ), and as_host() returns None.
Is this change intended behavior?

This change makes the HostError accessible from an ErrorKind::ResumableHostTrap, as it is from an ErrorKind::Host.
