### PR TITLE
Add GitHub Actions check using `cargo-deny`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -241,7 +241,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-deny
         run: |
           # Note: We use `|| true` because cargo install returns an error


### PR DESCRIPTION
This does _not_ (yet) check licenses.
