### PR TITLE
Add `-Cllvm-args="--switch-to-lookup=true"` to Cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+[build]
+rustflags = [
+    # This flag is extremely important to make LLVM _not_ pessimize
+    # codegen for the conversion of `OpCode` to execution handler.
+    # This resulted in massive wins for compile-time and execution
+    # performance, especially when `indirect-dispatch` is enabled.
+    #
+    # Tested with: Rust 1.96 using LLVM 22.1.2
+    "-C",
+    "llvm-args=--switch-to-lookup=true",
+]


### PR DESCRIPTION
This flag is extremely important to make LLVM _not_ pessimize
codegen for the conversion of `OpCode` to execution handler.
This resulted in massive wins for compile-time and execution
performance, especially when the `indirect-dispatch` crate feature is enabled.

Tested with: Rust 1.96 using LLVM 22.1.2

This change also unblocks https://github.com/wasmi-labs/wasmi/pull/1855.