### PR TITLE
Improve `coverage` GitHub CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -424,7 +424,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
+          cargo tarpaulin --verbose --all-features --workspace --timeout 180 --engine llvm --out xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v6.0.1
         with:


### PR DESCRIPTION
- increased timeout: 120s -> 180s
- now uses the `llvm` tracing engine