### PR TITLE
Allow for register branch parameters in control flow

### DIFF
--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -118,7 +118,8 @@ criterion_group! {
         bench_execute_json_parse,
         bench_execute_reverse_complement,
         bench_execute_regex_redux,
-        bench_execute_counter,
+        bench_execute_count_via_locals,
+        bench_execute_count_via_params,
         bench_execute_br_table,
         bench_execute_trunc_f2i,
         bench_execute_global_bump,
@@ -1103,11 +1104,27 @@ fn bench_execute_regex_redux(c: &mut Criterion) {
     });
 }
 
-fn bench_execute_counter(c: &mut Criterion) {
+fn bench_execute_count_via_locals(c: &mut Criterion) {
     const ITERATIONS: i32 = 1_000_000;
-    c.bench_function("execute/counter", |b| {
+    c.bench_function("execute/count/locals", |b| {
         let (mut store, instance) = load_instance_from_wat(include_bytes!("wat/counter.wat"));
-        let run = instance.get_typed_func::<i32, i32>(&store, "run").unwrap();
+        let run = instance
+            .get_typed_func::<i32, i32>(&store, "count-via-locals")
+            .unwrap();
+        b.iter(|| {
+            let result = run.call(&mut store, ITERATIONS).unwrap();
+            assert_eq!(result, 0);
+        })
+    });
+}
+
+fn bench_execute_count_via_params(c: &mut Criterion) {
+    const ITERATIONS: i32 = 1_000_000;
+    c.bench_function("execute/count/params", |b| {
+        let (mut store, instance) = load_instance_from_wat(include_bytes!("wat/counter.wat"));
+        let run = instance
+            .get_typed_func::<i32, i32>(&store, "count-via-params")
+            .unwrap();
         b.iter(|| {
             let result = run.call(&mut store, ITERATIONS).unwrap();
             assert_eq!(result, 0);

--- a/crates/wasmi/benches/wat/counter.wat
+++ b/crates/wasmi/benches/wat/counter.wat
@@ -1,16 +1,27 @@
 (module
-  (func (export "run") (param $n i32) (result i32)
-    (loop $continue
-        (br_if
-            $continue
-            (local.tee $n
-                (i32.sub
-                    (local.get $n)
-                    (i32.const 1)
+    (func (export "count-via-locals") (param $n i32) (result i32)
+        (loop $continue
+            (br_if
+                $continue
+                (local.tee $n
+                    (i32.sub
+                        (local.get $n)
+                        (i32.const 1)
+                    )
                 )
             )
         )
+        (return (local.get $n))
     )
-    (return (local.get $n))
-  )
+
+    (func (export "count-via-params") (param $n i32) (result i32)
+        (local.get $n)
+        (loop $continue (param i32) (result i32)
+            (i32.const 1)
+            (i32.sub)
+            (local.tee $n)
+            (local.get $n)
+            (br_if $continue)
+        )
+    )
 )

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -948,39 +948,13 @@ impl FuncTranslator {
     }
 
     fn copy_operand_to_reg(&mut self, operand: Operand) -> Result<(), Error> {
-        #[cold]
-        #[inline(never)]
-        fn unsupported_v128(operand: Operand) -> ! {
-            unimplemented!(
-                "operands of type `v128` cannot be put in registers but found: {operand:?}"
-            )
-        }
         let ty = operand.ty();
-        let operator = match self.resolve_operand::<RawVal>(operand)? {
-            ResolvedOperand::Reg(ty) => {
-                // Case: No copy needed as operand already resides in register.
-                self.push_result_reg(ty)?;
-                return Ok(());
-            }
-            ResolvedOperand::Slot(value) => match ty {
-                ValType::I32 | ValType::I64 | ValType::FuncRef | ValType::ExternRef => {
-                    Op::u64_copy_rs(value)
-                }
-                ValType::F32 => Op::f32_copy_rs(value),
-                ValType::F64 => Op::f64_copy_rs(value),
-                ValType::V128 => unsupported_v128(operand),
-            },
-            ResolvedOperand::Immediate(value) => match ty {
-                ValType::FuncRef | ValType::ExternRef | ValType::I32 => {
-                    Op::u32_copy_ri(u32::from(value))
-                }
-                ValType::I64 => Op::u64_copy_ri(u64::from(value)),
-                ValType::F32 => Op::f32_copy_ri(f32::from(value)),
-                ValType::F64 => Op::f64_copy_ri(f64::from(value)),
-                ValType::V128 => unsupported_v128(operand),
-            },
+        let Some(op) = Self::select_copy_rx_op(operand, &self.layout)? else {
+            // Case: No copy needed as operand already resides in register.
+            self.push_result_reg(ty)?;
+            return Ok(());
         };
-        self.push_op_with_result_reg(ty, operator, FuelCostsProvider::base)?;
+        self.push_op_with_result_reg(ty, op, FuelCostsProvider::base)?;
         Ok(())
     }
 

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -442,9 +442,9 @@ impl FuncTranslator {
         params: BranchParams,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        for (depth, ty) in params.reg_tys().iter().enumerate() {
+        for (depth, kind) in params.reg_tys().iter().enumerate() {
             let value = self.stack.peek(depth);
-            debug_assert_eq!(*ty, value.ty());
+            debug_assert!(kind.matches_ty(value.ty()));
             self.encode_copy_rx_op(value, fuel_pos)?;
         }
         Ok(())

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -413,7 +413,7 @@ impl FuncTranslator {
         params: BranchParams,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        for (depth, kind) in params.reg_tys().iter().enumerate() {
+        for (depth, kind) in params.regs().iter().enumerate() {
             let value = self.stack.peek(depth);
             debug_assert!(kind.matches_ty(value.ty()));
             self.encode_copy_rx_op(value, fuel_pos)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -427,9 +427,9 @@ impl FuncTranslator {
             return Ok(());
         }
         let mut result = params.temp_slots().head();
-        let start = params.len() - 1;
+        let start = params.len();
         let end = params.len_regs();
-        for depth in start..=end {
+        for depth in (end..start).rev() {
             let value = self.stack.peek(depth.into());
             let ty = value.ty();
             self.encode_copy_sx_op(result, value, fuel_pos)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1,3 +1,5 @@
+#![expect(dead_code)] // TODO: remove
+
 #[macro_use]
 mod utils;
 mod encoder;
@@ -374,11 +376,17 @@ impl FuncTranslator {
         let height = frame.height();
         self.stack.discard_local_regs();
         self.stack.trunc(height);
+        let params = frame.branch_params();
+        let len_temps = usize::from(params.len_temps());
         frame
             .ty()
             .func_type_with(&self.engine, |func_ty| -> Result<(), Error> {
-                for result in func_ty.results() {
-                    self.stack.push_temp(*result, Allocation::None)?;
+                for (n, result) in func_ty.results().iter().enumerate() {
+                    let alloc = match n < len_temps {
+                        true => Allocation::None,
+                        false => Allocation::Reg,
+                    };
+                    self.stack.push_temp(*result, alloc)?;
                 }
                 Ok(())
             })?;
@@ -388,7 +396,7 @@ impl FuncTranslator {
     /// Emits copy operators to copy all operands to satisfy the [`BranchParams`].
     ///
     /// # Note
-    /// 
+    ///
     /// - This does _not_ change or mutate the operand stack.
     /// - Uses `fuel_pos` to bump fuel consumption if enabled.
     fn copy_branch_params(
@@ -396,38 +404,164 @@ impl FuncTranslator {
         params: BranchParams,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        let results = params.temp_slots();
-        let len_values = params.len();
-        match len_values {
-            0 => {}
-            1 => {
-                let result = results.head();
-                let value = self.stack.peek(0);
-                self.encode_copy(result, value, fuel_pos)?;
-            }
-            _ => {
-                self.encode_copy_many(results, len_values, fuel_pos)?;
-            }
+        self.copy_branch_params_temps(params, fuel_pos)?;
+        self.copy_branch_params_regs(params, fuel_pos)?;
+        Ok(())
+    }
+
+    /// Copies the branch params that are expected in temporary stack slots.
+    ///
+    /// Part of [`Self::copy_branch_params`].
+    fn copy_branch_params_temps(
+        &mut self,
+        params: BranchParams,
+        fuel_pos: Option<Pos<ir::BlockFuel>>,
+    ) -> Result<(), Error> {
+        let len_temps = params.len_temps();
+        if len_temps == 0 {
+            return Ok(());
+        }
+        let mut result = params.temp_slots().head();
+        let start = params.len() - 1;
+        let end = params.len_regs();
+        for depth in start..=end {
+            let value = self.stack.peek(depth.into());
+            let ty = value.ty();
+            self.encode_copy_sx_op(result, value, fuel_pos)?;
+            // TODO: enhance with copy op-fusion and support for `copy_span_{asc,des}`.
+            result = result.next_n(required_cells_for_ty(ty));
         }
         Ok(())
     }
 
-    /// Convenience wrapper for [`Self::encode_copy_impl`].
-    fn encode_copy(
+    /// Copies the branch params that are expected in their respective registers.
+    ///
+    /// Part of [`Self::copy_branch_params`].
+    fn copy_branch_params_regs(
+        &mut self,
+        params: BranchParams,
+        fuel_pos: Option<Pos<ir::BlockFuel>>,
+    ) -> Result<(), Error> {
+        for (depth, ty) in params.reg_tys().iter().enumerate() {
+            let value = self.stack.peek(depth);
+            debug_assert_eq!(*ty, value.ty());
+            self.encode_copy_rx_op(value, fuel_pos)?;
+        }
+        Ok(())
+    }
+
+    /// Encodes a single `copy_rx` operator.
+    ///
+    /// # Note
+    ///
+    /// This won't encode a copy if `value` is already in its register.
+    fn encode_copy_rx_op(
+        &mut self,
+        value: Operand,
+        fuel_pos: Option<Pos<ir::BlockFuel>>,
+    ) -> Result<(), Error> {
+        let Some(op) = Self::select_copy_rx_op(value, &self.layout)? else {
+            return Ok(());
+        };
+        self.instrs
+            .encode_op(op, fuel_pos, FuelCostsProvider::base)?;
+        Ok(())
+    }
+
+    /// Returns the [`Op`] to copy `value` into its register.
+    ///
+    /// Returns `None` if `value` is already in its register.
+    fn select_copy_rx_op(value: Operand, layout: &StackLayout) -> Result<Option<Op>, Error> {
+        match value.ty() {
+            ValType::I32 | ValType::FuncRef | ValType::ExternRef => {
+                Self::select_u32_copy_rx_op(value, layout)
+            }
+            ValType::I64 => Self::select_u64_copy_rx_op(value, layout),
+            ValType::F32 => Self::select_f32_copy_rx_op(value, layout),
+            ValType::F64 => Self::select_f64_copy_rx_op(value, layout),
+            ValType::V128 => unreachable!(),
+        }
+    }
+
+    /// Returns the [`Op`] to copy `value` of type `u32` into its register.
+    ///
+    /// Returns `None` if `value` is already in its register.
+    fn select_u32_copy_rx_op(value: Operand, layout: &StackLayout) -> Result<Option<Op>, Error> {
+        let op = match value.resolve(layout)? {
+            ResolvedOperand::Reg(ty) => {
+                debug_assert!(matches!(
+                    ty,
+                    ValType::I32 | ValType::ExternRef | ValType::FuncRef
+                ));
+                return Ok(None);
+            }
+            ResolvedOperand::Slot(value) => Op::u64_copy_rs(value),
+            ResolvedOperand::Immediate(value) => Op::u32_copy_ri(u32::from(value.raw())),
+        };
+        Ok(Some(op))
+    }
+
+    /// Returns the [`Op`] to copy `value` of type `u64` into its register.
+    ///
+    /// Returns `None` if `value` is already in its register.
+    fn select_u64_copy_rx_op(value: Operand, layout: &StackLayout) -> Result<Option<Op>, Error> {
+        let op = match value.resolve_as::<u64>(layout)? {
+            ResolvedOperand::Reg(ty) => {
+                debug_assert_eq!(ty, ValType::I64);
+                return Ok(None);
+            }
+            ResolvedOperand::Slot(value) => Op::u64_copy_rs(value),
+            ResolvedOperand::Immediate(value) => Op::u64_copy_ri(value),
+        };
+        Ok(Some(op))
+    }
+
+    /// Returns the [`Op`] to copy `value` of type `f32` into its register.
+    ///
+    /// Returns `None` if `value` is already in its register.
+    fn select_f32_copy_rx_op(value: Operand, layout: &StackLayout) -> Result<Option<Op>, Error> {
+        let op = match value.resolve_as::<f32>(layout)? {
+            ResolvedOperand::Reg(ty) => {
+                debug_assert_eq!(ty, ValType::F32);
+                return Ok(None);
+            }
+            ResolvedOperand::Slot(value) => Op::f32_copy_rs(value),
+            ResolvedOperand::Immediate(value) => Op::f32_copy_ri(value),
+        };
+        Ok(Some(op))
+    }
+
+    /// Returns the [`Op`] to copy `value` of type `f64` into its register.
+    ///
+    /// Returns `None` if `value` is already in its register.
+    fn select_f64_copy_rx_op(value: Operand, layout: &StackLayout) -> Result<Option<Op>, Error> {
+        let op = match value.resolve_as::<f64>(layout)? {
+            ResolvedOperand::Reg(ty) => {
+                debug_assert_eq!(ty, ValType::F64);
+                return Ok(None);
+            }
+            ResolvedOperand::Slot(value) => Op::f64_copy_rs(value),
+            ResolvedOperand::Immediate(value) => Op::f64_copy_ri(value),
+        };
+        Ok(Some(op))
+    }
+
+    /// Convenience wrapper for [`Self::encode_copy_sx_op_impl`].
+    fn encode_copy_sx_op(
         &mut self,
         result: Slot,
         value: Operand,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<Option<Pos<Op>>, Error> {
-        Self::encode_copy_impl(result, value, fuel_pos, &self.layout, &mut self.instrs)
+        Self::encode_copy_sx_op_impl(result, value, fuel_pos, &self.layout, &mut self.instrs)
     }
 
-    /// Encodes a single copy instruction.
+    /// Encodes a single `copy_sx` operator.
     ///
     /// # Note
     ///
     /// This won't encode a copy if `result` and `value` yields a no-op copy.
-    fn encode_copy_impl(
+    fn encode_copy_sx_op_impl(
         result: Slot,
         value: Operand,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
@@ -621,7 +755,7 @@ impl FuncTranslator {
             [val0] => {
                 let result = results.head();
                 let value = *val0;
-                self.encode_copy(result, value, fuel_pos)?;
+                self.encode_copy_sx_op(result, value, fuel_pos)?;
                 return Ok(());
             }
             _values => {}
@@ -650,7 +784,7 @@ impl FuncTranslator {
             let results = value.temp_slots();
             let result = results.head();
             let value = *value;
-            Self::encode_copy_impl(result, value, pos_fuel, layout, instrs)?;
+            Self::encode_copy_sx_op_impl(result, value, pos_fuel, layout, instrs)?;
             copied_slots = copied_slots
                 .checked_add(results.len())
                 .ok_or(TranslationError::SlotOutOfBounds)?;
@@ -830,7 +964,7 @@ impl FuncTranslator {
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<Slot, Error> {
         let result = operand.temp_slots().head();
-        self.encode_copy(result, operand, fuel_pos)?;
+        self.encode_copy_sx_op(result, operand, fuel_pos)?;
         Ok(result)
     }
 
@@ -2774,7 +2908,7 @@ impl FuncTranslator {
                 // Case: `lhs` is temporary and thus might need a copy to its new result.
                 let fuel_pos = self.stack.fuel_pos();
                 let result = result.temp_slots().head();
-                self.encode_copy(result, lhs, fuel_pos)?;
+                self.encode_copy_sx_op(result, lhs, fuel_pos)?;
             }
             self.stack.push_immediate(0_i64)?; // hi-bits
             return Ok(true);

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -707,7 +707,7 @@ impl FuncTranslator {
         len: u16,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        let Some(op) = Self::make_copy_span(results, values, len) else {
+        let Some(op) = Self::select_copy_span_op(results, values, len) else {
             // Case: results and values are equal and therefore the copy is a no-op
             return Ok(());
         };
@@ -721,7 +721,7 @@ impl FuncTranslator {
     /// Returns an [`Op::copy_span_asc`] or [`Op::copy_span_des`] depending on inputs.
     ///
     /// Returns `None` if the `copy_span` operation is a no-op.
-    fn make_copy_span(results: SlotSpan, values: SlotSpan, len: u16) -> Option<Op> {
+    fn select_copy_span_op(results: SlotSpan, values: SlotSpan, len: u16) -> Option<Op> {
         if results == values {
             // Case: results and values are equal and therefore the copy is a no-op
             return None;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1192,7 +1192,7 @@ impl FuncTranslator {
             let results = frame.branch_params().temp_slots();
             self.instrs.encode_branch(
                 frame.label(),
-                |offset| ir::BranchTableTarget::new(results, offset),
+                |offset| ir::BranchTableTarget::new(results.span(), offset),
                 fuel_pos,
                 0,
             )?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -364,40 +364,6 @@ impl FuncTranslator {
         Ok(BoundedSlotSpan::new(SlotSpan::new(first), copied_cells))
     }
 
-    /// Pushes the branch params of the control `frame` onto the [`Stack`].
-    ///
-    /// # Note
-    ///
-    /// - Before pushing the results, the [`Stack`] is truncated to the `frame`'s height.
-    /// - Not all control frames have temporary results, e.g. Wasm `loop`s, Wasm `if`s with
-    ///   a compile-time known branch or Wasm `block`s that are never branched to, do not
-    ///   require to call this function.
-    fn push_branch_params(&mut self, frame: &impl ControlFrameBase) -> Result<(), Error> {
-        let height = frame.height();
-        self.stack.discard_local_regs();
-        self.stack.trunc(height);
-        let kind = frame.kind();
-        let params = frame.branch_params();
-        let len_temps = usize::from(params.len_temps());
-        frame
-            .ty()
-            .func_type_with(&self.engine, |func_ty| -> Result<(), Error> {
-                let params = match kind {
-                    ControlFrameKind::Loop => func_ty.params(),
-                    _ => func_ty.results(),
-                };
-                for (n, result) in params.iter().enumerate() {
-                    let alloc = match n < len_temps {
-                        true => Allocation::None,
-                        false => Allocation::Reg,
-                    };
-                    self.stack.push_temp(*result, alloc)?;
-                }
-                Ok(())
-            })?;
-        Ok(())
-    }
-
     /// Emits copy operators to copy all operands to satisfy the [`BranchParams`].
     ///
     /// # Note
@@ -1444,7 +1410,7 @@ impl FuncTranslator {
             if self.reachable {
                 self.copy_branch_params(frame.branch_params(), fuel_pos)?;
             }
-            self.push_branch_params(&frame)?;
+            self.stack.push_branch_params(&frame)?;
         }
         self.instrs.pin_label(frame.label())?;
         self.reachable |= frame.is_branched_to();
@@ -1493,7 +1459,7 @@ impl FuncTranslator {
             let fuel_pos = self.instrs.encode_consume_fuel_op()?;
             self.copy_branch_params(frame.branch_params(), fuel_pos)?;
         }
-        self.push_branch_params(&frame)?;
+        self.stack.push_branch_params(&frame)?;
         self.instrs.pin_label(frame.label())?;
         self.reachable = true;
         Ok(())
@@ -1523,7 +1489,7 @@ impl FuncTranslator {
         if end_of_else_reachable {
             self.copy_branch_params(frame.branch_params(), fuel_pos)?;
         }
-        self.push_branch_params(&frame)?;
+        self.stack.push_branch_params(&frame)?;
         self.instrs.pin_label(frame.label())?;
         self.reachable = reachable;
         Ok(())
@@ -1540,7 +1506,7 @@ impl FuncTranslator {
             if end_is_reachable {
                 self.copy_branch_params(frame.branch_params(), fuel_pos)?;
             }
-            self.push_branch_params(&frame)?;
+            self.stack.push_branch_params(&frame)?;
         }
         self.instrs.pin_label(frame.label())?;
         self.reachable = end_is_reachable || frame.is_branched_to();

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -62,7 +62,7 @@ use crate::{
             },
             func::{
                 op::BinaryOpRhs,
-                stack::{Allocation, PreservedRegs, TempOperand},
+                stack::{Allocation, BranchParams, PreservedRegs, TempOperand},
             },
             utils::{ToBits, WasmInteger, required_cells_for_ty},
         },
@@ -370,14 +370,10 @@ impl FuncTranslator {
     /// - Does nothing if an [`Operand`] is already an [`Operand::Temp`].
     fn copy_branch_params(
         &mut self,
-        target: &impl ControlFrameBase,
+        params: BranchParams,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        let len_branch_params = target.len_branch_params(&self.engine);
-        let Some(branch_slots) = target.branch_slots() else {
-            return Ok(());
-        };
-        self.encode_copies(branch_slots.span(), len_branch_params, fuel_pos)?;
+        self.encode_copies(params.temp_slots(), params.len(), fuel_pos)?;
         Ok(())
     }
 
@@ -788,7 +784,8 @@ impl FuncTranslator {
     /// Some instructions can be encoded in a more efficient way if no branch parameter copies are required.
     fn requires_branch_param_copies(&self, depth: usize) -> bool {
         let frame = self.stack.peek_control(depth);
-        let len_branch_params = usize::from(frame.len_branch_params(&self.engine));
+        let branch_params = frame.branch_params();
+        let len_branch_params = usize::from(branch_params.len());
         let frame_height = frame.height();
         let height_matches = frame_height == (self.stack.height() - len_branch_params);
         let only_temps = (0..len_branch_params)
@@ -1100,12 +1097,10 @@ impl FuncTranslator {
                 panic!("out of bounds `br_table` target does not fit `usize`: {target:?}");
             };
             let mut frame = self.stack.peek_control_mut(depth).control_frame();
-            let Some(results) = frame.branch_slots() else {
-                panic!("must have frame results since `br_table` requires to copy values");
-            };
+            let results = frame.branch_params().temp_slots();
             self.instrs.encode_branch(
                 frame.label(),
-                |offset| ir::BranchTableTarget::new(results.span(), offset),
+                |offset| ir::BranchTableTarget::new(results, offset),
                 fuel_pos,
                 0,
             )?;
@@ -1321,7 +1316,7 @@ impl FuncTranslator {
         let fuel_pos = frame.fuel_pos();
         if frame.is_branched_to() {
             if self.reachable {
-                self.copy_branch_params(&frame, fuel_pos)?;
+                self.copy_branch_params(frame.branch_params(), fuel_pos)?;
             }
             self.push_frame_results(&frame)?;
         }
@@ -1358,7 +1353,7 @@ impl FuncTranslator {
         let has_results = len_results >= 1;
         let fuel_pos = frame.fuel_pos();
         if is_end_of_then_reachable && has_results {
-            self.copy_branch_params(&frame, fuel_pos)?;
+            self.copy_branch_params(frame.branch_params(), fuel_pos)?;
             self.encode_branch_op(frame.label(), Op::branch, fuel_pos)?;
         }
         self.instrs.pin_label_if_unpinned(else_label)?;
@@ -1370,7 +1365,7 @@ impl FuncTranslator {
             // when entering the `if` block so that we can properly copy
             // the `else` results to were they are expected.
             let fuel_pos = self.instrs.encode_consume_fuel_op()?;
-            self.copy_branch_params(&frame, fuel_pos)?;
+            self.copy_branch_params(frame.branch_params(), fuel_pos)?;
         }
         self.push_frame_results(&frame)?;
         self.instrs.pin_label(frame.label())?;
@@ -1400,7 +1395,7 @@ impl FuncTranslator {
         };
         let fuel_pos = frame.fuel_pos();
         if end_of_else_reachable {
-            self.copy_branch_params(&frame, fuel_pos)?;
+            self.copy_branch_params(frame.branch_params(), fuel_pos)?;
         }
         self.push_frame_results(&frame)?;
         self.instrs.pin_label(frame.label())?;
@@ -1417,7 +1412,7 @@ impl FuncTranslator {
         let fuel_pos = frame.fuel_pos();
         if frame.is_branched_to() {
             if end_is_reachable {
-                self.copy_branch_params(&frame, fuel_pos)?;
+                self.copy_branch_params(frame.branch_params(), fuel_pos)?;
             }
             self.push_frame_results(&frame)?;
         }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -898,22 +898,48 @@ impl FuncTranslator {
         Ok(false)
     }
 
-    /// Returns `true` if the [`ControlFrame`] at `depth` requires copying for its branch parameters.
+    /// Returns `true` if there is a need to copy branch parameters for the frame at `depth` with the current stack.
+    ///
+    /// # Dev. Note
+    ///
+    /// We take `depth` to a frame instead of a reference to the frame directly
+    /// to avoid some borrow-checking issues at users.
     ///
     /// # Note
     ///
-    /// Some instructions can be encoded in a more efficient way if no branch parameter copies are required.
+    /// Conditional branches can be encoded in a more efficient way
+    /// if no branch parameter copies are required.
     fn requires_branch_param_copies(&self, depth: usize) -> bool {
         let frame = self.stack.peek_control(depth);
         let branch_params = frame.branch_params();
-        let len_branch_params = usize::from(branch_params.len());
+        let len_params = usize::from(branch_params.len());
+        if len_params == 0 {
+            // The frame has no branch params and thus no copies need to be performed.
+            return false;
+        }
         let frame_height = frame.height();
-        let height_matches = frame_height == (self.stack.height() - len_branch_params);
-        let only_temps = (0..len_branch_params)
+        let height_matches = frame_height == (self.stack.height() - len_params);
+        let has_temp_params = branch_params.len_temps() > 0;
+        if !height_matches && has_temp_params {
+            // If the height does not match we need to copy
+            return true;
+        }
+        let len_regs = usize::from(branch_params.len_regs());
+        let temp_params_require_copies = (len_regs..len_params)
             .map(|depth| self.stack.peek(depth))
-            .all(|o| o.is_temp() && !o.in_reg());
-        let can_avoid_copies = height_matches && only_temps;
-        !can_avoid_copies
+            .any(|o| !(o.is_temp() && !o.in_reg()));
+        if temp_params_require_copies {
+            // The branch paramters expected in temporary stack slots require copy operations.
+            return true;
+        }
+        let reg_params_require_copies = (0..len_regs)
+            .map(|depth| self.stack.peek(depth))
+            .any(|o| !o.in_reg());
+        if reg_params_require_copies {
+            // The branch paramters expected in registers require copy operations.
+            return true;
+        }
+        false
     }
 
     fn copy_operand_to_reg(&mut self, operand: Operand) -> Result<(), Error> {

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -364,7 +364,7 @@ impl FuncTranslator {
         Ok(BoundedSlotSpan::new(SlotSpan::new(first), copied_cells))
     }
 
-    /// Pushes the temporary results of the control `frame` onto the [`Stack`].
+    /// Pushes the branch params of the control `frame` onto the [`Stack`].
     ///
     /// # Note
     ///
@@ -372,7 +372,7 @@ impl FuncTranslator {
     /// - Not all control frames have temporary results, e.g. Wasm `loop`s, Wasm `if`s with
     ///   a compile-time known branch or Wasm `block`s that are never branched to, do not
     ///   require to call this function.
-    fn push_frame_results(&mut self, frame: &impl ControlFrameBase) -> Result<(), Error> {
+    fn push_branch_params(&mut self, frame: &impl ControlFrameBase) -> Result<(), Error> {
         let height = frame.height();
         self.stack.discard_local_regs();
         self.stack.trunc(height);
@@ -1465,7 +1465,7 @@ impl FuncTranslator {
             if self.reachable {
                 self.copy_branch_params(frame.branch_params(), fuel_pos)?;
             }
-            self.push_frame_results(&frame)?;
+            self.push_branch_params(&frame)?;
         }
         self.instrs.pin_label(frame.label())?;
         self.reachable |= frame.is_branched_to();
@@ -1514,7 +1514,7 @@ impl FuncTranslator {
             let fuel_pos = self.instrs.encode_consume_fuel_op()?;
             self.copy_branch_params(frame.branch_params(), fuel_pos)?;
         }
-        self.push_frame_results(&frame)?;
+        self.push_branch_params(&frame)?;
         self.instrs.pin_label(frame.label())?;
         self.reachable = true;
         Ok(())
@@ -1544,7 +1544,7 @@ impl FuncTranslator {
         if end_of_else_reachable {
             self.copy_branch_params(frame.branch_params(), fuel_pos)?;
         }
-        self.push_frame_results(&frame)?;
+        self.push_branch_params(&frame)?;
         self.instrs.pin_label(frame.label())?;
         self.reachable = reachable;
         Ok(())
@@ -1561,7 +1561,7 @@ impl FuncTranslator {
             if end_is_reachable {
                 self.copy_branch_params(frame.branch_params(), fuel_pos)?;
             }
-            self.push_frame_results(&frame)?;
+            self.push_branch_params(&frame)?;
         }
         self.instrs.pin_label(frame.label())?;
         self.reachable = end_is_reachable || frame.is_branched_to();

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1170,12 +1170,11 @@ impl FuncTranslator {
         &mut self,
         table: wasmparser::BrTable,
         index: Location,
-        len_values: u16,
+        default_branch_params: BranchParams,
     ) -> Result<(), Error> {
         let len_targets = table.len() + 1;
         debug_assert_eq!(self.immediates.len(), len_targets as usize);
-        let fuel_pos = self.stack.fuel_pos();
-        let values = self.try_form_slot_span_or_move(usize::from(len_values), fuel_pos)?;
+        let values = default_branch_params.temp_slots();
         let op = match index {
             Location::Reg(_) => Op::branch_table_span_r(len_targets, values),
             Location::Slot(index) => Op::branch_table_span_s(len_targets, index, values),

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -376,12 +376,17 @@ impl FuncTranslator {
         let height = frame.height();
         self.stack.discard_local_regs();
         self.stack.trunc(height);
+        let kind = frame.kind();
         let params = frame.branch_params();
         let len_temps = usize::from(params.len_temps());
         frame
             .ty()
             .func_type_with(&self.engine, |func_ty| -> Result<(), Error> {
-                for (n, result) in func_ty.results().iter().enumerate() {
+                let params = match kind {
+                    ControlFrameKind::Loop => func_ty.params(),
+                    _ => func_ty.results(),
+                };
+                for (n, result) in params.iter().enumerate() {
                     let alloc = match n < len_temps {
                         true => Allocation::None,
                         false => Allocation::Reg,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -362,18 +362,30 @@ impl FuncTranslator {
         Ok(BoundedSlotSpan::new(SlotSpan::new(first), copied_cells))
     }
 
-    /// Convert all branch params up to `depth` to [`Operand::Temp`].
+    /// Emits copy operators to copy all operands to satisfy the [`BranchParams`].
     ///
     /// # Note
-    ///
-    /// - The top-most `depth` operands on the [`Stack`] will be [`Operand::Temp`] upon completion.
-    /// - Does nothing if an [`Operand`] is already an [`Operand::Temp`].
+    /// 
+    /// - This does _not_ change or mutate the operand stack.
+    /// - Uses `fuel_pos` to bump fuel consumption if enabled.
     fn copy_branch_params(
         &mut self,
         params: BranchParams,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        self.encode_copies(params.temp_slots(), params.len(), fuel_pos)?;
+        let results = params.temp_slots();
+        let len_values = params.len();
+        match len_values {
+            0 => {}
+            1 => {
+                let result = results.head();
+                let value = self.stack.peek(0);
+                self.encode_copy(result, value, fuel_pos)?;
+            }
+            _ => {
+                self.encode_copy_many(results, len_values, fuel_pos)?;
+            }
+        }
         Ok(())
     }
 
@@ -398,31 +410,6 @@ impl FuncTranslator {
                 Ok(())
             })?;
         Ok(())
-    }
-
-    /// Encodes a copy instruction for the top-most `len_values` on the stack to `results`.
-    ///
-    /// # Note
-    ///
-    /// - This does _not_ pop values from the stack or manipulate the stack otherwise.
-    /// - This might allocate new function local constant values if necessary.
-    /// - This does _not_ encode a copy if the copy is a no-op.
-    fn encode_copies(
-        &mut self,
-        results: SlotSpan,
-        len_values: u16,
-        fuel_pos: Option<Pos<ir::BlockFuel>>,
-    ) -> Result<(), Error> {
-        match len_values {
-            0 => Ok(()),
-            1 => {
-                let result = results.head();
-                let value = self.stack.peek(0);
-                self.encode_copy(result, value, fuel_pos)?;
-                Ok(())
-            }
-            _ => self.encode_copy_many(results, len_values, fuel_pos),
-        }
     }
 
     /// Convenience wrapper for [`Self::encode_copy_impl`].

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -362,6 +362,29 @@ impl FuncTranslator {
         Ok(BoundedSlotSpan::new(SlotSpan::new(first), copied_cells))
     }
 
+    /// Pushes the temporary results of the control `frame` onto the [`Stack`].
+    ///
+    /// # Note
+    ///
+    /// - Before pushing the results, the [`Stack`] is truncated to the `frame`'s height.
+    /// - Not all control frames have temporary results, e.g. Wasm `loop`s, Wasm `if`s with
+    ///   a compile-time known branch or Wasm `block`s that are never branched to, do not
+    ///   require to call this function.
+    fn push_frame_results(&mut self, frame: &impl ControlFrameBase) -> Result<(), Error> {
+        let height = frame.height();
+        self.stack.discard_local_regs();
+        self.stack.trunc(height);
+        frame
+            .ty()
+            .func_type_with(&self.engine, |func_ty| -> Result<(), Error> {
+                for result in func_ty.results() {
+                    self.stack.push_temp(*result, Allocation::None)?;
+                }
+                Ok(())
+            })?;
+        Ok(())
+    }
+
     /// Emits copy operators to copy all operands to satisfy the [`BranchParams`].
     ///
     /// # Note
@@ -386,29 +409,6 @@ impl FuncTranslator {
                 self.encode_copy_many(results, len_values, fuel_pos)?;
             }
         }
-        Ok(())
-    }
-
-    /// Pushes the temporary results of the control `frame` onto the [`Stack`].
-    ///
-    /// # Note
-    ///
-    /// - Before pushing the results, the [`Stack`] is truncated to the `frame`'s height.
-    /// - Not all control frames have temporary results, e.g. Wasm `loop`s, Wasm `if`s with
-    ///   a compile-time known branch or Wasm `block`s that are never branched to, do not
-    ///   require to call this function.
-    fn push_frame_results(&mut self, frame: &impl ControlFrameBase) -> Result<(), Error> {
-        let height = frame.height();
-        self.stack.discard_local_regs();
-        self.stack.trunc(height);
-        frame
-            .ty()
-            .func_type_with(&self.engine, |func_ty| -> Result<(), Error> {
-                for result in func_ty.results() {
-                    self.stack.push_temp(*result, Allocation::None)?;
-                }
-                Ok(())
-            })?;
         Ok(())
     }
 

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -478,6 +478,10 @@ impl ControlStack {
 pub struct ControlFrameMut<'a>(&'a mut ControlFrame);
 
 impl<'a> ControlFrameBase for ControlFrameMut<'a> {
+    fn kind(&self) -> ControlFrameKind {
+        self.0.kind()
+    }
+
     fn ty(&self) -> BlockType {
         self.0.ty()
     }
@@ -594,6 +598,9 @@ impl From<ControlFrameKind> for ControlFrame {
 
 /// Trait implemented by control frame types that share a common API.
 pub trait ControlFrameBase {
+    /// Returns the [`ControlFrameKind`] of the control frame.
+    fn kind(&self) -> ControlFrameKind;
+
     /// Returns the [`BlockType`] of the control frame.
     fn ty(&self) -> BlockType;
 
@@ -619,6 +626,18 @@ pub trait ControlFrameBase {
 }
 
 impl ControlFrameBase for ControlFrame {
+    fn kind(&self) -> ControlFrameKind {
+        match self {
+            ControlFrame::Block(frame) => frame.kind(),
+            ControlFrame::Loop(frame) => frame.kind(),
+            ControlFrame::If(frame) => frame.kind(),
+            ControlFrame::Else(frame) => frame.kind(),
+            ControlFrame::Unreachable(_) => {
+                panic!("invalid query for unreachable control frame: `ControlFrameBase::kind`")
+            }
+        }
+    }
+
     fn ty(&self) -> BlockType {
         match self {
             ControlFrame::Block(frame) => frame.ty(),
@@ -730,6 +749,10 @@ pub struct BlockControlFrame {
 }
 
 impl ControlFrameBase for BlockControlFrame {
+    fn kind(&self) -> ControlFrameKind {
+        ControlFrameKind::Block
+    }
+
     fn ty(&self) -> BlockType {
         self.ty
     }
@@ -781,6 +804,10 @@ pub struct LoopControlFrame {
 }
 
 impl ControlFrameBase for LoopControlFrame {
+    fn kind(&self) -> ControlFrameKind {
+        ControlFrameKind::Loop
+    }
+
     fn ty(&self) -> BlockType {
         self.ty
     }
@@ -862,6 +889,10 @@ impl IfControlFrame {
 }
 
 impl ControlFrameBase for IfControlFrame {
+    fn kind(&self) -> ControlFrameKind {
+        ControlFrameKind::If
+    }
+
     fn ty(&self) -> BlockType {
         self.ty
     }
@@ -999,6 +1030,10 @@ impl ElseControlFrame {
 }
 
 impl ControlFrameBase for ElseControlFrame {
+    fn kind(&self) -> ControlFrameKind {
+        ControlFrameKind::Else
+    }
+
     fn ty(&self) -> BlockType {
         self.ty
     }

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -100,10 +100,7 @@ impl BranchParams {
 
     /// Returns `true` if `kind` is claimed by `self`.
     fn claims_reg(&self, kind: RegKind) -> bool {
-        self.regs
-            .as_ref()
-            .map(|regs| regs.claims(kind))
-            .unwrap_or(false)
+        self.regs().contains(&kind)
     }
 }
 

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -61,6 +61,11 @@ impl BranchParams {
         }
     }
 
+    /// Returns `true` if no branch parameters exist.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns the total number of branch parameter operands.
     ///
     /// # Note

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -1,13 +1,17 @@
+#![expect(dead_code)] // TODO: remove
+
 use super::{Operand, Reset};
 use crate::{
     Engine,
+    ValType,
     engine::{
         BlockType,
         translator::func::{Pos, labels::LabelRef, stack::operands::RegisterMap},
     },
-    ir::{self, BoundedSlotSpan},
+    ir::{self, BoundedSlotSpan, SlotSpan},
 };
 use alloc::vec::{Drain, Vec};
+use core::slice;
 
 #[cfg(doc)]
 use crate::ir::Op;
@@ -28,6 +32,145 @@ impl From<usize> for StackHeight {
             panic!("out of bounds stack height: {height}")
         };
         Self(height)
+    }
+}
+
+/// The branch parameters of a control flow `block`, `if` or `loop`.
+#[derive(Debug, Copy, Clone)]
+pub struct BranchParams {
+    /// The span of slots for the branch params expected in temporary operands.
+    temp_slots: SlotSpan,
+    /// The number of branch parameter operands expected in temporary stack slots.
+    temp_len: u16,
+    /// The branch params expected in accumulator registers if any.
+    ///
+    /// # Dev. Note
+    ///
+    /// This can be `None` if all branch params are of type [`ValType::V128`]
+    /// or if the number of branch params is zero (0).
+    regs: Option<BranchParamRegs>,
+}
+
+impl BranchParams {
+    /// Creates a new [`BranchParams`] from its raw parts.
+    pub fn new(temp_slots: SlotSpan, temp_len: u16, regs: Option<BranchParamRegs>) -> Self {
+        Self {
+            temp_slots,
+            temp_len,
+            regs,
+        }
+    }
+
+    /// Returns the total number of branch parameter operands.
+    ///
+    /// # Note
+    ///
+    /// This includes the branch parameter operands expected in temporary stack slots
+    /// as well as the branch parameter operands expected in accumulator registers.
+    pub fn len(&self) -> u16 {
+        self.len_temps() + self.len_regs()
+    }
+
+    /// Returns the number of branch parameter operands expected in accumulator registers.
+    pub fn len_regs(&self) -> u16 {
+        self.regs.as_ref().map(BranchParamRegs::len).unwrap_or(0)
+    }
+
+    /// Returns the number of branch parameter operands expected in temporary stack slots.
+    pub fn len_temps(&self) -> u16 {
+        self.temp_len
+    }
+
+    /// Returns the [`ValType`] of all branch parameter operands expected in accumulator registers.
+    ///
+    /// The order is reversed from the back, thus the first [`ValType`] refers to the last operand etc.
+    pub fn reg_tys(&self) -> &[ValType] {
+        self.regs
+            .as_ref()
+            .map(BranchParamRegs::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Returns the [`SlotSpan`] for branch parameter operands that are expected in temporary stack slots.
+    pub fn temp_slots(&self) -> SlotSpan {
+        self.temp_slots
+    }
+}
+
+/// The branch parameters that are expected in accumulator registers.
+#[derive(Debug, Copy, Clone)]
+pub enum BranchParamRegs {
+    /// The last branch parameter is expected in its accumulator.
+    ///
+    /// # Note
+    ///
+    /// - The [`ValType`] must not refer to [`ValType::V128`].
+    One(ValType),
+    /// The last 2 branch parameters are expected in their accumulators.
+    ///
+    /// # Note
+    ///
+    /// - Item at index `0` refers to the last operand, item at index `1` to the 2nd last.
+    /// - No [`ValType`] must refer to [`ValType::V128`].
+    /// - All [`ValType`] must be unequal.
+    Two([ValType; 2]),
+    /// The last 3 branch parameters are expected in their accumulators.
+    ///
+    /// # Note
+    ///
+    /// - Items at indices refer to the following operands:
+    ///     - index `0`: last operand
+    ///     - index `1`: 2nd last operand
+    ///     - index `2`: 3rd last operand
+    /// - No [`ValType`] must refer to [`ValType::V128`].
+    /// - All [`ValType`] must be unequal.
+    Three([ValType; 3]),
+}
+
+impl BranchParamRegs {
+    /// Create a new [`BranchParamRegs::One`] from `ty`.
+    pub fn new_one(ty: ValType) -> Self {
+        Self::One(ty)
+    }
+
+    /// Create a new [`BranchParamRegs::Two`] from `tys`.
+    ///
+    /// # Panics (Debug)
+    ///
+    /// If `tys` contains the same [`ValType`] more than once.
+    pub fn new_two(tys: [ValType; 2]) -> Self {
+        debug_assert_ne!(tys[0], tys[1]);
+        Self::Two(tys)
+    }
+
+    /// Create a new [`BranchParamRegs::Three`] from `tys`.
+    ///
+    /// # Panics (Debug)
+    ///
+    /// If `tys` contains the same [`ValType`] more than once.
+    pub fn new_three(tys: [ValType; 3]) -> Self {
+        debug_assert_ne!(tys[0], tys[1]);
+        debug_assert_ne!(tys[0], tys[2]);
+        debug_assert_ne!(tys[1], tys[2]);
+        Self::Three(tys)
+    }
+
+    /// Returns the number of branch params expected in accumulator registers.
+    pub fn len(&self) -> u16 {
+        match self {
+            Self::One(_) => 1,
+            Self::Two(_) => 2,
+            Self::Three(_) => 3,
+        }
+    }
+
+    /// Returns a slice over the type of branch params expected in accumulator registers.
+    pub fn as_slice(&self) -> &[ValType] {
+        match self {
+            Self::One(ty) => slice::from_ref(ty),
+            Self::Two(tys) => &tys[..],
+            Self::Three(tys) => &tys[..],
+        }
     }
 }
 
@@ -129,6 +272,7 @@ impl ControlStack {
         ty: BlockType,
         height: usize,
         branch_slots: BoundedSlotSpan,
+        branch_params: BranchParams,
         label: LabelRef,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) {
@@ -137,6 +281,7 @@ impl ControlStack {
             ty,
             height: StackHeight::from(height),
             branch_slots,
+            branch_params,
             is_branched_to: false,
             fuel_pos,
             label,
@@ -150,6 +295,7 @@ impl ControlStack {
         ty: BlockType,
         height: usize,
         branch_slots: BoundedSlotSpan,
+        branch_params: BranchParams,
         label: LabelRef,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) {
@@ -158,6 +304,7 @@ impl ControlStack {
             ty,
             height: StackHeight::from(height),
             branch_slots,
+            branch_params,
             is_branched_to: false,
             fuel_pos,
             label,
@@ -172,6 +319,7 @@ impl ControlStack {
         ty: BlockType,
         height: usize,
         branch_slots: BoundedSlotSpan,
+        branch_params: BranchParams,
         label: LabelRef,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
         reachability: IfReachability,
@@ -183,6 +331,7 @@ impl ControlStack {
             ty,
             height: StackHeight::from(height),
             branch_slots,
+            branch_params,
             is_branched_to: false,
             fuel_pos,
             label,
@@ -208,6 +357,7 @@ impl ControlStack {
         let ty = if_frame.ty();
         let height = if_frame.height();
         let branch_slots = if_frame.branch_slots;
+        let branch_params = if_frame.branch_params;
         let label = if_frame.label();
         let is_branched_to = if_frame.is_branched_to();
         let reachability = match if_frame.reachability {
@@ -223,6 +373,7 @@ impl ControlStack {
             ty,
             height: StackHeight::from(height),
             branch_slots,
+            branch_params,
             is_branched_to,
             fuel_pos,
             label,
@@ -299,6 +450,10 @@ impl<'a> ControlFrameBase for ControlFrameMut<'a> {
 
     fn height(&self) -> usize {
         self.0.height()
+    }
+
+    fn branch_params(&self) -> BranchParams {
+        self.0.branch_params()
     }
 
     fn branch_slots(&self) -> Option<BoundedSlotSpan> {
@@ -420,6 +575,9 @@ pub trait ControlFrameBase {
     /// Returns the height of the control frame.
     fn height(&self) -> usize;
 
+    /// Returns the [`BranchParams`] of the control frame.
+    fn branch_params(&self) -> BranchParams;
+
     /// Returns the branch slots of the control frame as [`BoundedSlotSpan`].
     ///
     /// Returns `None` if no values need to be copied for branching.
@@ -465,6 +623,20 @@ impl ControlFrameBase for ControlFrame {
             ControlFrame::Else(frame) => frame.height(),
             ControlFrame::Unreachable(_) => {
                 panic!("invalid query for unreachable control frame: `ControlFrameBase::height`")
+            }
+        }
+    }
+
+    fn branch_params(&self) -> BranchParams {
+        match self {
+            ControlFrame::Block(frame) => frame.branch_params(),
+            ControlFrame::Loop(frame) => frame.branch_params(),
+            ControlFrame::If(frame) => frame.branch_params(),
+            ControlFrame::Else(frame) => frame.branch_params(),
+            ControlFrame::Unreachable(_) => {
+                panic!(
+                    "invalid query for unreachable control frame: `ControlFrameBase::branch_params`"
+                )
             }
         }
     }
@@ -558,6 +730,8 @@ pub struct BlockControlFrame {
     height: StackHeight,
     /// The [`BoundedSlotSpan`] referring to the results of the [`BlockControlFrame`].
     branch_slots: BoundedSlotSpan,
+    /// The [`BranchParams`] of the [`BlockControlFrame`].
+    branch_params: BranchParams,
     /// This is `true` if there is at least one branch to this [`BlockControlFrame`].
     is_branched_to: bool,
     /// The [`BlockControlFrame`]'s [`Op::ConsumeFuel`] if fuel metering is enabled.
@@ -577,6 +751,10 @@ impl ControlFrameBase for BlockControlFrame {
 
     fn height(&self) -> usize {
         self.height.into()
+    }
+
+    fn branch_params(&self) -> BranchParams {
+        self.branch_params
     }
 
     fn branch_slots(&self) -> Option<BoundedSlotSpan> {
@@ -617,6 +795,8 @@ pub struct LoopControlFrame {
     height: StackHeight,
     /// The [`BoundedSlotSpan`] referring to the results of the [`LoopControlFrame`].
     branch_slots: BoundedSlotSpan,
+    /// The [`BranchParams`] of the [`LoopControlFrame`].
+    branch_params: BranchParams,
     /// This is `true` if there is at least one branch to this [`LoopControlFrame`].
     is_branched_to: bool,
     /// The [`LoopControlFrame`]'s [`Op::ConsumeFuel`] if fuel metering is enabled.
@@ -636,6 +816,10 @@ impl ControlFrameBase for LoopControlFrame {
 
     fn height(&self) -> usize {
         self.height.into()
+    }
+
+    fn branch_params(&self) -> BranchParams {
+        self.branch_params
     }
 
     fn branch_slots(&self) -> Option<BoundedSlotSpan> {
@@ -676,6 +860,8 @@ pub struct IfControlFrame {
     height: StackHeight,
     /// The [`BoundedSlotSpan`] referring to the results of the [`IfControlFrame`].
     branch_slots: BoundedSlotSpan,
+    /// The [`BranchParams`] of the [`IfControlFrame`].
+    branch_params: BranchParams,
     /// This is `true` if there is at least one branch to this [`IfControlFrame`].
     is_branched_to: bool,
     /// The [`IfControlFrame`]'s [`Op::ConsumeFuel`] if fuel metering is enabled.
@@ -725,6 +911,10 @@ impl ControlFrameBase for IfControlFrame {
 
     fn height(&self) -> usize {
         self.height.into()
+    }
+
+    fn branch_params(&self) -> BranchParams {
+        self.branch_params
     }
 
     fn branch_slots(&self) -> Option<BoundedSlotSpan> {
@@ -790,6 +980,8 @@ pub struct ElseControlFrame {
     height: StackHeight,
     /// The [`BoundedSlotSpan`] referring to the results of the [`ElseControlFrame`].
     branch_slots: BoundedSlotSpan,
+    /// The [`BranchParams`] of the [`ElseControlFrame`].
+    branch_params: BranchParams,
     /// This is `true` if there is at least one branch to this [`ElseControlFrame`].
     is_branched_to: bool,
     /// The [`LoopControlFrame`]'s [`Op::ConsumeFuel`] if fuel metering is enabled.
@@ -870,6 +1062,10 @@ impl ControlFrameBase for ElseControlFrame {
 
     fn height(&self) -> usize {
         self.height.into()
+    }
+
+    fn branch_params(&self) -> BranchParams {
+        self.branch_params
     }
 
     fn branch_slots(&self) -> Option<BoundedSlotSpan> {

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -2,7 +2,6 @@
 
 use super::{Operand, Reset};
 use crate::{
-    Engine,
     ValType,
     engine::{
         BlockType,
@@ -461,10 +460,6 @@ impl<'a> ControlFrameBase for ControlFrameMut<'a> {
         self.0.branch_params()
     }
 
-    fn branch_slots(&self) -> Option<BoundedSlotSpan> {
-        self.0.branch_slots()
-    }
-
     fn label(&self) -> LabelRef {
         self.0.label()
     }
@@ -475,11 +470,6 @@ impl<'a> ControlFrameBase for ControlFrameMut<'a> {
 
     fn branch_to(&mut self) {
         self.0.branch_to()
-    }
-
-    fn len_branch_params(&self, engine: &Engine) -> u16 {
-        // TODO: remove in favor of `branch_slots`
-        self.0.len_branch_params(engine)
     }
 
     fn fuel_pos(&self) -> Option<Pos<ir::BlockFuel>> {
@@ -583,11 +573,6 @@ pub trait ControlFrameBase {
     /// Returns the [`BranchParams`] of the control frame.
     fn branch_params(&self) -> BranchParams;
 
-    /// Returns the branch slots of the control frame as [`BoundedSlotSpan`].
-    ///
-    /// Returns `None` if no values need to be copied for branching.
-    fn branch_slots(&self) -> Option<BoundedSlotSpan>;
-
     /// Returns the branch label of `self`.
     fn label(&self) -> LabelRef;
 
@@ -596,10 +581,6 @@ pub trait ControlFrameBase {
 
     /// Makes `self` aware that there is a branch to it.
     fn branch_to(&mut self);
-
-    /// Returns the number of operands required for branching to `self`.
-    // TODO: remove in favor of `branch_slots`
-    fn len_branch_params(&self, engine: &Engine) -> u16;
 
     /// Returns a reference to the [`Op::ConsumeFuel`] of `self`.
     ///
@@ -646,20 +627,6 @@ impl ControlFrameBase for ControlFrame {
         }
     }
 
-    fn branch_slots(&self) -> Option<BoundedSlotSpan> {
-        match self {
-            ControlFrame::Block(frame) => frame.branch_slots(),
-            ControlFrame::Loop(frame) => frame.branch_slots(),
-            ControlFrame::If(frame) => frame.branch_slots(),
-            ControlFrame::Else(frame) => frame.branch_slots(),
-            ControlFrame::Unreachable(_) => {
-                panic!(
-                    "invalid query for unreachable control frame: `ControlFrameBase::branch_slots`"
-                )
-            }
-        }
-    }
-
     fn label(&self) -> LabelRef {
         match self {
             ControlFrame::Block(frame) => frame.label(),
@@ -694,21 +661,6 @@ impl ControlFrameBase for ControlFrame {
             ControlFrame::Else(frame) => frame.branch_to(),
             ControlFrame::Unreachable(_) => {
                 panic!("invalid query for unreachable control frame: `ControlFrame::branch_to`")
-            }
-        }
-    }
-
-    fn len_branch_params(&self, engine: &Engine) -> u16 {
-        // TODO: remove in favor of `branch_slots`
-        match self {
-            ControlFrame::Block(frame) => frame.len_branch_params(engine),
-            ControlFrame::Loop(frame) => frame.len_branch_params(engine),
-            ControlFrame::If(frame) => frame.len_branch_params(engine),
-            ControlFrame::Else(frame) => frame.len_branch_params(engine),
-            ControlFrame::Unreachable(_) => {
-                panic!(
-                    "invalid query for unreachable control frame: `ControlFrame::len_branch_params`"
-                )
             }
         }
     }
@@ -762,13 +714,6 @@ impl ControlFrameBase for BlockControlFrame {
         self.branch_params
     }
 
-    fn branch_slots(&self) -> Option<BoundedSlotSpan> {
-        if self.branch_slots.is_empty() {
-            return None;
-        }
-        Some(self.branch_slots)
-    }
-
     fn label(&self) -> LabelRef {
         self.label
     }
@@ -779,11 +724,6 @@ impl ControlFrameBase for BlockControlFrame {
 
     fn branch_to(&mut self) {
         self.is_branched_to = true;
-    }
-
-    fn len_branch_params(&self, engine: &Engine) -> u16 {
-        // TODO: remove in favor of `branch_slots`
-        self.ty.len_results(engine)
     }
 
     fn fuel_pos(&self) -> Option<Pos<ir::BlockFuel>> {
@@ -827,13 +767,6 @@ impl ControlFrameBase for LoopControlFrame {
         self.branch_params
     }
 
-    fn branch_slots(&self) -> Option<BoundedSlotSpan> {
-        if self.branch_slots.is_empty() {
-            return None;
-        }
-        Some(self.branch_slots)
-    }
-
     fn label(&self) -> LabelRef {
         self.label
     }
@@ -844,11 +777,6 @@ impl ControlFrameBase for LoopControlFrame {
 
     fn branch_to(&mut self) {
         self.is_branched_to = true;
-    }
-
-    fn len_branch_params(&self, engine: &Engine) -> u16 {
-        // TODO: remove in favor of `branch_slots`
-        self.ty.len_params(engine)
     }
 
     fn fuel_pos(&self) -> Option<Pos<ir::BlockFuel>> {
@@ -922,13 +850,6 @@ impl ControlFrameBase for IfControlFrame {
         self.branch_params
     }
 
-    fn branch_slots(&self) -> Option<BoundedSlotSpan> {
-        if self.branch_slots.is_empty() {
-            return None;
-        }
-        Some(self.branch_slots)
-    }
-
     fn label(&self) -> LabelRef {
         self.label
     }
@@ -939,11 +860,6 @@ impl ControlFrameBase for IfControlFrame {
 
     fn branch_to(&mut self) {
         self.is_branched_to = true;
-    }
-
-    fn len_branch_params(&self, engine: &Engine) -> u16 {
-        // TODO: remove in favor of `branch_slots`
-        self.ty.len_results(engine)
     }
 
     fn fuel_pos(&self) -> Option<Pos<ir::BlockFuel>> {
@@ -1073,13 +989,6 @@ impl ControlFrameBase for ElseControlFrame {
         self.branch_params
     }
 
-    fn branch_slots(&self) -> Option<BoundedSlotSpan> {
-        if self.branch_slots.is_empty() {
-            return None;
-        }
-        Some(self.branch_slots)
-    }
-
     fn label(&self) -> LabelRef {
         self.label
     }
@@ -1090,11 +999,6 @@ impl ControlFrameBase for ElseControlFrame {
 
     fn branch_to(&mut self) {
         self.is_branched_to = true;
-    }
-
-    fn len_branch_params(&self, engine: &Engine) -> u16 {
-        // TODO: remove in favor of `branch_slots`
-        self.ty.len_results(engine)
     }
 
     fn fuel_pos(&self) -> Option<Pos<ir::BlockFuel>> {

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -5,7 +5,8 @@ use crate::{
         BlockType,
         translator::func::{Pos, labels::LabelRef, stack::operands::RegisterMap},
     },
-    ir::{self, SlotSpan},
+    ir,
+    ir::BoundedSlotSpan,
 };
 use alloc::vec::{Drain, Vec};
 use core::slice;
@@ -36,7 +37,7 @@ impl From<usize> for StackHeight {
 #[derive(Debug, Copy, Clone)]
 pub struct BranchParams {
     /// The span of slots for the branch params expected in temporary operands.
-    temp_slots: SlotSpan,
+    temp_slots: BoundedSlotSpan,
     /// The number of branch parameter operands expected in temporary stack slots.
     temp_len: u16,
     /// The branch params expected in accumulator registers if any.
@@ -50,7 +51,7 @@ pub struct BranchParams {
 
 impl BranchParams {
     /// Creates a new [`BranchParams`] from its raw parts.
-    pub fn new(temp_slots: SlotSpan, temp_len: u16, regs: Option<BranchParamRegs>) -> Self {
+    pub fn new(temp_slots: BoundedSlotSpan, temp_len: u16, regs: Option<BranchParamRegs>) -> Self {
         Self {
             temp_slots,
             temp_len,
@@ -93,8 +94,8 @@ impl BranchParams {
             .unwrap_or(&[])
     }
 
-    /// Returns the [`SlotSpan`] for branch parameter operands that are expected in temporary stack slots.
-    pub fn temp_slots(&self) -> SlotSpan {
+    /// Returns the [`BoundedSlotSpan`] for branch parameter operands that are expected in temporary stack slots.
+    pub fn temp_slots(&self) -> BoundedSlotSpan {
         self.temp_slots
     }
 

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -1,5 +1,3 @@
-#![expect(dead_code)] // TODO: remove
-
 use super::{Operand, Reset};
 use crate::{
     ValType,

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -337,17 +337,19 @@ impl ControlStack {
         branch_params: BranchParams,
         label: LabelRef,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
-    ) {
+    ) -> LoopControlFrame {
         debug_assert!(!self.orphaned_else_operands);
-        self.frames.push(ControlFrame::from(LoopControlFrame {
+        let loop_frame = LoopControlFrame {
             ty,
             height: StackHeight::from(height),
             branch_params,
             is_branched_to: false,
             fuel_pos,
             label,
-        }));
+        };
+        self.frames.push(ControlFrame::from(loop_frame.clone()));
         self.fuel_pos = fuel_pos;
+        loop_frame
     }
 
     /// Pushes a new Wasm `if` onto the [`ControlStack`].
@@ -783,7 +785,7 @@ impl ControlFrameBase for BlockControlFrame {
 }
 
 /// A Wasm `loop` control frame.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LoopControlFrame {
     /// The block type of the [`LoopControlFrame`].
     ty: BlockType,

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -97,6 +97,14 @@ impl BranchParams {
     pub fn temp_slots(&self) -> SlotSpan {
         self.temp_slots
     }
+
+    /// Returns `true` if `kind` is claimed by `self`.
+    fn claims_reg(&self, kind: RegKind) -> bool {
+        self.regs
+            .as_ref()
+            .map(|regs| regs.claims(kind))
+            .unwrap_or(false)
+    }
 }
 
 /// The branch parameters that are expected in accumulator registers.
@@ -175,6 +183,11 @@ impl BranchParamRegs {
                 &kinds[..]
             }
         }
+    }
+
+    /// Returns `true` if `kind` is claimed by `self`.
+    fn claims(&self, kind: RegKind) -> bool {
+        self.as_slice().contains(&kind)
     }
 }
 

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -99,7 +99,7 @@ impl BranchParams {
     }
 
     /// Returns `true` if `kind` is claimed by `self`.
-    fn claims_reg(&self, kind: RegKind) -> bool {
+    pub fn claims_reg(&self, kind: RegKind) -> bool {
         self.regs().contains(&kind)
     }
 }

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -184,6 +184,32 @@ impl BranchParamRegs {
     }
 }
 
+/// The kind of a register.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RegKind {
+    /// The general purpose register for `i32` and `i64` values.
+    Ireg,
+    /// The `f32` register.
+    Freg32,
+    /// The `f64` register.
+    Freg64,
+}
+
+impl RegKind {
+    /// Creates a [`RegKind`] from a [`ValType`] if possible.
+    ///
+    /// Returns `None` if there is no register kind available to `ty`.
+    pub fn new(ty: ValType) -> Option<Self> {
+        let kind = match ty {
+            ValType::I32 | ValType::FuncRef | ValType::ExternRef | ValType::I64 => Self::Ireg,
+            ValType::F32 => Self::Freg32,
+            ValType::F64 => Self::Freg64,
+            ValType::V128 => return None,
+        };
+        Some(kind)
+    }
+}
+
 /// The Wasm control stack.
 #[derive(Debug, Default)]
 pub struct ControlStack {

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -86,7 +86,7 @@ impl BranchParams {
     /// Returns the [`RegKind`] of all branch parameter operands expected in accumulator registers.
     ///
     /// The order is reversed from the back, thus the first [`RegKind`] refers to the last operand etc.
-    pub fn reg_tys(&self) -> &[RegKind] {
+    pub fn regs(&self) -> &[RegKind] {
         self.regs
             .as_ref()
             .map(BranchParamRegs::as_slice)

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -7,7 +7,7 @@ use crate::{
         BlockType,
         translator::func::{Pos, labels::LabelRef, stack::operands::RegisterMap},
     },
-    ir::{self, BoundedSlotSpan, SlotSpan},
+    ir::{self, SlotSpan},
 };
 use alloc::vec::{Drain, Vec};
 use core::slice;
@@ -275,7 +275,6 @@ impl ControlStack {
         &mut self,
         ty: BlockType,
         height: usize,
-        branch_slots: BoundedSlotSpan,
         branch_params: BranchParams,
         label: LabelRef,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
@@ -284,7 +283,6 @@ impl ControlStack {
         self.frames.push(ControlFrame::from(BlockControlFrame {
             ty,
             height: StackHeight::from(height),
-            branch_slots,
             branch_params,
             is_branched_to: false,
             fuel_pos,
@@ -298,7 +296,6 @@ impl ControlStack {
         &mut self,
         ty: BlockType,
         height: usize,
-        branch_slots: BoundedSlotSpan,
         branch_params: BranchParams,
         label: LabelRef,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
@@ -307,7 +304,6 @@ impl ControlStack {
         self.frames.push(ControlFrame::from(LoopControlFrame {
             ty,
             height: StackHeight::from(height),
-            branch_slots,
             branch_params,
             is_branched_to: false,
             fuel_pos,
@@ -322,7 +318,6 @@ impl ControlStack {
         &mut self,
         ty: BlockType,
         height: usize,
-        branch_slots: BoundedSlotSpan,
         branch_params: BranchParams,
         label: LabelRef,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
@@ -334,7 +329,6 @@ impl ControlStack {
         self.frames.push(ControlFrame::from(IfControlFrame {
             ty,
             height: StackHeight::from(height),
-            branch_slots,
             branch_params,
             is_branched_to: false,
             fuel_pos,
@@ -360,7 +354,6 @@ impl ControlStack {
         debug_assert!(!self.orphaned_else_operands);
         let ty = if_frame.ty();
         let height = if_frame.height();
-        let branch_slots = if_frame.branch_slots;
         let branch_params = if_frame.branch_params;
         let label = if_frame.label();
         let is_branched_to = if_frame.is_branched_to();
@@ -376,7 +369,6 @@ impl ControlStack {
         self.frames.push(ControlFrame::from(ElseControlFrame {
             ty,
             height: StackHeight::from(height),
-            branch_slots,
             branch_params,
             is_branched_to,
             fuel_pos,
@@ -685,8 +677,6 @@ pub struct BlockControlFrame {
     ty: BlockType,
     /// The value stack height upon entering the [`BlockControlFrame`].
     height: StackHeight,
-    /// The [`BoundedSlotSpan`] referring to the results of the [`BlockControlFrame`].
-    branch_slots: BoundedSlotSpan,
     /// The [`BranchParams`] of the [`BlockControlFrame`].
     branch_params: BranchParams,
     /// This is `true` if there is at least one branch to this [`BlockControlFrame`].
@@ -738,8 +728,6 @@ pub struct LoopControlFrame {
     ty: BlockType,
     /// The value stack height upon entering the [`LoopControlFrame`].
     height: StackHeight,
-    /// The [`BoundedSlotSpan`] referring to the results of the [`LoopControlFrame`].
-    branch_slots: BoundedSlotSpan,
     /// The [`BranchParams`] of the [`LoopControlFrame`].
     branch_params: BranchParams,
     /// This is `true` if there is at least one branch to this [`LoopControlFrame`].
@@ -791,8 +779,6 @@ pub struct IfControlFrame {
     ty: BlockType,
     /// The value stack height upon entering the [`IfControlFrame`].
     height: StackHeight,
-    /// The [`BoundedSlotSpan`] referring to the results of the [`IfControlFrame`].
-    branch_slots: BoundedSlotSpan,
     /// The [`BranchParams`] of the [`IfControlFrame`].
     branch_params: BranchParams,
     /// This is `true` if there is at least one branch to this [`IfControlFrame`].
@@ -899,8 +885,6 @@ pub struct ElseControlFrame {
     ty: BlockType,
     /// The value stack height upon entering the [`ElseControlFrame`].
     height: StackHeight,
-    /// The [`BoundedSlotSpan`] referring to the results of the [`ElseControlFrame`].
-    branch_slots: BoundedSlotSpan,
     /// The [`BranchParams`] of the [`ElseControlFrame`].
     branch_params: BranchParams,
     /// This is `true` if there is at least one branch to this [`ElseControlFrame`].

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -83,10 +83,10 @@ impl BranchParams {
         self.temp_len
     }
 
-    /// Returns the [`ValType`] of all branch parameter operands expected in accumulator registers.
+    /// Returns the [`RegKind`] of all branch parameter operands expected in accumulator registers.
     ///
-    /// The order is reversed from the back, thus the first [`ValType`] refers to the last operand etc.
-    pub fn reg_tys(&self) -> &[ValType] {
+    /// The order is reversed from the back, thus the first [`RegKind`] refers to the last operand etc.
+    pub fn reg_tys(&self) -> &[RegKind] {
         self.regs
             .as_ref()
             .map(BranchParamRegs::as_slice)
@@ -103,19 +103,14 @@ impl BranchParams {
 #[derive(Debug, Copy, Clone)]
 pub enum BranchParamRegs {
     /// The last branch parameter is expected in its accumulator.
-    ///
-    /// # Note
-    ///
-    /// - The [`ValType`] must not refer to [`ValType::V128`].
-    One(ValType),
+    One(RegKind),
     /// The last 2 branch parameters are expected in their accumulators.
     ///
     /// # Note
     ///
     /// - Item at index `0` refers to the last operand, item at index `1` to the 2nd last.
-    /// - No [`ValType`] must refer to [`ValType::V128`].
-    /// - All [`ValType`] must be unequal.
-    Two([ValType; 2]),
+    /// - All [`RegKind`] must be unequal.
+    Two([RegKind; 2]),
     /// The last 3 branch parameters are expected in their accumulators.
     ///
     /// # Note
@@ -124,15 +119,14 @@ pub enum BranchParamRegs {
     ///     - index `0`: last operand
     ///     - index `1`: 2nd last operand
     ///     - index `2`: 3rd last operand
-    /// - No [`ValType`] must refer to [`ValType::V128`].
-    /// - All [`ValType`] must be unequal.
-    Three([ValType; 3]),
+    /// - All [`RegKind`] must be unequal.
+    Three([RegKind; 3]),
 }
 
 impl BranchParamRegs {
     /// Create a new [`BranchParamRegs::One`] from `ty`.
-    pub fn new_one(ty: ValType) -> Self {
-        Self::One(ty)
+    pub fn new_one(kind: RegKind) -> Self {
+        Self::One(kind)
     }
 
     /// Create a new [`BranchParamRegs::Two`] from `tys`.
@@ -140,9 +134,9 @@ impl BranchParamRegs {
     /// # Panics (Debug)
     ///
     /// If `tys` contains the same [`ValType`] more than once.
-    pub fn new_two(tys: [ValType; 2]) -> Self {
-        debug_assert_ne!(tys[0], tys[1]);
-        Self::Two(tys)
+    pub fn new_two(kinds: [RegKind; 2]) -> Self {
+        debug_assert_ne!(kinds[0], kinds[1]);
+        Self::Two(kinds)
     }
 
     /// Create a new [`BranchParamRegs::Three`] from `tys`.
@@ -150,11 +144,11 @@ impl BranchParamRegs {
     /// # Panics (Debug)
     ///
     /// If `tys` contains the same [`ValType`] more than once.
-    pub fn new_three(tys: [ValType; 3]) -> Self {
-        debug_assert_ne!(tys[0], tys[1]);
-        debug_assert_ne!(tys[0], tys[2]);
-        debug_assert_ne!(tys[1], tys[2]);
-        Self::Three(tys)
+    pub fn new_three(kinds: [RegKind; 3]) -> Self {
+        debug_assert_ne!(kinds[0], kinds[1]);
+        debug_assert_ne!(kinds[0], kinds[2]);
+        debug_assert_ne!(kinds[1], kinds[2]);
+        Self::Three(kinds)
     }
 
     /// Returns the number of branch params expected in accumulator registers.
@@ -167,18 +161,18 @@ impl BranchParamRegs {
     }
 
     /// Returns a slice over the type of branch params expected in accumulator registers.
-    pub fn as_slice(&self) -> &[ValType] {
+    pub fn as_slice(&self) -> &[RegKind] {
         match self {
-            Self::One(ty) => slice::from_ref(ty),
-            Self::Two(tys) => {
-                debug_assert_ne!(tys[0], tys[1]);
-                &tys[..]
+            Self::One(kind) => slice::from_ref(kind),
+            Self::Two(kinds) => {
+                debug_assert_ne!(kinds[0], kinds[1]);
+                &kinds[..]
             }
-            Self::Three(tys) => {
-                debug_assert_ne!(tys[0], tys[1]);
-                debug_assert_ne!(tys[0], tys[2]);
-                debug_assert_ne!(tys[1], tys[2]);
-                &tys[..]
+            Self::Three(kinds) => {
+                debug_assert_ne!(kinds[0], kinds[1]);
+                debug_assert_ne!(kinds[0], kinds[2]);
+                debug_assert_ne!(kinds[1], kinds[2]);
+                &kinds[..]
             }
         }
     }
@@ -207,6 +201,18 @@ impl RegKind {
             ValType::V128 => return None,
         };
         Some(kind)
+    }
+
+    /// Returns `true` if `self` matches `ty`.
+    pub fn matches_ty(&self, ty: ValType) -> bool {
+        match self {
+            RegKind::Ireg => matches!(
+                ty,
+                ValType::I32 | ValType::FuncRef | ValType::ExternRef | ValType::I64
+            ),
+            RegKind::Freg32 => matches!(ty, ValType::F32),
+            RegKind::Freg64 => matches!(ty, ValType::F64),
+        }
     }
 }
 

--- a/crates/wasmi/src/engine/translator/func/stack/control.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/control.rs
@@ -172,8 +172,16 @@ impl BranchParamRegs {
     pub fn as_slice(&self) -> &[ValType] {
         match self {
             Self::One(ty) => slice::from_ref(ty),
-            Self::Two(tys) => &tys[..],
-            Self::Three(tys) => &tys[..],
+            Self::Two(tys) => {
+                debug_assert_ne!(tys[0], tys[1]);
+                &tys[..]
+            }
+            Self::Three(tys) => {
+                debug_assert_ne!(tys[0], tys[1]);
+                debug_assert_ne!(tys[0], tys[2]);
+                debug_assert_ne!(tys[1], tys[2]);
+                &tys[..]
+            }
         }
     }
 }

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -205,23 +205,31 @@ impl Stack {
         Some(regs)
     }
 
-    /// Creates [`BranchParams`] from `temp_slots`, `ty` and the control flow `kind`.
-    fn branch_params(
-        &self,
-        temp_slots: SlotSpan,
-        ty: BlockType,
-        kind: ControlFrameKind,
-    ) -> BranchParams {
-        ty.func_type_with(&self.engine, |func_ty| {
-            let (tys, len_tys) = match kind {
-                ControlFrameKind::Loop => (func_ty.params(), func_ty.len_params()),
-                _ => (func_ty.results(), func_ty.len_results()),
-            };
-            let regs = Self::branch_params_regs(tys);
-            let regs_len = regs.as_ref().map(BranchParamRegs::len).unwrap_or(0);
-            let temp_len = len_tys - regs_len;
-            BranchParams::new(temp_slots, temp_len, regs)
+    /// Creates [`BranchParams`] from `ty` and the control flow `kind`.
+    fn branch_params_for(&self, func_ty: &FuncType, kind: ControlFrameKind) -> BranchParams {
+        let len_params = func_ty.len_params();
+        let temp_slots = self.branch_slots(len_params.into());
+        let (tys, len_tys) = match kind {
+            ControlFrameKind::Loop => (func_ty.params(), func_ty.len_params()),
+            _ => (func_ty.results(), func_ty.len_results()),
+        };
+        let regs = Self::branch_params_regs(tys);
+        let regs_len = regs.as_ref().map(BranchParamRegs::len).unwrap_or(0);
+        let temp_len = len_tys - regs_len;
+        BranchParams::new(temp_slots, temp_len, regs)
+    }
+
+    /// Creates [`BranchParams`] from `ty` and the control flow `kind`.
+    fn branch_params(&self, block_ty: BlockType, kind: ControlFrameKind) -> BranchParams {
+        block_ty.func_type_with(&self.engine, |func_ty| {
+            self.branch_params_for(func_ty, kind)
         })
+    }
+
+    /// Returns the height of the control frame with `block_ty` for `self`.
+    fn block_height(&self, block_ty: BlockType) -> usize {
+        let len_block_params = usize::from(block_ty.len_params(&self.engine));
+        self.height() - len_block_params
     }
 
     /// Pushes the function enclosing Wasm `block` onto the [`Stack`].
@@ -261,10 +269,8 @@ impl Stack {
     /// If the stack height exceeds the maximum height.
     pub fn push_block(&mut self, ty: BlockType, label: LabelRef) -> Result<(), Error> {
         debug_assert!(!self.controls.is_empty());
-        let len_params = usize::from(ty.len_params(&self.engine));
-        let block_height = self.height() - len_params;
-        let temp_slots = self.branch_slots(len_params);
-        let branch_params = self.branch_params(temp_slots, ty, ControlFrameKind::Block);
+        let block_height = self.block_height(ty);
+        let branch_params = self.branch_params(ty, ControlFrameKind::Block);
         let consume_fuel = self.fuel_pos();
         self.controls
             .push_block(ty, block_height, branch_params, label, consume_fuel);
@@ -289,15 +295,8 @@ impl Stack {
     ) -> Result<(), Error> {
         debug_assert!(!self.controls.is_empty());
         debug_assert!(self.is_fuel_metering_enabled() == fuel_pos.is_some());
-        let len_params = usize::from(ty.len_params(&self.engine));
-        let block_height = self.height() - len_params;
-        debug_assert!(
-            self.operands
-                .peek(len_params)
-                .all(|operand| operand.is_temp())
-        );
-        let temp_slots = self.branch_slots(len_params);
-        let branch_params = self.branch_params(temp_slots, ty, ControlFrameKind::Loop);
+        let block_height = self.block_height(ty);
+        let branch_params = self.branch_params(ty, ControlFrameKind::Loop);
         self.controls
             .push_loop(ty, block_height, branch_params, label, fuel_pos);
         Ok(())
@@ -321,13 +320,12 @@ impl Stack {
     ) -> Result<(), Error> {
         debug_assert!(!self.controls.is_empty());
         debug_assert!(self.is_fuel_metering_enabled() == fuel_pos.is_some());
-        let len_params = usize::from(ty.len_params(&self.engine));
-        let block_height = self.height() - len_params;
-        let else_operands = self.operands.peek(len_params);
+        let block_height = self.block_height(ty);
+        let len_block_params = usize::from(ty.len_params(&self.engine));
+        let else_operands = self.operands.peek(len_block_params);
         let registers = self.operands.get_registers();
-        debug_assert!(len_params == else_operands.len());
-        let temp_slots = self.branch_slots(len_params);
-        let branch_params = self.branch_params(temp_slots, ty, ControlFrameKind::If);
+        debug_assert!(len_block_params == else_operands.len());
+        let branch_params = self.branch_params(ty, ControlFrameKind::If);
         self.controls.push_if(
             ty,
             block_height,

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -149,6 +149,40 @@ impl Stack {
         self.engine.config().get_consume_fuel()
     }
 
+    /// Pushes the branch params of the control `frame` onto the [`Stack`].
+    ///
+    /// # Note
+    ///
+    /// - Before pushing the results, the [`Stack`] is truncated to the `frame`'s height.
+    /// - Not all control frames have temporary results, e.g. Wasm `loop`s, Wasm `if`s with
+    ///   a compile-time known branch or Wasm `block`s that are never branched to, do not
+    ///   require to call this function.
+    pub fn push_branch_params(&mut self, frame: &impl ControlFrameBase) -> Result<(), Error> {
+        let height = frame.height();
+        self.discard_local_regs();
+        self.trunc(height);
+        let kind = frame.kind();
+        let params = frame.branch_params();
+        let len_temps = usize::from(params.len_temps());
+        frame
+            .ty()
+            .func_type_with(&self.engine, |func_ty| -> Result<(), Error> {
+                let params = match kind {
+                    ControlFrameKind::Loop => func_ty.params(),
+                    _ => func_ty.results(),
+                };
+                for (n, result) in params.iter().enumerate() {
+                    let alloc = match n < len_temps {
+                        true => Allocation::None,
+                        false => Allocation::Reg,
+                    };
+                    self.operands.push_temp(*result, alloc)?;
+                }
+                Ok(())
+            })?;
+        Ok(())
+    }
+
     /// Returns the branch slots for the control frame with `len_params` operand parameters.
     fn branch_slots(&self, len_params: usize) -> SlotSpan {
         match len_params {

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -3,11 +3,6 @@ mod locals;
 mod operand;
 mod operands;
 
-use self::{
-    control::ControlStack,
-    locals::LocalsHead,
-    operands::{OperandStack, StackOperand, StackPos},
-};
 pub use self::{
     control::{
         AcquiredTarget,
@@ -24,6 +19,11 @@ pub use self::{
     operand::{ImmediateOperand, LocalOperand, Location, Operand, ResolvedOperand, TempOperand},
     operands::{Allocation, PreservedAllLocalsIter, PreservedLocalsIter, PreservedRegs},
 };
+use self::{
+    control::{BranchParamRegs, ControlStack},
+    locals::LocalsHead,
+    operands::{OperandStack, StackOperand, StackPos},
+};
 use super::{Reset, ReusableAllocations};
 use crate::{
     Engine,
@@ -33,7 +33,12 @@ use crate::{
     engine::{
         BlockType,
         translator::{
-            func::{LocalIdx, Pos, labels::LabelRef, stack::operands::PeekedOperands},
+            func::{
+                LocalIdx,
+                Pos,
+                labels::LabelRef,
+                stack::{control::BranchParams, operands::PeekedOperands},
+            },
             utils::required_cells_for_tys,
         },
     },
@@ -156,6 +161,53 @@ impl Stack {
         }
     }
 
+    /// Creates [`BranchParamRegs`] from `tys` if any.
+    ///
+    /// Returns `None` if `tys` is empty.
+    fn branch_params_regs(tys: &[ValType]) -> Option<BranchParamRegs> {
+        let regs = match tys {
+            [] => return None,
+            [ty] => BranchParamRegs::new_one(*ty),
+            [.., last2, last1, last0] => {
+                let [last2, last1, last0] = [*last2, *last1, *last0];
+                if last0 == last1 {
+                    return Some(BranchParamRegs::new_one(last0));
+                }
+                if last0 == last2 || last1 == last2 {
+                    return Some(BranchParamRegs::new_two([last0, last1]));
+                }
+                match last0 != last2 && last1 != last2 {
+                    true => BranchParamRegs::new_three([last0, last1, last2]),
+                    false => BranchParamRegs::new_two([last0, last1]),
+                }
+            }
+            [.., last1, last0] => match last0 != last1 {
+                true => BranchParamRegs::new_two([*last0, *last1]),
+                false => BranchParamRegs::new_one(*last0),
+            },
+        };
+        Some(regs)
+    }
+
+    /// Creates [`BranchParams`] from `temp_slots`, `ty` and the control flow `kind`.
+    fn branch_params(
+        &self,
+        temp_slots: SlotSpan,
+        ty: BlockType,
+        kind: ControlFrameKind,
+    ) -> BranchParams {
+        ty.func_type_with(&self.engine, |func_ty| {
+            let (tys, len_tys) = match kind {
+                ControlFrameKind::Loop => (func_ty.params(), func_ty.len_params()),
+                _ => (func_ty.results(), func_ty.len_results()),
+            };
+            let regs = Self::branch_params_regs(tys);
+            let regs_len = regs.as_ref().map(BranchParamRegs::len).unwrap_or(0);
+            let temp_len = len_tys - regs_len;
+            BranchParams::new(temp_slots, temp_len, regs)
+        })
+    }
+
     /// Pushes the function enclosing Wasm `block` onto the [`Stack`].
     ///
     /// # Note
@@ -178,8 +230,9 @@ impl Stack {
         let branch_slots_len =
             ty.func_type_with(&self.engine, |ty| required_cells_for_tys(ty.results()))?;
         let branch_slots = BoundedSlotSpan::new(branch_slots_head, branch_slots_len);
+        let branch_params = self.branch_params(branch_slots_head, ty, ControlFrameKind::Block);
         self.controls
-            .push_block(ty, 0, branch_slots, label, fuel_pos);
+            .push_block(ty, 0, branch_slots, branch_params, label, fuel_pos);
         Ok(())
     }
 
@@ -200,9 +253,16 @@ impl Stack {
         let branch_slots_len =
             ty.func_type_with(&self.engine, |ty| required_cells_for_tys(ty.results()))?;
         let branch_slots = BoundedSlotSpan::new(branch_slots_head, branch_slots_len);
+        let branch_params = self.branch_params(branch_slots_head, ty, ControlFrameKind::Block);
         let consume_fuel = self.fuel_pos();
-        self.controls
-            .push_block(ty, block_height, branch_slots, label, consume_fuel);
+        self.controls.push_block(
+            ty,
+            block_height,
+            branch_slots,
+            branch_params,
+            label,
+            consume_fuel,
+        );
         Ok(())
     }
 
@@ -235,8 +295,15 @@ impl Stack {
         let branch_slots_len =
             ty.func_type_with(&self.engine, |ty| required_cells_for_tys(ty.params()))?;
         let branch_slots = BoundedSlotSpan::new(branch_slots_head, branch_slots_len);
-        self.controls
-            .push_loop(ty, block_height, branch_slots, label, fuel_pos);
+        let branch_params = self.branch_params(branch_slots_head, ty, ControlFrameKind::Loop);
+        self.controls.push_loop(
+            ty,
+            block_height,
+            branch_slots,
+            branch_params,
+            label,
+            fuel_pos,
+        );
         Ok(())
     }
 
@@ -267,10 +334,12 @@ impl Stack {
         let branch_slots_len =
             ty.func_type_with(&self.engine, |ty| required_cells_for_tys(ty.results()))?;
         let branch_slots = BoundedSlotSpan::new(branch_slots_head, branch_slots_len);
+        let branch_params = self.branch_params(branch_slots_head, ty, ControlFrameKind::If);
         self.controls.push_if(
             ty,
             block_height,
             branch_slots,
+            branch_params,
             label,
             fuel_pos,
             reachability,

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -254,7 +254,7 @@ impl Stack {
     }
 
     /// Creates [`BranchParams`] from `ty` and the control flow `kind`.
-    fn branch_params(&self, block_ty: BlockType, kind: ControlFrameKind) -> BranchParams {
+    pub fn branch_params(&self, block_ty: BlockType, kind: ControlFrameKind) -> BranchParams {
         block_ty.func_type_with(&self.engine, |func_ty| {
             self.branch_params_for(func_ty, kind)
         })
@@ -331,8 +331,10 @@ impl Stack {
         debug_assert!(self.is_fuel_metering_enabled() == fuel_pos.is_some());
         let block_height = self.block_height(ty);
         let branch_params = self.branch_params(ty, ControlFrameKind::Loop);
-        self.controls
+        let loop_frame = self
+            .controls
             .push_loop(ty, block_height, branch_params, label, fuel_pos);
+        self.push_branch_params(&loop_frame)?;
         Ok(())
     }
 

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -36,9 +36,10 @@ use crate::{
     core::TypedRawVal,
     engine::{
         BlockType,
+        required_cells_for_tys,
         translator::func::{LocalIdx, Pos, labels::LabelRef, stack::operands::PeekedOperands},
     },
-    ir::{self, SlotSpan},
+    ir::{self, BoundedSlotSpan, SlotSpan},
 };
 
 #[cfg(doc)]
@@ -184,11 +185,22 @@ impl Stack {
     }
 
     /// Returns the branch slots for the control frame with `len_params` operand parameters.
-    fn branch_slots(&self, len_params: usize) -> SlotSpan {
-        match len_params {
+    fn branch_slots(
+        &self,
+        func_ty: &FuncType,
+        kind: ControlFrameKind,
+    ) -> Result<BoundedSlotSpan, Error> {
+        let len_params = usize::from(func_ty.len_params());
+        let slots = match len_params {
             0 => self.operands.next_temp_slots(),
-            _ => self.operands.get(len_params - 1).temp_slots().span(),
-        }
+            _ => self.operands.get(len_params - 1usize).temp_slots().span(),
+        };
+        let param_tys = match kind {
+            ControlFrameKind::Loop => func_ty.params(),
+            _ => func_ty.results(),
+        };
+        let len_slots = required_cells_for_tys(param_tys)?;
+        Ok(BoundedSlotSpan::new(slots, len_slots))
     }
 
     /// Creates [`BranchParamRegs`] from `tys` if any.
@@ -240,9 +252,12 @@ impl Stack {
     }
 
     /// Creates [`BranchParams`] from `ty` and the control flow `kind`.
-    fn branch_params_for(&self, func_ty: &FuncType, kind: ControlFrameKind) -> BranchParams {
-        let len_params = func_ty.len_params();
-        let temp_slots = self.branch_slots(len_params.into());
+    fn branch_params_for(
+        &self,
+        temp_slots: BoundedSlotSpan,
+        func_ty: &FuncType,
+        kind: ControlFrameKind,
+    ) -> Result<BranchParams, Error> {
         let (tys, len_tys) = match kind {
             ControlFrameKind::Loop => (func_ty.params(), func_ty.len_params()),
             _ => (func_ty.results(), func_ty.len_results()),
@@ -250,13 +265,18 @@ impl Stack {
         let regs = Self::branch_params_regs(tys);
         let regs_len = regs.as_ref().map(BranchParamRegs::len).unwrap_or(0);
         let temp_len = len_tys - regs_len;
-        BranchParams::new(temp_slots, temp_len, regs)
+        Ok(BranchParams::new(temp_slots, temp_len, regs))
     }
 
     /// Creates [`BranchParams`] from `ty` and the control flow `kind`.
-    pub fn branch_params(&self, block_ty: BlockType, kind: ControlFrameKind) -> BranchParams {
+    pub fn branch_params(
+        &self,
+        block_ty: BlockType,
+        kind: ControlFrameKind,
+    ) -> Result<BranchParams, Error> {
         block_ty.func_type_with(&self.engine, |func_ty| {
-            self.branch_params_for(func_ty, kind)
+            let temp_slots = self.branch_slots(func_ty, kind)?;
+            self.branch_params_for(temp_slots, func_ty, kind)
         })
     }
 
@@ -285,6 +305,10 @@ impl Stack {
         debug_assert!(self.controls.is_empty());
         debug_assert!(self.is_fuel_metering_enabled() == fuel_pos.is_some());
         let temp_slots = self.operands.next_temp_slots();
+        let temp_slots_len = ty.func_type_with(&self.engine, |func_ty| {
+            required_cells_for_tys(func_ty.results())
+        })?;
+        let temp_slots = BoundedSlotSpan::new(temp_slots, temp_slots_len);
         let temp_len = ty.func_type_with(&self.engine, FuncType::len_results);
         let branch_params = BranchParams::new(temp_slots, temp_len, None);
         self.controls
@@ -304,7 +328,7 @@ impl Stack {
     pub fn push_block(&mut self, ty: BlockType, label: LabelRef) -> Result<(), Error> {
         debug_assert!(!self.controls.is_empty());
         let block_height = self.block_height(ty);
-        let branch_params = self.branch_params(ty, ControlFrameKind::Block);
+        let branch_params = self.branch_params(ty, ControlFrameKind::Block)?;
         let consume_fuel = self.fuel_pos();
         self.controls
             .push_block(ty, block_height, branch_params, label, consume_fuel);
@@ -330,7 +354,7 @@ impl Stack {
         debug_assert!(!self.controls.is_empty());
         debug_assert!(self.is_fuel_metering_enabled() == fuel_pos.is_some());
         let block_height = self.block_height(ty);
-        let branch_params = self.branch_params(ty, ControlFrameKind::Loop);
+        let branch_params = self.branch_params(ty, ControlFrameKind::Loop)?;
         let loop_frame = self
             .controls
             .push_loop(ty, block_height, branch_params, label, fuel_pos);
@@ -361,7 +385,7 @@ impl Stack {
         let else_operands = self.operands.peek(len_block_params);
         let registers = self.operands.get_registers();
         debug_assert!(len_block_params == else_operands.len());
-        let branch_params = self.branch_params(ty, ControlFrameKind::If);
+        let branch_params = self.branch_params(ty, ControlFrameKind::If)?;
         self.controls.push_if(
             ty,
             block_height,

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -227,10 +227,14 @@ impl Stack {
         debug_assert!(self.controls.is_empty());
         debug_assert!(self.is_fuel_metering_enabled() == fuel_pos.is_some());
         let branch_slots_head = self.operands.next_temp_slots();
-        let branch_slots_len =
-            ty.func_type_with(&self.engine, |ty| required_cells_for_tys(ty.results()))?;
+        let (temp_len, branch_slots_len) =
+            ty.func_type_with(&self.engine, |ty| -> Result<(u16, u16), Error> {
+                let len_results = ty.len_results();
+                let len_branch_slots = required_cells_for_tys(ty.results())?;
+                Ok((len_results, len_branch_slots))
+            })?;
         let branch_slots = BoundedSlotSpan::new(branch_slots_head, branch_slots_len);
-        let branch_params = self.branch_params(branch_slots_head, ty, ControlFrameKind::Block);
+        let branch_params = BranchParams::new(branch_slots_head, temp_len, None);
         self.controls
             .push_block(ty, 0, branch_slots, branch_params, label, fuel_pos);
         Ok(())

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -195,9 +195,7 @@ impl Stack {
             [.., last2, last1, last0] => {
                 let [last2, last1, last0] = [*last2, *last1, *last0];
                 let [kind2, kind1, kind0] = [last2, last1, last0].map(Self::ty_to_reg_kind);
-                let Some(kind0) = kind0 else {
-                    return None
-                };
+                let kind0 = kind0?;
                 let Some(kind1) = kind1 else {
                     return Some(BranchParamRegs::new_one(last0));
                 };
@@ -221,9 +219,7 @@ impl Stack {
             [.., last1, last0] => {
                 let [last1, last0] = [*last1, *last0];
                 let [kind1, kind0] = [last1, last0].map(Self::ty_to_reg_kind);
-                let Some(kind0) = kind0 else {
-                    return None
-                };
+                let kind0 = kind0?;
                 let Some(kind1) = kind1 else {
                     return Some(BranchParamRegs::new_one(last0));
                 };

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -22,6 +22,7 @@ pub use self::{
         IfControlFrame,
         IfReachability,
         LoopControlFrame,
+        RegKind,
     },
     operand::{ImmediateOperand, LocalOperand, Location, Operand, ResolvedOperand, TempOperand},
     operands::{Allocation, PreservedAllLocalsIter, PreservedLocalsIter, PreservedRegs},
@@ -155,35 +156,7 @@ impl Stack {
             _ => self.operands.get(len_params - 1).temp_slots().span(),
         }
     }
-}
 
-/// The kind of a register.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum RegKind {
-    /// The general purpose register for `i32` and `i64` values.
-    Ireg,
-    /// The `f32` register.
-    Freg32,
-    /// The `f64` register.
-    Freg64,
-}
-
-impl RegKind {
-    /// Creates a [`RegKind`] from a [`ValType`] if possible.
-    ///
-    /// Returns `None` if there is no register kind available to `ty`.
-    pub fn new(ty: ValType) -> Option<Self> {
-        let kind = match ty {
-            ValType::I32 | ValType::FuncRef | ValType::ExternRef | ValType::I64 => Self::Ireg,
-            ValType::F32 => Self::Freg32,
-            ValType::F64 => Self::Freg64,
-            ValType::V128 => return None,
-        };
-        Some(kind)
-    }
-}
-
-impl Stack {
     /// Creates [`BranchParamRegs`] from `tys` if any.
     ///
     /// Returns `None` if `tys` is empty.

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -164,43 +164,41 @@ impl Stack {
         let regs = match tys {
             [] => return None,
             [ty] => {
-                RegKind::new(*ty)?;
-                BranchParamRegs::new_one(*ty)
+                let kind = RegKind::new(*ty)?;
+                BranchParamRegs::new_one(kind)
             }
             [.., last2, last1, last0] => {
-                let [last2, last1, last0] = [*last2, *last1, *last0];
-                let [kind2, kind1, kind0] = [last2, last1, last0].map(RegKind::new);
+                let [kind2, kind1, kind0] = [*last2, *last1, *last0].map(RegKind::new);
                 let kind0 = kind0?;
                 let Some(kind1) = kind1 else {
-                    return Some(BranchParamRegs::new_one(last0));
+                    return Some(BranchParamRegs::new_one(kind0));
                 };
                 let Some(kind2) = kind2 else {
                     match kind0 != kind1 {
-                        true => return Some(BranchParamRegs::new_two([last0, last1])),
-                        false => return Some(BranchParamRegs::new_one(last0)),
+                        true => return Some(BranchParamRegs::new_two([kind0, kind1])),
+                        false => return Some(BranchParamRegs::new_one(kind0)),
                     }
                 };
                 if kind0 == kind1 {
-                    return Some(BranchParamRegs::new_one(last0));
+                    return Some(BranchParamRegs::new_one(kind0));
                 }
                 if kind0 == kind2 || kind1 == kind2 {
-                    return Some(BranchParamRegs::new_two([last0, last1]));
+                    return Some(BranchParamRegs::new_two([kind0, kind1]));
                 }
                 match kind0 != kind2 && kind1 != kind2 {
-                    true => BranchParamRegs::new_three([last0, last1, last2]),
-                    false => BranchParamRegs::new_two([last0, last1]),
+                    true => BranchParamRegs::new_three([kind0, kind1, kind2]),
+                    false => BranchParamRegs::new_two([kind0, kind1]),
                 }
             }
             [.., last1, last0] => {
-                let [last1, last0] = [*last1, *last0];
-                let [kind1, kind0] = [last1, last0].map(RegKind::new);
+                let [kind1, kind0] = [*last1, *last0].map(RegKind::new);
                 let kind0 = kind0?;
                 let Some(kind1) = kind1 else {
-                    return Some(BranchParamRegs::new_one(last0));
+                    return Some(BranchParamRegs::new_one(kind0));
                 };
                 match kind0 != kind1 {
-                    true => BranchParamRegs::new_two([last0, last1]),
-                    false => BranchParamRegs::new_one(last0),
+                    true => BranchParamRegs::new_two([kind0, kind1]),
+                    false => BranchParamRegs::new_one(kind0),
                 }
             }
         };

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -3,10 +3,17 @@ mod locals;
 mod operand;
 mod operands;
 
+use self::{
+    control::ControlStack,
+    locals::LocalsHead,
+    operands::{OperandStack, StackOperand, StackPos},
+};
 pub use self::{
     control::{
         AcquiredTarget,
         BlockControlFrame,
+        BranchParamRegs,
+        BranchParams,
         ControlFrame,
         ControlFrameBase,
         ControlFrameKind,
@@ -19,11 +26,6 @@ pub use self::{
     operand::{ImmediateOperand, LocalOperand, Location, Operand, ResolvedOperand, TempOperand},
     operands::{Allocation, PreservedAllLocalsIter, PreservedLocalsIter, PreservedRegs},
 };
-use self::{
-    control::{BranchParamRegs, ControlStack},
-    locals::LocalsHead,
-    operands::{OperandStack, StackOperand, StackPos},
-};
 use super::{Reset, ReusableAllocations};
 use crate::{
     Engine,
@@ -33,12 +35,7 @@ use crate::{
     engine::{
         BlockType,
         translator::{
-            func::{
-                LocalIdx,
-                Pos,
-                labels::LabelRef,
-                stack::{control::BranchParams, operands::PeekedOperands},
-            },
+            func::{LocalIdx, Pos, labels::LabelRef, stack::operands::PeekedOperands},
             utils::required_cells_for_tys,
         },
     },

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -30,16 +30,14 @@ use super::{Reset, ReusableAllocations};
 use crate::{
     Engine,
     Error,
+    FuncType,
     ValType,
     core::TypedRawVal,
     engine::{
         BlockType,
-        translator::{
-            func::{LocalIdx, Pos, labels::LabelRef, stack::operands::PeekedOperands},
-            utils::required_cells_for_tys,
-        },
+        translator::func::{LocalIdx, Pos, labels::LabelRef, stack::operands::PeekedOperands},
     },
-    ir::{self, BoundedSlotSpan, SlotSpan},
+    ir::{self, SlotSpan},
 };
 
 #[cfg(doc)]
@@ -223,17 +221,11 @@ impl Stack {
     ) -> Result<(), Error> {
         debug_assert!(self.controls.is_empty());
         debug_assert!(self.is_fuel_metering_enabled() == fuel_pos.is_some());
-        let branch_slots_head = self.operands.next_temp_slots();
-        let (temp_len, branch_slots_len) =
-            ty.func_type_with(&self.engine, |ty| -> Result<(u16, u16), Error> {
-                let len_results = ty.len_results();
-                let len_branch_slots = required_cells_for_tys(ty.results())?;
-                Ok((len_results, len_branch_slots))
-            })?;
-        let branch_slots = BoundedSlotSpan::new(branch_slots_head, branch_slots_len);
-        let branch_params = BranchParams::new(branch_slots_head, temp_len, None);
+        let temp_slots = self.operands.next_temp_slots();
+        let temp_len = ty.func_type_with(&self.engine, FuncType::len_results);
+        let branch_params = BranchParams::new(temp_slots, temp_len, None);
         self.controls
-            .push_block(ty, 0, branch_slots, branch_params, label, fuel_pos);
+            .push_block(ty, 0, branch_params, label, fuel_pos);
         Ok(())
     }
 
@@ -250,20 +242,11 @@ impl Stack {
         debug_assert!(!self.controls.is_empty());
         let len_params = usize::from(ty.len_params(&self.engine));
         let block_height = self.height() - len_params;
-        let branch_slots_head = self.branch_slots(len_params);
-        let branch_slots_len =
-            ty.func_type_with(&self.engine, |ty| required_cells_for_tys(ty.results()))?;
-        let branch_slots = BoundedSlotSpan::new(branch_slots_head, branch_slots_len);
-        let branch_params = self.branch_params(branch_slots_head, ty, ControlFrameKind::Block);
+        let temp_slots = self.branch_slots(len_params);
+        let branch_params = self.branch_params(temp_slots, ty, ControlFrameKind::Block);
         let consume_fuel = self.fuel_pos();
-        self.controls.push_block(
-            ty,
-            block_height,
-            branch_slots,
-            branch_params,
-            label,
-            consume_fuel,
-        );
+        self.controls
+            .push_block(ty, block_height, branch_params, label, consume_fuel);
         Ok(())
     }
 
@@ -292,19 +275,10 @@ impl Stack {
                 .peek(len_params)
                 .all(|operand| operand.is_temp())
         );
-        let branch_slots_head = self.branch_slots(len_params);
-        let branch_slots_len =
-            ty.func_type_with(&self.engine, |ty| required_cells_for_tys(ty.params()))?;
-        let branch_slots = BoundedSlotSpan::new(branch_slots_head, branch_slots_len);
-        let branch_params = self.branch_params(branch_slots_head, ty, ControlFrameKind::Loop);
-        self.controls.push_loop(
-            ty,
-            block_height,
-            branch_slots,
-            branch_params,
-            label,
-            fuel_pos,
-        );
+        let temp_slots = self.branch_slots(len_params);
+        let branch_params = self.branch_params(temp_slots, ty, ControlFrameKind::Loop);
+        self.controls
+            .push_loop(ty, block_height, branch_params, label, fuel_pos);
         Ok(())
     }
 
@@ -331,15 +305,11 @@ impl Stack {
         let else_operands = self.operands.peek(len_params);
         let registers = self.operands.get_registers();
         debug_assert!(len_params == else_operands.len());
-        let branch_slots_head = self.branch_slots(len_params);
-        let branch_slots_len =
-            ty.func_type_with(&self.engine, |ty| required_cells_for_tys(ty.results()))?;
-        let branch_slots = BoundedSlotSpan::new(branch_slots_head, branch_slots_len);
-        let branch_params = self.branch_params(branch_slots_head, ty, ControlFrameKind::If);
+        let temp_slots = self.branch_slots(len_params);
+        let branch_params = self.branch_params(temp_slots, ty, ControlFrameKind::If);
         self.controls.push_if(
             ty,
             block_height,
-            branch_slots,
             branch_params,
             label,
             fuel_pos,

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -155,6 +155,35 @@ impl Stack {
             _ => self.operands.get(len_params - 1).temp_slots().span(),
         }
     }
+}
+
+/// The kind of a register.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RegKind {
+    /// The general purpose register for `i32` and `i64` values.
+    Ireg,
+    /// The `f32` register.
+    Freg32,
+    /// The `f64` register.
+    Freg64,
+}
+
+impl Stack {
+    /// Converts a [`ValType`] into a [`RegKind`].
+    /// 
+    /// Returns `None` if there is no register kind available to `ty`.
+    fn ty_to_reg_kind(ty: ValType) -> Option<RegKind> {
+        let kind = match ty {
+            ValType::I32 |
+            ValType::FuncRef |
+            ValType::ExternRef |
+            ValType::I64 => RegKind::Ireg,
+            ValType::F32 => RegKind::Freg32,
+            ValType::F64 => RegKind::Freg64,
+            ValType::V128 => return None,
+        };
+        Some(kind)
+    }
 
     /// Creates [`BranchParamRegs`] from `tys` if any.
     ///
@@ -162,24 +191,50 @@ impl Stack {
     fn branch_params_regs(tys: &[ValType]) -> Option<BranchParamRegs> {
         let regs = match tys {
             [] => return None,
-            [ty] => BranchParamRegs::new_one(*ty),
+            [ty] => {
+                Self::ty_to_reg_kind(*ty)?;
+                BranchParamRegs::new_one(*ty)
+            }
             [.., last2, last1, last0] => {
                 let [last2, last1, last0] = [*last2, *last1, *last0];
-                if last0 == last1 {
+                let [kind2, kind1, kind0] = [last2, last1, last0].map(Self::ty_to_reg_kind);
+                let Some(kind0) = kind0 else {
+                    return None
+                };
+                let Some(kind1) = kind1 else {
+                    return Some(BranchParamRegs::new_one(last0));
+                };
+                let Some(kind2) = kind2 else {
+                    match kind0 != kind1 {
+                        true => return Some(BranchParamRegs::new_two([last0, last1])),
+                        false => return Some(BranchParamRegs::new_one(last0)),
+                    }
+                };
+                if kind0 == kind1 {
                     return Some(BranchParamRegs::new_one(last0));
                 }
-                if last0 == last2 || last1 == last2 {
+                if kind0 == kind2 || kind1 == kind2 {
                     return Some(BranchParamRegs::new_two([last0, last1]));
                 }
-                match last0 != last2 && last1 != last2 {
+                match kind0 != kind2 && kind1 != kind2 {
                     true => BranchParamRegs::new_three([last0, last1, last2]),
                     false => BranchParamRegs::new_two([last0, last1]),
                 }
             }
-            [.., last1, last0] => match last0 != last1 {
-                true => BranchParamRegs::new_two([*last0, *last1]),
-                false => BranchParamRegs::new_one(*last0),
-            },
+            [.., last1, last0] => {
+                let [last1, last0] = [*last1, *last0];
+                let [kind1, kind0] = [last1, last0].map(Self::ty_to_reg_kind);
+                let Some(kind0) = kind0 else {
+                    return None
+                };
+                let Some(kind1) = kind1 else {
+                    return Some(BranchParamRegs::new_one(last0));
+                };
+                match kind0 != kind1 {
+                    true => BranchParamRegs::new_two([last0, last1]),
+                    false => BranchParamRegs::new_one(last0),
+                }
+            }
         };
         Some(regs)
     }

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -168,20 +168,22 @@ pub enum RegKind {
     Freg64,
 }
 
-impl Stack {
-    /// Converts a [`ValType`] into a [`RegKind`].
+impl RegKind {
+    /// Creates a [`RegKind`] from a [`ValType`] if possible.
     ///
     /// Returns `None` if there is no register kind available to `ty`.
-    fn ty_to_reg_kind(ty: ValType) -> Option<RegKind> {
+    pub fn new(ty: ValType) -> Option<Self> {
         let kind = match ty {
-            ValType::I32 | ValType::FuncRef | ValType::ExternRef | ValType::I64 => RegKind::Ireg,
-            ValType::F32 => RegKind::Freg32,
-            ValType::F64 => RegKind::Freg64,
+            ValType::I32 | ValType::FuncRef | ValType::ExternRef | ValType::I64 => Self::Ireg,
+            ValType::F32 => Self::Freg32,
+            ValType::F64 => Self::Freg64,
             ValType::V128 => return None,
         };
         Some(kind)
     }
+}
 
+impl Stack {
     /// Creates [`BranchParamRegs`] from `tys` if any.
     ///
     /// Returns `None` if `tys` is empty.
@@ -189,12 +191,12 @@ impl Stack {
         let regs = match tys {
             [] => return None,
             [ty] => {
-                Self::ty_to_reg_kind(*ty)?;
+                RegKind::new(*ty)?;
                 BranchParamRegs::new_one(*ty)
             }
             [.., last2, last1, last0] => {
                 let [last2, last1, last0] = [*last2, *last1, *last0];
-                let [kind2, kind1, kind0] = [last2, last1, last0].map(Self::ty_to_reg_kind);
+                let [kind2, kind1, kind0] = [last2, last1, last0].map(RegKind::new);
                 let kind0 = kind0?;
                 let Some(kind1) = kind1 else {
                     return Some(BranchParamRegs::new_one(last0));
@@ -218,7 +220,7 @@ impl Stack {
             }
             [.., last1, last0] => {
                 let [last1, last0] = [*last1, *last0];
-                let [kind1, kind0] = [last1, last0].map(Self::ty_to_reg_kind);
+                let [kind1, kind0] = [last1, last0].map(RegKind::new);
                 let kind0 = kind0?;
                 let Some(kind1) = kind1 else {
                     return Some(BranchParamRegs::new_one(last0));

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -170,14 +170,11 @@ pub enum RegKind {
 
 impl Stack {
     /// Converts a [`ValType`] into a [`RegKind`].
-    /// 
+    ///
     /// Returns `None` if there is no register kind available to `ty`.
     fn ty_to_reg_kind(ty: ValType) -> Option<RegKind> {
         let kind = match ty {
-            ValType::I32 |
-            ValType::FuncRef |
-            ValType::ExternRef |
-            ValType::I64 => RegKind::Ireg,
+            ValType::I32 | ValType::FuncRef | ValType::ExternRef | ValType::I64 => RegKind::Ireg,
             ValType::F32 => RegKind::Freg32,
             ValType::F64 => RegKind::Freg64,
             ValType::V128 => return None,

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -309,8 +309,9 @@ impl Stack {
             required_cells_for_tys(func_ty.results())
         })?;
         let temp_slots = BoundedSlotSpan::new(temp_slots, temp_slots_len);
-        let temp_len = ty.func_type_with(&self.engine, FuncType::len_results);
-        let branch_params = BranchParams::new(temp_slots, temp_len, None);
+        let branch_params = ty.func_type_with(&self.engine, |func_ty| {
+            self.branch_params_for(temp_slots, func_ty, ControlFrameKind::Block)
+        })?;
         self.controls
             .push_block(ty, 0, branch_params, label, fuel_pos);
         Ok(())

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -134,11 +134,10 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         self.preserve_regs(fuel_pos)?;
         let block_ty = BlockType::new(block_ty, &self.module);
         let len_params = block_ty.len_params(&self.engine);
-        let continue_label = self.instrs.new_label();
-        let fuel_pos = self.stack.fuel_pos();
         if len_params > 0 {
-            self.move_operands_to_temp(usize::from(len_params), fuel_pos)?;
+            self.move_operands_to_temp(len_params.into(), fuel_pos)?;
         }
+        let continue_label = self.instrs.new_label();
         self.instrs.pin_label(continue_label)?;
         let fuel_pos = self.instrs.encode_consume_fuel_op()?;
         self.stack.push_loop(block_ty, continue_label, fuel_pos)?;

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -224,7 +224,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         if let IfReachability::Both { else_label } = frame.reachability() {
             let fuel_pos = frame.fuel_pos();
             if is_end_of_then_reachable {
-                self.copy_branch_params(&frame, fuel_pos)?;
+                self.copy_branch_params(frame.branch_params(), fuel_pos)?;
                 frame.branch_to();
                 self.encode_br(frame.label())?;
             }
@@ -261,10 +261,8 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             AcquiredTarget::Branch(mut frame) => {
                 frame.branch_to();
                 let label = frame.label();
-                let len_params = frame.len_branch_params(&self.engine);
-                if let Some(branch_results) = frame.branch_slots() {
-                    self.encode_copies(branch_results.span(), len_params, fuel_pos)?;
-                }
+                let branch_params = frame.branch_params();
+                self.copy_branch_params(branch_params, fuel_pos)?;
                 self.encode_br(label)?;
                 self.reachable = false;
                 Ok(())
@@ -289,12 +287,12 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let mut frame = self.stack.peek_control_mut(depth).control_frame();
         frame.branch_to();
         let label = frame.label();
-        let Some(branch_slots) = frame.branch_slots() else {
+        let branch_params = frame.branch_params();
+        if branch_params.is_empty() {
             // Case: no branch values are required to be copied
             self.encode_br_nez(condition, label)?;
             return Ok(());
         };
-        let len_branch_params = frame.len_branch_params(&self.engine);
         if !self.requires_branch_param_copies(depth) {
             // Case: no branch values are required to be copied
             self.encode_br_nez(condition, label)?;
@@ -304,7 +302,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let fuel_pos = self.stack.fuel_pos();
         let skip_label = self.instrs.new_label();
         self.encode_br_eqz(condition, skip_label)?;
-        self.encode_copies(branch_slots.span(), len_branch_params, fuel_pos)?;
+        self.copy_branch_params(branch_params, fuel_pos)?;
         self.encode_br(label)?;
         self.instrs.pin_label(skip_label)?;
         Ok(())
@@ -349,7 +347,8 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let len_branch_params = self
             .stack
             .peek_control(default_target)
-            .len_branch_params(&self.engine);
+            .branch_params()
+            .len();
         match len_branch_params {
             0 => self.encode_br_table_0(table, index)?,
             n => self.encode_br_table_n(table, index, n)?,

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -130,13 +130,12 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             return Ok(());
         }
         let fuel_pos = self.stack.fuel_pos();
-        self.preserve_all_locals(0)?;
-        self.preserve_regs(fuel_pos)?;
         let block_ty = BlockType::new(block_ty, &self.module);
-        let len_params = block_ty.len_params(&self.engine);
-        if len_params > 0 {
-            self.move_operands_to_temp(len_params.into(), fuel_pos)?;
-        }
+        let branch_params = self.stack.branch_params(block_ty, ControlFrameKind::Loop);
+        let len_params = block_ty.len_params(self.engine());
+        self.copy_branch_params(branch_params, fuel_pos)?;
+        self.preserve_all_locals(len_params.into())?;
+        self.preserve_temp_regs(fuel_pos, len_params.into())?;
         let continue_label = self.instrs.new_label();
         self.instrs.pin_label(continue_label)?;
         let fuel_pos = self.instrs.encode_consume_fuel_op()?;

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -18,7 +18,14 @@ use crate::{
                 LocalSetCodegen,
                 Operand,
                 op,
-                stack::{AcquiredTarget, Allocation, IfReachability, Location, ResolvedOperand},
+                stack::{
+                    AcquiredTarget,
+                    Allocation,
+                    IfReachability,
+                    Location,
+                    RegKind,
+                    ResolvedOperand,
+                },
             },
         },
     },
@@ -315,17 +322,21 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
             // Case: the `br_table` only has a single target `t` which is equal to a `br t`.
             return self.visit_br(default_target);
         }
-        if let Operand::Immediate(index) = index {
-            // Case: the `br_table` index is a constant value, therefore always taking the same branch.
-            // Note: `usize::MAX` is used to fallback to the default target.
-            let chosen_index = usize::try_from(u32::from(index.val())).unwrap_or(usize::MAX);
-            let chosen_target = table
-                .targets()
-                .nth(chosen_index)
-                .transpose()?
-                .unwrap_or(default_target);
-            return self.visit_br(chosen_target);
-        }
+        let index_loc = match self.resolve_operand::<RawVal>(index)? {
+            ResolvedOperand::Slot(index) => Location::Slot(index),
+            ResolvedOperand::Reg(ty) => Location::Reg(ty),
+            ResolvedOperand::Immediate(index) => {
+                // Case: the `br_table` index is a constant value, therefore always taking the same branch.
+                // Note: `usize::MAX` is used to fallback to the default target.
+                let chosen_index = usize::try_from(u32::from(index)).unwrap_or(usize::MAX);
+                let chosen_target = table
+                    .targets()
+                    .nth(chosen_index)
+                    .transpose()?
+                    .unwrap_or(default_target);
+                return self.visit_br(chosen_target);
+            }
+        };
         Self::copy_targets_from_br_table(&table, &mut self.immediates)?;
         let targets = &self.immediates[..];
         if targets
@@ -341,15 +352,38 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         let Ok(default_target) = usize::try_from(default_target) else {
             panic!("out of bounds `default_target` does not fit into `usize`: {default_target}");
         };
-        let index = self.copy_immediate_to_slot(index)?;
-        let len_branch_params = self
-            .stack
-            .peek_control(default_target)
-            .branch_params()
-            .len();
-        match len_branch_params {
-            0 => self.encode_br_table_0(table, index)?,
-            n => self.encode_br_table_n(table, index, n)?,
+        let fuel_pos = self.stack.fuel_pos();
+        let default_frame = self.stack.peek_control(default_target);
+        let default_height = default_frame.height();
+        let equal_heights = targets.iter().all(|target| {
+            // - This is true if all branch targets have the same stack height.
+            // - If all branch targets share the same height there is no need to
+            //   perform per-branch copies.
+            let depth = u32::from(*target) as usize;
+            self.stack.peek_control(depth).height() == default_height
+        });
+        let default_branch_params = default_frame.branch_params();
+        let index_loc = match index_loc {
+            Location::Slot(index) => Location::Slot(index),
+            Location::Reg(_) => {
+                // We need to preserve `index: Reg` to a `Slot` since it
+                // would be overwritten by copying the branch parameters.
+                match default_branch_params.claims_reg(RegKind::Ireg) {
+                    true => {
+                        let temp_result = index.temp_slots().head();
+                        self.encode_copy_sx_op(temp_result, index, fuel_pos)?;
+                        Location::Slot(temp_result)
+                    }
+                    false => index_loc,
+                }
+            }
+        };
+        self.copy_branch_params(default_branch_params, fuel_pos)?;
+        let required_temp_copies = default_branch_params.len_temps() != 0;
+        let requires_branch_copies = required_temp_copies && equal_heights;
+        match requires_branch_copies {
+            false => self.encode_br_table_0(table, index_loc)?,
+            true => self.encode_br_table_n(table, index_loc, default_branch_params)?,
         };
         self.reachable = false;
         Ok(())

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -131,7 +131,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
         }
         let fuel_pos = self.stack.fuel_pos();
         let block_ty = BlockType::new(block_ty, &self.module);
-        let branch_params = self.stack.branch_params(block_ty, ControlFrameKind::Loop);
+        let branch_params = self.stack.branch_params(block_ty, ControlFrameKind::Loop)?;
         let len_params = block_ty.len_params(self.engine());
         self.copy_branch_params(branch_params, fuel_pos)?;
         self.preserve_all_locals(len_params.into())?;


### PR DESCRIPTION
An optimization on top of https://github.com/wasmi-labs/wasmi/pull/1855.

- [x] `block`
- [x] `if`
- [x] `else`
- [x] `loop`
- [x] `end`
- [x] `br`
- [x] `br_if`
- [x] `br_table`
