### PR TITLE
Disable `wasmi_wast` default features be default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ wasmi_wasi = { version = "1.0.0", path = "crates/wasi", default-features = false
 wasmi_core = { version = "1.0.0", path = "crates/core", default-features = false }
 wasmi_ir = { version = "1.0.0", path = "crates/ir", default-features = false }
 wasmi_collections = { version = "1.0.0", path = "crates/collections", default-features = false }
+wasmi_wast = { version = "1.0.0", path = "crates/wast", default-features = false }
 wasmi_c_api_impl = { version = "1.0.0", path = "crates/c_api" }
 wasmi_c_api_macros = { version = "1.0.0", path = "crates/c_api/macro" }
 wasmi_fuzz = { version = "1.0.0", path = "crates/fuzz" }
-wasmi_wast = { version = "1.0.0", path = "crates/wast" }
 
 # wasm-tools dependencies
 wat = { version = "1.228.0", default-features = false }


### PR DESCRIPTION
I was wondering why `cargo build -p wasmi_cli` was using all those debug features such as `portable-dispatch` and `extra-checks` without specifying them explicitly.

Turned out, that since `wasmi_cli` depends on `wasmi_wast` it pulled in all of its default features.
The fix is easy: simply disable default features in the workspace dependency.

So `cargo build -p wasmi_cli` now builds with the proper feature set.