### PR TITLE
Replace `clap` with `argh` for argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,54 +48,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "anyhow"
@@ -111,6 +67,34 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "argh"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f384d96bfd3c0b3c41f24dae69ee9602c091d64fc432225cf5295b5abbe0036"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938e5f66269c1f168035e29ed3fb437b084e476465e9314a0328f4005d7be599"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5127f8a5bc1cfb0faf1f6248491452b8a5b6901068d8da2d47cbb285986ae683"
 
 [[package]]
 name = "assert_cmd"
@@ -309,7 +293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
- "clap_derive",
 ]
 
 [[package]]
@@ -318,22 +301,8 @@ version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -350,12 +319,6 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation-sys"
@@ -841,12 +804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,12 +955,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -1340,12 +1291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,12 +1436,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -1705,8 +1644,8 @@ name = "wasmi_cli"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "argh",
  "assert_cmd",
- "clap",
  "wasmi 1.0.0",
  "wasmi_wasi",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,7 +17,7 @@ exclude.workspace = true
 wasmi = { workspace = true }
 wasmi_wasi = { workspace = true, optional = true }
 anyhow = "1"
-clap = { version = "4", features = ["derive"] }
+argh = { version = "0.1.14", default-features = false, features = ["help"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.7"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,7 +3,6 @@ use crate::{
     display::{DisplayExportedFuncs, DisplayFuncType, DisplaySequence, DisplayValue},
 };
 use anyhow::{Error, Result, anyhow, bail};
-use clap::Parser;
 use context::Context;
 use std::{path::Path, process};
 use wasmi::{Func, FuncType, Val};
@@ -17,7 +16,7 @@ mod utils;
 mod tests;
 
 fn main() -> Result<()> {
-    let args = Args::parse();
+    let args: Args = argh::from_env();
     let wasm_file = args.wasm_file();
     let wasi_ctx = args.store_context()?;
     let mut ctx = Context::new(wasm_file, wasi_ctx, args.fuel(), args.compilation_mode())?;


### PR DESCRIPTION
Find benchmarks and comparisons below.

tl;dr:

- **Debug Build:** tie
- **Optimized Build:** tie (minor`argh` win)
- **Artifact Size (opt):** `argh` wins
- **Help Output:** `clap` wins

# Benchmarks

## Using `clap`

- **Debug Build:** 5.54s
- **Optimized Build:** 19.91s
- **Artifact Size (opt):** 2.0M

## Using `argh`

- **Debug Build:** 5.78s
- **Optimized Build:** 17.65s
- **Artifact Size (opt):** 1.7M

# Help Command

## Using `clap`

```
WebAssembly interpreter

Usage: wasmi_cli [OPTIONS] <MODULE> [ARGS]...

Arguments:
  <MODULE>
          The file containing the WebAssembly module to execute

  [ARGS]...
          Arguments given to the Wasm module or the invoked function

Options:
      --dir <DIRECTORY>
          The host directory to pre-open for the `guest` to use

      --tcplisten <SOCKET ADDRESS>
          The socket address provided to the module. Allows it to perform socket-related `WASI` ops

      --env <NAME=VAL>
          The environment variable pair made available for the program

      --invoke <FUNCTION>
          The function to invoke.
          
          If this argument is missing, Wasmi CLI will try to run `""` or `_start`.
          
          If neither are exported the Wasmi CLI will display out all exported functions of the Wasm module and return with an error.

      --compilation-mode <COMPILATION_MODE>
          Select Wasmi's mode of compilation
          
          [default: lazy-translation]
          [possible values: eager, lazy-translation, lazy]

      --fuel <N>
          Enable execution fuel metering with N units of fuel.
          
          The execution will trap after running out of the N units of fuel.

      --verbose
          Enable informational messages beyond warnings or errors

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```

## Using `argh`

```
Usage: wasmi_cli [--dir <dir...>] [--tcplisten <tcplisten...>] [--env <env...>] [--invoke <invoke>] [--compilation-mode <compilation-mode>] [--fuel <fuel>] [--verbose] [--] <wasm_file> [<func_args...>]

The Wasmi CLI application.

Positional Arguments:
  wasm_file         the file containing the WebAssembly module to execute
  func_args         arguments given to the Wasm module or the invoked function

Options:
  --dir             the host directory to pre-open for the `guest` to use
  --tcplisten       the socket address provided to the module
  --env             the environment variable pair made available for the program
  --invoke          the name of the exported function to invoke
  --compilation-mode
                    select Wasmi's mode of compilation (default =
                    lazy-translation)
  --fuel            enable execution fuel metering with N units of fuel
  --verbose         enable informational messages beyond warnings or errors
  --help, help      display usage information
```