### PR TITLE
Add forwarding `validate` crate feature to control Wasm validation support

### DIFF
--- a/crates/c_api/Cargo.toml
+++ b/crates/c_api/Cargo.toml
@@ -15,7 +15,7 @@ exclude.workspace = true
 links = "wasmi_c_api"
 
 [dependencies]
-wasmi = { workspace = true }
+wasmi = { workspace = true, features = ["validate"] }
 wasmi_c_api_macros = { workspace = true }
 
 [lib]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-wasmi = { workspace = true, features = ["validate"] }
+wasmi = { workspace = true, features = ["std"] }
 wasmi_wasi = { workspace = true, optional = true }
 wasmi_wast = { workspace = true, optional = true }
 anyhow = "1"
@@ -29,14 +29,19 @@ clap = { version = "4", features = ["derive"] }
 assert_cmd = "2.0.7"
 
 [features]
-default = ["stable", "run", "wast", "wasi", "wat"]
+default = ["stable", "run", "wast", "wasi", "wat", "validate"]
 hash-collections = ["wasmi/hash-collections"]
 prefer-btree-collections = ["wasmi/prefer-btree-collections"]
 simd = ["wasmi/simd"]
 wasi = ["wasmi_wasi"]
-wat = ["wasmi/wat"]
+# Note: `wat` (and `wast`) imply `validate` because parsing the Wasm text format
+#       and running the spec testsuite only make sense with Wasm validation enabled.
+wat = ["wasmi/wat", "validate"]
 run = []
-wast = ["wasmi_wast"]
+wast = ["wasmi_wast", "validate"]
+# Enables Wasm validation. Without it the CLI compiles `Module` via the `unsafe`
+# unchecked path and never validates its inputs (only safe for trusted Wasm).
+validate = ["wasmi/validate"]
 portable-dispatch = ["wasmi/portable-dispatch"]
 indirect-dispatch = ["wasmi/indirect-dispatch"]
 stable = ["wasmi/stable"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-wasmi = { workspace = true }
+wasmi = { workspace = true, features = ["validate"] }
 wasmi_wasi = { workspace = true, optional = true }
 wasmi_wast = { workspace = true, optional = true }
 anyhow = "1"

--- a/crates/cli/src/context.rs
+++ b/crates/cli/src/context.rs
@@ -38,14 +38,28 @@ impl Context {
             config.consume_fuel(true);
         }
         config.compilation_mode(compilation_mode);
-        config.wasm_custom_page_sizes(true);
-        config.wasm_wide_arithmetic(true);
+        #[cfg(feature = "validate")]
+        {
+            config.wasm_custom_page_sizes(true);
+            config.wasm_wide_arithmetic(true);
+        }
         let engine = wasmi::Engine::new(&config);
         let wasm =
             fs::read(wasm_file).map_err(|_| anyhow!("failed to read Wasm file {wasm_file:?}"))?;
-        let module = wasmi::Module::new(&engine, wasm).map_err(|error| {
-            anyhow!("failed to parse and validate Wasm module {wasm_file:?}: {error}")
-        })?;
+        let module = {
+            #[cfg(feature = "validate")]
+            {
+                wasmi::Module::new(&engine, &wasm[..])
+            }
+            #[cfg(not(feature = "validate"))]
+            {
+                // SAFETY: Without the `validate` feature the Wasmi CLI does not validate its
+                //         inputs. It is the user's responsibility to only feed valid Wasm;
+                //         feeding invalid Wasm is undefined behavior.
+                unsafe { wasmi::Module::new_unchecked(&engine, &wasm[..]) }
+            }
+        }
+        .map_err(|error| anyhow!("failed to compile Wasm module {wasm_file:?}: {error}"))?;
         let mut store = wasmi::Store::new(&engine, store_ctx);
         if let Some(fuel) = fuel {
             store.set_fuel(fuel).unwrap_or_else(|error| {

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -15,7 +15,13 @@ exclude.workspace = true
 publish = false
 
 [dependencies]
-wasmi = { workspace = true, features = ["std", "simd", "portable-dispatch", "extra-checks"] }
+wasmi = { workspace = true, features = [
+    "std",
+    "simd",
+    "portable-dispatch",
+    "extra-checks",
+    "validate",
+] }
 wasmtime = { workspace = true, optional = true, features = [
     "cranelift",
     "runtime",

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 wasmi_core = { workspace = true }
 wasmi_collections = { workspace = true }
 wasmi_ir = { workspace = true }
-wasmparser = { workspace = true, features = ["validate", "features"] }
+wasmparser = { workspace = true, features = [] }
 wat = { workspace = true, optional = true }
 spin = { version = "0.9", default-features = false, features = [
     "mutex",
@@ -35,7 +35,7 @@ assert_matches = "1.5"
 criterion = { version = "0.5", default-features = false }
 
 [features]
-default = ["stable", "std", "wat"]
+default = ["stable", "std", "wat", "validate"]
 std = [
     "wasmi_ir/std",
     "wasmi_core/std",
@@ -53,6 +53,7 @@ prefer-btree-collections = [
 ]
 wat = ["dep:wat", "std"]
 simd = ["wasmi_core/simd", "wasmi_ir/simd", "wasmparser/simd"]
+validate = ["wasmparser/validate", "wasmparser/features"]
 stable = []
 unstable = []
 

--- a/crates/wasmi/src/engine/code_map/mod.rs
+++ b/crates/wasmi/src/engine/code_map/mod.rs
@@ -10,7 +10,8 @@ mod utils;
 
 pub use self::span::{EngineFunc, EngineFuncSpan, EngineFuncSpanIter};
 use self::utils::SmallByteSlice;
-use super::{FuncTranslationDriver, FuncTranslator, TranslationError, ValidatingFuncTranslator};
+use super::ValidatingFuncTranslator;
+use super::{FuncToValidate, FuncTranslationDriver, FuncTranslator, TranslationError};
 use crate::{
     Config,
     Error,
@@ -117,7 +118,7 @@ impl CodeMap {
         func_idx: FuncIdx,
         bytes: &[u8],
         module: &ModuleHeader,
-        func_to_validate: Option<FuncToValidate<ValidatorResources>>,
+        func_to_validate: Option<FuncToValidate>,
     ) {
         let func = match self.funcs.get(func) {
             Some(func) => func,
@@ -849,7 +850,7 @@ impl UncompiledFuncEntry {
         func_index: FuncIdx,
         bytes: &[u8],
         module: ModuleHeader,
-        func_to_validate: impl Into<Option<FuncToValidate<ValidatorResources>>>,
+        func_to_validate: impl Into<Option<FuncToValidate>>,
     ) -> Self {
         let validation = func_to_validate.into().map(|func_to_validate| {
             assert_eq!(

--- a/crates/wasmi/src/engine/code_map/mod.rs
+++ b/crates/wasmi/src/engine/code_map/mod.rs
@@ -10,6 +10,7 @@ mod utils;
 
 pub use self::span::{EngineFunc, EngineFuncSpan, EngineFuncSpanIter};
 use self::utils::SmallByteSlice;
+#[cfg(feature = "validate")]
 use super::ValidatingFuncTranslator;
 use super::{FuncToValidate, FuncTranslationDriver, FuncTranslator, TranslationError};
 use crate::{
@@ -33,7 +34,9 @@ use core::{
     sync::atomic::{AtomicU8, AtomicUsize, Ordering},
 };
 use spin::Mutex;
-use wasmparser::{FuncToValidate, ValidatorResources, WasmFeatures};
+#[cfg(feature = "validate")]
+use wasmparser::ValidatorResources;
+use wasmparser::WasmFeatures;
 
 #[cfg(doc)]
 use crate::ir::Op;
@@ -823,6 +826,7 @@ mod state {
 }
 
 /// A function type index into the Wasm module.
+#[cfg(feature = "validate")]
 #[derive(Debug, Copy, Clone)]
 #[repr(transparent)]
 pub struct TypeIndex(u32);
@@ -841,6 +845,7 @@ struct UncompiledFuncEntry {
     /// Optional Wasm validation information.
     ///
     /// This is `Some` if the [`UncompiledFuncEntry`] is to be validated upon compilation.
+    #[cfg(feature = "validate")]
     validation: Option<(TypeIndex, ValidatorResources)>,
 }
 
@@ -850,8 +855,11 @@ impl UncompiledFuncEntry {
         func_index: FuncIdx,
         bytes: &[u8],
         module: ModuleHeader,
-        func_to_validate: impl Into<Option<FuncToValidate>>,
+        #[cfg_attr(not(feature = "validate"), expect(unused_variables))] func_to_validate: impl Into<
+            Option<FuncToValidate>,
+        >,
     ) -> Self {
+        #[cfg(feature = "validate")]
         let validation = func_to_validate.into().map(|func_to_validate| {
             assert_eq!(
                 func_to_validate.index,
@@ -867,6 +875,7 @@ impl UncompiledFuncEntry {
             func_index,
             bytes,
             module,
+            #[cfg(feature = "validate")]
             validation,
         }
     }
@@ -882,6 +891,7 @@ impl UncompiledFuncEntry {
     ///
     /// - If function translation failed.
     /// - If `ctx` ran out of fuel in case fuel consumption is enabled.
+    #[cfg_attr(not(feature = "validate"), allow(unused_variables))]
     fn compile(
         &mut self,
         fuel: Option<&mut Fuel>,
@@ -909,7 +919,16 @@ impl UncompiledFuncEntry {
 
         let func_idx = self.func_index;
         let wasm_bytes = self.bytes.as_slice();
-        let needs_validation = self.validation.is_some();
+        let needs_validation = {
+            #[cfg(feature = "validate")]
+            {
+                self.validation.is_some()
+            }
+            #[cfg(not(feature = "validate"))]
+            {
+                false
+            }
+        };
         let compilation_fuel = |_costs: &FuelCostsProvider| {
             let len_bytes = wasm_bytes.len() as u64;
             let fuel_per_byte = match needs_validation {
@@ -934,7 +953,18 @@ impl UncompiledFuncEntry {
             )
         };
         let mut result = MaybeUninit::uninit();
-        match self.validation.take() {
+        let validation = {
+            #[cfg(feature = "validate")]
+            {
+                self.validation.take()
+            }
+            #[cfg(not(feature = "validate"))]
+            {
+                <Option<FuncToValidate>>::None
+            }
+        };
+        match validation {
+            #[cfg(feature = "validate")]
             Some((type_index, resources)) => {
                 let allocs = engine.get_allocs();
                 let translator = FuncTranslator::new(func_idx, module, allocs.0)?;
@@ -970,12 +1000,13 @@ impl UncompiledFuncEntry {
 
 impl fmt::Debug for UncompiledFuncEntry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("UncompiledFuncEntry")
-            .field("func_idx", &self.func_index)
+        let mut dbg = f.debug_struct("UncompiledFuncEntry");
+        dbg.field("func_idx", &self.func_index)
             .field("bytes", &self.bytes)
-            .field("module", &self.module)
-            .field("validate", &self.validation.is_some())
-            .finish()
+            .field("module", &self.module);
+        #[cfg(feature = "validate")]
+        dbg.field("validate", &self.validation.is_some());
+        dbg.finish()
     }
 }
 

--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
     /// The limits set on the value stack and call stack.
     pub(crate) stack: StackConfig,
     /// The Wasm features used when validating or translating functions.
+    #[cfg(feature = "validate")]
     features: WasmFeatures,
     /// Is `true` if Wasmi executions shall consume fuel.
     consume_fuel: bool,
@@ -44,6 +45,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             stack: StackConfig::default(),
+            #[cfg(feature = "validate")]
             features: Self::default_features(),
             consume_fuel: false,
             ignore_custom_sections: false,
@@ -56,6 +58,7 @@ impl Default for Config {
 
 impl Config {
     /// Returns the default [`WasmFeatures`].
+    #[cfg(feature = "validate")]
     fn default_features() -> WasmFeatures {
         let mut features = WasmFeatures::empty();
         features.set(WasmFeatures::MUTABLE_GLOBAL, true);
@@ -146,6 +149,7 @@ impl Config {
     /// Enabled by default.
     ///
     /// [`mutable-global`]: https://github.com/WebAssembly/mutable-global
+    #[cfg(feature = "validate")]
     pub fn wasm_mutable_global(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::MUTABLE_GLOBAL, enable);
         self
@@ -158,6 +162,7 @@ impl Config {
     /// Enabled by default.
     ///
     /// [`sign-extension`]: https://github.com/WebAssembly/sign-extension-ops
+    #[cfg(feature = "validate")]
     pub fn wasm_sign_extension(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::SIGN_EXTENSION, enable);
         self
@@ -171,6 +176,7 @@ impl Config {
     ///
     /// [`saturating-float-to-int`]:
     /// https://github.com/WebAssembly/nontrapping-float-to-int-conversions
+    #[cfg(feature = "validate")]
     pub fn wasm_saturating_float_to_int(&mut self, enable: bool) -> &mut Self {
         self.features
             .set(WasmFeatures::SATURATING_FLOAT_TO_INT, enable);
@@ -184,6 +190,7 @@ impl Config {
     /// Enabled by default.
     ///
     /// [`multi-value`]: https://github.com/WebAssembly/multi-value
+    #[cfg(feature = "validate")]
     pub fn wasm_multi_value(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::MULTI_VALUE, enable);
         self
@@ -196,6 +203,7 @@ impl Config {
     /// Enabled by default.
     ///
     /// [`multi-memory`]: https://github.com/WebAssembly/multi-memory
+    #[cfg(feature = "validate")]
     pub fn wasm_multi_memory(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::MULTI_MEMORY, enable);
         self
@@ -208,6 +216,7 @@ impl Config {
     /// Enabled by default.
     ///
     /// [`bulk-memory`]: https://github.com/WebAssembly/bulk-memory-operations
+    #[cfg(feature = "validate")]
     pub fn wasm_bulk_memory(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::BULK_MEMORY, enable);
         self
@@ -220,6 +229,7 @@ impl Config {
     /// Enabled by default.
     ///
     /// [`reference-types`]: https://github.com/WebAssembly/reference-types
+    #[cfg(feature = "validate")]
     pub fn wasm_reference_types(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::REFERENCE_TYPES, enable);
         self.features.set(WasmFeatures::GC_TYPES, enable);
@@ -233,6 +243,7 @@ impl Config {
     /// Enabled by default.
     ///
     /// [`tail-call`]: https://github.com/WebAssembly/tail-call
+    #[cfg(feature = "validate")]
     pub fn wasm_tail_call(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::TAIL_CALL, enable);
         self
@@ -245,6 +256,7 @@ impl Config {
     /// Enabled by default.
     ///
     /// [`extended-const`]: https://github.com/WebAssembly/extended-const
+    #[cfg(feature = "validate")]
     pub fn wasm_extended_const(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::EXTENDED_CONST, enable);
         self
@@ -257,6 +269,7 @@ impl Config {
     /// Disabled by default.
     ///
     /// [`custom-page-sizes`]: https://github.com/WebAssembly/custom-page-sizes
+    #[cfg(feature = "validate")]
     pub fn wasm_custom_page_sizes(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::CUSTOM_PAGE_SIZES, enable);
         self
@@ -269,6 +282,7 @@ impl Config {
     /// Disabled by default.
     ///
     /// [`memory64`]: https://github.com/WebAssembly/memory64
+    #[cfg(feature = "validate")]
     pub fn wasm_memory64(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::MEMORY64, enable);
         self
@@ -279,6 +293,7 @@ impl Config {
     /// Disabled by default.
     ///
     /// [`wide-arithmetic`]: https://github.com/WebAssembly/wide-arithmetic
+    #[cfg(feature = "validate")]
     pub fn wasm_wide_arithmetic(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::WIDE_ARITHMETIC, enable);
         self
@@ -309,6 +324,7 @@ impl Config {
     /// Enable or disable Wasm floating point (`f32` and `f64`) instructions and types.
     ///
     /// Enabled by default.
+    #[cfg(feature = "validate")]
     pub fn floats(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::FLOATS, enable);
         self
@@ -396,7 +412,14 @@ impl Config {
     }
 
     /// Returns the [`WasmFeatures`] represented by the [`Config`].
+    #[cfg(feature = "validate")]
     pub(crate) fn wasm_features(&self) -> WasmFeatures {
         self.features
+    }
+
+    /// Returns the [`WasmFeatures`] represented by the [`Config`].
+    #[cfg(not(feature = "validate"))]
+    pub(crate) fn wasm_features(&self) -> WasmFeatures {
+        WasmFeatures::default()
     }
 }

--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -41,6 +41,10 @@ pub enum CompilationMode {
     Lazy,
 }
 
+// Note: without the `validate` feature there is no `features` field, so every
+//       field equals its default; clippy then suggests deriving `Default`, but
+//       the manual impl is still required for the `validate`-enabled build.
+#[cfg_attr(not(feature = "validate"), allow(clippy::derivable_impls))]
 impl Default for Config {
     fn default() -> Self {
         Self {

--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -304,7 +304,7 @@ impl Config {
     /// Enabled by default.
     ///
     /// [`simd`]: https://github.com/WebAssembly/simd
-    #[cfg(feature = "simd")]
+    #[cfg(all(feature = "simd", feature = "validate"))]
     pub fn wasm_simd(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::SIMD, enable);
         self
@@ -315,7 +315,7 @@ impl Config {
     /// Enabled by default.
     ///
     /// [`relaxed-simd`]: https://github.com/WebAssembly/relaxed-simd
-    #[cfg(feature = "simd")]
+    #[cfg(all(feature = "simd", feature = "validate"))]
     pub fn wasm_relaxed_simd(&mut self, enable: bool) -> &mut Self {
         self.features.set(WasmFeatures::RELAXED_SIMD, enable);
         self

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -11,6 +11,8 @@ mod resumable;
 mod translator;
 mod utils;
 
+#[cfg(feature = "validate")]
+pub(crate) use self::translator::ValidatingFuncTranslator;
 pub(crate) use self::{
     block_type::BlockType,
     executor::{
@@ -29,7 +31,6 @@ pub(crate) use self::{
         FuncTranslator,
         FuncTranslatorAllocations,
         LazyFuncTranslator,
-        ValidatingFuncTranslator,
         WasmTranslator,
         required_cells_for_tys,
     },
@@ -262,6 +263,7 @@ impl Engine {
     }
 
     /// Returns reusable [`FuncTranslatorAllocations`] and [`FuncValidatorAllocations`] from the [`Engine`].
+    #[cfg(feature = "validate")]
     pub(crate) fn get_allocs(&self) -> (FuncTranslatorAllocations, FuncValidatorAllocations) {
         self.inner.get_allocs()
     }
@@ -272,6 +274,7 @@ impl Engine {
     }
 
     /// Recycles the given [`FuncTranslatorAllocations`] and [`FuncValidatorAllocations`] in the [`Engine`].
+    #[cfg(feature = "validate")]
     pub(crate) fn recycle_allocs(
         &self,
         translation: FuncTranslatorAllocations,
@@ -485,6 +488,7 @@ pub struct ReusableAllocationStack {
     /// Allocations required by Wasm function translators.
     translation: Vec<FuncTranslatorAllocations>,
     /// Allocations required by Wasm function validators.
+    #[cfg(feature = "validate")]
     validation: Vec<FuncValidatorAllocations>,
 }
 
@@ -493,6 +497,7 @@ impl Default for ReusableAllocationStack {
         Self {
             max_height: 1,
             translation: Vec::new(),
+            #[cfg(feature = "validate")]
             validation: Vec::new(),
         }
     }
@@ -500,13 +505,14 @@ impl Default for ReusableAllocationStack {
 
 impl core::fmt::Debug for ReusableAllocationStack {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("ReusableAllocationStack")
-            .field("translation", &self.translation)
-            // Note: FuncValidatorAllocations is missing Debug impl at the time of writing this commit.
-            //       We should derive Debug as soon as FuncValidatorAllocations has a Debug impl in future
-            //       wasmparser versions.
-            .field("validation", &self.validation.len())
-            .finish()
+        let mut dbg = f.debug_struct("ReusableAllocationStack");
+        dbg.field("translation", &self.translation);
+        // Note: FuncValidatorAllocations is missing Debug impl at the time of writing this commit.
+        //       We should derive Debug as soon as FuncValidatorAllocations has a Debug impl in future
+        //       wasmparser versions.
+        #[cfg(feature = "validate")]
+        dbg.field("validation", &self.validation.len());
+        dbg.finish()
     }
 }
 
@@ -517,6 +523,7 @@ impl ReusableAllocationStack {
     }
 
     /// Returns reusable [`FuncValidatorAllocations`] from the [`Engine`].
+    #[cfg(feature = "validate")]
     pub fn get_validation_allocs(&mut self) -> FuncValidatorAllocations {
         self.validation.pop().unwrap_or_default()
     }
@@ -531,6 +538,7 @@ impl ReusableAllocationStack {
     }
 
     /// Recycles the given [`FuncValidatorAllocations`] in the [`Engine`].
+    #[cfg(feature = "validate")]
     pub fn recycle_validation_allocs(&mut self, recycled: FuncValidatorAllocations) {
         debug_assert!(self.validation.len() <= self.max_height);
         if self.validation.len() >= self.max_height {
@@ -666,6 +674,7 @@ impl EngineInner {
     ) -> Result<(), Error> {
         let features = self.config().wasm_features();
         match (self.config.get_compilation_mode(), func_to_validate) {
+            #[cfg(feature = "validate")]
             (CompilationMode::Eager, Some(func_to_validate)) => {
                 let (translation_allocs, validation_allocs) = self.get_allocs();
                 let validator = func_to_validate.into_validator(validation_allocs);
@@ -682,6 +691,7 @@ impl EngineInner {
                     .translate(|func_entity| self.init_func(engine_func, func_entity))?;
                 self.recycle_translation_allocs(allocs);
             }
+            #[cfg(feature = "validate")]
             (CompilationMode::LazyTranslation, Some(func_to_validate)) => {
                 let allocs = self.get_validation_allocs();
                 let translator =
@@ -694,6 +704,7 @@ impl EngineInner {
             }
             (CompilationMode::Lazy | CompilationMode::LazyTranslation, func_to_validate) => {
                 let translator = match func_to_validate {
+                    #[cfg(feature = "validate")]
                     Some(func_to_validate) => {
                         LazyFuncTranslator::new(func_index, engine_func, module, func_to_validate)
                     }
@@ -714,6 +725,7 @@ impl EngineInner {
     }
 
     /// Returns reusable [`FuncValidatorAllocations`] from the [`Engine`].
+    #[cfg(feature = "validate")]
     fn get_validation_allocs(&self) -> FuncValidatorAllocations {
         self.allocs.lock().get_validation_allocs()
     }
@@ -725,6 +737,7 @@ impl EngineInner {
     /// This method is a bit more efficient than calling both
     /// - [`EngineInner::get_translation_allocs`]
     /// - [`EngineInner::get_validation_allocs`]
+    #[cfg(feature = "validate")]
     fn get_allocs(&self) -> (FuncTranslatorAllocations, FuncValidatorAllocations) {
         let mut allocs = self.allocs.lock();
         let translation = allocs.get_translation_allocs();
@@ -738,6 +751,7 @@ impl EngineInner {
     }
 
     /// Recycles the given [`FuncValidatorAllocations`] in the [`Engine`].
+    #[cfg(feature = "validate")]
     fn recycle_validation_allocs(&self, allocs: FuncValidatorAllocations) {
         self.allocs.lock().recycle_validation_allocs(allocs)
     }
@@ -749,6 +763,7 @@ impl EngineInner {
     /// This method is a bit more efficient than calling both
     /// - [`EngineInner::recycle_translation_allocs`]
     /// - [`EngineInner::recycle_validation_allocs`]
+    #[cfg(feature = "validate")]
     fn recycle_allocs(
         &self,
         translation: FuncTranslatorAllocations,

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -69,7 +69,14 @@ use alloc::{
 };
 use core::sync::atomic::{AtomicU32, Ordering};
 use spin::{Mutex, RwLock};
-use wasmparser::{FuncToValidate, FuncValidatorAllocations, ValidatorResources};
+#[cfg(feature = "validate")]
+use wasmparser::FuncValidatorAllocations;
+
+/// `wasmparser` validation info for a function; uninhabited when `validate` is off.
+#[cfg(feature = "validate")]
+pub(crate) type FuncToValidate = wasmparser::FuncToValidate<wasmparser::ValidatorResources>;
+#[cfg(not(feature = "validate"))]
+pub(crate) enum FuncToValidate {}
 
 #[cfg(doc)]
 use crate::Store;
@@ -237,7 +244,7 @@ impl Engine {
         offset: usize,
         bytes: &[u8],
         module: ModuleHeader,
-        func_to_validate: Option<FuncToValidate<ValidatorResources>>,
+        func_to_validate: Option<FuncToValidate>,
     ) -> Result<(), Error> {
         self.inner.translate_func(
             func_index,
@@ -290,7 +297,7 @@ impl Engine {
         func: EngineFunc,
         bytes: &[u8],
         module: &ModuleHeader,
-        func_to_validate: Option<FuncToValidate<ValidatorResources>>,
+        func_to_validate: Option<FuncToValidate>,
     ) {
         self.inner
             .init_lazy_func(func_idx, func, bytes, module, func_to_validate)
@@ -655,7 +662,7 @@ impl EngineInner {
         offset: usize,
         bytes: &[u8],
         module: ModuleHeader,
-        func_to_validate: Option<FuncToValidate<ValidatorResources>>,
+        func_to_validate: Option<FuncToValidate>,
     ) -> Result<(), Error> {
         let features = self.config().wasm_features();
         match (self.config.get_compilation_mode(), func_to_validate) {
@@ -784,7 +791,7 @@ impl EngineInner {
         func: EngineFunc,
         bytes: &[u8],
         module: &ModuleHeader,
-        func_to_validate: Option<FuncToValidate<ValidatorResources>>,
+        func_to_validate: Option<FuncToValidate>,
     ) {
         self.code_map
             .init_func_as_uncompiled(func, func_idx, bytes, module, func_to_validate)

--- a/crates/wasmi/src/engine/translator/driver.rs
+++ b/crates/wasmi/src/engine/translator/driver.rs
@@ -25,8 +25,16 @@ where
         translator: T,
     ) -> Result<Self, Error> {
         let offset = offset.into().unwrap_or(0);
-        let features = translator.features();
-        let reader = BinaryReader::new_features(bytes, offset, features);
+        let reader = {
+            #[cfg(feature = "validate")]
+            {
+                BinaryReader::new_features(bytes, offset, translator.features())
+            }
+            #[cfg(not(feature = "validate"))]
+            {
+                BinaryReader::new(bytes, offset)
+            }
+        };
         let func_body = FunctionBody::new(reader);
         Ok(Self {
             func_body,

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -15,7 +15,7 @@ pub use self::{
     func::{FuncTranslator, FuncTranslatorAllocations},
     utils::required_cells_for_tys,
 };
-use super::code_map::CompiledFuncEntry;
+use super::{FuncToValidate, code_map::CompiledFuncEntry};
 use crate::{
     Error,
     engine::EngineFunc,
@@ -361,7 +361,7 @@ impl Validation {
     }
 
     /// Returns the [`FuncToValidate`] if `self` is checked.
-    pub fn take_func_to_validate(&mut self) -> Option<FuncToValidate<ValidatorResources>> {
+    pub fn take_func_to_validate(&mut self) -> Option<FuncToValidate> {
         let features = self.features();
         match mem::replace(self, Self::Unchecked(features)) {
             Self::Checked(func_to_validate) => Some(func_to_validate),
@@ -385,7 +385,7 @@ impl LazyFuncTranslator {
         func_idx: FuncIdx,
         engine_func: EngineFunc,
         module: ModuleHeader,
-        func_to_validate: FuncToValidate<ValidatorResources>,
+        func_to_validate: FuncToValidate,
     ) -> Self {
         Self {
             func_idx,

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -22,19 +22,16 @@ use crate::{
     module::{FuncIdx, ModuleHeader},
 };
 use core::{fmt, mem};
-use wasmparser::{
-    BinaryReaderError,
-    FuncToValidate,
-    FuncValidatorAllocations,
-    ValidatorResources,
-    VisitOperator,
-    WasmFeatures,
-};
+#[cfg(feature = "validate")]
+use wasmparser::{BinaryReaderError, FuncValidatorAllocations};
+use wasmparser::{VisitOperator, WasmFeatures};
 
 /// The used function validator type.
+#[cfg(feature = "validate")]
 type FuncValidator = wasmparser::FuncValidator<wasmparser::ValidatorResources>;
 
 /// A Wasm to Wasmi IR function translator that also validates its input.
+#[cfg(feature = "validate")]
 pub struct ValidatingFuncTranslator<T> {
     /// The current position in the Wasm binary while parsing operators.
     pos: usize,
@@ -45,6 +42,7 @@ pub struct ValidatingFuncTranslator<T> {
 }
 
 /// Reusable heap allocations for function validation and translation.
+#[cfg(feature = "validate")]
 #[derive(Default)]
 pub struct ReusableAllocations<T> {
     pub translation: T,
@@ -101,6 +99,7 @@ pub trait WasmTranslator<'parser>:
     fn setup(&mut self, bytes: &[u8]) -> Result<bool, Error>;
 
     /// Returns a reference to the [`WasmFeatures`] used by the [`WasmTranslator`].
+    #[cfg_attr(not(feature = "validate"), allow(dead_code))]
     fn features(&self) -> WasmFeatures;
 
     /// Translates the given local variables for the translated function.
@@ -142,6 +141,7 @@ pub trait WasmTranslator<'parser>:
     fn finish(self, finalize: impl FnOnce(CompiledFuncEntry)) -> Result<Self::Allocations, Error>;
 }
 
+#[cfg(feature = "validate")]
 impl<T> ValidatingFuncTranslator<T> {
     /// Creates a new [`ValidatingFuncTranslator`].
     pub fn new(validator: FuncValidator, translator: T) -> Result<Self, Error> {
@@ -173,6 +173,7 @@ impl<T> ValidatingFuncTranslator<T> {
     }
 }
 
+#[cfg(feature = "validate")]
 impl<'parser, T> WasmTranslator<'parser> for ValidatingFuncTranslator<T>
 where
     T: WasmTranslator<'parser>,
@@ -226,6 +227,7 @@ where
     }
 }
 
+#[cfg(feature = "validate")]
 macro_rules! impl_visit_operator {
     ( @mvp BrTable { $arg:ident: $argty:ty } => $visit:ident $_ann:tt $($rest:tt)* ) => {
         // We need to special case the `BrTable` operand since its
@@ -282,6 +284,7 @@ macro_rules! impl_visit_operator {
     () => {};
 }
 
+#[cfg(feature = "validate")]
 impl<'a, T> VisitOperator<'a> for ValidatingFuncTranslator<T>
 where
     T: WasmTranslator<'a>,
@@ -298,7 +301,7 @@ where
     wasmparser::for_each_visit_operator!(impl_visit_operator);
 }
 
-#[cfg(feature = "simd")]
+#[cfg(all(feature = "simd", feature = "validate"))]
 macro_rules! impl_visit_simd_operator {
     ( @$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident $_ann:tt $($rest:tt)* ) => {
         fn $visit(&mut self $($(,$arg: $argty)*)?) -> Self::Output {
@@ -313,7 +316,7 @@ macro_rules! impl_visit_simd_operator {
     () => {};
 }
 
-#[cfg(feature = "simd")]
+#[cfg(all(feature = "simd", feature = "validate"))]
 impl<'a, T> wasmparser::VisitSimdOperator<'a> for ValidatingFuncTranslator<T>
 where
     T: WasmTranslator<'a>,
@@ -337,7 +340,8 @@ pub struct LazyFuncTranslator {
 /// Information about Wasm validation for lazy translation.
 enum Validation {
     /// Wasm validation is performed.
-    Checked(FuncToValidate<ValidatorResources>),
+    #[cfg(feature = "validate")]
+    Checked(FuncToValidate),
     /// Wasm validation is checked.
     ///
     /// # Dev. Note
@@ -349,12 +353,20 @@ enum Validation {
 impl Validation {
     /// Returns `true` if `self` performs validates Wasm upon lazy translation.
     pub fn is_checked(&self) -> bool {
-        matches!(self, Self::Checked(_))
+        #[cfg(feature = "validate")]
+        {
+            matches!(self, Self::Checked(_))
+        }
+        #[cfg(not(feature = "validate"))]
+        {
+            false
+        }
     }
 
     /// Returns the [`WasmFeatures`] used for Wasm parsing and validation.
     pub fn features(&self) -> WasmFeatures {
         match self {
+            #[cfg(feature = "validate")]
             Validation::Checked(func_to_validate) => func_to_validate.features,
             Validation::Unchecked(wasm_features) => *wasm_features,
         }
@@ -364,6 +376,7 @@ impl Validation {
     pub fn take_func_to_validate(&mut self) -> Option<FuncToValidate> {
         let features = self.features();
         match mem::replace(self, Self::Unchecked(features)) {
+            #[cfg(feature = "validate")]
             Self::Checked(func_to_validate) => Some(func_to_validate),
             Self::Unchecked(_) => None,
         }
@@ -381,6 +394,7 @@ impl fmt::Debug for Validation {
 
 impl LazyFuncTranslator {
     /// Create a new [`LazyFuncTranslator`].
+    #[cfg(feature = "validate")]
     pub fn new(
         func_idx: FuncIdx,
         engine_func: EngineFunc,

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -70,7 +70,7 @@
 //! | `hash-collections` | `wasmi`<br>`wasmi_collections` | Enables use of hash-map based collections in Wasmi internals. This might yield performance improvements in some use cases. <br><br> Disabled by default. |
 //! | `prefer-btree-collections` | `wasmi`<br>`wasmi_collections` | Enforces use of btree-map based collections in Wasmi internals. This may yield performance improvements and memory consumption decreases in some use cases. Also it enables Wasmi to run on platforms that have no random source. <br><br> Disabled by default. |
 //! | `extra-checks` | `wasmi` | Enables extra runtime checks in the Wasmi executor. Expected execution overhead is ~20%. Enable this if your focus is on safety. Disable this for maximum execution performance. <br><br> Disabled by default. |
-//! | `validate` | `wasmi`<br>`wasmi_cli` | Enable Wasm validation support. Turning this off allows user with control over their inputs to slim down Wasmi's binary size significantly. <br><br> Enabled by default. | 
+//! | `validate` | `wasmi`<br>`wasmi_cli` | Enable Wasm validation support. Turning this off allows user with control over their inputs to slim down Wasmi's binary size significantly. <br><br> Enabled by default. |
 
 #![no_std]
 #![warn(

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -65,12 +65,12 @@
 //! | Feature | Crates | Description |
 //! |:-:|:--|:--|
 //! | `std` | `wasmi`<br>`wasmi_core`<br>`wasmi_ir`<br>`wasmi_collections` | Enables usage of Rust's standard library. This may have some performance advantages when enabled. Disabling this feature makes Wasmi compile on platforms that do not provide Rust's standard library such as many embedded platforms. <br><br> Enabled by default. |
-//! | `wat` | `wasmi` | Enables support to parse Wat encoded Wasm modules. <br><br> Enabled by default. |
+//! | `wat` | `wasmi`<br>`wasmi_cli` | Enables support to parse Wat encoded Wasm modules. <br><br> Enabled by default. |
 //! | `simd` | `wasmi`<br>`wasmi_core`<br>`wasmi_ir`<br>`wasmi_cli` | Enables support for the Wasm `simd` and `relaxed-simd` proposals. <br><br> Disabled by default. |
 //! | `hash-collections` | `wasmi`<br>`wasmi_collections` | Enables use of hash-map based collections in Wasmi internals. This might yield performance improvements in some use cases. <br><br> Disabled by default. |
 //! | `prefer-btree-collections` | `wasmi`<br>`wasmi_collections` | Enforces use of btree-map based collections in Wasmi internals. This may yield performance improvements and memory consumption decreases in some use cases. Also it enables Wasmi to run on platforms that have no random source. <br><br> Disabled by default. |
 //! | `extra-checks` | `wasmi` | Enables extra runtime checks in the Wasmi executor. Expected execution overhead is ~20%. Enable this if your focus is on safety. Disable this for maximum execution performance. <br><br> Disabled by default. |
-//! | `validate` | `wasmi` | Enable Wasm validation support. Turning this off allows user with control over their inputs to slim down Wasmi's binary size significantly. <br><br> Enabled by default. | 
+//! | `validate` | `wasmi`<br>`wasmi_cli` | Enable Wasm validation support. Turning this off allows user with control over their inputs to slim down Wasmi's binary size significantly. <br><br> Enabled by default. | 
 
 #![no_std]
 #![warn(

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -70,6 +70,7 @@
 //! | `hash-collections` | `wasmi`<br>`wasmi_collections` | Enables use of hash-map based collections in Wasmi internals. This might yield performance improvements in some use cases. <br><br> Disabled by default. |
 //! | `prefer-btree-collections` | `wasmi`<br>`wasmi_collections` | Enforces use of btree-map based collections in Wasmi internals. This may yield performance improvements and memory consumption decreases in some use cases. Also it enables Wasmi to run on platforms that have no random source. <br><br> Disabled by default. |
 //! | `extra-checks` | `wasmi` | Enables extra runtime checks in the Wasmi executor. Expected execution overhead is ~20%. Enable this if your focus is on safety. Disable this for maximum execution performance. <br><br> Disabled by default. |
+//! | `validate` | `wasmi` | Enable Wasm validation support. Turning this off allows user with control over their inputs to slim down Wasmi's binary size significantly. | 
 
 #![no_std]
 #![warn(

--- a/crates/wasmi/src/lib.rs
+++ b/crates/wasmi/src/lib.rs
@@ -70,7 +70,7 @@
 //! | `hash-collections` | `wasmi`<br>`wasmi_collections` | Enables use of hash-map based collections in Wasmi internals. This might yield performance improvements in some use cases. <br><br> Disabled by default. |
 //! | `prefer-btree-collections` | `wasmi`<br>`wasmi_collections` | Enforces use of btree-map based collections in Wasmi internals. This may yield performance improvements and memory consumption decreases in some use cases. Also it enables Wasmi to run on platforms that have no random source. <br><br> Disabled by default. |
 //! | `extra-checks` | `wasmi` | Enables extra runtime checks in the Wasmi executor. Expected execution overhead is ~20%. Enable this if your focus is on safety. Disable this for maximum execution performance. <br><br> Disabled by default. |
-//! | `validate` | `wasmi` | Enable Wasm validation support. Turning this off allows user with control over their inputs to slim down Wasmi's binary size significantly. | 
+//! | `validate` | `wasmi` | Enable Wasm validation support. Turning this off allows user with control over their inputs to slim down Wasmi's binary size significantly. <br><br> Enabled by default. | 
 
 #![no_std]
 #![warn(

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -46,6 +46,7 @@ use crate::{
 };
 use alloc::{boxed::Box, sync::Arc};
 use core::{iter, slice::Iter as SliceIter};
+#[cfg(feature = "validate")]
 use wasmparser::{FuncValidatorAllocations, Parser, ValidPayload, Validator};
 
 /// A parsed and validated WebAssembly module.
@@ -283,6 +284,7 @@ impl Module {
     /// If Wasm validation for `wasm` fails for the given [`Config`] provided via `engine`.
     ///
     /// [`Config`]: crate::Config
+    #[cfg(feature = "validate")]
     pub fn validate(engine: &Engine, wasm: &[u8]) -> Result<(), Error> {
         let mut validator = Validator::new_with_features(engine.config().wasm_features());
         for payload in Parser::new(0).parse_all(wasm) {

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -222,6 +222,7 @@ impl Module {
     /// - If Wasmi cannot translate the Wasm bytecode.
     ///
     /// [`Config`]: crate::Config
+    #[cfg(feature = "validate")]
     pub fn new(engine: &Engine, wasm: impl AsRef<[u8]>) -> Result<Self, Error> {
         let wasm = wasm.as_ref();
         #[cfg(feature = "wat")]

--- a/crates/wasmi/src/module/parser/buffered.rs
+++ b/crates/wasmi/src/module/parser/buffered.rs
@@ -6,7 +6,9 @@ use super::{
     ModuleParser,
 };
 use crate::{Error, Module};
-use wasmparser::{Chunk, Payload, Validator};
+#[cfg(feature = "validate")]
+use wasmparser::Validator;
+use wasmparser::{Chunk, Payload};
 
 #[cfg_attr(not(feature = "validate"), allow(unused_mut, unused_variables))]
 impl ModuleParser {

--- a/crates/wasmi/src/module/parser/buffered.rs
+++ b/crates/wasmi/src/module/parser/buffered.rs
@@ -19,12 +19,10 @@ impl ModuleParser {
     /// # Errors
     ///
     /// If the Wasm bytecode stream fails to validate.
+    #[cfg(feature = "validate")]
     pub fn parse_buffered(mut self, buffer: &[u8]) -> Result<Module, Error> {
         let features = self.engine.config().wasm_features();
-        #[cfg(feature = "validate")]
-        {
-            self.validator = Some(Validator::new_with_features(features));
-        }
+        self.validator = Some(Validator::new_with_features(features));
         // SAFETY: we just pre-populated the Wasm module parser with a validator
         //         thus calling this method is safe.
         unsafe { self.parse_buffered_impl(buffer) }

--- a/crates/wasmi/src/module/parser/buffered.rs
+++ b/crates/wasmi/src/module/parser/buffered.rs
@@ -8,6 +8,7 @@ use super::{
 use crate::{Error, Module};
 use wasmparser::{Chunk, Payload, Validator};
 
+#[cfg_attr(not(feature = "validate"), allow(unused_mut, unused_variables))]
 impl ModuleParser {
     /// Starts parsing and validating the Wasm bytecode stream.
     ///
@@ -18,7 +19,10 @@ impl ModuleParser {
     /// If the Wasm bytecode stream fails to validate.
     pub fn parse_buffered(mut self, buffer: &[u8]) -> Result<Module, Error> {
         let features = self.engine.config().wasm_features();
-        self.validator = Some(Validator::new_with_features(features));
+        #[cfg(feature = "validate")]
+        {
+            self.validator = Some(Validator::new_with_features(features));
+        }
         // SAFETY: we just pre-populated the Wasm module parser with a validator
         //         thus calling this method is safe.
         unsafe { self.parse_buffered_impl(buffer) }

--- a/crates/wasmi/src/module/parser/mod.rs
+++ b/crates/wasmi/src/module/parser/mod.rs
@@ -20,6 +20,8 @@ use crate::{
 };
 use alloc::boxed::Box;
 use core::ops::Range;
+#[cfg(feature = "validate")]
+use wasmparser::Validator;
 use wasmparser::{
     CustomSectionReader,
     DataSectionReader,
@@ -35,7 +37,6 @@ use wasmparser::{
     Payload,
     TableSectionReader,
     TypeSectionReader,
-    Validator,
 };
 
 #[cfg(doc)]
@@ -48,6 +49,7 @@ pub struct ModuleParser {
     /// The engine used for translation.
     engine: Engine,
     /// The Wasm validator used throughout stream parsing.
+    #[cfg(feature = "validate")]
     validator: Option<Validator>,
     /// The underlying Wasm parser.
     parser: WasmParser,
@@ -55,6 +57,7 @@ pub struct ModuleParser {
     engine_funcs: u32,
 }
 
+#[cfg_attr(not(feature = "validate"), allow(unused_mut, unused_variables))]
 impl ModuleParser {
     /// Creates a new [`ModuleParser`] for the given [`Engine`].
     pub fn new(engine: &Engine) -> Self {
@@ -63,6 +66,7 @@ impl ModuleParser {
         parser.set_features(engine.config().wasm_features());
         Self {
             engine: engine.clone(),
+            #[cfg(feature = "validate")]
             validator: None,
             parser,
             engine_funcs: 0,
@@ -71,6 +75,7 @@ impl ModuleParser {
 
     /// Processes the end of the Wasm binary.
     fn process_end(&mut self, offset: usize) -> Result<(), Error> {
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             // This only checks if the number of code section entries and data segments match
             // their expected numbers thus we must avoid this check in header-only mode because
@@ -87,6 +92,7 @@ impl ModuleParser {
         encoding: Encoding,
         range: Range<usize>,
     ) -> Result<(), Error> {
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.version(num, encoding, &range)?;
         }
@@ -107,6 +113,7 @@ impl ModuleParser {
         section: TypeSectionReader,
         header: &mut ModuleHeaderBuilder,
     ) -> Result<(), Error> {
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.type_section(&section)?;
         }
@@ -147,6 +154,7 @@ impl ModuleParser {
         section: ImportSectionReader,
         header: &mut ModuleHeaderBuilder,
     ) -> Result<(), Error> {
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.import_section(&section)?;
         }
@@ -176,6 +184,7 @@ impl ModuleParser {
                 return Err(Error::from(EnforcedLimitsError::TooManyFunctions { limit }));
             }
         }
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.function_section(&section)?;
         }
@@ -205,6 +214,7 @@ impl ModuleParser {
                 return Err(Error::from(EnforcedLimitsError::TooManyTables { limit }));
             }
         }
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.table_section(&section)?;
         }
@@ -238,6 +248,7 @@ impl ModuleParser {
                 return Err(Error::from(EnforcedLimitsError::TooManyMemories { limit }));
             }
         }
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.memory_section(&section)?;
         }
@@ -267,6 +278,7 @@ impl ModuleParser {
                 return Err(Error::from(EnforcedLimitsError::TooManyGlobals { limit }));
             }
         }
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.global_section(&section)?;
         }
@@ -291,6 +303,7 @@ impl ModuleParser {
         section: ExportSectionReader,
         header: &mut ModuleHeaderBuilder,
     ) -> Result<(), Error> {
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.export_section(&section)?;
         }
@@ -319,6 +332,7 @@ impl ModuleParser {
         range: Range<usize>,
         header: &mut ModuleHeaderBuilder,
     ) -> Result<(), Error> {
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.start_section(func, &range)?;
         }
@@ -352,6 +366,7 @@ impl ModuleParser {
                 }));
             }
         }
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.element_section(&section)?;
         }
@@ -376,6 +391,7 @@ impl ModuleParser {
                 }));
             }
         }
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.data_count_section(count, &range)?;
         }
@@ -403,6 +419,7 @@ impl ModuleParser {
                 }));
             }
         }
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             // Note: data section does not belong to the Wasm module header.
             //
@@ -456,6 +473,7 @@ impl ModuleParser {
                 }
             }
         }
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.code_section_start(count, &range)?;
         }
@@ -495,9 +513,18 @@ impl ModuleParser {
         let (func, engine_func) = self.next_func(header);
         let module = header.clone();
         let offset = func_body.get_binary_reader().original_position();
-        let func_to_validate = match &mut self.validator {
-            Some(validator) => Some(validator.code_section_entry(&func_body)?),
-            None => None,
+        let func_to_validate = {
+            #[cfg(feature = "validate")]
+            {
+                match &mut self.validator {
+                    Some(validator) => Some(validator.code_section_entry(&func_body)?),
+                    None => None,
+                }
+            }
+            #[cfg(not(feature = "validate"))]
+            {
+                None
+            }
         };
         self.engine
             .translate_func(func, engine_func, offset, bytes, module, func_to_validate)?;
@@ -519,6 +546,7 @@ impl ModuleParser {
 
     /// Process an unexpected, unsupported or malformed Wasm module section payload.
     fn process_invalid_payload(&mut self, payload: Payload<'_>) -> Result<(), Error> {
+        #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             if let Err(error) = validator.payload(&payload) {
                 return Err(Error::from(error));

--- a/crates/wasmi/src/module/parser/mod.rs
+++ b/crates/wasmi/src/module/parser/mod.rs
@@ -59,6 +59,7 @@ impl ModuleParser {
     /// Creates a new [`ModuleParser`] for the given [`Engine`].
     pub fn new(engine: &Engine) -> Self {
         let mut parser = WasmParser::new(0);
+        #[cfg(feature = "validate")]
         parser.set_features(engine.config().wasm_features());
         Self {
             engine: engine.clone(),

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 exclude.workspace = true
 
 [dependencies]
-wasmi = { workspace = true, features = ["std", "simd"] }
+wasmi = { workspace = true, features = ["std", "simd", "validate"] }
 wast = { workspace = true, features = ["wasm-module"] }
 anyhow = "1.0"
 


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1854.

## Benchmark: Wasmi CLI App Size

Below are the effects on the binary artifact size on the Wasmi CLI application with `validate` turned ON or OFF.
The table represents raw unstripped binary size and stripped binary size.

In summary: disabling validation removes ~320–365 KB of the stripped binary -> 17–21%, with the largest relative win under size-optimization.

| Profile | raw ON | raw OFF | Δ raw | stripped ON | stripped OFF | Δ stripped |
|:--|--:|--:|--:|--:|--:|--:|
| `release` | 2,442 KB | 2,025 KB | −17.1% | 1,912 KB | 1,591 KB | −16.8% |
| `bench (lto=fat)` | 2,361 KB | 1,912 KB | −19.0% | 1,893 KB | 1,529 KB | −19.2% |
| `bench-size (lto=fat, opt=s)` | 2,207 KB | 1,732 KB | −21.5% | 1,646 KB | 1,315 KB | −20.1% |

```toml
[profile.bench-size]
inherits = "release"
lto = "fat"
codegen-units = 1
opt-level = "s"
```