### PR TITLE
Ignore tests that depend on `wat` feature if `wat` is disabled

### DIFF
--- a/crates/wasmi/src/engine/limits/tests.rs
+++ b/crates/wasmi/src/engine/limits/tests.rs
@@ -11,6 +11,7 @@ fn parse_with(wasm: &str, limits: EnforcedLimits) -> Result<Module, Error> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_globals_ok() {
     let wasm = "
         (module
@@ -29,6 +30,7 @@ fn max_globals_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_globals_err() {
     let wasm = "
         (module
@@ -48,6 +50,7 @@ fn max_globals_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_functions_ok() {
     let wasm = "
         (module
@@ -66,6 +69,7 @@ fn max_functions_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_functions_err() {
     let wasm = "
         (module
@@ -85,6 +89,7 @@ fn max_functions_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_tables_ok() {
     let wasm = "
         (module
@@ -103,6 +108,7 @@ fn max_tables_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_tables_err() {
     let wasm = "
         (module
@@ -122,6 +128,7 @@ fn max_tables_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_memories_ok() {
     let wasm = "
         (module
@@ -140,6 +147,7 @@ fn max_memories_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_memories_err() {
     let wasm = "
         (module
@@ -159,6 +167,7 @@ fn max_memories_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_element_segments_ok() {
     let wasm = "
         (module
@@ -179,6 +188,7 @@ fn max_element_segments_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_element_segments_err() {
     let wasm = "
         (module
@@ -200,6 +210,7 @@ fn max_element_segments_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_data_segments_ok() {
     let wasm = "
         (module
@@ -219,6 +230,7 @@ fn max_data_segments_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_data_segments_err() {
     let wasm = "
         (module
@@ -239,6 +251,7 @@ fn max_data_segments_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_params_func_ok() {
     let wasm = "
         (module
@@ -256,6 +269,7 @@ fn max_params_func_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_params_func_err() {
     let wasm = "
         (module
@@ -273,6 +287,7 @@ fn max_params_func_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_params_control_ok() {
     let wasm = "
         (module
@@ -297,6 +312,7 @@ fn max_params_control_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_params_control_err() {
     let wasm = "
         (module
@@ -322,6 +338,7 @@ fn max_params_control_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_results_func_ok() {
     let wasm = "
         (module
@@ -342,6 +359,7 @@ fn max_results_func_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_results_func_err() {
     let wasm = "
         (module
@@ -363,6 +381,7 @@ fn max_results_func_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_results_control_ok() {
     let wasm = "
         (module
@@ -387,6 +406,7 @@ fn max_results_control_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn max_results_control_err() {
     let wasm = "
         (module
@@ -413,6 +433,7 @@ fn max_results_control_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn min_avg_code_bytes_ok() {
     let wasm = "
         (module
@@ -442,6 +463,7 @@ fn min_avg_code_bytes_ok() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn min_avg_code_bytes_err() {
     let wasm = "
         (module
@@ -470,6 +492,7 @@ fn min_avg_code_bytes_err() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn min_avg_code_bytes_ok_threshold() {
     let wasm = "
         (module

--- a/crates/wasmi/src/instance/tests.rs
+++ b/crates/wasmi/src/instance/tests.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn instantiate_no_imports() {
     let wasm = r#"
         (module
@@ -34,6 +35,7 @@ fn instantiate_no_imports() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn instantiate_with_start() {
     let wasm = r#"
         (module
@@ -48,6 +50,7 @@ fn instantiate_with_start() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn instantiate_with_trapping_start() {
     let wasm = r#"
         (module
@@ -65,6 +68,7 @@ fn instantiate_with_trapping_start() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn instantiate_with_imports_and_start() {
     let wasm = r#"
         (module
@@ -115,6 +119,7 @@ fn instantiate_with_imports_and_start() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn instantiate_with_invalid_global_import() {
     let wasm = r#"
         (module
@@ -137,6 +142,7 @@ fn instantiate_with_invalid_global_import() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn instantiate_with_invalid_memory_import() {
     let wasm = r#"
         (module
@@ -159,6 +165,7 @@ fn instantiate_with_invalid_memory_import() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn instantiate_with_invalid_table_import() {
     let wasm = r#"
         (module
@@ -187,6 +194,7 @@ fn instantiate_with_invalid_table_import() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn instantiate_with_invalid_func_import() {
     let wasm = r#"
         (module

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -18,6 +18,9 @@
 //!
 //! // In this simple example we are going to compile the below Wasm source,
 //! // instantiate a Wasm module from it and call its exported "hello" function.
+//! # #[cfg(not(feature = "wat"))]
+//! # fn main() {}
+//! # #[cfg(feature = "wat")]
 //! fn main() -> Result<(), wasmi::Error> {
 //!     let wasm = r#"
 //!         (module

--- a/crates/wasmi/src/linker.rs
+++ b/crates/wasmi/src/linker.rs
@@ -643,6 +643,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "wat"), ignore)]
     fn linker_funcs_work() {
         let engine = Engine::default();
         let mut linker = <Linker<HostState>>::new(&engine);
@@ -733,6 +734,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "wat"), ignore)]
     fn populate_via_imports() {
         use crate::{Engine, Func, Linker, Memory, MemoryType, Module, Store};
         let wasm = r#"

--- a/crates/wasmi/src/module/instantiate/tests.rs
+++ b/crates/wasmi/src/module/instantiate/tests.rs
@@ -55,6 +55,7 @@ fn assert_no_duplicates(store: &Store<()>, instance: Instance) {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_import_memory_and_table() {
     let wat = r#"
         (module
@@ -68,6 +69,7 @@ fn test_import_memory_and_table() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_import_memory() {
     let wat = r#"
         (module
@@ -80,6 +82,7 @@ fn test_import_memory() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_import_table() {
     let wat = r#"
         (module
@@ -92,6 +95,7 @@ fn test_import_table() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_no_memory_no_table() {
     let wat = "(module)";
     let (store, instance) = instantiate_from_wat(wat);
@@ -101,6 +105,7 @@ fn test_no_memory_no_table() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_internal_memory() {
     let wat = "(module (memory 1 10) )";
     let (store, instance) = instantiate_from_wat(wat);
@@ -110,6 +115,7 @@ fn test_internal_memory() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_internal_table() {
     let wat = "(module (table 4 funcref) )";
     let (store, instance) = instantiate_from_wat(wat);

--- a/crates/wasmi/tests/integration/call_hook.rs
+++ b/crates/wasmi/tests/integration/call_hook.rs
@@ -63,6 +63,7 @@ fn execute_wasm_fn_a(
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn call_hooks_get_called() {
     let (mut store, mut linker) = test_setup();
 
@@ -158,6 +159,7 @@ fn generate_error_after_n_calls<E: Into<Error> + Clone + Send + Sync + 'static>(
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn call_hook_prevents_wasm_execution() {
     let (mut store, mut linker) = test_setup();
 
@@ -186,6 +188,7 @@ fn call_hook_prevents_wasm_execution() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn call_hook_prevents_host_execution() {
     let (mut store, mut linker) = test_setup();
 
@@ -211,6 +214,7 @@ fn call_hook_prevents_host_execution() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn call_hook_prevents_nested_wasm_execution() {
     let (mut store, mut linker) = test_setup();
 

--- a/crates/wasmi/tests/integration/call_host_via_engine.rs
+++ b/crates/wasmi/tests/integration/call_host_via_engine.rs
@@ -85,6 +85,7 @@ fn host_call_from_host_params_4_results_4() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn host_tail_calls_0() {
     let wasm = r#"
         (module
@@ -117,6 +118,7 @@ fn host_tail_calls_0() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn host_tail_calls_1() {
     let wasm = r#"
         (module

--- a/crates/wasmi/tests/integration/fuel_consumption.rs
+++ b/crates/wasmi/tests/integration/fuel_consumption.rs
@@ -73,6 +73,7 @@ fn check_fuel_consumption(given_fuel: u64, consumed_fuel: u64) {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn fuel_consumption_01() {
     check_fuel_consumption(4, 4);
 }

--- a/crates/wasmi/tests/integration/fuel_metering.rs
+++ b/crates/wasmi/tests/integration/fuel_metering.rs
@@ -92,16 +92,19 @@ fn run_test(mode: CompilationMode, final_fuel: u64) {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn metered_i32_add_eager() {
     run_test(CompilationMode::Eager, 97)
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn metered_i32_add_lazy_translation() {
     run_test(CompilationMode::LazyTranslation, 48)
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn metered_i32_add_lazy() {
     run_test(CompilationMode::Lazy, 34)
 }

--- a/crates/wasmi/tests/integration/host_call_compilation.rs
+++ b/crates/wasmi/tests/integration/host_call_compilation.rs
@@ -15,6 +15,7 @@ fn compile_module(engine: &Engine) -> wasmi::Module {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_compile_in_host_call() {
     let engine = Engine::default();
     let mut store = <Store<()>>::new(&engine, ());

--- a/crates/wasmi/tests/integration/host_call_instantiation.rs
+++ b/crates/wasmi/tests/integration/host_call_instantiation.rs
@@ -31,6 +31,7 @@ impl core::error::Error for Error {}
 impl wasmi::errors::HostError for Error {}
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_instantiate_in_host_call() {
     let engine = Engine::default();
     let mut store = <Store<Data>>::new(&engine, Data::Uninit);

--- a/crates/wasmi/tests/integration/host_calls_wasm.rs
+++ b/crates/wasmi/tests/integration/host_calls_wasm.rs
@@ -11,6 +11,7 @@ fn test_setup() -> (Store<()>, Linker<()>) {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn host_calls_wasm() {
     let (mut store, mut linker) = test_setup();
     let host_fn = Func::wrap(&mut store, |mut caller: Caller<()>, input: i32| -> i32 {

--- a/crates/wasmi/tests/integration/instantitation.rs
+++ b/crates/wasmi/tests/integration/instantitation.rs
@@ -1,6 +1,7 @@
 use wasmi::{Engine, Instance, Module, Store};
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn instantiate_out_of_memory() {
     let wasm = r#"
         (module

--- a/crates/wasmi/tests/integration/resource_limiter.rs
+++ b/crates/wasmi/tests/integration/resource_limiter.rs
@@ -75,6 +75,7 @@ impl Test {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_big_memory_fails_to_instantiate() {
     let loose_limits = StoreLimitsBuilder::new().memory_size(3 * (1 << 16)).build();
     let tight_limits = StoreLimitsBuilder::new().memory_size(2 * (1 << 16)).build();
@@ -83,6 +84,7 @@ fn test_big_memory_fails_to_instantiate() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_big_table_fails_to_instantiate() {
     let loose_limits = StoreLimitsBuilder::new().table_elements(100).build();
     let tight_limits = StoreLimitsBuilder::new().table_elements(99).build();
@@ -91,24 +93,28 @@ fn test_big_table_fails_to_instantiate() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_memory_count_limit() {
     let limits = StoreLimitsBuilder::new().memories(0).build();
     assert!(Test::new(0, 0, limits).is_err());
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_instance_count_limit() {
     let limits = StoreLimitsBuilder::new().instances(0).build();
     assert!(Test::new(0, 0, limits).is_err());
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_tables_count_limit() {
     let limits = StoreLimitsBuilder::new().tables(0).build();
     assert!(Test::new(0, 0, limits).is_err());
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_memory_does_not_grow_on_limited_growth() -> Result<(), Error> {
     let limits = StoreLimitsBuilder::new().memory_size(3 * (1 << 16)).build();
     let mut test = Test::new(2, 0, limits)?;
@@ -130,6 +136,7 @@ fn test_memory_does_not_grow_on_limited_growth() -> Result<(), Error> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_memory_traps_on_limited_growth() -> Result<(), Error> {
     let limits = StoreLimitsBuilder::new()
         .memory_size(3 * (1 << 16))
@@ -156,6 +163,7 @@ fn test_memory_traps_on_limited_growth() -> Result<(), Error> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_table_does_not_grow_on_limited_growth() -> Result<(), Error> {
     let limits = StoreLimitsBuilder::new().table_elements(100).build();
     let mut test = Test::new(0, 99, limits)?;
@@ -177,6 +185,7 @@ fn test_table_does_not_grow_on_limited_growth() -> Result<(), Error> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn test_table_traps_on_limited_growth() -> Result<(), Error> {
     let limits = StoreLimitsBuilder::new()
         .table_elements(100)

--- a/crates/wasmi/tests/integration/resumable_call.rs
+++ b/crates/wasmi/tests/integration/resumable_call.rs
@@ -106,6 +106,7 @@ impl<Results> ResumableExt for Result<TypedResumableCall<Results>, Error> {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn resumable_call_smoldot_01() {
     let (mut store, wasm_fn) = resumable_call_smoldot_common(
         r#"
@@ -126,6 +127,7 @@ fn resumable_call_smoldot_01() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn resumable_call_smoldot_tail_01() {
     let (mut store, wasm_fn) = resumable_call_smoldot_common(
         r#"
@@ -147,6 +149,7 @@ fn resumable_call_smoldot_tail_01() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn resumable_call_smoldot_tail_02() {
     let (mut store, wasm_fn) = resumable_call_smoldot_common(
         r#"
@@ -170,6 +173,7 @@ fn resumable_call_smoldot_tail_02() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn resumable_call_smoldot_02() {
     let (mut store, wasm_fn) = resumable_call_smoldot_common(
         r#"
@@ -222,6 +226,7 @@ fn resumable_call_host() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
 fn resumable_call() {
     let (mut store, mut linker) = test_setup(0);
     let host_fn = Func::wrap(&mut store, |input: i32| -> Result<i32, Error> {


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1881.