### PR TITLE
Use `cargo-nextest`'s new `on-timeout="pass"` option

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
 [profile.default-miri]
-slow-timeout = { period = "120s", terminate-after = 5 }
+slow-timeout = { period = "120s", terminate-after = 5, on-timeout = "pass" }
 test-threads = "num-cpus"
 fail-fast = false


### PR DESCRIPTION
This new option was introduced in https://github.com/nextest-rs/nextest/releases/tag/cargo-nextest-0.9.115.

This helps to finally make Wasmi's `miri` CRON job not fail on timeouts.