### PR TITLE
Optimize fibonacci benchmarks

### DIFF
--- a/crates/wasmi/benches/wat/fibonacci.wat
+++ b/crates/wasmi/benches/wat/fibonacci.wat
@@ -22,11 +22,6 @@
                 (return (local.get $a))
             )
         )
-        (if (i64.eq (local.get $N) (i64.const 1))
-            (then
-                (return (local.get $b))
-            )
-        )
         (return_call $fib_tail_recursive
             (i64.sub (local.get $N) (i64.const 1))
             (local.get $b)
@@ -38,32 +33,29 @@
         (return_call $fib_tail_recursive (local.get $N) (i64.const 0) (i64.const 1))
     )
 
-    (func $fib_iterative (export "fibonacci_iter") (param $N i64) (result i64)
-        (local $n1 i64)
-        (local $n2 i64)
-        (local $tmp i64)
+    (func (export "fibonacci_iter") (param $n i64) (result i64)
+        (local $a i64)
+        (local $b i64)
         (local $i i64)
-        ;; return $N for N <= 1
         (if
-            (i64.le_s (local.get $N) (i64.const 1))
-            (then (return (local.get $N)))
-        )
-        (local.set $n1 (i64.const 1))
-        (local.set $n2 (i64.const 1))
-        (local.set $i (i64.const 2))
-        ;;since we normally return n2, handle n=1 case specially
-        (loop $continue
-            (if
-                (i64.lt_s (local.get $i) (local.get $N))
-                (then
-                    (local.set $tmp (i64.add (local.get $n1) (local.get $n2)))
-                    (local.set $n1 (local.get $n2))
-                    (local.set $n2 (local.get $tmp))
-                    (local.set $i (i64.add (local.get $i) (i64.const 1)))
-                    (br $continue)
-                )
+            (i64.le_s (local.get $n) (i64.const 1))
+            (then
+                (return (local.get $n))
             )
         )
-        (local.get $n2)
+        (local.set $a (i64.const 1))
+        (local.set $b (i64.const 1))
+        (local.set $i (i64.const 2))
+        (block $break
+            (br_if $break (i64.le_s (local.get $n) (local.get $i)))
+            (loop $continue
+                (i64.add (local.get $a) (local.get $b))
+                (local.set $a (local.get $b))
+                (local.set $b)
+                (local.set $i (i64.add (local.get $i) (i64.const 1)))
+                (br_if $continue (i64.gt_s (local.get $n) (local.get $i)))
+            )
+        )
+        (local.get $b)
     )
 )


### PR DESCRIPTION
- `fib/tail`: removed one branch per call.
    - The small trade-off is that recursion goes one step further.
    - However, each step is more efficient.
- `fib/iter`: uses the Wasm stack more efficiently and applied loop inversion.
    - Thanks to @ttraenkler for pointing out the potential optimizations.