### PR TITLE
Add new Rust based benchmarks

### DIFF
--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -106,6 +106,7 @@ criterion_group! {
         .warm_up_time(Duration::from_millis(1000));
     targets =
         bench_execute_sort,
+        bench_execute_prime_sieve,
         bench_execute_tiny_keccak,
         bench_execute_reverse_complement,
         bench_execute_regex_redux,
@@ -682,6 +683,35 @@ fn bench_execute_sort(c: &mut Criterion) {
         b.iter(|| {
             run.call(&mut store, benchmark).unwrap();
         });
+        instance
+            .get_typed_func::<u32, ()>(&store, "teardown")
+            .unwrap()
+            .call(&mut store, benchmark)
+            .unwrap();
+    });
+}
+
+fn bench_execute_prime_sieve(c: &mut Criterion) {
+    c.bench_function("execute/prime_sieve", |b| {
+        let (mut store, instance) =
+            load_instance_from_file("benches/rust/cases/prime_sieve/out.wasm");
+        let benchmark = instance
+            .get_typed_func::<u64, u32>(&store, "setup")
+            .unwrap()
+            .call(&mut store, 10_000_000)
+            .unwrap();
+        let run = instance.get_typed_func::<u32, ()>(&store, "run").unwrap();
+        b.iter(|| {
+            run.call(&mut store, benchmark).unwrap();
+        });
+        let len_primes = instance
+            .get_typed_func::<u32, u64>(&store, "len_primes")
+            .unwrap();
+        let largest_prime = instance
+            .get_typed_func::<u32, u64>(&store, "largest_prime")
+            .unwrap();
+        assert_eq!(len_primes.call(&mut store, benchmark).unwrap(), 664579);
+        assert_eq!(largest_prime.call(&mut store, benchmark).unwrap(), 9999991);
         instance
             .get_typed_func::<u32, ()>(&store, "teardown")
             .unwrap()

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -107,6 +107,7 @@ criterion_group! {
     targets =
         bench_execute_sort,
         bench_execute_prime_sieve,
+        bench_execute_matrix_mul,
         bench_execute_tiny_keccak,
         bench_execute_reverse_complement,
         bench_execute_regex_redux,
@@ -712,6 +713,27 @@ fn bench_execute_prime_sieve(c: &mut Criterion) {
             .unwrap();
         assert_eq!(len_primes.call(&mut store, benchmark).unwrap(), 664579);
         assert_eq!(largest_prime.call(&mut store, benchmark).unwrap(), 9999991);
+        instance
+            .get_typed_func::<u32, ()>(&store, "teardown")
+            .unwrap()
+            .call(&mut store, benchmark)
+            .unwrap();
+    });
+}
+
+fn bench_execute_matrix_mul(c: &mut Criterion) {
+    c.bench_function("execute/matrix_mul", |b| {
+        let (mut store, instance) =
+            load_instance_from_file("benches/rust/cases/matrix_mul/out.wasm");
+        let benchmark = instance
+            .get_typed_func::<u32, u32>(&store, "setup")
+            .unwrap()
+            .call(&mut store, 400)
+            .unwrap();
+        let run = instance.get_typed_func::<u32, ()>(&store, "run").unwrap();
+        b.iter(|| {
+            run.call(&mut store, benchmark).unwrap();
+        });
         instance
             .get_typed_func::<u32, ()>(&store, "teardown")
             .unwrap()

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -672,8 +672,7 @@ fn bench_instantiate_erc1155(c: &mut Criterion) {
 
 fn bench_execute_sort(c: &mut Criterion) {
     c.bench_function("execute/sort", |b| {
-        let (mut store, instance) =
-            load_instance_from_file("benches/rust/cases/sort/out.wasm");
+        let (mut store, instance) = load_instance_from_file("benches/rust/cases/sort/out.wasm");
         let benchmark = instance
             .get_typed_func::<u32, u32>(&store, "setup")
             .unwrap()

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -105,6 +105,7 @@ criterion_group! {
         .measurement_time(Duration::from_millis(2000))
         .warm_up_time(Duration::from_millis(1000));
     targets =
+        bench_execute_sort,
         bench_execute_tiny_keccak,
         bench_execute_reverse_complement,
         bench_execute_regex_redux,
@@ -667,6 +668,27 @@ fn bench_instantiate_erc721(c: &mut Criterion) {
 #[allow(dead_code)]
 fn bench_instantiate_erc1155(c: &mut Criterion) {
     bench_instantiate_contract(c, "erc1155", "benches/wasm/erc1155.wasm")
+}
+
+fn bench_execute_sort(c: &mut Criterion) {
+    c.bench_function("execute/sort", |b| {
+        let (mut store, instance) =
+            load_instance_from_file("benches/rust/cases/sort/out.wasm");
+        let benchmark = instance
+            .get_typed_func::<u32, u32>(&store, "setup")
+            .unwrap()
+            .call(&mut store, 1_000_000)
+            .unwrap();
+        let run = instance.get_typed_func::<u32, ()>(&store, "run").unwrap();
+        b.iter(|| {
+            run.call(&mut store, benchmark).unwrap();
+        });
+        instance
+            .get_typed_func::<u32, ()>(&store, "teardown")
+            .unwrap()
+            .call(&mut store, benchmark)
+            .unwrap();
+    });
 }
 
 fn bench_execute_tiny_keccak(c: &mut Criterion) {


### PR DESCRIPTION
New bechmarks

- `sort`: using Rust's `sort_unstable`
- `matrix_mul`: using `f32` cells and pre-transpose step O(m^3)
- `prime_sieve`: using bit-vector for odd values
