### PR TITLE
Improve `minimal` release artifacts builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,10 @@ jobs:
       # Per feature set: `full` => 3 (max speed, the release default), `minimal` => "s"
       # (optimize for size). Every other build setting is identical for both.
       CARGO_PROFILE_RELEASE_OPT_LEVEL: ${{ matrix.featureset.opt_level }}
+      # Per feature set: `full` keeps unwinding; `minimal` uses `abort` to drop unwind
+      # tables/landing pads for a smaller binary (safe — the minimal CLI has no
+      # `catch_unwind` in its dependency tree; that only lives in `wasmi_c_api_impl`).
+      CARGO_PROFILE_RELEASE_PANIC: ${{ matrix.featureset.panic }}
       CARGO_TERM_COLOR: always
     strategy:
       fail-fast: false
@@ -97,11 +101,13 @@ jobs:
           - name: full
             features: run,wat,wast,wasi,validate,stable,simd
             opt_level: "3"
+            panic: unwind
           # `minimal` == smallest useful CLI: run validated modules only.
-          # Built at opt-level "s" to shrink the binary further.
+          # Built at opt-level "s" + panic=abort to shrink the binary further.
           - name: minimal
             features: run,validate
             opt_level: "s"
+            panic: abort
         # Exactly the subset of Wasmtime's target-triples that matches our
         # {x86_64, aarch64} × {Linux, macOS, Windows} scope. All native runners.
         #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,25 +181,6 @@ jobs:
           --features ${{ matrix.featureset.features }}
           --target ${{ matrix.platform.target }}
 
-      - name: Strip binary (minimal builds)
-        # `minimal` artifacts target small size, so strip with the platform's `strip`
-        # tool — it removes more than Cargo's `strip = symbols` alone. Runs *before*
-        # the smoke test so CI validates the final stripped binary. Skipped on Windows
-        # (MSVC keeps debug info in a separate .pdb, so the .exe has nothing to strip
-        # and `strip` isn't on the runners).
-        if: matrix.featureset.name == 'minimal' && matrix.platform.os == 'unix'
-        shell: bash
-        run: |
-          set -euo pipefail
-          bin="target/${{ matrix.platform.target }}/release/wasmi"
-          strip "$bin"
-          # On Apple Silicon a binary must carry a valid (ad-hoc) code signature to run;
-          # `strip` modifies the binary and invalidates the linker's signature, so re-sign.
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            codesign --sign - --force "$bin"
-          fi
-          ls -l "$bin"
-
       - name: Smoke test binary
         shell: bash
         run: |


### PR DESCRIPTION
The `minimal` builds now use `panic="abort"` to shrink the resulting sizes a bit further.

On MacOS my local machine now compiles `minimal` to ~1.6MB.

With `nightly`, `build-std` and `immediate-abort` we could get this down to ~1.0MB, however, at this point, we don't want to introduce unstable nightly features into the build pipeline.

Note, in comparison the `full` builds on my machine are ~3.7MB.