### PR TITLE
Add slot-result `i{32,64}.add` operators

### DIFF
--- a/crates/ir/build/display/decode.rs
+++ b/crates/ir/build/display/decode.rs
@@ -181,6 +181,9 @@ impl Display for DisplayDecode<&'_ LoadOp> {
         let ptr_ty = match op.ptr {
             OperandKind::Reg => DisplayMaybe::Some(DisplayConcat((',', FieldTy::RegInt))),
             OperandKind::Slot => DisplayMaybe::Some(DisplayConcat((',', FieldTy::Slot))),
+            OperandKind::SlotAndReg => {
+                DisplayMaybe::Some(DisplayConcat((',', FieldTy::SlotAndRegInt)))
+            }
             OperandKind::Immediate => DisplayMaybe::None,
             OperandKind::Local(_index) => DisplayMaybe::None,
         };
@@ -213,7 +216,9 @@ impl Display for DisplayDecode<&'_ StoreOp> {
             OffsetOperand::Offset16 => "Offset16",
         };
         let ptr_ty = match op.ptr {
-            OperandKind::Reg | OperandKind::Slot => Some(DisplayConcat((op.ptr_field().ty, ','))),
+            OperandKind::Reg | OperandKind::Slot | OperandKind::SlotAndReg => {
+                Some(DisplayConcat((op.ptr_field().ty, ',')))
+            }
             OperandKind::Immediate => None,
             OperandKind::Local(_index) => None,
         }

--- a/crates/ir/build/display/ident.rs
+++ b/crates/ir/build/display/ident.rs
@@ -230,6 +230,7 @@ impl Display for CamelCase<Suffix<OperandKind>> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self.0.0 {
             OperandKind::Slot => "S",
+            OperandKind::SlotAndReg => "Rs_",
             OperandKind::Reg => "R",
             OperandKind::Immediate => "I",
             OperandKind::Local(index) => return write!(f, "S{index}"),
@@ -242,6 +243,7 @@ impl Display for SnakeCase<Suffix<OperandKind>> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self.0.0 {
             OperandKind::Slot => "s",
+            OperandKind::SlotAndReg => "rs_",
             OperandKind::Reg => "r",
             OperandKind::Immediate => "i",
             OperandKind::Local(index) => return write!(f, "s{index}"),

--- a/crates/ir/build/display/result.rs
+++ b/crates/ir/build/display/result.rs
@@ -43,12 +43,20 @@ impl Display for DisplayResultLoc<&'_ Op> {
 impl Display for DisplayResultMut<&'_ Isa> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let indent = self.indent;
-        let variants = DisplaySequence::new(
+        let variants_slot = DisplaySequence::new(
             "\n",
             self.value
                 .ops
                 .iter()
                 .filter(|op| op.has_result_slot())
+                .map(|op| DisplayResultMut::new(op, indent.inc_by(3))),
+        );
+        let variants_slot_and_reg = DisplaySequence::new(
+            "\n",
+            self.value
+                .ops
+                .iter()
+                .filter(|op| op.has_result_slot_and_reg())
                 .map(|op| DisplayResultMut::new(op, indent.inc_by(3))),
         );
         let variants_loc = DisplaySequence::new(
@@ -74,7 +82,8 @@ impl Display for DisplayResultMut<&'_ Isa> {
             {indent}    /// Returns a shared reference to the result [`Slot`] of `self` if any.\n\
             {indent}    pub fn result_ref(&self) -> Option<&Slot> {{\n\
             {indent}        let res = match self {{\n\
-                                {variants} => result,\n\
+                                {variants_slot} => result,\n\
+                                {variants_slot_and_reg} => &result.slot,\n\
             {indent}            _ => return None,\n\
             {indent}        }};\n\
             {indent}        Some(res)\n\
@@ -83,7 +92,8 @@ impl Display for DisplayResultMut<&'_ Isa> {
             {indent}    /// Returns an exclusive reference to the result [`Slot`] of `self` if any.\n\
             {indent}    pub fn result_mut(&mut self) -> Option<&mut Slot> {{\n\
             {indent}        let res = match self {{\n\
-                                {variants} => result,\n\
+                                {variants_slot} => result,\n\
+                                {variants_slot_and_reg} => &mut result.slot,\n\
             {indent}            _ => return None,\n\
             {indent}        }};\n\
             {indent}        Some(res)\n\
@@ -109,6 +119,8 @@ pub enum Location {
     Reg,
     /// The operand resides in a stack slot.
     Slot,
+    /// The operand resides in both a stack slot and a register.
+    SlotAndReg,
 }
 
 impl<const N: usize> GenericOp<N> {
@@ -132,6 +144,7 @@ impl OperandKind {
         match self {
             OperandKind::Reg => Some(Location::Reg),
             OperandKind::Slot => Some(Location::Slot),
+            OperandKind::SlotAndReg => Some(Location::SlotAndReg),
             OperandKind::Local(_) => None,
             OperandKind::Immediate => unreachable!(),
         }
@@ -170,5 +183,10 @@ impl Op {
     /// Returns `true` if `self` has a `Slot` result field.
     pub fn has_result_slot(&self) -> bool {
         matches!(self.result_loc(), Some(Location::Slot))
+    }
+
+    /// Returns `true` if `self` has a `Slot` result field.
+    pub fn has_result_slot_and_reg(&self) -> bool {
+        matches!(self.result_loc(), Some(Location::SlotAndReg))
     }
 }

--- a/crates/ir/build/isa.rs
+++ b/crates/ir/build/isa.rs
@@ -197,7 +197,7 @@ fn add_binary_ops(isa: &mut Isa) {
         (Ident::NotLt, Ty::I32, Ty::F64, Ty::F64, BinaryOpCaps::CMP),
         (Ident::NotLe, Ty::I32, Ty::F64, Ty::F64, BinaryOpCaps::CMP),
         // i32
-        (Ident::Add, Ty::I32, Ty::I32, Ty::I32, BinaryOpCaps::COMMUTATIVE),
+        (Ident::Add, Ty::I32, Ty::I32, Ty::I32, BinaryOpCaps::COMMUTATIVE | BinaryOpCaps::SLOT_RESULT),
         (Ident::Sub, Ty::I32, Ty::I32, Ty::I32, BinaryOpCaps::NONE),
         (Ident::Mul, Ty::I32, Ty::I32, Ty::I32, BinaryOpCaps::COMMUTATIVE),
         (Ident::Div, Ty::I32, Ty::I32, Ty::NonZeroI32, BinaryOpCaps::NONE),
@@ -213,7 +213,7 @@ fn add_binary_ops(isa: &mut Isa) {
         (Ident::Rotl, Ty::I32, Ty::I32, Ty::ShiftAmount, BinaryOpCaps::NONE),
         (Ident::Rotr, Ty::I32, Ty::I32, Ty::ShiftAmount, BinaryOpCaps::NONE),
         // i64
-        (Ident::Add, Ty::I64, Ty::I64, Ty::I64, BinaryOpCaps::COMMUTATIVE),
+        (Ident::Add, Ty::I64, Ty::I64, Ty::I64, BinaryOpCaps::COMMUTATIVE | BinaryOpCaps::SLOT_RESULT),
         (Ident::Sub, Ty::I64, Ty::I64, Ty::I64, BinaryOpCaps::NONE),
         (Ident::Mul, Ty::I64, Ty::I64, Ty::I64, BinaryOpCaps::COMMUTATIVE),
         (Ident::Div, Ty::I64, Ty::I64, Ty::NonZeroI64, BinaryOpCaps::NONE),
@@ -246,26 +246,25 @@ fn add_binary_ops(isa: &mut Isa) {
         (Ident::Copysign, Ty::F64, Ty::F64, Ty::SignF64, BinaryOpCaps::NONE),
     ];
     for (ident, result_ty, lhs_ty, rhs_ty, caps) in ops {
-        for lhs in [OperandKind::Reg, OperandKind::Slot, OperandKind::Immediate] {
-            for rhs in [OperandKind::Reg, OperandKind::Slot, OperandKind::Immediate] {
-                if lhs == rhs && (lhs.is_reg() || lhs.is_immediate()) {
-                    // Both operands must not be registers or immediates.
-                    continue;
+        let results = match caps.allows_slot_result() {
+            true => &[OperandKind::Reg, OperandKind::SlotAndReg][..],
+            false => &[OperandKind::Reg][..],
+        };
+        for result in results.iter().copied() {
+            for lhs in [OperandKind::Reg, OperandKind::Slot, OperandKind::Immediate] {
+                for rhs in [OperandKind::Reg, OperandKind::Slot, OperandKind::Immediate] {
+                    if lhs == rhs && (lhs.is_reg() || lhs.is_immediate()) {
+                        // Both operands must not be registers or immediates.
+                        continue;
+                    }
+                    if caps.is_commutative() && lhs > rhs {
+                        // Commutative operators don't need variants with swapped operand order.
+                        continue;
+                    }
+                    isa.push_op(BinaryOp::new(
+                        ident, result_ty, lhs_ty, rhs_ty, result, lhs, rhs, caps,
+                    ));
                 }
-                if caps.is_commutative() && lhs > rhs {
-                    // Commutative operators don't need variants with swapped operand order.
-                    continue;
-                }
-                isa.push_op(BinaryOp::new(
-                    ident,
-                    result_ty,
-                    lhs_ty,
-                    rhs_ty,
-                    OperandKind::Reg,
-                    lhs,
-                    rhs,
-                    caps,
-                ));
             }
         }
     }

--- a/crates/ir/build/op.rs
+++ b/crates/ir/build/op.rs
@@ -230,6 +230,7 @@ impl BinaryOpCaps {
     pub const NONE: Self = Self(0b0000);
     pub const COMMUTATIVE: Self = Self(0b0001);
     pub const CMP: Self = Self(0b0010);
+    pub const SLOT_RESULT: Self = Self(0b0100);
 
     pub fn is_cmp(self) -> bool {
         (self & Self::CMP).0 != 0
@@ -237,6 +238,10 @@ impl BinaryOpCaps {
 
     pub fn is_commutative(self) -> bool {
         (self & Self::COMMUTATIVE).0 != 0
+    }
+
+    pub fn allows_slot_result(self) -> bool {
+        (self & Self::SLOT_RESULT).0 != 0
     }
 }
 

--- a/crates/ir/build/op.rs
+++ b/crates/ir/build/op.rs
@@ -87,6 +87,8 @@ pub enum OperandKind {
     Immediate,
     /// The operand is a fixed stack slot value.
     Local(u16),
+    /// The operand is both a slot and a register value.
+    SlotAndReg,
 }
 
 impl OperandKind {
@@ -108,6 +110,11 @@ impl OperandKind {
                 _ => FieldTy::RegInt,
             },
             OperandKind::Local(index) => FieldTy::Local(index),
+            OperandKind::SlotAndReg => match hint {
+                Ty::F32 | Ty::SignF32 => FieldTy::SlotAndRegF32,
+                Ty::F64 | Ty::SignF64 => FieldTy::SlotAndRegF64,
+                _ => FieldTy::SlotAndRegInt,
+            },
         }
     }
 }
@@ -532,6 +539,7 @@ impl LoadOp {
             OperandKind::Immediate => FieldTy::Address,
             OperandKind::Reg => FieldTy::RegInt,
             OperandKind::Local(index) => FieldTy::Local(index),
+            OperandKind::SlotAndReg => FieldTy::SlotAndRegInt,
         };
         Field::new(Ident::Ptr, ptr_ty)
     }
@@ -542,8 +550,7 @@ impl LoadOp {
                 OffsetOperand::Offset => FieldTy::U64,
                 OffsetOperand::Offset16 => FieldTy::Offset16,
             },
-            OperandKind::Immediate => return None,
-            OperandKind::Local(_index) => return None,
+            _ => return None,
         };
         Some(Field::new(Ident::Offset, offset_ty))
     }
@@ -667,6 +674,7 @@ impl StoreOp {
             OperandKind::Reg => FieldTy::RegInt,
             OperandKind::Immediate => FieldTy::Address,
             OperandKind::Local(index) => FieldTy::Local(index),
+            OperandKind::SlotAndReg => FieldTy::SlotAndRegInt,
         };
         Field::new(Ident::Ptr, ptr_ty)
     }
@@ -677,8 +685,7 @@ impl StoreOp {
                 OffsetOperand::Offset16 => FieldTy::Offset16,
                 OffsetOperand::Offset => FieldTy::U64,
             },
-            OperandKind::Immediate => return None,
-            OperandKind::Local(_index) => return None,
+            _ => return None,
         };
         Some(Field::new(Ident::Offset, offset_ty))
     }
@@ -686,7 +693,9 @@ impl StoreOp {
     pub fn value_field(&self) -> Field {
         let value = self.value;
         let field_ty = match value {
-            OperandKind::Slot | OperandKind::Reg => value.field_ty(self.value_ty),
+            OperandKind::Slot | OperandKind::Reg | OperandKind::SlotAndReg => {
+                value.field_ty(self.value_ty)
+            }
             OperandKind::Immediate => match self.kind {
                 StoreKind::Value => FieldTy::from(self.value_ty),
                 StoreKind::Wrap { wrapped } => FieldTy::from(wrapped),
@@ -997,6 +1006,11 @@ impl ReplaceLaneOp {
     pub fn value_field(&self) -> Field {
         let value_ty = match self.value {
             OperandKind::Slot => FieldTy::Slot,
+            OperandKind::SlotAndReg => match self.ty.item_ty() {
+                FieldTy::F32 => FieldTy::SlotAndRegF32,
+                FieldTy::F64 => FieldTy::SlotAndRegF64,
+                _ => FieldTy::SlotAndRegInt,
+            },
             OperandKind::Reg => match self.ty.item_ty() {
                 FieldTy::F32 => FieldTy::RegF32,
                 FieldTy::F64 => FieldTy::RegF64,

--- a/crates/ir/build/ty.rs
+++ b/crates/ir/build/ty.rs
@@ -127,6 +127,9 @@ pub enum Ty {
 pub enum FieldTy {
     Slot,
     SlotSpan,
+    SlotAndRegInt,
+    SlotAndRegF32,
+    SlotAndRegF64,
     RegInt,
     RegF32,
     RegF64,
@@ -221,6 +224,9 @@ impl Display for FieldTy {
         let s = match self {
             Self::Slot => "Slot",
             Self::SlotSpan => "SlotSpan",
+            Self::SlotAndRegInt => "SlotAndReg<i64>",
+            Self::SlotAndRegF32 => "SlotAndReg<f32>",
+            Self::SlotAndRegF64 => "SlotAndReg<f64>",
             Self::RegInt => "Reg<i64>",
             Self::RegF32 => "Reg<f32>",
             Self::RegF64 => "Reg<f64>",

--- a/crates/ir/src/decode/mod.rs
+++ b/crates/ir/src/decode/mod.rs
@@ -47,6 +47,7 @@ use crate::{
     OpCode,
     Reg,
     Slot,
+    SlotAndReg,
     SlotSpan,
     core::{ShiftAmount, Sign, TrapCode},
     index::{Data, Elem, Func, FuncType, Global, InternalFunc, Memory, RawSlot, Table},
@@ -253,6 +254,16 @@ impl<const N: u16> Decode for Local<N> {
     #[inline]
     fn decode<D: Decoder>(_decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(Self::default())
+    }
+}
+
+impl<T> Decode for SlotAndReg<T> {
+    #[inline]
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
+        Ok(Self {
+            slot: <Slot as Decode>::decode(decoder)?,
+            reg: <Reg<T> as Decode>::decode(decoder)?,
+        })
     }
 }
 

--- a/crates/ir/src/encode.rs
+++ b/crates/ir/src/encode.rs
@@ -13,6 +13,7 @@ use crate::{
     OpCode,
     Reg,
     Slot,
+    SlotAndReg,
     SlotSpan,
     core::{ShiftAmount, Sign, TrapCode},
     index::{Data, Elem, Func, FuncType, Global, InternalFunc, Memory, RawSlot, Table},
@@ -254,6 +255,18 @@ impl<const N: u16> Encode for Local<N> {
         E: Encoder,
     {
         encoder.write_bytes(&[])
+    }
+}
+
+impl<T> Encode for SlotAndReg<T> {
+    #[inline]
+    fn encode<E>(&self, encoder: &mut E) -> Result<E::Pos, E::Error>
+    where
+        E: Encoder,
+    {
+        let pos = self.slot.encode(encoder)?;
+        self.reg.encode(encoder)?;
+        Ok(pos)
     }
 }
 

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -23,6 +23,15 @@ pub use self::{
     index::Slot,
     op::{Location, Op},
     opcode::{InvalidOpCode, OpCode},
-    primitive::{Address, BlockFuel, BranchOffset, BranchTableTarget, Local, Offset16, Reg},
+    primitive::{
+        Address,
+        BlockFuel,
+        BranchOffset,
+        BranchTableTarget,
+        Local,
+        Offset16,
+        Reg,
+        SlotAndReg,
+    },
     span::{BoundedSlotSpan, FixedSlotSpan, SlotSpan, SlotSpanIter},
 };

--- a/crates/ir/src/op.rs
+++ b/crates/ir/src/op.rs
@@ -12,6 +12,7 @@ use crate::{
     Offset16,
     Reg,
     Slot,
+    SlotAndReg,
     SlotSpan,
     core::{ShiftAmount, Sign, TrapCode, ValType},
     index::{Data, Elem, Func, FuncType, Global, InternalFunc, Memory, Table},
@@ -47,6 +48,13 @@ impl Slot {
     #[inline]
     pub fn location(&self) -> Location {
         Location::Slot(*self)
+    }
+}
+
+impl<T> SlotAndReg<T> {
+    #[inline]
+    pub fn location(&self) -> Location {
+        Location::Slot(self.slot)
     }
 }
 

--- a/crates/ir/src/primitive.rs
+++ b/crates/ir/src/primitive.rs
@@ -1,4 +1,4 @@
-use crate::{Error, SlotSpan};
+use crate::{Error, Slot, SlotSpan};
 use core::{
     any::type_name,
     fmt::{Debug, Formatter, Write as _},
@@ -9,6 +9,40 @@ use core::{
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Local<const N: u16> {
     marker: PhantomData<fn()>,
+}
+
+pub struct SlotAndReg<T> {
+    pub slot: Slot,
+    pub reg: Reg<T>,
+}
+
+impl<T> Copy for SlotAndReg<T> {}
+impl<T> Clone for SlotAndReg<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> From<SlotAndReg<T>> for Slot {
+    fn from(value: SlotAndReg<T>) -> Self {
+        value.slot
+    }
+}
+impl<T> From<Slot> for SlotAndReg<T> {
+    fn from(slot: Slot) -> Self {
+        Self {
+            slot,
+            reg: Reg::default(),
+        }
+    }
+}
+
+impl<T> Debug for SlotAndReg<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SlotAndReg")
+            .field("slot", &self.slot)
+            .field("reg", &self.reg)
+            .finish()
+    }
 }
 
 /// A generic register type.

--- a/crates/wasmi/src/engine/executor/handler/exec.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec.rs
@@ -1552,6 +1552,10 @@ handler_binary! {
     fn i32_add_rri(I32Add_Rri) = wasm::i32_add;
     fn i32_add_rss(I32Add_Rss) = wasm::i32_add;
     fn i32_add_rsi(I32Add_Rsi) = wasm::i32_add;
+    fn i32_add_rs_rs(I32Add_Rs_rs) = wasm::i32_add;
+    fn i32_add_rs_ri(I32Add_Rs_ri) = wasm::i32_add;
+    fn i32_add_rs_ss(I32Add_Rs_ss) = wasm::i32_add;
+    fn i32_add_rs_si(I32Add_Rs_si) = wasm::i32_add;
     fn i32_mul_rrr(I32Mul_Rrr) = wasm::i32_mul;
     fn i32_mul_rrs(I32Mul_Rrs) = wasm::i32_mul;
     fn i32_mul_rri(I32Mul_Rri) = wasm::i32_mul;
@@ -1700,6 +1704,10 @@ handler_binary! {
     fn i64_add_rri(I64Add_Rri) = wasm::i64_add;
     fn i64_add_rss(I64Add_Rss) = wasm::i64_add;
     fn i64_add_rsi(I64Add_Rsi) = wasm::i64_add;
+    fn i64_add_rs_rs(I64Add_Rs_rs) = wasm::i64_add;
+    fn i64_add_rs_ri(I64Add_Rs_ri) = wasm::i64_add;
+    fn i64_add_rs_ss(I64Add_Rs_ss) = wasm::i64_add;
+    fn i64_add_rs_si(I64Add_Rs_si) = wasm::i64_add;
     fn i64_mul_rrr(I64Mul_Rrr) = wasm::i64_mul;
     fn i64_mul_rrs(I64Mul_Rrs) = wasm::i64_mul;
     fn i64_mul_rri(I64Mul_Rri) = wasm::i64_mul;

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -35,7 +35,17 @@ use crate::{
     func::{FuncEntity, HostFuncEntity},
     instance::InstanceEntity,
     ir,
-    ir::{Address, BoundedSlotSpan, BranchOffset, Local, Offset16, Slot, SlotSpan, index},
+    ir::{
+        Address,
+        BoundedSlotSpan,
+        BranchOffset,
+        Local,
+        Offset16,
+        Slot,
+        SlotAndReg,
+        SlotSpan,
+        index,
+    },
     memory::{DataSegment, DataSegmentEntity},
     store::{CallHooks, PrunedStore, StoreError, StoreInner},
     table::ElementSegment,
@@ -347,6 +357,60 @@ where
         freg64: Freg64,
     ) -> (Ireg, Freg32, Freg64) {
         <Slot as SetValue<T>>::set_value(Slot::from(N), src, sp, ireg, freg32, freg64)
+    }
+}
+
+impl<T> SetValue<T> for SlotAndReg<i64>
+where
+    T: StoreToCells + Into<Ireg> + Copy,
+{
+    #[inline]
+    fn set_value(
+        dst: Self,
+        src: T,
+        sp: Sp,
+        ireg: Ireg,
+        freg32: Freg32,
+        freg64: Freg64,
+    ) -> (Ireg, Freg32, Freg64) {
+        let (ireg, freg32, freg64) = set_value(dst.slot, src, sp, ireg, freg32, freg64);
+        set_value(dst.reg, src, sp, ireg, freg32, freg64)
+    }
+}
+
+impl<T> SetValue<T> for SlotAndReg<f32>
+where
+    T: StoreToCells + Into<Freg32> + Copy,
+{
+    #[inline]
+    fn set_value(
+        dst: Self,
+        src: T,
+        sp: Sp,
+        ireg: Ireg,
+        freg32: Freg32,
+        freg64: Freg64,
+    ) -> (Ireg, Freg32, Freg64) {
+        let (ireg, freg32, freg64) = set_value(dst.slot, src, sp, ireg, freg32, freg64);
+        set_value(dst.reg, src, sp, ireg, freg32, freg64)
+    }
+}
+
+impl<T> SetValue<T> for SlotAndReg<f64>
+where
+    T: StoreToCells + Into<Freg64> + Copy,
+{
+    #[inline]
+    fn set_value(
+        dst: Self,
+        src: T,
+        sp: Sp,
+        ireg: Ireg,
+        freg32: Freg32,
+        freg64: Freg64,
+    ) -> (Ireg, Freg32, Freg64) {
+        let (ireg, freg32, freg64) = set_value(dst.slot, src, sp, ireg, freg32, freg64);
+        set_value(dst.reg, src, sp, ireg, freg32, freg64)
     }
 }
 

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -61,7 +61,7 @@ use crate::{
             },
             func::{
                 op::BinaryOpRhs,
-                stack::{Allocation, BranchParams, PreservedRegs},
+                stack::{Allocation, BranchParams, PreservedRegs, RegKind},
             },
             utils::{ToBits, WasmInteger, required_cells_for_ty},
         },
@@ -75,6 +75,7 @@ use crate::{
         Offset16,
         Op,
         Slot,
+        SlotAndReg,
         SlotSpan,
         index::{self, Memory},
     },
@@ -804,6 +805,36 @@ impl FuncTranslator {
         Ok(instr)
     }
 
+    /// Returns `Some` if the staged [`Op`] can be fused with a `copy_sr` with `result`.
+    ///
+    /// Returns `None` otherwise.
+    fn fuse_copy_sr(&self, result: Slot, input_ty: ValType) -> Option<Op> {
+        if !RegKind::Ireg.matches_ty(input_ty) {
+            // This check is required to filter out incorrect fusions
+            // where input is not originating from the staged operator.
+            //
+            // Today, all fused operators have an `ireg` result.
+            // We need to change this logic if we add more fused operators later.
+            return None;
+        }
+        let result = SlotAndReg::from(result);
+        let staged_op = self.instrs.peek_staged()?;
+        let op = match staged_op {
+            // i32
+            Op::I32Add_Rrs { rhs, .. } => Op::i32_add_rs_rs(result, rhs),
+            Op::I32Add_Rri { rhs, .. } => Op::i32_add_rs_ri(result, rhs),
+            Op::I32Add_Rss { lhs, rhs, .. } => Op::i32_add_rs_ss(result, lhs, rhs),
+            Op::I32Add_Rsi { lhs, rhs, .. } => Op::i32_add_rs_si(result, lhs, rhs),
+            // i64
+            Op::I64Add_Rrs { rhs, .. } => Op::i64_add_rs_rs(result, rhs),
+            Op::I64Add_Rri { rhs, .. } => Op::i64_add_rs_ri(result, rhs),
+            Op::I64Add_Rss { lhs, rhs, .. } => Op::i64_add_rs_ss(result, lhs, rhs),
+            Op::I64Add_Rsi { lhs, rhs, .. } => Op::i64_add_rs_si(result, lhs, rhs),
+            _ => return None,
+        };
+        Some(op)
+    }
+
     /// Pushes a result register operand onto the stack.
     ///
     /// If a register operand of an equivalent type is already on the stack
@@ -813,9 +844,15 @@ impl FuncTranslator {
         let fuel_pos = self.stack.fuel_pos();
         if let Some(operand) = self.stack.dealloc_reg(ty) {
             let result = operand.temp_slots().head();
-            let copy_op = Self::select_copy_sr_op(result, operand.ty())?;
+            let op = match self.fuse_copy_sr(result, ty) {
+                Some(fused_op) => {
+                    self.instrs.drop_staged();
+                    fused_op
+                }
+                None => Self::select_copy_sr_op(result, operand.ty())?,
+            };
             self.instrs
-                .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;
+                .encode_op(op, fuel_pos, FuelCostsProvider::base)?;
         };
         self.stack.push_temp(ty, Allocation::Reg)?;
         Ok(())
@@ -1217,7 +1254,7 @@ impl FuncTranslator {
         }
         let unfused_op = Self::select_copy_sx_op(result, input, &self.layout)?
             .expect("already filtered out no-op copies above");
-        let fused_op = self.fused_local_set(local_idx, input)?;
+        let fused_op = self.fused_local_set(result, input)?;
         let staged_fuel = match fused_op {
             Some(_) => {
                 let (_, fuel_used) = self.instrs.drop_staged();
@@ -1267,7 +1304,13 @@ impl FuncTranslator {
     /// - The `local` argument reflects the local index and `input` is the `input` operand of the `local.set`.
     /// - This does not unstage or drop the staged [`Op`], nor does it encode the fused [`Op`].
     /// - This only returns the resulting fused [`Op`] if any for later consideration.
-    fn fused_local_set(&self, local: LocalIdx, input: Operand) -> Result<Option<Op>, Error> {
+    fn fused_local_set(&self, result: Slot, input: Operand) -> Result<Option<Op>, Error> {
+        if let ResolvedOperand::Reg(_) = self.resolve_operand::<TypedRawVal>(input)? {
+            if let Some(fused_op) = self.fuse_copy_sr(result, input.ty()) {
+                // The staged operator can be fused with a `copy_sr` operator.
+                return Ok(Some(fused_op));
+            }
+        }
         let Some(mut staged) = self.instrs.peek_staged() else {
             // Cannot replace result if no staged operator exists.
             return Ok(None);
@@ -1289,8 +1332,7 @@ impl FuncTranslator {
             return Ok(None);
         }
         // All checks passed, now replace result and return new fused `Op`.
-        let new_result = self.layout.local_to_slot(local)?;
-        *old_result = new_result;
+        *old_result = result;
         Ok(Some(staged))
     }
 


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1889.

Benchmarks indicate performance wins (some decisive) across the board:

<img width="954" height="1324" alt="image" src="https://github.com/user-attachments/assets/6c55fe3d-eae0-406e-bcf1-b95f629e5467" />
