### PR TITLE
Add some new `execute/` benchmarks

### DIFF
--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -113,6 +113,7 @@ criterion_group! {
         bench_execute_tiny_keccak,
         bench_execute_mandelbrot,
         bench_execute_spectralnorm,
+        bench_execute_json_parse,
         bench_execute_reverse_complement,
         bench_execute_regex_redux,
         bench_execute_counter,
@@ -860,6 +861,49 @@ fn bench_execute_spectralnorm(c: &mut Criterion) {
             1.2742241159529095
         );
         teardown.call(&mut store, data_ptr).unwrap();
+    });
+}
+
+fn bench_execute_json_parse(c: &mut Criterion) {
+    c.bench_function("execute/json_parse", |b| {
+        let (mut store, instance) =
+            load_instance_from_file("benches/rust/cases/json_parse/out.wasm");
+        let input_data = std::fs::read_to_string("benches/rust/res/citm_catalog.json").unwrap();
+        // Allocate buffers for the input and output.
+        let data_ptr = instance
+            .get_typed_func::<u32, u32>(&store, "setup")
+            .unwrap()
+            .call(&mut store, input_data.as_bytes().len() as u32)
+            .unwrap();
+        // Get the pointer to the input buffer.
+        let input_offset = instance
+            .get_typed_func::<u32, u32>(&store, "input_ptr")
+            .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
+        // Copy test data inside the wasm memory.
+        let memory = instance.get_memory(&store, "memory").unwrap();
+        memory
+            .write(&mut store, input_offset as usize, input_data.as_bytes())
+            .unwrap();
+        // Run the benchmark.
+        let run = instance.get_typed_func::<u32, ()>(&store, "run").unwrap();
+        b.iter(|| {
+            run.call(&mut store, data_ptr).unwrap();
+        });
+        // Get the pointer to the output buffer.
+        let node_count = instance
+            .get_typed_func::<u32, u64>(&store, "node_count")
+            .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
+        assert_eq!(node_count, 37_778);
+        // Teardown benchmark data.
+        instance
+            .get_typed_func::<u32, ()>(&store, "teardown")
+            .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
     });
 }
 

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -827,15 +827,12 @@ fn bench_execute_mandelbrot(c: &mut Criterion) {
         let output = instance
             .get_typed_func::<u32, u64>(&store, "output")
             .unwrap();
-        let data_ptr = setup
-            .call(&mut store, 150)
-            .unwrap();
+        let data_ptr = setup.call(&mut store, 150).unwrap();
         b.iter(|| {
             run.call(&mut store, data_ptr).unwrap();
         });
         assert_eq!(output.call(&mut store, data_ptr).unwrap(), 5_595_328);
-        teardown
-            .call(&mut store, data_ptr)
+        teardown.call(&mut store, data_ptr).unwrap();
             .unwrap();
     });
 }

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -114,6 +114,7 @@ criterion_group! {
         bench_execute_mandelbrot,
         bench_execute_spectralnorm,
         bench_execute_compression,
+        bench_execute_word_count,
         bench_execute_json_parse,
         bench_execute_reverse_complement,
         bench_execute_regex_redux,
@@ -899,6 +900,55 @@ fn bench_execute_compression(c: &mut Criterion) {
             .call(&mut store, data_ptr)
             .unwrap();
         assert_eq!(len_compressed, 97_649);
+        // Teardown benchmark data.
+        instance
+            .get_typed_func::<u32, ()>(&store, "teardown")
+            .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
+    });
+}
+
+fn bench_execute_word_count(c: &mut Criterion) {
+    c.bench_function("execute/word_count", |b| {
+        let (mut store, instance) =
+            load_instance_from_file("benches/rust/cases/word_count/out.wasm");
+        let input_data = std::fs::read_to_string("benches/rust/res/alice29.txt").unwrap();
+        // Allocate buffers for the input and output.
+        let data_ptr = instance
+            .get_typed_func::<u32, u32>(&store, "setup")
+            .unwrap()
+            .call(&mut store, input_data.as_bytes().len() as u32)
+            .unwrap();
+        // Get the pointer to the input buffer.
+        let input_offset = instance
+            .get_typed_func::<u32, u32>(&store, "input_ptr")
+            .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
+        // Copy test data inside the wasm memory.
+        let memory = instance.get_memory(&store, "memory").unwrap();
+        memory
+            .write(&mut store, input_offset as usize, input_data.as_bytes())
+            .unwrap();
+        // Run the benchmark.
+        let run = instance.get_typed_func::<u32, ()>(&store, "run").unwrap();
+        b.iter(|| {
+            run.call(&mut store, data_ptr).unwrap();
+        });
+        // Check results for correctness.
+        let len_unique_words = instance
+            .get_typed_func::<u32, u64>(&store, "len_unique_words")
+            .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
+        let len_special_chars = instance
+            .get_typed_func::<u32, u64>(&store, "len_special_chars")
+            .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
+        assert_eq!(len_unique_words, 2213);
+        assert_eq!(len_special_chars, 6314);
         // Teardown benchmark data.
         instance
             .get_typed_func::<u32, ()>(&store, "teardown")

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -113,6 +113,7 @@ criterion_group! {
         bench_execute_tiny_keccak,
         bench_execute_mandelbrot,
         bench_execute_spectralnorm,
+        bench_execute_compression,
         bench_execute_json_parse,
         bench_execute_reverse_complement,
         bench_execute_regex_redux,
@@ -861,6 +862,49 @@ fn bench_execute_spectralnorm(c: &mut Criterion) {
             1.2742241159529095
         );
         teardown.call(&mut store, data_ptr).unwrap();
+    });
+}
+
+fn bench_execute_compression(c: &mut Criterion) {
+    c.bench_function("execute/compression", |b| {
+        let (mut store, instance) =
+            load_instance_from_file("benches/rust/cases/compression/out.wasm");
+        let input_data = std::fs::read_to_string("benches/rust/res/alice29.txt").unwrap();
+        // Allocate buffers for the input and output.
+        let data_ptr = instance
+            .get_typed_func::<u32, u32>(&store, "setup")
+            .unwrap()
+            .call(&mut store, input_data.as_bytes().len() as u32)
+            .unwrap();
+        // Get the pointer to the input buffer.
+        let input_offset = instance
+            .get_typed_func::<u32, u32>(&store, "input_ptr")
+            .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
+        // Copy test data inside the wasm memory.
+        let memory = instance.get_memory(&store, "memory").unwrap();
+        memory
+            .write(&mut store, input_offset as usize, input_data.as_bytes())
+            .unwrap();
+        // Run the benchmark.
+        let run = instance.get_typed_func::<u32, ()>(&store, "run").unwrap();
+        b.iter(|| {
+            run.call(&mut store, data_ptr).unwrap();
+        });
+        // Get the pointer to the output buffer.
+        let len_compressed = instance
+            .get_typed_func::<u32, u64>(&store, "len_compressed")
+            .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
+        assert_eq!(len_compressed, 97_649);
+        // Teardown benchmark data.
+        instance
+            .get_typed_func::<u32, ()>(&store, "teardown")
+            .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
     });
 }
 

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -111,6 +111,7 @@ criterion_group! {
         bench_execute_nbody,
         bench_execute_argon2,
         bench_execute_tiny_keccak,
+        bench_execute_mandelbrot,
         bench_execute_reverse_complement,
         bench_execute_regex_redux,
         bench_execute_counter,
@@ -807,6 +808,33 @@ fn bench_execute_tiny_keccak(c: &mut Criterion) {
         instance
             .get_typed_func::<i32, ()>(&store, "teardown")
             .unwrap()
+            .call(&mut store, data_ptr)
+            .unwrap();
+    });
+}
+
+fn bench_execute_mandelbrot(c: &mut Criterion) {
+    c.bench_function("execute/mandelbrot", |b| {
+        let (mut store, instance) =
+            load_instance_from_file("benches/rust/cases/mandelbrot/out.wasm");
+        let setup = instance
+            .get_typed_func::<u32, u32>(&store, "setup")
+            .unwrap();
+        let run = instance.get_typed_func::<u32, ()>(&store, "run").unwrap();
+        let teardown = instance
+            .get_typed_func::<u32, ()>(&store, "teardown")
+            .unwrap();
+        let output = instance
+            .get_typed_func::<u32, u64>(&store, "output")
+            .unwrap();
+        let data_ptr = setup
+            .call(&mut store, 150)
+            .unwrap();
+        b.iter(|| {
+            run.call(&mut store, data_ptr).unwrap();
+        });
+        assert_eq!(output.call(&mut store, data_ptr).unwrap(), 5_595_328);
+        teardown
             .call(&mut store, data_ptr)
             .unwrap();
     });

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -875,7 +875,7 @@ fn bench_execute_compression(c: &mut Criterion) {
         let data_ptr = instance
             .get_typed_func::<u32, u32>(&store, "setup")
             .unwrap()
-            .call(&mut store, input_data.as_bytes().len() as u32)
+            .call(&mut store, input_data.len() as u32)
             .unwrap();
         // Get the pointer to the input buffer.
         let input_offset = instance
@@ -918,7 +918,7 @@ fn bench_execute_word_count(c: &mut Criterion) {
         let data_ptr = instance
             .get_typed_func::<u32, u32>(&store, "setup")
             .unwrap()
-            .call(&mut store, input_data.as_bytes().len() as u32)
+            .call(&mut store, input_data.len() as u32)
             .unwrap();
         // Get the pointer to the input buffer.
         let input_offset = instance
@@ -967,7 +967,7 @@ fn bench_execute_json_parse(c: &mut Criterion) {
         let data_ptr = instance
             .get_typed_func::<u32, u32>(&store, "setup")
             .unwrap()
-            .call(&mut store, input_data.as_bytes().len() as u32)
+            .call(&mut store, input_data.len() as u32)
             .unwrap();
         // Get the pointer to the input buffer.
         let input_offset = instance

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -112,6 +112,7 @@ criterion_group! {
         bench_execute_argon2,
         bench_execute_tiny_keccak,
         bench_execute_mandelbrot,
+        bench_execute_spectralnorm,
         bench_execute_reverse_complement,
         bench_execute_regex_redux,
         bench_execute_counter,
@@ -833,7 +834,32 @@ fn bench_execute_mandelbrot(c: &mut Criterion) {
         });
         assert_eq!(output.call(&mut store, data_ptr).unwrap(), 5_595_328);
         teardown.call(&mut store, data_ptr).unwrap();
+    });
+}
+
+fn bench_execute_spectralnorm(c: &mut Criterion) {
+    c.bench_function("execute/spectralnorm", |b| {
+        let (mut store, instance) =
+            load_instance_from_file("benches/rust/cases/spectralnorm/out.wasm");
+        let setup = instance
+            .get_typed_func::<u32, u32>(&store, "setup")
             .unwrap();
+        let run = instance.get_typed_func::<u32, ()>(&store, "run").unwrap();
+        let teardown = instance
+            .get_typed_func::<u32, ()>(&store, "teardown")
+            .unwrap();
+        let output = instance
+            .get_typed_func::<u32, f64>(&store, "output")
+            .unwrap();
+        let data_ptr = setup.call(&mut store, 500).unwrap();
+        b.iter(|| {
+            run.call(&mut store, data_ptr).unwrap();
+        });
+        assert_eq!(
+            output.call(&mut store, data_ptr).unwrap(),
+            1.2742241159529095
+        );
+        teardown.call(&mut store, data_ptr).unwrap();
     });
 }
 


### PR DESCRIPTION
New `execute/` benchmarks include:

- `mandelbrot`
- `spetralnorm`
- `json_parsing`
- `compression`
- `word_count`