### PR TITLE
Use OIDC in GitHub Actions CI `coverage` job and update dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -389,6 +389,9 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     container:
       image: xd009642/tarpaulin:develop-nightly
       options: --security-opt seccomp=unconfined


### PR DESCRIPTION
This PR is an improved version of https://github.com/wasmi-labs/wasmi/pull/1740.

- This replaces the `CODECOV_TOKEN` secret usage with OIDC which is the future direction and more secure.
- This updates `actions/upload-artifact` from `v4` to `v6`.