### PR TITLE
Zero-initialize only non-parameter locals upon function call

### DIFF
--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -795,13 +795,13 @@ impl<'a> From<&'a [u8]> for SmallByteSlice {
 pub struct CompiledFuncEntity {
     /// The sequence of [`Op`] of the [`CompiledFuncEntity`].
     ops: Pin<Box<[u8]>>,
-    /// The number of stack slots used by the [`EngineFunc`] in total.
+    /// The total number of stack slots used by the [`EngineFunc`].
     ///
     /// # Note
     ///
     /// This includes stack slots to store the function local constant values,
     /// function parameters, function locals and dynamically used stack slots.
-    len_stack_slots: u16,
+    len_slots: u16,
 }
 
 impl CompiledFuncEntity {
@@ -811,7 +811,7 @@ impl CompiledFuncEntity {
     ///
     /// - If `ops` is empty.
     /// - If `ops` contains more than `i32::MAX` encoded bytes.
-    pub fn new(len_stack_slots: u16, ops: &[u8]) -> Self {
+    pub fn new(len_slots: u16, ops: &[u8]) -> Self {
         let ops: Pin<Box<[u8]>> = Pin::new(ops.into());
         assert!(
             !ops.is_empty(),
@@ -826,10 +826,7 @@ impl CompiledFuncEntity {
             "compiled function has too many instructions: {}",
             ops.len(),
         );
-        Self {
-            ops,
-            len_stack_slots,
-        }
+        Self { ops, len_slots }
     }
 }
 
@@ -847,7 +844,7 @@ impl<'a> From<&'a CompiledFuncEntity> for CompiledFuncRef<'a> {
     fn from(func: &'a CompiledFuncEntity) -> Self {
         Self {
             ops: func.ops.as_ref(),
-            len_stack_slots: func.len_stack_slots,
+            len_stack_slots: func.len_slots,
         }
     }
 }

--- a/crates/wasmi/src/engine/code_map.rs
+++ b/crates/wasmi/src/engine/code_map.rs
@@ -795,23 +795,35 @@ impl<'a> From<&'a [u8]> for SmallByteSlice {
 pub struct CompiledFuncEntity {
     /// The sequence of [`Op`] of the [`CompiledFuncEntity`].
     ops: Pin<Box<[u8]>>,
+    /// The total number of stack slots for locals for the [`EngineFunc`].
+    ///
+    /// # Note
+    ///
+    /// This includes defined Wasm function parameters and locals.
+    len_local_slots: u16,
     /// The total number of stack slots used by the [`EngineFunc`].
     ///
     /// # Note
     ///
     /// This includes stack slots to store the function local constant values,
     /// function parameters, function locals and dynamically used stack slots.
-    len_slots: u16,
+    len_stack_slots: u16,
 }
 
 impl CompiledFuncEntity {
     /// Create a new initialized [`CompiledFuncEntity`].
     ///
+    /// # Note
+    ///
+    /// - `len_locals` is the total number of stack slots used for function parameters or locals.
+    /// - `len_slots`: is the total number of stack slots used by the function.
+    ///
     /// # Panics
     ///
     /// - If `ops` is empty.
     /// - If `ops` contains more than `i32::MAX` encoded bytes.
-    pub fn new(len_slots: u16, ops: &[u8]) -> Self {
+    pub fn new(len_local_slots: u16, len_stack_slots: u16, ops: &[u8]) -> Self {
+        debug_assert!(len_local_slots <= len_stack_slots);
         let ops: Pin<Box<[u8]>> = Pin::new(ops.into());
         assert!(
             !ops.is_empty(),
@@ -826,7 +838,11 @@ impl CompiledFuncEntity {
             "compiled function has too many instructions: {}",
             ops.len(),
         );
-        Self { ops, len_slots }
+        Self {
+            ops,
+            len_local_slots,
+            len_stack_slots,
+        }
     }
 }
 
@@ -835,7 +851,9 @@ impl CompiledFuncEntity {
 pub struct CompiledFuncRef<'a> {
     /// The sequence of encoded [`Op`]s of the [`CompiledFuncEntity`].
     ops: Pin<&'a [u8]>,
-    /// The number of stack slots used by the [`EngineFunc`] in total.
+    /// The total number of stack slots used for locals of the [`EngineFunc`].
+    len_local_slots: u16,
+    /// The number of stack slots used by the [`EngineFunc`].
     len_stack_slots: u16,
 }
 
@@ -844,7 +862,8 @@ impl<'a> From<&'a CompiledFuncEntity> for CompiledFuncRef<'a> {
     fn from(func: &'a CompiledFuncEntity) -> Self {
         Self {
             ops: func.ops.as_ref(),
-            len_stack_slots: func.len_slots,
+            len_local_slots: func.len_local_slots,
+            len_stack_slots: func.len_stack_slots,
         }
     }
 }
@@ -856,7 +875,13 @@ impl<'a> CompiledFuncRef<'a> {
         self.ops.get_ref()
     }
 
-    /// Returns the number of stack slots used by the [`EngineFunc`].
+    /// Returns the total number of stack slots used for locals of the [`EngineFunc`].
+    #[inline]
+    pub fn len_local_slots(&self) -> u16 {
+        self.len_local_slots
+    }
+
+    /// Returns the total number of stack slots used by the [`EngineFunc`].
     #[inline]
     pub fn len_stack_slots(&self) -> u16 {
         self.len_stack_slots

--- a/crates/wasmi/src/engine/executor/handler/func.rs
+++ b/crates/wasmi/src/engine/executor/handler/func.rs
@@ -171,13 +171,7 @@ pub fn init_wasm_func_call<'a, T>(
     //       so we simply default to 0.
     let callee_params = BoundedSlotSpan::new(SlotSpan::new(Slot::from(0)), 0);
     let instance = resolve_instance(store.prune(), &instance).into();
-    let callee_sp = stack.push_frame(
-        None,
-        callee_ip,
-        callee_params,
-        usize::from(frame_size),
-        Some(instance),
-    )?;
+    let callee_sp = stack.push_frame(None, callee_ip, callee_params, frame_size, Some(instance))?;
     let (ireg, freg32, freg64) = stack.regs();
     Ok(WasmFuncCall {
         store,

--- a/crates/wasmi/src/engine/executor/handler/func.rs
+++ b/crates/wasmi/src/engine/executor/handler/func.rs
@@ -164,14 +164,22 @@ pub fn init_wasm_func_call<'a, T>(
 ) -> Result<WasmFuncCall<'a, T, state::Uninit>, Error> {
     let compiled_func = code.get(Some(store.inner.fuel_mut()), engine_func)?;
     let callee_ip = Ip::from(compiled_func.ops());
-    let frame_size = compiled_func.len_stack_slots();
+    let len_local_slots = compiled_func.len_local_slots();
+    let len_stack_slots = compiled_func.len_stack_slots();
     // Note: using a length of 0 for `callee_params` simply has the effect that all frame
     //       cells are initialized to zero which is a safe default. There currently is not
     //       an easy and efficient way to get the number of parameter cells at this point
     //       so we simply default to 0.
     let callee_params = BoundedSlotSpan::new(SlotSpan::new(Slot::from(0)), 0);
     let instance = resolve_instance(store.prune(), &instance).into();
-    let callee_sp = stack.push_frame(None, callee_ip, callee_params, frame_size, Some(instance))?;
+    let callee_sp = stack.push_frame(
+        None,
+        callee_ip,
+        callee_params,
+        len_local_slots,
+        len_stack_slots,
+        Some(instance),
+    )?;
     let (ireg, freg32, freg64) = stack.regs();
     Ok(WasmFuncCall {
         store,

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -844,13 +844,15 @@ impl Stack {
         caller_ip: Option<Ip>,
         callee_ip: Ip,
         callee_params: BoundedSlotSpan,
+        callee_locals: u16,
         callee_slots: u16,
         callee_instance: Option<Inst>,
     ) -> Result<Sp, TrapCode> {
         let start = self
             .frames
             .push(caller_ip, callee_ip, callee_params, callee_instance)?;
-        self.values.push(start, callee_slots, callee_params.len())
+        self.values
+            .push(start, callee_locals, callee_slots, callee_params.len())
     }
 
     /// Adjusts `self` after returning from a function.
@@ -879,11 +881,13 @@ impl Stack {
         &mut self,
         callee_ip: Ip,
         callee_params: BoundedSlotSpan,
+        callee_locals: u16,
         callee_size: u16,
         callee_instance: Option<Inst>,
     ) -> Result<Sp, TrapCode> {
         let start = self.frames.replace(callee_ip, callee_instance)?;
-        self.values.replace(start, callee_size, callee_params)
+        self.values
+            .replace(start, callee_locals, callee_size, callee_params)
     }
 }
 
@@ -1085,17 +1089,39 @@ impl ValueStack {
 
     /// Adjusts `self` for a normal function call.
     #[inline(always)]
-    fn push(&mut self, start: SpOffset, len_slots: u16, len_params: u16) -> Result<Sp, TrapCode> {
-        debug_assert!(len_params <= len_slots);
-        let len_slots = usize::from(len_slots);
+    fn push(
+        &mut self,
+        start: SpOffset,
+        len_local_slots: u16,
+        len_stack_slots: u16,
+        len_params: u16,
+    ) -> Result<Sp, TrapCode> {
+        debug_assert!(
+            len_params <= len_stack_slots,
+            "number of parameter slots must be smaller than or equal to the number of total stack slots but found: \
+            #params = {len_params}, #slots = {len_stack_slots}",
+        );
+        debug_assert!(
+            len_params <= len_local_slots,
+            "number of parameter slots must be smaller than or equal to the number of total local slots but found: \
+            #params = {len_params}, #locals = {len_local_slots}",
+        );
+        debug_assert!(
+            len_local_slots <= len_stack_slots,
+            "number of local slots must be smaller than or equal to the number of total slots but found: \
+            #locals = {len_local_slots}, #slots = {len_stack_slots}",
+        );
+        let len_local_slots = usize::from(len_local_slots);
+        let len_stack_slots = usize::from(len_stack_slots);
         let len_params = usize::from(len_params);
-        if len_slots == 0 {
+        if len_stack_slots == 0 {
             return Ok(Sp::dangling());
         }
-        let end = start.add(len_slots)?;
+        let end = start.add(len_stack_slots)?;
         self.grow_if_needed(end)?;
         let start_locals = start.into_inner().wrapping_add(len_params);
-        self.cells[start_locals..end.into_inner()].fill_with(Cell::default);
+        let end_locals = start.into_inner().wrapping_add(len_local_slots);
+        self.cells[start_locals..end_locals].fill_with(Cell::default);
         let sp = self.sp(start);
         Ok(sp)
     }
@@ -1105,9 +1131,12 @@ impl ValueStack {
     fn replace(
         &mut self,
         callee_start: SpOffset,
+        callee_locals: u16,
         callee_size: u16,
         callee_params: BoundedSlotSpan,
     ) -> Result<Sp, TrapCode> {
+        debug_assert!(callee_locals <= callee_size);
+        let callee_locals = usize::from(callee_locals);
         let callee_size = usize::from(callee_size);
         let params_len = usize::from(callee_params.len());
         let params_start = usize::from(u16::from(callee_params.span().head()));
@@ -1121,7 +1150,7 @@ impl ValueStack {
             unsafe { unreachable_unchecked!("ValueStack::replace: out of bounds callee cells") }
         };
         callee_cells.copy_within(params_start..params_end, 0);
-        callee_cells[params_len..callee_size].fill_with(Cell::default);
+        callee_cells[params_len..callee_locals].fill_with(Cell::default);
         let sp = self.sp(callee_start);
         Ok(sp)
     }

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -844,13 +844,13 @@ impl Stack {
         caller_ip: Option<Ip>,
         callee_ip: Ip,
         callee_params: BoundedSlotSpan,
-        callee_size: usize,
+        callee_slots: u16,
         callee_instance: Option<Inst>,
     ) -> Result<Sp, TrapCode> {
         let start = self
             .frames
             .push(caller_ip, callee_ip, callee_params, callee_instance)?;
-        self.values.push(start, callee_size, callee_params.len())
+        self.values.push(start, callee_slots, callee_params.len())
     }
 
     /// Adjusts `self` after returning from a function.
@@ -879,7 +879,7 @@ impl Stack {
         &mut self,
         callee_ip: Ip,
         callee_params: BoundedSlotSpan,
-        callee_size: usize,
+        callee_size: u16,
         callee_instance: Option<Inst>,
     ) -> Result<Sp, TrapCode> {
         let start = self.frames.replace(callee_ip, callee_instance)?;
@@ -1085,9 +1085,10 @@ impl ValueStack {
 
     /// Adjusts `self` for a normal function call.
     #[inline(always)]
-    fn push(&mut self, start: SpOffset, len_slots: usize, len_params: u16) -> Result<Sp, TrapCode> {
-        let len_params = usize::from(len_params);
+    fn push(&mut self, start: SpOffset, len_slots: u16, len_params: u16) -> Result<Sp, TrapCode> {
         debug_assert!(len_params <= len_slots);
+        let len_slots = usize::from(len_slots);
+        let len_params = usize::from(len_params);
         if len_slots == 0 {
             return Ok(Sp::dangling());
         }
@@ -1104,9 +1105,10 @@ impl ValueStack {
     fn replace(
         &mut self,
         callee_start: SpOffset,
-        callee_size: usize,
+        callee_size: u16,
         callee_params: BoundedSlotSpan,
     ) -> Result<Sp, TrapCode> {
+        let callee_size = usize::from(callee_size);
         let params_len = usize::from(callee_params.len());
         let params_start = usize::from(u16::from(callee_params.span().head()));
         let params_end = params_start.wrapping_add(params_len);

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -63,18 +63,19 @@ macro_rules! out_of_fuel {
     }};
 }
 
-pub fn compile_or_get_func(state: &mut VmState, func: EngineFunc) -> Result<(Ip, u16), Error> {
+pub fn compile_or_get_func(state: &mut VmState, func: EngineFunc) -> Result<(Ip, u16, u16), Error> {
     let fuel_mut = state.store.inner_mut().fuel_mut();
     let compiled_func = state.code.get(Some(fuel_mut), func)?;
     let ip = Ip::from(compiled_func.ops());
-    let len_slots = compiled_func.len_stack_slots();
-    Ok((ip, len_slots))
+    let len_local_slots = compiled_func.len_local_slots();
+    let len_stack_slots = compiled_func.len_stack_slots();
+    Ok((ip, len_local_slots, len_stack_slots))
 }
 
 macro_rules! compile_or_get_func {
     ($state:expr, $func:expr) => {{
         match $crate::engine::executor::handler::utils::compile_or_get_func($state, $func) {
-            Ok((ip, size)) => (ip, size),
+            Ok((ip, len_local_slots, len_stack_slots)) => (ip, len_local_slots, len_stack_slots),
             Err(error) => done!($state, DoneReason::error(error)),
         }
     }};
@@ -671,10 +672,17 @@ pub fn call_wasm(
     func: EngineFunc,
     instance: Option<Inst>,
 ) -> Control<(Ip, Sp), Break> {
-    let (callee_ip, callee_slots) = compile_or_get_func!(state, func);
+    let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func!(state, func);
     let callee_sp = state
         .stack
-        .push_frame(Some(caller_ip), callee_ip, params, callee_slots, instance)
+        .push_frame(
+            Some(caller_ip),
+            callee_ip,
+            params,
+            len_local_slots,
+            len_stack_slots,
+            instance,
+        )
         .into_control()?;
     Control::Continue((callee_ip, callee_sp))
 }
@@ -685,10 +693,16 @@ pub fn return_call_wasm(
     func: EngineFunc,
     instance: Option<Inst>,
 ) -> Control<(Ip, Sp), Break> {
-    let (callee_ip, size) = compile_or_get_func!(state, func);
+    let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func!(state, func);
     let callee_sp = state
         .stack
-        .replace_frame(callee_ip, params, size, instance)
+        .replace_frame(
+            callee_ip,
+            params,
+            len_local_slots,
+            len_stack_slots,
+            instance,
+        )
         .into_control()?;
     Control::Continue((callee_ip, callee_sp))
 }

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -63,12 +63,12 @@ macro_rules! out_of_fuel {
     }};
 }
 
-pub fn compile_or_get_func(state: &mut VmState, func: EngineFunc) -> Result<(Ip, usize), Error> {
+pub fn compile_or_get_func(state: &mut VmState, func: EngineFunc) -> Result<(Ip, u16), Error> {
     let fuel_mut = state.store.inner_mut().fuel_mut();
     let compiled_func = state.code.get(Some(fuel_mut), func)?;
     let ip = Ip::from(compiled_func.ops());
-    let size = usize::from(compiled_func.len_stack_slots());
-    Ok((ip, size))
+    let len_slots = compiled_func.len_stack_slots();
+    Ok((ip, len_slots))
 }
 
 macro_rules! compile_or_get_func {
@@ -671,10 +671,10 @@ pub fn call_wasm(
     func: EngineFunc,
     instance: Option<Inst>,
 ) -> Control<(Ip, Sp), Break> {
-    let (callee_ip, size) = compile_or_get_func!(state, func);
+    let (callee_ip, callee_slots) = compile_or_get_func!(state, func);
     let callee_sp = state
         .stack
-        .push_frame(Some(caller_ip), callee_ip, params, size, instance)
+        .push_frame(Some(caller_ip), callee_ip, params, callee_slots, instance)
         .into_control()?;
     Control::Continue((callee_ip, callee_sp))
 }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -188,11 +188,13 @@ impl WasmTranslator<'_> for FuncTranslator {
         // operators need to be encoded as their fallbacks which requires to allocate more function
         // local constant values, thus increasing the size of the function frame.
         self.instrs.update_branch_offsets()?;
-        let Some(frame_size) = self.frame_size() else {
+        let len_local_slots = self.stack.get_local_slots();
+        let Some(len_stack_slots) = self.len_stack_slots() else {
             return Err(Error::from(TranslationError::AllocatedTooManySlots));
         };
         finalize(CompiledFuncEntity::new(
-            frame_size,
+            len_local_slots,
+            len_stack_slots,
             self.instrs.encoded_ops(),
         ));
         Ok(self.into_allocations())
@@ -282,15 +284,15 @@ impl FuncTranslator {
         Ok(())
     }
 
-    /// Returns the frame size of the to-be-compiled function.
+    /// Returns the total number of stack slots used by the compiled function.
     ///
-    /// Returns `None` if the frame size is out of bounds.
-    fn frame_size(&self) -> Option<u16> {
-        let frame_size = self
+    /// Returns `None` if the this number is out of bounds.
+    fn len_stack_slots(&self) -> Option<u16> {
+        let len_stack_slots = self
             .stack
             .max_stack_offset()
             .checked_add(self.locals.len())?;
-        u16::try_from(frame_size).ok()
+        u16::try_from(len_stack_slots).ok()
     }
 
     /// Returns the [`FuncType`] of the function that is currently translated.

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -117,6 +117,11 @@ impl Stack {
         self.operands.height()
     }
 
+    /// Returns the total number of stack slots used for locals on the [`Stack`].
+    pub fn get_local_slots(&self) -> u16 {
+        self.operands.get_local_slots()
+    }
+
     /// Returns the maximum stack offset of the [`Stack`].
     ///
     /// # Note

--- a/crates/wasmi/src/engine/translator/func/stack/operands.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/operands.rs
@@ -116,6 +116,8 @@ pub struct OperandStack {
     ///
     /// This field is required to optimize [`OperandStack::preserve_all_locals`].
     len_locals: usize,
+    /// The total number of stack slots used for locals.
+    local_slots: u16,
     /// The current top-most temporary stack offset.
     ///
     /// # Note
@@ -250,6 +252,7 @@ impl Reset for OperandStack {
         self.operands.clear();
         self.local_heads.reset();
         self.len_locals = 0;
+        self.local_slots = 0;
         self.temp_offset = 0;
         self.max_offset = 0;
         self.regs.reset();
@@ -271,6 +274,7 @@ impl OperandStack {
         let required_cells = amount
             .checked_mul(cells_per_item)
             .ok_or_else(|| Error::from(TranslationError::AllocatedTooManySlots))?;
+        self.push_local_slots(required_cells)?;
         self.push_temp_offset(required_cells)?;
         Ok(())
     }
@@ -340,6 +344,24 @@ impl OperandStack {
     /// Restores the state of registers of `self`.
     pub fn set_registers(&mut self, registers: RegisterMap) {
         self.regs = registers;
+    }
+
+    /// Returns the total number of stack slots used for locals.
+    pub fn get_local_slots(&self) -> u16 {
+        self.local_slots
+    }
+
+    /// Pushes the total number of local slots by `delta`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if too many local slots are in use.
+    fn push_local_slots(&mut self, delta: u16) -> Result<(), Error> {
+        let Some(new_value) = self.local_slots.checked_add(delta) else {
+            return Err(Error::from(TranslationError::AllocatedTooManySlots));
+        };
+        self.local_slots = new_value;
+        Ok(())
     }
 
     /// Pushes the offset for temporary operands by `delta`.

--- a/crates/wasmi/src/engine/translator/func/stack/operands.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/operands.rs
@@ -275,7 +275,6 @@ impl OperandStack {
             .checked_mul(cells_per_item)
             .ok_or_else(|| Error::from(TranslationError::AllocatedTooManySlots))?;
         self.push_local_slots(required_cells)?;
-        self.push_temp_offset(required_cells)?;
         Ok(())
     }
 
@@ -357,10 +356,13 @@ impl OperandStack {
     ///
     /// Returns an error if too many local slots are in use.
     fn push_local_slots(&mut self, delta: u16) -> Result<(), Error> {
+        debug_assert_eq!(self.local_slots, self.max_offset);
         let Some(new_value) = self.local_slots.checked_add(delta) else {
             return Err(Error::from(TranslationError::AllocatedTooManySlots));
         };
         self.local_slots = new_value;
+        self.temp_offset = new_value;
+        self.max_offset = self.max_offset.max(self.temp_offset);
         Ok(())
     }
 
@@ -373,9 +375,10 @@ impl OperandStack {
     /// Returns an error if the new temporary offset is out of bounds.
     fn push_temp_offset(&mut self, delta: u16) -> Result<SlotSpan, Error> {
         let old_offset = self.temp_offset;
-        self.temp_offset = old_offset
-            .checked_add(delta)
-            .ok_or_else(|| Error::from(TranslationError::AllocatedTooManySlots))?;
+        let Some(new_value) = old_offset.checked_add(delta) else {
+            return Err(Error::from(TranslationError::AllocatedTooManySlots));
+        };
+        self.temp_offset = new_value;
         self.max_offset = self.max_offset.max(self.temp_offset);
         Ok(SlotSpan::new(Slot::from(old_offset)))
     }


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1886.

Benchmarks show significant performance improvements for call-intense cases:

<img width="952" height="440" alt="image" src="https://github.com/user-attachments/assets/2113296d-bd11-4d90-8354-4ac00dc798e4" />

<img width="948" height="342" alt="image" src="https://github.com/user-attachments/assets/8dac3727-dcd9-4a44-a715-808a49ae33cf" />

No regressions during benchmark run found.