### PR TITLE
Add dispatch selection to Wasmi CLI

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,6 +28,8 @@ hash-collections = ["wasmi/hash-collections"]
 prefer-btree-collections = ["wasmi/prefer-btree-collections"]
 simd = ["wasmi/simd"]
 wasi = ["wasmi_wasi"]
+portable-dispatch = ["wasmi/portable-dispatch"]
+indirect-dispatch = ["wasmi/indirect-dispatch"]
 
 # We need to put this [profile.release] section due to this bug in Cargo:
 # https://github.com/rust-lang/cargo/issues/8264


### PR DESCRIPTION
This adds the following Cargo crate features to the Wasmi CLI application: `wasmi_cli`

- `portable-dispatch`
- `indirect-dispatch`

Different dispatching modes have different advantages and disadvantages.