### PR TITLE
fix: re-extract mem0 after host function calls

### DIFF
--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -743,6 +743,10 @@ pub fn call_wasm_or_host(
                 Some(instance),
                 CallHooks::Call,
             )?;
+            // Host functions may re-enter WASM (e.g. calling cabi_realloc)
+            // which can trigger memory.grow, invalidating the cached mem0
+            // pointer. Re-extract to avoid stale pointer dereference.
+            let (mem0, mem0_len) = extract_mem0(state.store, instance);
             (caller_ip, sp, mem0, mem0_len, instance)
         }
     };


### PR DESCRIPTION
Host functions may re-enter WASM execution (e.g. calling `cabi_realloc` or other exported functions). If that re-entrant execution triggers `memory.grow`, the cached `mem0` pointer in `call_wasm_or_host()` becomes stale. Subsequent wasm load/store instructions then dereference the dangling pointer, causing a SIGSEGV.

The `FuncEntity::Wasm` branch already refreshes `mem0` via `update_instance()`. This applies the same treatment to the `FuncEntity::Host` branch by calling `extract_mem0()` after `call_host()` returns.

**Reproducer**: Any WASI component that calls `cabi_realloc` from a host function (standard component-model pattern), where the underlying WASM allocator eventually calls `memory.grow`.

**Impact**: SIGSEGV crash in `load_into<1>` at `dispatch_handler` during execution of large WASM modules with significant memory allocation patterns (e.g., ONNX inference).