### PR TITLE
Fix benchmark tests for Windows runner on GitHub Actions CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -175,6 +175,10 @@ jobs:
         env:
           RUSTFLAGS: "-C debug-assertions"
         run: cargo test --workspace --locked --all-features
+      - name: Build (benches)
+        env:
+          RUSTFLAGS: "-C debug-assertions"
+        run: cargo build --bench benches --release --locked
       - name: Test (benches)
         env:
           RUSTFLAGS: "-C debug-assertions"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -175,6 +175,10 @@ jobs:
         env:
           RUSTFLAGS: "-C debug-assertions"
         run: cargo test --workspace --locked --all-features
+      - name: Test (benches)
+        env:
+          RUSTFLAGS: "-C debug-assertions"
+        run: cargo test --bench benches --release --locked
 
   fmt:
     name: Formatting

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -1020,10 +1020,22 @@ fn bench_execute_reverse_complement(c: &mut Criterion) {
             .call(&mut store, data_ptr)
             .unwrap();
 
+        let [input, output]: [Box<[u8]>; 2] = {
+            // Make sure the input and output `.txt` files are properly FASTA
+            // encoded which requires line endings with LF and not CRLF.
+            //
+            // On Windows these files might be checked-out with CRLF new-line
+            // encoding which invalidates the benchmark computation.
+            let mut input = REVCOMP_INPUT.to_vec();
+            let mut output = REVCOMP_OUTPUT.to_vec();
+            input.retain(|b| *b != b'\r');
+            output.retain(|b| *b != b'\r');
+            [input.into(), output.into()]
+        };
         // Copy test data inside the wasm memory.
         let memory = instance.get_memory(&store, "memory").unwrap();
         memory
-            .write(&mut store, input_offset as usize, REVCOMP_INPUT)
+            .write(&mut store, input_offset as usize, &input[..])
             .unwrap();
 
         // Run the rev complement benchmark.
@@ -1039,11 +1051,11 @@ fn bench_execute_reverse_complement(c: &mut Criterion) {
             .call(&mut store, data_ptr)
             .unwrap();
 
-        let mut result = [0x00_u8; REVCOMP_OUTPUT.len()];
+        let mut result: Box<[u8]> = vec![0x00_u8; output.len()].into();
         memory
-            .read(&store, output_offset as usize, &mut result)
+            .read(&store, output_offset as usize, &mut result[..])
             .unwrap();
-        assert_eq!(&result[..], REVCOMP_OUTPUT);
+        assert_eq!(result, output);
 
         // Teardown benchmark data.
         instance

--- a/crates/wasmi/benches/benches.rs
+++ b/crates/wasmi/benches/benches.rs
@@ -1020,22 +1020,10 @@ fn bench_execute_reverse_complement(c: &mut Criterion) {
             .call(&mut store, data_ptr)
             .unwrap();
 
-        let [input, output]: [Box<[u8]>; 2] = {
-            // Make sure the input and output `.txt` files are properly FASTA
-            // encoded which requires line endings with LF and not CRLF.
-            //
-            // On Windows these files might be checked-out with CRLF new-line
-            // encoding which invalidates the benchmark computation.
-            let mut input = REVCOMP_INPUT.to_vec();
-            let mut output = REVCOMP_OUTPUT.to_vec();
-            input.retain(|b| *b != b'\r');
-            output.retain(|b| *b != b'\r');
-            [input.into(), output.into()]
-        };
         // Copy test data inside the wasm memory.
         let memory = instance.get_memory(&store, "memory").unwrap();
         memory
-            .write(&mut store, input_offset as usize, &input[..])
+            .write(&mut store, input_offset as usize, REVCOMP_INPUT)
             .unwrap();
 
         // Run the rev complement benchmark.
@@ -1051,11 +1039,11 @@ fn bench_execute_reverse_complement(c: &mut Criterion) {
             .call(&mut store, data_ptr)
             .unwrap();
 
-        let mut result: Box<[u8]> = vec![0x00_u8; output.len()].into();
+        let mut result = [0x00_u8; REVCOMP_OUTPUT.len()];
         memory
-            .read(&store, output_offset as usize, &mut result[..])
+            .read(&store, output_offset as usize, &mut result)
             .unwrap();
-        assert_eq!(result, output);
+        assert_eq!(&result[..], REVCOMP_OUTPUT);
 
         // Teardown benchmark data.
         instance


### PR DESCRIPTION
The suspected problem is that the `reverse_complement` compute kernel expects its `input.txt` file to be in FASTA encoding which requires LF encoding for new-lines.
However, on Windows, those `input.txt` and `output.txt` files might have been checked out with CRLF encoding for new-lines which breaks the `reverse_complement` compute kernel.

Fix is to make `git` check-out those two files in LF encoding via `.gitattributes` file in the `rust-benchmarks` Git submodule.
The remaining diff is adding testing of benchmarks to GitHub Actions CI test job.

CI errors look like this:
https://github.com/wasmi-labs/wasmi/actions/runs/27506064089/job/81297400245?pr=1855