### PR TITLE
Add `isub` to `iadd` lowering to translator

### DIFF
--- a/crates/ir/build/isa.rs
+++ b/crates/ir/build/isa.rs
@@ -261,6 +261,13 @@ fn add_binary_ops(isa: &mut Isa) {
                         // Commutative operators don't need variants with swapped operand order.
                         continue;
                     }
+                    if matches!(ident, Ident::Sub)
+                        && matches!(rhs_ty, Ty::I32 | Ty::I64)
+                        && matches!(rhs, OperandKind::Immediate)
+                    {
+                        // Note: `isub` operators with immediate `rhs` are lowered to `iadd`.
+                        continue;
+                    }
                     isa.push_op(BinaryOp::new(
                         ident, result_ty, lhs_ty, rhs_ty, result, lhs, rhs, caps,
                     ));

--- a/crates/wasmi/src/engine/executor/handler/exec.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec.rs
@@ -1575,10 +1575,8 @@ handler_binary! {
     fn i32_bitxor_rsi(I32BitXor_Rsi) = wasm::i32_bitxor;
     // i32: non-commutative
     fn i32_sub_rrs(I32Sub_Rrs) = wasm::i32_sub;
-    fn i32_sub_rri(I32Sub_Rri) = wasm::i32_sub;
     fn i32_sub_rsr(I32Sub_Rsr) = wasm::i32_sub;
     fn i32_sub_rss(I32Sub_Rss) = wasm::i32_sub;
-    fn i32_sub_rsi(I32Sub_Rsi) = wasm::i32_sub;
     fn i32_sub_rir(I32Sub_Rir) = wasm::i32_sub;
     fn i32_sub_ris(I32Sub_Ris) = wasm::i32_sub;
     fn i32_div_rrs(I32Div_Rrs) = wasm::i32_div_s;
@@ -1727,10 +1725,8 @@ handler_binary! {
     fn i64_bitxor_rsi(I64BitXor_Rsi) = wasm::i64_bitxor;
     // i64: non-commutative
     fn i64_sub_rrs(I64Sub_Rrs) = wasm::i64_sub;
-    fn i64_sub_rri(I64Sub_Rri) = wasm::i64_sub;
     fn i64_sub_rsr(I64Sub_Rsr) = wasm::i64_sub;
     fn i64_sub_rss(I64Sub_Rss) = wasm::i64_sub;
-    fn i64_sub_rsi(I64Sub_Rsi) = wasm::i64_sub;
     fn i64_sub_rir(I64Sub_Rir) = wasm::i64_sub;
     fn i64_sub_ris(I64Sub_Ris) = wasm::i64_sub;
     fn i64_div_rrs(I64Div_Rrs) = wasm::i64_div_s;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1820,7 +1820,7 @@ impl FuncTranslator {
             ResolvedOperand::Slot(lhs) => Op::i32_add_rsi(lhs, -rhs),
             ResolvedOperand::Immediate(_) => return Ok(false),
         };
-        self.push_op_with_result_reg(ValType::I32, op, FuelCostsProvider::base)?;
+        self.stage_op_with_result_reg(ValType::I32, op, FuelCostsProvider::base)?;
         Ok(true)
     }
 
@@ -1837,7 +1837,7 @@ impl FuncTranslator {
             ResolvedOperand::Slot(lhs) => Op::i64_add_rsi(lhs, -rhs),
             ResolvedOperand::Immediate(_) => return Ok(false),
         };
-        self.push_op_with_result_reg(ValType::I64, op, FuelCostsProvider::base)?;
+        self.stage_op_with_result_reg(ValType::I64, op, FuelCostsProvider::base)?;
         Ok(true)
     }
 

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1815,9 +1815,10 @@ impl FuncTranslator {
     /// - Returns `Ok(false)` otherwise.
     fn try_lower_i32_sub(&mut self, lhs: Operand, rhs: i32) -> Result<bool, Error> {
         debug_assert!(matches!(lhs.ty(), ValType::I32));
+        let neg_rhs = rhs.wrapping_neg();
         let op = match self.resolve_operand::<i32>(lhs)? {
-            ResolvedOperand::Reg(_) => Op::i32_add_rri(-rhs),
-            ResolvedOperand::Slot(lhs) => Op::i32_add_rsi(lhs, -rhs),
+            ResolvedOperand::Reg(_) => Op::i32_add_rri(neg_rhs),
+            ResolvedOperand::Slot(lhs) => Op::i32_add_rsi(lhs, neg_rhs),
             ResolvedOperand::Immediate(_) => return Ok(false),
         };
         self.stage_op_with_result_reg(ValType::I32, op, FuelCostsProvider::base)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1753,7 +1753,10 @@ impl FuncTranslator {
     }
 
     /// Translates a non-commutative binary Wasm operator to Wasmi bytecode.
-    fn translate_binary<T: BinaryOp>(&mut self) -> Result<(), Error>
+    fn translate_binary<T: BinaryOp>(
+        &mut self,
+        opt_rhs_imm: fn(this: &mut Self, lhs: Operand, rhs: T::Rhs) -> Result<bool, Error>,
+    ) -> Result<(), Error>
     where
         T::Lhs: From<TypedRawVal> + Copy,
         T::Rhs: Copy,
@@ -1778,6 +1781,11 @@ impl FuncTranslator {
         if let (ResolvedOperand::Immediate(lhs), ResolvedOperand::Immediate(rhs)) = (l, r) {
             return self.translate_binary_consteval(lhs, rhs, T::consteval);
         }
+        if let (_, ResolvedOperand::Immediate(rhs)) = (l, r) {
+            if opt_rhs_imm(self, lhs, rhs)? {
+                return Ok(());
+            }
+        }
         let operator = match (l, r) {
             (ResolvedOperand::Reg(_), ResolvedOperand::Reg(_)) => match T::op_rrr() {
                 Some(op) => op,
@@ -1797,6 +1805,40 @@ impl FuncTranslator {
         };
         self.stage_op_with_result_reg(<T::Result as Typed>::TY, operator, FuelCostsProvider::base)?;
         Ok(())
+    }
+
+    /// Lowers an `i32.sub` into a `i32.add` if possible.
+    ///
+    /// # Returns
+    ///
+    /// - Returns `Ok(true)` is lowering was successful.
+    /// - Returns `Ok(false)` otherwise.
+    fn try_lower_i32_sub(&mut self, lhs: Operand, rhs: i32) -> Result<bool, Error> {
+        debug_assert!(matches!(lhs.ty(), ValType::I32));
+        let op = match self.resolve_operand::<i32>(lhs)? {
+            ResolvedOperand::Reg(_) => Op::i32_add_rri(-rhs),
+            ResolvedOperand::Slot(lhs) => Op::i32_add_rsi(lhs, -rhs),
+            ResolvedOperand::Immediate(_) => return Ok(false),
+        };
+        self.push_op_with_result_reg(ValType::I32, op, FuelCostsProvider::base)?;
+        Ok(true)
+    }
+
+    /// Lowers an `i64.sub` into a `i64.add` if possible.
+    ///
+    /// # Returns
+    ///
+    /// - Returns `Ok(true)` is lowering was successful.
+    /// - Returns `Ok(false)` otherwise.
+    fn try_lower_i64_sub(&mut self, lhs: Operand, rhs: i64) -> Result<bool, Error> {
+        debug_assert!(matches!(lhs.ty(), ValType::I64));
+        let op = match self.resolve_operand::<i64>(lhs)? {
+            ResolvedOperand::Reg(_) => Op::i64_add_rri(-rhs),
+            ResolvedOperand::Slot(lhs) => Op::i64_add_rsi(lhs, -rhs),
+            ResolvedOperand::Immediate(_) => return Ok(false),
+        };
+        self.push_op_with_result_reg(ValType::I64, op, FuelCostsProvider::base)?;
+        Ok(true)
     }
 
     /// Evaluates `consteval(lhs, rhs)` and pushed either its result or tranlates a `trap`.

--- a/crates/wasmi/src/engine/translator/func/op/binary.rs
+++ b/crates/wasmi/src/engine/translator/func/op/binary.rs
@@ -516,10 +516,10 @@ impl_binary_op_for! {
         fn decode_rhs = decode_rhs_as_value;
         fn consteval = wasm::i32_sub;
         fn op_rrs = I32Sub_Rrs;
-        fn op_rri = I32Sub_Rri;
+        fn op_rri = I32Add_Rri; // unreachable due to lowering
         fn op_rsr = I32Sub_Rsr;
         fn op_rss = I32Sub_Rss;
-        fn op_rsi = I32Sub_Rsi;
+        fn op_rsi = I32Add_Rsi; // unreachable due to lowering
         fn op_rir = I32Sub_Rir;
         fn op_ris = I32Sub_Ris;
     }
@@ -727,10 +727,10 @@ impl_binary_op_for! {
         fn decode_rhs = decode_rhs_as_value;
         fn consteval = wasm::i64_sub;
         fn op_rrs = I64Sub_Rrs;
-        fn op_rri = I64Sub_Rri;
+        fn op_rri = I64Add_Rri; // unreachable due to lowering
         fn op_rsr = I64Sub_Rsr;
         fn op_rss = I64Sub_Rss;
-        fn op_rsi = I64Sub_Rsi;
+        fn op_rsi = I64Add_Rsi; // unreachable due to lowering
         fn op_rir = I64Sub_Rir;
         fn op_ris = I64Sub_Ris;
     }

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -803,42 +803,42 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_i32_lt_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Lt>()
+        self.translate_binary::<op::I32Lt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_lt_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U32Lt>()
+        self.translate_binary::<op::U32Lt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_gt_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Gt>()
+        self.translate_binary::<op::I32Gt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_gt_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U32Gt>()
+        self.translate_binary::<op::U32Gt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_le_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Le>()
+        self.translate_binary::<op::I32Le>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_le_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U32Le>()
+        self.translate_binary::<op::U32Le>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_ge_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Ge>()
+        self.translate_binary::<op::I32Ge>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_ge_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U32Ge>()
+        self.translate_binary::<op::U32Ge>(Self::no_opt_ri)
     }
 
     #[inline(never)]
@@ -860,42 +860,42 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_i64_lt_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Lt>()
+        self.translate_binary::<op::I64Lt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_lt_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U64Lt>()
+        self.translate_binary::<op::U64Lt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_gt_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Gt>()
+        self.translate_binary::<op::I64Gt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_gt_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U64Gt>()
+        self.translate_binary::<op::U64Gt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_le_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Le>()
+        self.translate_binary::<op::I64Le>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_le_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U64Le>()
+        self.translate_binary::<op::U64Le>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_ge_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Ge>()
+        self.translate_binary::<op::I64Ge>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_ge_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U64Ge>()
+        self.translate_binary::<op::U64Ge>(Self::no_opt_ri)
     }
 
     #[inline(never)]
@@ -910,22 +910,22 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_f32_lt(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Lt>()
+        self.translate_binary::<op::F32Lt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f32_gt(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Gt>()
+        self.translate_binary::<op::F32Gt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f32_le(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Le>()
+        self.translate_binary::<op::F32Le>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f32_ge(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Ge>()
+        self.translate_binary::<op::F32Ge>(Self::no_opt_ri)
     }
 
     #[inline(never)]
@@ -940,22 +940,22 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_f64_lt(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Lt>()
+        self.translate_binary::<op::F64Lt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f64_gt(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Gt>()
+        self.translate_binary::<op::F64Gt>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f64_le(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Le>()
+        self.translate_binary::<op::F64Le>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f64_ge(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Ge>()
+        self.translate_binary::<op::F64Ge>(Self::no_opt_ri)
     }
 
     #[inline(never)]
@@ -980,7 +980,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_i32_sub(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Sub>()
+        self.translate_binary::<op::I32Sub>(Self::try_lower_i32_sub)
     }
 
     #[inline(never)]
@@ -990,22 +990,22 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_i32_div_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Div>()
+        self.translate_binary::<op::I32Div>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_div_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U32Div>()
+        self.translate_binary::<op::U32Div>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_rem_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Rem>()
+        self.translate_binary::<op::I32Rem>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_rem_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U32Rem>()
+        self.translate_binary::<op::U32Rem>(Self::no_opt_ri)
     }
 
     #[inline(never)]
@@ -1025,27 +1025,27 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_i32_shl(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Shl>()
+        self.translate_binary::<op::I32Shl>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_shr_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Shr>()
+        self.translate_binary::<op::I32Shr>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_shr_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U32Shr>()
+        self.translate_binary::<op::U32Shr>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_rotl(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Rotl>()
+        self.translate_binary::<op::I32Rotl>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i32_rotr(&mut self) -> Self::Output {
-        self.translate_binary::<op::I32Rotr>()
+        self.translate_binary::<op::I32Rotr>(Self::no_opt_ri)
     }
 
     #[inline(never)]
@@ -1070,7 +1070,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_i64_sub(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Sub>()
+        self.translate_binary::<op::I64Sub>(Self::try_lower_i64_sub)
     }
 
     #[inline(never)]
@@ -1080,22 +1080,22 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_i64_div_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Div>()
+        self.translate_binary::<op::I64Div>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_div_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U64Div>()
+        self.translate_binary::<op::U64Div>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_rem_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Rem>()
+        self.translate_binary::<op::I64Rem>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_rem_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U64Rem>()
+        self.translate_binary::<op::U64Rem>(Self::no_opt_ri)
     }
 
     #[inline(never)]
@@ -1115,27 +1115,27 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_i64_shl(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Shl>()
+        self.translate_binary::<op::I64Shl>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_shr_s(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Shr>()
+        self.translate_binary::<op::I64Shr>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_shr_u(&mut self) -> Self::Output {
-        self.translate_binary::<op::U64Shr>()
+        self.translate_binary::<op::U64Shr>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_rotl(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Rotl>()
+        self.translate_binary::<op::I64Rotl>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_i64_rotr(&mut self) -> Self::Output {
-        self.translate_binary::<op::I64Rotr>()
+        self.translate_binary::<op::I64Rotr>(Self::no_opt_ri)
     }
 
     #[inline(never)]
@@ -1175,37 +1175,37 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_f32_add(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Add>()
+        self.translate_binary::<op::F32Add>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f32_sub(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Sub>()
+        self.translate_binary::<op::F32Sub>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f32_mul(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Mul>()
+        self.translate_binary::<op::F32Mul>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f32_div(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Div>()
+        self.translate_binary::<op::F32Div>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f32_min(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Min>()
+        self.translate_binary::<op::F32Min>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f32_max(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Max>()
+        self.translate_binary::<op::F32Max>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f32_copysign(&mut self) -> Self::Output {
-        self.translate_binary::<op::F32Copysign>()
+        self.translate_binary::<op::F32Copysign>(Self::no_opt_ri)
     }
 
     #[inline(never)]
@@ -1245,37 +1245,37 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_f64_add(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Add>()
+        self.translate_binary::<op::F64Add>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f64_sub(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Sub>()
+        self.translate_binary::<op::F64Sub>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f64_mul(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Mul>()
+        self.translate_binary::<op::F64Mul>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f64_div(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Div>()
+        self.translate_binary::<op::F64Div>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f64_min(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Min>()
+        self.translate_binary::<op::F64Min>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f64_max(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Max>()
+        self.translate_binary::<op::F64Max>(Self::no_opt_ri)
     }
 
     #[inline(never)]
     fn visit_f64_copysign(&mut self) -> Self::Output {
-        self.translate_binary::<op::F64Copysign>()
+        self.translate_binary::<op::F64Copysign>(Self::no_opt_ri)
     }
 
     #[inline(never)]


### PR DESCRIPTION
Since https://github.com/wasmi-labs/wasmi/pull/1895 `iadd` operators have an edge over `isub` concerning performance.

- [x] Implement lowering for translator.
- [x] Remove unused `i{32,64}_sub_r{r,s}i` operators.

Some benchmarks improved significantly:

<img width="1100" height="258" alt="image" src="https://github.com/user-attachments/assets/53dd8edb-7d26-4ae7-bf9e-6523cca48c25" />

<img width="1096" height="366" alt="image" src="https://github.com/user-attachments/assets/adab8d60-1fad-4462-a960-3ac19e05cc96" />

<img width="1100" height="114" alt="image" src="https://github.com/user-attachments/assets/9c37d403-8ee6-4d64-a0cf-03c47bc8ca87" />
