### PR TITLE
Simplify the `counter` benchmark

### DIFF
--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -921,7 +921,7 @@ fn bench_execute_counter(c: &mut Criterion) {
         let run = instance.get_typed_func::<i32, i32>(&store, "run").unwrap();
         b.iter(|| {
             let result = run.call(&mut store, ITERATIONS).unwrap();
-            assert_eq!(result, ITERATIONS);
+            assert_eq!(result, 0);
         })
     });
 }

--- a/crates/wasmi/benches/wat/counter.wat
+++ b/crates/wasmi/benches/wat/counter.wat
@@ -1,20 +1,16 @@
 (module
   (func (export "run") (param $n i32) (result i32)
-    (local $i i32)
     (loop $continue
         (br_if
             $continue
-            (i32.ne
-                (local.tee $i
-                    (i32.add
-                        (local.get $i)
-                        (i32.const 1)
-                    )
+            (local.tee $n
+                (i32.sub
+                    (local.get $n)
+                    (i32.const 1)
                 )
-                (local.get $n)
             )
         )
     )
-    (return (local.get $i))
+    (return (local.get $n))
   )
 )


### PR DESCRIPTION
The `counter` benchmark represents an artificial minimal benchmark. So we make it the most minimal it can be.