### PR TITLE
Add copy op-code fusion to `copy_branch_params`

### DIFF
--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -540,7 +540,6 @@ pub fn exec_copy_span(sp: Sp, dst: SlotSpan, src: SlotSpan, len: u16) {
 }
 
 pub fn exec_copy_span_asc(sp: Sp, dst: SlotSpan, src: SlotSpan, len: u16) {
-    std::println!("exec_copy_span_asc dst = {dst:?}, src = {src:?}, len = {len}");
     debug_assert!(dst.head() < src.head());
     debug_assert!(len > 0);
     let mut dst = dst.head();
@@ -555,7 +554,6 @@ pub fn exec_copy_span_asc(sp: Sp, dst: SlotSpan, src: SlotSpan, len: u16) {
 }
 
 pub fn exec_copy_span_des(sp: Sp, dst: SlotSpan, src: SlotSpan, len: u16) {
-    std::println!("exec_copy_span_des dst = {dst:?}, src = {src:?}, len = {len}");
     debug_assert!(dst.head() > src.head());
     debug_assert!(len > 0);
     let dst_end = dst.head();

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -540,6 +540,7 @@ pub fn exec_copy_span(sp: Sp, dst: SlotSpan, src: SlotSpan, len: u16) {
 }
 
 pub fn exec_copy_span_asc(sp: Sp, dst: SlotSpan, src: SlotSpan, len: u16) {
+    std::println!("exec_copy_span_asc dst = {dst:?}, src = {src:?}, len = {len}");
     debug_assert!(dst.head() < src.head());
     debug_assert!(len > 0);
     let mut dst = dst.head();
@@ -554,6 +555,7 @@ pub fn exec_copy_span_asc(sp: Sp, dst: SlotSpan, src: SlotSpan, len: u16) {
 }
 
 pub fn exec_copy_span_des(sp: Sp, dst: SlotSpan, src: SlotSpan, len: u16) {
+    std::println!("exec_copy_span_des dst = {dst:?}, src = {src:?}, len = {len}");
     debug_assert!(dst.head() > src.head());
     debug_assert!(len > 0);
     let dst_end = dst.head();

--- a/crates/wasmi/src/engine/translator/func/fuse_copy.rs
+++ b/crates/wasmi/src/engine/translator/func/fuse_copy.rs
@@ -1,6 +1,6 @@
 use crate::ir::{Op, SlotSpan};
 
-/// Represents fused copy [`Op`] for copy fusion in the translator.
+/// Represents a fused copy [`Op`] for copy fusion in the translator.
 #[derive(Copy, Clone)]
 pub struct FusedCopy {
     /// The result slots of the fused copy [`Op`].

--- a/crates/wasmi/src/engine/translator/func/fuse_copy.rs
+++ b/crates/wasmi/src/engine/translator/func/fuse_copy.rs
@@ -1,0 +1,103 @@
+use crate::ir::{Op, SlotSpan};
+
+/// Represents fused copy [`Op`] used by [`FuncTranslator::encode_copy_or_fuse_sx`].
+#[derive(Copy, Clone)]
+pub struct FusedCopy {
+    /// The result slots of the fused copy [`Op`].
+    results: SlotSpan,
+    /// The value slots of the fused copy [`Op`].
+    values: SlotSpan,
+    /// The number of copied slots of the fused copy [`Op`].
+    len: u16,
+}
+
+impl FusedCopy {
+    /// Creates a new [`FusedCopy`] from its raw parts.
+    fn new(results: SlotSpan, values: SlotSpan, len: u16) -> Self {
+        Self {
+            results,
+            values,
+            len,
+        }
+    }
+
+    /// Returns `Some` if `op` is a copy [`Op`] that can be fused.
+    ///
+    /// Otherwise returns `None`.
+    pub fn from_op(op: Op) -> Option<Self> {
+        let (results, values, len) = match op {
+            Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
+            #[cfg(feature = "simd")]
+            Op::V128Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 2),
+            Op::CopySpanAsc {
+                results,
+                values,
+                len,
+            }
+            | Op::CopySpanDes {
+                results,
+                values,
+                len,
+            } => (results, values, len),
+            _ => return None,
+        };
+        Some(Self::new(results, values, len))
+    }
+
+    /// Returns `Some` if `self` and the `new` copy-span [`Op`] can be fused.
+    ///
+    /// Otherwise returns `None`.
+    pub fn try_fuse(self, new: Self) -> Option<Self> {
+        if let Some(fused) = self.try_fuse_copy_asc(new) {
+            return Some(fused);
+        }
+        if let Some(fused) = self.try_fuse_copy_des(new) {
+            return Some(fused);
+        }
+        None
+    }
+
+    /// Returns `Some` if `self` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
+    ///
+    /// Otherwise returns `None`.
+    fn try_fuse_copy_asc(self, new: Self) -> Option<Self> {
+        let can_fuse = new.results.head() == self.results.head().next_n(self.len)
+            && new.values.head() == self.values.head().next_n(self.len);
+        if can_fuse {
+            // Case: copy fusion in ascending slot order can be applied.
+            return Some(Self::new(self.results, self.values, self.len + new.len));
+        }
+        None
+    }
+
+    /// Returns `Some` if `self` and the `new` copy-span [`Op`] can be fused in descending slot-order.
+    ///
+    /// Otherwise returns `None`.
+    fn try_fuse_copy_des(self, new: Self) -> Option<Self> {
+        let can_fuse = new.results.head() == self.results.head().prev_n(new.len)
+            && new.values.head() == self.values.head().prev_n(new.len);
+        if can_fuse {
+            // Case: copy fusion in descending slot order can be applied.
+            return Some(Self::new(new.results, new.values, self.len + new.len));
+        }
+        None
+    }
+
+    /// Lowers `self` back into an [`Op`] for encoding.
+    ///
+    /// This returns the most efficient [`Op`] that preserves copy semantics.
+    pub fn into_op(self) -> Op {
+        let Self {
+            results,
+            values,
+            len,
+        } = self;
+        match len {
+            1 => Op::u64_copy_ss(results.head(), values.head()),
+            #[cfg(feature = "simd")]
+            2 => Op::v128_copy_ss(results.head(), values.head()),
+            _ if results < values => Op::copy_span_asc(results, values, len),
+            _ => Op::copy_span_des(results, values, len),
+        }
+    }
+}

--- a/crates/wasmi/src/engine/translator/func/fuse_copy.rs
+++ b/crates/wasmi/src/engine/translator/func/fuse_copy.rs
@@ -1,6 +1,6 @@
 use crate::ir::{Op, SlotSpan};
 
-/// Represents fused copy [`Op`] used by [`FuncTranslator::encode_copy_or_fuse_sx`].
+/// Represents fused copy [`Op`] for copy fusion in the translator.
 #[derive(Copy, Clone)]
 pub struct FusedCopy {
     /// The result slots of the fused copy [`Op`].

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 mod utils;
 mod encoder;
+mod fuse_copy;
 mod labels;
 mod layout;
 mod locals;
@@ -15,6 +16,7 @@ use self::stack::ImmediateOperand;
 
 use self::{
     encoder::{OpEncoder, OpEncoderAllocations, Pos},
+    fuse_copy::FusedCopy,
     labels::{LabelRef, LabelRegistry},
     layout::{StackLayout, StackSpace},
     locals::{LocalIdx, LocalsRegistry},
@@ -417,111 +419,7 @@ impl FuncTranslator {
         }
         Ok(())
     }
-}
 
-/// Represents fused copy [`Op`] used by [`FuncTranslator::encode_copy_or_fuse_sx`].
-#[derive(Copy, Clone)]
-struct FusedCopy {
-    /// The result slots of the fused copy [`Op`].
-    results: SlotSpan,
-    /// The value slots of the fused copy [`Op`].
-    values: SlotSpan,
-    /// The number of copied slots of the fused copy [`Op`].
-    len: u16,
-}
-
-impl FusedCopy {
-    /// Creates a new [`FusedCopy`] from its raw parts.
-    fn new(results: SlotSpan, values: SlotSpan, len: u16) -> Self {
-        Self {
-            results,
-            values,
-            len,
-        }
-    }
-
-    /// Returns `Some` if `op` is a copy [`Op`] that can be fused.
-    ///
-    /// Otherwise returns `None`.
-    pub fn from_op(op: Op) -> Option<Self> {
-        let (results, values, len) = match op {
-            Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
-            #[cfg(feature = "simd")]
-            Op::V128Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 2),
-            Op::CopySpanAsc {
-                results,
-                values,
-                len,
-            }
-            | Op::CopySpanDes {
-                results,
-                values,
-                len,
-            } => (results, values, len),
-            _ => return None,
-        };
-        Some(Self::new(results, values, len))
-    }
-
-    /// Returns `Some` if `self` and the `new` copy-span [`Op`] can be fused.
-    ///
-    /// Otherwise returns `None`.
-    pub fn try_fuse(self, new: Self) -> Option<Self> {
-        if let Some(fused) = self.try_fuse_copy_asc(new) {
-            return Some(fused);
-        }
-        if let Some(fused) = self.try_fuse_copy_des(new) {
-            return Some(fused);
-        }
-        None
-    }
-
-    /// Returns `Some` if `self` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
-    ///
-    /// Otherwise returns `None`.
-    fn try_fuse_copy_asc(self, new: Self) -> Option<Self> {
-        let can_fuse = new.results.head() == self.results.head().next_n(self.len)
-            && new.values.head() == self.values.head().next_n(self.len);
-        if can_fuse {
-            // Case: copy fusion in ascending slot order can be applied.
-            return Some(Self::new(self.results, self.values, self.len + new.len));
-        }
-        None
-    }
-
-    /// Returns `Some` if `self` and the `new` copy-span [`Op`] can be fused in descending slot-order.
-    ///
-    /// Otherwise returns `None`.
-    fn try_fuse_copy_des(self, new: Self) -> Option<Self> {
-        let can_fuse = new.results.head() == self.results.head().prev_n(new.len)
-            && new.values.head() == self.values.head().prev_n(new.len);
-        if can_fuse {
-            // Case: copy fusion in descending slot order can be applied.
-            return Some(Self::new(new.results, new.values, self.len + new.len));
-        }
-        None
-    }
-
-    /// Lowers `self` back into an [`Op`] for encoding.
-    ///
-    /// This returns the most efficient [`Op`] that preserves copy semantics.
-    pub fn into_op(self) -> Op {
-        let Self {
-            results,
-            values,
-            len,
-        } = self;
-        match len {
-            1 => Op::u64_copy_ss(results.head(), values.head()),
-            #[cfg(feature = "simd")]
-            2 => Op::v128_copy_ss(results.head(), values.head()),
-            _ if results < values => Op::copy_span_asc(results, values, len),
-            _ => Op::copy_span_des(results, values, len),
-        }
-    }
-}
-
-impl FuncTranslator {
     /// Encodes `copy_op` or fuses it with `prev` if possible.
     fn encode_copy_or_fuse_sx(
         &mut self,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -463,7 +463,7 @@ impl FuncTranslator {
     /// Tries to fuse `prev` and `copy_op` if possible.
     ///
     /// # Returns
-    /// 
+    ///
     /// - `Some` if `prev` and `copy_op` was successfully fused.
     /// - `Some` if `prev` was `None` and `copy_op` could be fused.
     /// - `None` otherwise.
@@ -484,9 +484,9 @@ impl FuncTranslator {
             } => (results, values, len),
             _ => return None,
         };
-        if prev.is_none() {
+        let Some(prev) = prev else {
             return Some(FusedCopy::new(new_results, new_values, new_len));
-        }
+        };
         if let Some(fused) = Self::try_fuse_copy_asc(prev, new_results, new_values, new_len) {
             return Some(fused);
         }
@@ -501,12 +501,11 @@ impl FuncTranslator {
     ///
     /// Otherwise returns `None`.
     fn try_fuse_copy_asc(
-        prev: Option<FusedCopy>,
+        prev: FusedCopy,
         new_results: SlotSpan,
         new_values: SlotSpan,
         new_len: u16,
     ) -> Option<FusedCopy> {
-        let prev = prev?;
         let can_fuse_asc = new_results.head() == prev.results.head().next_n(prev.len)
             && new_values.head() == prev.values.head().next_n(prev.len);
         if can_fuse_asc {
@@ -524,12 +523,11 @@ impl FuncTranslator {
     ///
     /// Otherwise returns `None`.
     fn try_fuse_copy_des(
-        prev: Option<FusedCopy>,
+        prev: FusedCopy,
         new_results: SlotSpan,
         new_values: SlotSpan,
         new_len: u16,
     ) -> Option<FusedCopy> {
-        let prev = prev?;
         let can_fuse_des = new_results.head() == prev.results.head().prev_n(new_len)
             && new_values.head() == prev.values.head().prev_n(new_len);
         if can_fuse_des {

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -459,8 +459,8 @@ impl FuncTranslator {
             len,
         } = prev
         {
-            let can_fuse = results.head() == results.head().next_n(len)
-                && values.head() == values.head().next_n(len);
+            let can_fuse = new_results.head() == results.head().next_n(len)
+                && new_values.head() == values.head().next_n(len);
             if can_fuse {
                 let prev = Some(Op::CopySpanAsc {
                     results,
@@ -496,8 +496,8 @@ impl FuncTranslator {
             len,
         } = prev
         {
-            let can_fuse = results.head() == results.head().prev_n(new_len)
-                && values.head() == values.head().prev_n(new_len);
+            let can_fuse = new_results.head() == results.head().prev_n(new_len)
+                && new_values.head() == values.head().prev_n(new_len);
             if can_fuse {
                 let prev = Some(Op::CopySpanDes {
                     results: new_results,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1158,8 +1158,8 @@ impl FuncTranslator {
 
     /// Prepares to encode a return operator returning `n` (`n > 1`) values.
     ///
-    /// This will attemp to copy the `n` values on top of the stack to the
-    /// stack slots required for returning to teh caller.
+    /// This will attempt to copy the `n` values on top of the stack to the
+    /// stack slots required for returning to the caller.
     fn prepare_return_n_op(
         &mut self,
         len: u16,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -416,6 +416,7 @@ impl FuncTranslator {
     fn copy_branch_params_temps_fuse(prev: Option<Op>, copy_op: Op) -> (Option<Op>, Option<Op>) {
         let (results, values, len) = match copy_op {
             Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
+            #[cfg(feature = "simd")]
             Op::V128Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 2),
             Op::CopySpanAsc {
                 results,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -481,7 +481,7 @@ impl FuncTranslator {
                 values,
                 len: 2,
             } => {
-                // Note: `copy_span_asc` with `len = 2` is equivalent to `v128_copy_ss` but less efficient.`
+                // Note: `copy_span_asc` with `len = 2` is equivalent to `v128_copy_ss` but less efficient.
                 let result = results.head();
                 let value = values.head();
                 Op::v128_copy_ss(result, value)

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1147,10 +1147,9 @@ impl FuncTranslator {
                 .checked_add(temp_slots.len())
                 .ok_or(TranslationError::AllocatedTooManySlots)?;
             let result = temp_slots.head();
-            let Some(copy_op) = Self::select_copy_sx_op(result, param, &self.layout)? else {
-                continue;
+            if let Some(copy_op) = Self::select_copy_sx_op(result, param, &self.layout)? {
+                self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
             };
-            self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
         }
         // The `prev` might still contain `Some` at this point, so we have to "flush" it.
         self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1567,17 +1567,22 @@ impl FuncTranslator {
         let fuel_pos = self.stack.fuel_pos();
         self.preserve_regs(fuel_pos)?;
         let fuel_pos = self.stack.fuel_pos();
-        let mut params_start = self.stack.next_temp_slots();
+        let params_start = match ty.len_params() {
+            0 => self.stack.next_temp_slots(),
+            n => {
+                let first_param = self.stack.peek(usize::from(n) - 1);
+                first_param.temp_slots().span()
+            }
+        };
         let mut params_len: u16 = 0;
         let mut prev = None;
-        for _ in 0..ty.len_params() {
-            let param = self.stack.pop();
-            let slots = param.temp_slots();
-            params_start = slots.span();
+        for depth in (0..ty.len_params()).rev() {
+            let param = self.stack.peek(depth.into());
+            let temp_slots = param.temp_slots();
             params_len = params_len
-                .checked_add(slots.len())
+                .checked_add(temp_slots.len())
                 .ok_or(TranslationError::AllocatedTooManySlots)?;
-            let result = slots.head();
+            let result = temp_slots.head();
             let Some(copy_op) = Self::select_copy_sx_op(result, param, &self.layout)? else {
                 continue;
             };
@@ -1586,6 +1591,9 @@ impl FuncTranslator {
         // The `prev` might still contain `Some` at this point, so we have to "flush" it.
         self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
         let params = BoundedSlotSpan::new(params_start, params_len);
+        for _ in 0..ty.len_params() {
+            self.stack.pop();
+        }
         for result in ty.results() {
             self.stack.push_temp(*result, Allocation::None)?;
         }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -504,7 +504,7 @@ impl FusedCopy {
 
     /// Lowers `self` back into an [`Op`] for encoding.
     ///
-    /// This returns the an most efficient [`Op`] that preserves copy semantics.
+    /// This returns the most efficient [`Op`] that preserves copy semantics.
     pub fn into_op(self) -> Op {
         let Self {
             results,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -552,7 +552,6 @@ impl FuncTranslator {
     fn try_fuse_copy_if_any(prev: Option<FusedCopy>, copy_op: Op) -> Option<FusedCopy> {
         let new = FusedCopy::from_op(copy_op)?;
         let Some(prev) = prev else {
-            // return Some(FusedCopy::new(new_results, new_values, new_len));
             return Some(new);
         };
         if let Some(fused) = prev.try_fuse(new) {

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -450,7 +450,7 @@ impl FuncTranslator {
     }
 
     /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
-    /// 
+    ///
     /// Otherwise returns `None`.
     fn try_fuse_asc(
         prev: Option<Op>,
@@ -480,7 +480,7 @@ impl FuncTranslator {
     }
 
     /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
-    /// 
+    ///
     /// Otherwise returns `None`.
     fn try_fuse_des(
         prev: Option<Op>,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -532,7 +532,7 @@ impl FuncTranslator {
         let prev_fused = prev.take();
         let Some(new) = FusedCopy::from_op(copy_op) else {
             // Case: `copy_op` is not fusable => just encode it directly.
-            // Note: we need to flush `prev` to uphold order to emitted copy ops.
+            // Note: we need to flush `prev` to uphold order of emitted copy ops.
             self.encode_fused_copy_op_if_any(prev_fused, fuel_pos)?;
             self.instrs
                 .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -427,15 +427,20 @@ impl FuncTranslator {
                 result: prev_result,
                 value: prev_value,
             } => {
-                let can_fuse = result == prev_result.next() && value == prev_value.next();
-                if can_fuse {
+                let can_fuse_asc =
+                    result < value && result == prev_result.next() && value == prev_value.next();
+                if can_fuse_asc {
                     let results = SlotSpan::new(prev_result);
                     let values = SlotSpan::new(prev_value);
-                    let copy_span_op = match result < value {
-                        true => Op::copy_span_asc,
-                        false => Op::copy_span_des,
-                    };
-                    let prev = Some(copy_span_op(results, values, 2));
+                    let prev = Some(Op::copy_span_asc(results, values, 2));
+                    return (prev, None);
+                }
+                let can_fuse_des =
+                    result > value && result == prev_result.prev() && value == prev_value.prev();
+                if can_fuse_des {
+                    let results = SlotSpan::new(result);
+                    let values = SlotSpan::new(value);
+                    let prev = Some(Op::copy_span_des(results, values, 2));
                     return (prev, None);
                 }
             }
@@ -450,6 +455,22 @@ impl FuncTranslator {
                     let prev = Some(Op::CopySpanAsc {
                         results,
                         values,
+                        len: len + 1,
+                    });
+                    return (prev, None);
+                }
+            }
+            Op::CopySpanDes {
+                results,
+                values,
+                len,
+            } => {
+                let can_fuse =
+                    result == results.head().prev_n(len) && value == values.head().prev_n(len);
+                if can_fuse {
+                    let prev = Some(Op::CopySpanDes {
+                        results: SlotSpan::new(result),
+                        values: SlotSpan::new(value),
                         len: len + 1,
                     });
                     return (prev, None);

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -481,6 +481,8 @@ impl FuncTranslator {
         let Some(copy_op) = copy_op else {
             return Ok(());
         };
+        // Note: we only care about `CopySpanAsc` and not `CopySpanDes` because during fusion
+        //       we only ever memorize `CopySpanAsc` since we can easily restore slot order here.
         let lowered_op = match copy_op {
             Op::CopySpanAsc {
                 results,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -409,19 +409,22 @@ impl FuncTranslator {
         copy_op: Op,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        let (new_prev, copy_op) = Self::try_fuse_copy_if_any(prev.take(), copy_op);
-        *prev = new_prev;
-        self.encode_fused_copy_op_if_any(copy_op, fuel_pos)?;
+        let prev_op = prev.take();
+        if let Some(fused_op) = Self::try_fuse_copy_if_any(prev_op, copy_op) {
+            *prev = Some(fused_op);
+            return Ok(());
+        }
+        self.encode_fused_copy_op_if_any(prev_op, fuel_pos)?;
+        self.instrs
+            .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;
         Ok(())
     }
 
     /// Tries to fuse `prev` and `copy_op` if possible.
     ///
-    /// Returns a pair of [`Option<Op>`]:
-    ///
-    /// - The first item represents the new `prev` after this operation.
-    /// - The second item represents the [`Op`] to be encoded if any.
-    fn try_fuse_copy_if_any(prev: Option<Op>, copy_op: Op) -> (Option<Op>, Option<Op>) {
+    /// Returns `Some` if `prev` and `copy_op` was successfully fused.
+    /// Returns `None` otherwise.
+    fn try_fuse_copy_if_any(prev: Option<Op>, copy_op: Op) -> Option<Op> {
         let (new_results, new_values, new_len) = match copy_op {
             Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
             #[cfg(feature = "simd")]
@@ -436,17 +439,19 @@ impl FuncTranslator {
                 values,
                 len,
             } => (results, values, len),
-            _ => return (Some(copy_op), prev),
+            _ => return None,
         };
-        let copy_span = Op::copy_span_asc(new_results, new_values, new_len);
+        if prev.is_none() {
+            return Some(Op::copy_span_asc(new_results, new_values, new_len));
+        }
         if let Some(fused) = Self::try_fuse_copy_asc(prev, new_results, new_values, new_len) {
-            return (Some(fused), None);
+            return Some(fused);
         }
         if let Some(fused) = Self::try_fuse_copy_des(prev, new_results, new_values, new_len) {
-            return (Some(fused), None);
+            return Some(fused);
         }
         // Case: copy fusion was not applied.
-        (Some(copy_span), prev)
+        None
     }
 
     /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -751,6 +751,37 @@ impl FuncTranslator {
         Ok(result)
     }
 
+    /// Copies the top `n` operands on the stack to their respective stack slots.
+    ///
+    /// Returns a [`BoundedSlotSpan`] of the stack slots holding the copy results.
+    fn copy_operands_to_temp(
+        &mut self,
+        len: u16,
+        fuel_pos: Option<Pos<ir::BlockFuel>>,
+    ) -> Result<BoundedSlotSpan, Error> {
+        let len = usize::from(len);
+        let start = match len {
+            0 => self.stack.next_temp_slots(),
+            n => self.stack.peek(n - 1).temp_slots().span(),
+        };
+        let mut len_cells: u16 = 0;
+        let mut prev = None;
+        for depth in (0..len).rev() {
+            let param = self.stack.peek(depth);
+            let temp_slots = param.temp_slots();
+            len_cells = len_cells
+                .checked_add(temp_slots.len())
+                .ok_or(TranslationError::AllocatedTooManySlots)?;
+            let result = temp_slots.head();
+            if let Some(copy_op) = Self::select_copy_sx_op(result, param, &self.layout)? {
+                self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
+            };
+        }
+        // The `prev` might still contain `Some` at this point, so we have to "flush" it.
+        self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
+        Ok(BoundedSlotSpan::new(start, len_cells))
+    }
+
     /// Copies the `operand` to its temporary [`Slot`] if it is an immediate.
     ///
     /// Returns the temporary [`Slot`] of the `operand`.
@@ -1074,7 +1105,7 @@ impl FuncTranslator {
         let op = match len_results {
             0 => Op::Return {},
             1 => self.prepare_return_1_op(fuel_pos)?,
-            n => self.prepare_return_n_op(n.into(), fuel_pos)?,
+            n => self.prepare_return_n_op(n, fuel_pos)?,
         };
         let pos = self
             .instrs
@@ -1131,34 +1162,14 @@ impl FuncTranslator {
     /// stack slots required for returning to teh caller.
     fn prepare_return_n_op(
         &mut self,
-        len: usize,
+        len: u16,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<Op, Error> {
-        let start = match len {
-            0 => self.stack.next_temp_slots(),
-            n => self.stack.peek(n - 1).temp_slots().span(),
-        };
-        let mut len_cells: u16 = 0;
-        let mut prev = None;
-        for depth in (0..len).rev() {
-            let param = self.stack.peek(depth);
-            let temp_slots = param.temp_slots();
-            len_cells = len_cells
-                .checked_add(temp_slots.len())
-                .ok_or(TranslationError::AllocatedTooManySlots)?;
-            let result = temp_slots.head();
-            if let Some(copy_op) = Self::select_copy_sx_op(result, param, &self.layout)? {
-                self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
-            };
-        }
-        // The `prev` might still contain `Some` at this point, so we have to "flush" it.
-        self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
-        let op = match u16::from(start.head()) {
+        debug_assert!(len > 1);
+        let span = self.copy_operands_to_temp(len, fuel_pos)?;
+        let op = match u16::from(span.head()) {
             0 => Op::Return {},
-            _ => {
-                let span = BoundedSlotSpan::new(start, len_cells);
-                Op::return_span(span)
-            }
+            _ => Op::return_span(span),
         };
         Ok(op)
     }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -501,8 +501,8 @@ impl FuncTranslator {
         if can_fuse_des {
             // Case: copy fusion in ascending slot order can be applied.
             return Some(Op::CopySpanAsc {
-                results,
-                values,
+                results: new_results,
+                values: new_values,
                 len: len + new_len,
             });
         }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -529,26 +529,27 @@ impl FuncTranslator {
         copy_op: Op,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
+        let prev_fused = prev.take();
         let Some(new) = FusedCopy::from_op(copy_op) else {
             // Case: `copy_op` is not fusable => just encode it directly.
             // Note: we need to flush `prev` to uphold order to emitted copy ops.
-            self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
+            self.encode_fused_copy_op_if_any(prev_fused, fuel_pos)?;
             self.instrs
                 .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;
             return Ok(());
         };
-        let Some(prev_copy) = prev.take() else {
+        let Some(prev_fused) = prev_fused else {
             // Case: no previous fused => just memorize `copy_op` for later.
             *prev = Some(new);
             return Ok(());
         };
-        if let Some(fused) = prev_copy.try_fuse(new) {
+        if let Some(new_fused) = prev_fused.try_fuse(new) {
             // Case: successfully fused => memorize fused op for later.
-            *prev = Some(fused);
+            *prev = Some(new_fused);
             return Ok(());
         }
         // Case: couldn't fuse => emit fused-so-far and start new fusion candidate.
-        self.encode_fused_copy_op_if_any(Some(prev_copy), fuel_pos)?;
+        self.encode_fused_copy_op_if_any(Some(prev_fused), fuel_pos)?;
         *prev = Some(new);
         Ok(())
     }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -502,19 +502,15 @@ impl FuncTranslator {
     /// Otherwise returns `None`.
     fn try_fuse_copy_asc(
         prev: FusedCopy,
-        new_results: SlotSpan,
-        new_values: SlotSpan,
-        new_len: u16,
+        results: SlotSpan,
+        values: SlotSpan,
+        len: u16,
     ) -> Option<FusedCopy> {
-        let can_fuse_asc = new_results.head() == prev.results.head().next_n(prev.len)
-            && new_values.head() == prev.values.head().next_n(prev.len);
-        if can_fuse_asc {
+        let can_fuse = results.head() == prev.results.head().next_n(prev.len)
+            && values.head() == prev.values.head().next_n(prev.len);
+        if can_fuse {
             // Case: copy fusion in ascending slot order can be applied.
-            return Some(FusedCopy::new(
-                prev.results,
-                prev.values,
-                prev.len + new_len,
-            ));
+            return Some(FusedCopy::new(prev.results, prev.values, prev.len + len));
         }
         None
     }
@@ -524,15 +520,15 @@ impl FuncTranslator {
     /// Otherwise returns `None`.
     fn try_fuse_copy_des(
         prev: FusedCopy,
-        new_results: SlotSpan,
-        new_values: SlotSpan,
-        new_len: u16,
+        results: SlotSpan,
+        values: SlotSpan,
+        len: u16,
     ) -> Option<FusedCopy> {
-        let can_fuse_des = new_results.head() == prev.results.head().prev_n(new_len)
-            && new_values.head() == prev.values.head().prev_n(new_len);
-        if can_fuse_des {
+        let can_fuse = results.head() == prev.results.head().prev_n(len)
+            && values.head() == prev.values.head().prev_n(len);
+        if can_fuse {
             // Case: copy fusion in descending slot order can be applied.
-            return Some(FusedCopy::new(new_results, new_values, prev.len + new_len));
+            return Some(FusedCopy::new(results, values, prev.len + len));
         }
         None
     }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -447,7 +447,8 @@ impl FuncTranslator {
             return Ok(());
         }
         // Case: couldn't fuse => emit fused-so-far and start new fusion candidate.
-        self.encode_fused_copy_op_if_any(Some(prev_fused), fuel_pos)?;
+        self.instrs
+            .encode_op(prev_fused.into_op(), fuel_pos, FuelCostsProvider::base)?;
         *prev = Some(new);
         Ok(())
     }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -392,13 +392,10 @@ impl FuncTranslator {
         for depth in (end..start).rev() {
             let value = self.stack.peek(depth.into());
             let ty = value.ty();
-            let copy_if_not_noop = Self::select_copy_sx_op(result, value, &self.layout)?;
-            result = result.next_n(required_cells_for_ty(ty));
-            let Some(copy_op) = copy_if_not_noop else {
-                // Case: no-op copy instruction
-                continue;
+            if let Some(copy_op) = Self::select_copy_sx_op(result, value, &self.layout)? {
+                self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
             };
-            self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
+            result = result.next_n(required_cells_for_ty(ty));
         }
         // The `prev` might still contain `Some` at this point, so we have to "flush" it.
         self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -470,6 +470,7 @@ impl FuncTranslator {
             return Ok(());
         };
         let lowered_op = match copy_op {
+            #[cfg(feature = "simd")]
             Op::CopySpanAsc {
                 results,
                 values,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -439,45 +439,74 @@ impl FuncTranslator {
             _ => return (Some(copy_op), prev),
         };
         let copy_span = Op::copy_span_asc(new_results, new_values, new_len);
-        let Some(Op::CopySpanAsc {
-            results,
-            values,
-            len,
-        }) = prev
-        else {
-            // Case: no fusable previous copy for op-code fusion.
-            return (Some(copy_span), None);
-        };
-        {
-            // Try to fuse in ascending slot order:
-            let can_fuse_asc = new_results.head() == results.head().next_n(len)
-                && new_values.head() == values.head().next_n(len);
-            if can_fuse_asc {
-                // Case: copy fusion in ascending slot order can be applied.
-                let prev = Some(Op::CopySpanAsc {
-                    results,
-                    values,
-                    len: len + new_len,
-                });
-                return (prev, None);
-            }
+        if let Some(fused) = Self::try_fuse_asc(prev, new_results, new_values, new_len) {
+            return (Some(fused), None);
         }
-        {
-            // Try to fuse in ascending slot order:
-            let can_fuse_des = new_results.head() == results.head().prev_n(new_len)
-                && new_values.head() == values.head().prev_n(new_len);
-            if can_fuse_des {
-                // Case: copy fusion in descending slot order can be applied.
-                let prev = Some(Op::CopySpanDes {
-                    results: new_results,
-                    values: new_values,
-                    len: len + new_len,
-                });
-                return (prev, None);
-            }
+        if let Some(fused) = Self::try_fuse_des(prev, new_results, new_values, new_len) {
+            return (Some(fused), None);
         }
         // Case: copy fusion was not applied.
         (Some(copy_span), prev)
+    }
+
+    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
+    /// 
+    /// Otherwise returns `None`.
+    fn try_fuse_asc(
+        prev: Option<Op>,
+        new_results: SlotSpan,
+        new_values: SlotSpan,
+        new_len: u16,
+    ) -> Option<Op> {
+        let Op::CopySpanAsc {
+            results,
+            values,
+            len,
+        } = prev?
+        else {
+            return None;
+        };
+        let can_fuse_asc = new_results.head() == results.head().next_n(len)
+            && new_values.head() == values.head().next_n(len);
+        if can_fuse_asc {
+            // Case: copy fusion in ascending slot order can be applied.
+            return Some(Op::CopySpanAsc {
+                results,
+                values,
+                len: len + new_len,
+            });
+        }
+        None
+    }
+
+    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
+    /// 
+    /// Otherwise returns `None`.
+    fn try_fuse_des(
+        prev: Option<Op>,
+        new_results: SlotSpan,
+        new_values: SlotSpan,
+        new_len: u16,
+    ) -> Option<Op> {
+        let Op::CopySpanAsc {
+            results,
+            values,
+            len,
+        } = prev?
+        else {
+            return None;
+        };
+        let can_fuse_des = new_results.head() == results.head().prev_n(new_len)
+            && new_values.head() == values.head().prev_n(new_len);
+        if can_fuse_des {
+            // Case: copy fusion in ascending slot order can be applied.
+            return Some(Op::CopySpanAsc {
+                results,
+                values,
+                len: len + new_len,
+            });
+        }
+        None
     }
 
     /// Encodes `copy_op` if any as lowered (more efficient) version if possible.

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -439,10 +439,10 @@ impl FuncTranslator {
             _ => return (Some(copy_op), prev),
         };
         let copy_span = Op::copy_span_asc(new_results, new_values, new_len);
-        if let Some(fused) = Self::try_fuse_asc(prev, new_results, new_values, new_len) {
+        if let Some(fused) = Self::try_fuse_copy_asc(prev, new_results, new_values, new_len) {
             return (Some(fused), None);
         }
-        if let Some(fused) = Self::try_fuse_des(prev, new_results, new_values, new_len) {
+        if let Some(fused) = Self::try_fuse_copy_des(prev, new_results, new_values, new_len) {
             return (Some(fused), None);
         }
         // Case: copy fusion was not applied.
@@ -452,7 +452,7 @@ impl FuncTranslator {
     /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
     ///
     /// Otherwise returns `None`.
-    fn try_fuse_asc(
+    fn try_fuse_copy_asc(
         prev: Option<Op>,
         new_results: SlotSpan,
         new_values: SlotSpan,
@@ -482,7 +482,7 @@ impl FuncTranslator {
     /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
     ///
     /// Otherwise returns `None`.
-    fn try_fuse_des(
+    fn try_fuse_copy_des(
         prev: Option<Op>,
         new_results: SlotSpan,
         new_values: SlotSpan,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -361,20 +361,8 @@ impl FuncTranslator {
         if len_temps == 0 {
             return Ok(());
         }
-        let mut result = params.temp_slots().head();
-        let start = params.len();
-        let end = params.len_regs();
-        let mut prev = None;
-        for depth in (end..start).rev() {
-            let value = self.stack.peek(depth.into());
-            let ty = value.ty();
-            if let Some(copy_op) = Self::select_copy_sx_op(result, value, &self.layout)? {
-                self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
-            };
-            result = result.next_n(required_cells_for_ty(ty));
-        }
-        // The `prev` might still contain `Some` at this point, so we have to "flush" it.
-        self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
+        let dst = params.temp_slots();
+        self.copy_operands_to_dst(dst.span(), params.len_temps(), params.len_regs(), fuel_pos)?;
         Ok(())
     }
 

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -510,9 +510,7 @@ impl FusedCopy {
             _ => Op::copy_span_des(results, values, len),
         }
     }
-}
 
-impl FusedCopy {
     /// Creates a new [`FusedCopy`] from its raw parts.
     pub fn new(results: SlotSpan, values: SlotSpan, len: u16) -> Self {
         Self {

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -529,34 +529,28 @@ impl FuncTranslator {
         copy_op: Op,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        let prev_op = prev.take();
-        if let Some(fused_op) = Self::try_fuse_copy_if_any(prev_op, copy_op) {
-            *prev = Some(fused_op);
+        let Some(new) = FusedCopy::from_op(copy_op) else {
+            // Case: `copy_op` is not fusable => just encode it directly.
+            // Note: we need to flush `prev` to uphold order to emitted copy ops.
+            self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
+            self.instrs
+                .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;
+            return Ok(());
+        };
+        let Some(prev_copy) = prev.take() else {
+            // Case: no previous fused => just memorize `copy_op` for later.
+            *prev = Some(new);
+            return Ok(());
+        };
+        if let Some(fused) = prev_copy.try_fuse(new) {
+            // Case: successfully fused => memorize fused op for later.
+            *prev = Some(fused);
             return Ok(());
         }
-        self.encode_fused_copy_op_if_any(prev_op, fuel_pos)?;
-        self.instrs
-            .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;
+        // Case: couldn't fuse => emit fused-so-far and start new fusion candidate.
+        self.encode_fused_copy_op_if_any(Some(prev_copy), fuel_pos)?;
+        *prev = Some(new);
         Ok(())
-    }
-
-    /// Tries to fuse `prev` and `copy_op` if possible.
-    ///
-    /// # Returns
-    ///
-    /// - `Some` if `prev` and `copy_op` was successfully fused.
-    /// - `Some` if `prev` was `None` and `copy_op` could be fused.
-    /// - `None` otherwise.
-    fn try_fuse_copy_if_any(prev: Option<FusedCopy>, copy_op: Op) -> Option<FusedCopy> {
-        let new = FusedCopy::from_op(copy_op)?;
-        let Some(prev) = prev else {
-            return Some(new);
-        };
-        if let Some(fused) = prev.try_fuse(new) {
-            return Some(fused);
-        }
-        // Case: copy fusion was not applied.
-        None
     }
 
     /// Encodes `copy_op` if any as lowered (more efficient) version if possible.

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1569,15 +1569,22 @@ impl FuncTranslator {
         let fuel_pos = self.stack.fuel_pos();
         let mut params_start = self.stack.next_temp_slots();
         let mut params_len: u16 = 0;
+        let mut prev = None;
         for _ in 0..ty.len_params() {
-            let operand = self.stack.pop();
-            let slots = operand.temp_slots();
+            let param = self.stack.pop();
+            let slots = param.temp_slots();
             params_start = slots.span();
             params_len = params_len
                 .checked_add(slots.len())
                 .ok_or(TranslationError::AllocatedTooManySlots)?;
-            self.copy_operand_to_temp(operand, fuel_pos)?;
+            let result = slots.head();
+            let Some(copy_op) = Self::select_copy_sx_op(result, param, &self.layout)? else {
+                continue;
+            };
+            self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
         }
+        // The `prev` might still contain `Some` at this point, so we have to "flush" it.
+        self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
         let params = BoundedSlotSpan::new(params_start, params_len);
         for result in ty.results() {
             self.stack.push_temp(*result, Allocation::None)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -442,7 +442,7 @@ impl FusedCopy {
 }
 
 impl FuncTranslator {
-    /// Encodes `copy_or` or fuses it with `prev` if possible.
+    /// Encodes `copy_op` or fuses it with `prev` if possible.
     fn encode_copy_or_fuse_sx(
         &mut self,
         prev: &mut Option<FusedCopy>,
@@ -462,8 +462,11 @@ impl FuncTranslator {
 
     /// Tries to fuse `prev` and `copy_op` if possible.
     ///
-    /// Returns `Some` if `prev` and `copy_op` was successfully fused.
-    /// Returns `None` otherwise.
+    /// # Returns
+    /// 
+    /// - `Some` if `prev` and `copy_op` was successfully fused.
+    /// - `Some` if `prev` was `None` and `copy_op` could be fused.
+    /// - `None` otherwise.
     fn try_fuse_copy_if_any(prev: Option<FusedCopy>, copy_op: Op) -> Option<FusedCopy> {
         let (new_results, new_values, new_len) = match copy_op {
             Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
@@ -517,7 +520,7 @@ impl FuncTranslator {
         None
     }
 
-    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
+    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in descending slot-order.
     ///
     /// Otherwise returns `None`.
     fn try_fuse_copy_des(
@@ -530,7 +533,7 @@ impl FuncTranslator {
         let can_fuse_des = new_results.head() == prev.results.head().prev_n(new_len)
             && new_values.head() == prev.values.head().prev_n(new_len);
         if can_fuse_des {
-            // Case: copy fusion in ascending slot order can be applied.
+            // Case: copy fusion in descending slot order can be applied.
             return Some(FusedCopy::new(new_results, new_values, prev.len + new_len));
         }
         None

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -751,7 +751,7 @@ impl FuncTranslator {
         Ok(result)
     }
 
-    /// Copies the top `n` operands on the stack to their respective stack slots.
+    /// Copies the top `len` operands on the stack to their respective stack slots.
     ///
     /// Returns a [`BoundedSlotSpan`] of the stack slots holding the copy results.
     fn copy_operands_to_temp(
@@ -759,27 +759,39 @@ impl FuncTranslator {
         len: u16,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<BoundedSlotSpan, Error> {
+        if len == 0 {
+            return Ok(BoundedSlotSpan::new(self.stack.next_temp_slots(), 0));
+        }
+        let dst = self.stack.peek(usize::from(len) - 1).temp_slots().span();
+        self.copy_operands_to_dst(dst, len, fuel_pos)
+    }
+
+    /// Copies the top `len` operands on the stack to to `dst` slot span.
+    ///
+    /// Returns the `dst` slot span extended with the number of copied cells.
+    fn copy_operands_to_dst(
+        &mut self,
+        dst: SlotSpan,
+        len: u16,
+        fuel_pos: Option<Pos<ir::BlockFuel>>,
+    ) -> Result<BoundedSlotSpan, Error> {
         let len = usize::from(len);
-        let start = match len {
-            0 => self.stack.next_temp_slots(),
-            n => self.stack.peek(n - 1).temp_slots().span(),
-        };
         let mut len_cells: u16 = 0;
         let mut prev = None;
         for depth in (0..len).rev() {
-            let param = self.stack.peek(depth);
-            let temp_slots = param.temp_slots();
-            len_cells = len_cells
-                .checked_add(temp_slots.len())
-                .ok_or(TranslationError::AllocatedTooManySlots)?;
-            let result = temp_slots.head();
-            if let Some(copy_op) = Self::select_copy_sx_op(result, param, &self.layout)? {
+            let value = self.stack.peek(depth);
+            let result = dst.head().next_n(len_cells);
+            if let Some(copy_op) = Self::select_copy_sx_op(result, value, &self.layout)? {
                 self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
             };
+            let copied_cells = required_cells_for_ty(value.ty());
+            len_cells = len_cells
+                .checked_add(copied_cells)
+                .ok_or(TranslationError::AllocatedTooManySlots)?;
         }
         // The `prev` might still contain `Some` at this point, so we have to "flush" it.
         self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
-        Ok(BoundedSlotSpan::new(start, len_cells))
+        Ok(BoundedSlotSpan::new(dst, len_cells))
     }
 
     /// Copies the `operand` to its temporary [`Slot`] if it is an immediate.

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -431,6 +431,15 @@ struct FusedCopy {
 }
 
 impl FusedCopy {
+    /// Creates a new [`FusedCopy`] from its raw parts.
+    fn new(results: SlotSpan, values: SlotSpan, len: u16) -> Self {
+        Self {
+            results,
+            values,
+            len,
+        }
+    }
+
     /// Returns `Some` if `op` is a copy [`Op`] that can be fused.
     ///
     /// Otherwise returns `None`.
@@ -508,15 +517,6 @@ impl FusedCopy {
             2 => Op::v128_copy_ss(results.head(), values.head()),
             _ if results < values => Op::copy_span_asc(results, values, len),
             _ => Op::copy_span_des(results, values, len),
-        }
-    }
-
-    /// Creates a new [`FusedCopy`] from its raw parts.
-    pub fn new(results: SlotSpan, values: SlotSpan, len: u16) -> Self {
-        Self {
-            results,
-            values,
-            len,
         }
     }
 }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -419,7 +419,7 @@ impl FuncTranslator {
     }
 }
 
-/// A memorized fused copy [`Op`] used by [`FuncTranslator::encode_copy_or_fuse_sx`].
+/// Represents fused copy [`Op`] used by [`FuncTranslator::encode_copy_or_fuse_sx`].
 #[derive(Copy, Clone)]
 struct FusedCopy {
     /// The result slots of the fused copy [`Op`].
@@ -463,7 +463,7 @@ impl FusedCopy {
         Some(Self::new(results, values, len))
     }
 
-    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused.
+    /// Returns `Some` if `self` and the `new` copy-span [`Op`] can be fused.
     ///
     /// Otherwise returns `None`.
     pub fn try_fuse(self, new: Self) -> Option<Self> {
@@ -476,7 +476,7 @@ impl FusedCopy {
         None
     }
 
-    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
+    /// Returns `Some` if `self` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
     ///
     /// Otherwise returns `None`.
     fn try_fuse_copy_asc(self, new: Self) -> Option<Self> {
@@ -489,7 +489,7 @@ impl FusedCopy {
         None
     }
 
-    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in descending slot-order.
+    /// Returns `Some` if `self` and the `new` copy-span [`Op`] can be fused in descending slot-order.
     ///
     /// Otherwise returns `None`.
     fn try_fuse_copy_des(self, new: Self) -> Option<Self> {
@@ -504,7 +504,7 @@ impl FusedCopy {
 
     /// Lowers `self` back into an [`Op`] for encoding.
     ///
-    /// This returns the an most efficient [`Op`] that preserve copy semantics.
+    /// This returns the an most efficient [`Op`] that preserves copy semantics.
     pub fn into_op(self) -> Op {
         let Self {
             results,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -401,11 +401,35 @@ impl FuncTranslator {
         self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
         Ok(())
     }
+}
 
+/// A memorized fused copy [`Op`] used by [`FuncTranslator::encode_copy_or_fuse_sx`].
+#[derive(Copy, Clone)]
+struct FusedCopy {
+    /// The result slots of the fused copy [`Op`].
+    pub results: SlotSpan,
+    /// The value slots of the fused copy [`Op`].
+    pub values: SlotSpan,
+    /// The number of copied slots of the fused copy [`Op`].
+    pub len: u16,
+}
+
+impl FusedCopy {
+    /// Creates a new [`FusedCopy`] from its raw parts.
+    pub fn new(results: SlotSpan, values: SlotSpan, len: u16) -> Self {
+        Self {
+            results,
+            values,
+            len,
+        }
+    }
+}
+
+impl FuncTranslator {
     /// Encodes `copy_or` or fuses it with `prev` if possible.
     fn encode_copy_or_fuse_sx(
         &mut self,
-        prev: &mut Option<Op>,
+        prev: &mut Option<FusedCopy>,
         copy_op: Op,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
@@ -424,7 +448,7 @@ impl FuncTranslator {
     ///
     /// Returns `Some` if `prev` and `copy_op` was successfully fused.
     /// Returns `None` otherwise.
-    fn try_fuse_copy_if_any(prev: Option<Op>, copy_op: Op) -> Option<Op> {
+    fn try_fuse_copy_if_any(prev: Option<FusedCopy>, copy_op: Op) -> Option<FusedCopy> {
         let (new_results, new_values, new_len) = match copy_op {
             Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
             #[cfg(feature = "simd")]
@@ -442,7 +466,7 @@ impl FuncTranslator {
             _ => return None,
         };
         if prev.is_none() {
-            return Some(Op::copy_span_asc(new_results, new_values, new_len));
+            return Some(FusedCopy::new(new_results, new_values, new_len));
         }
         if let Some(fused) = Self::try_fuse_copy_asc(prev, new_results, new_values, new_len) {
             return Some(fused);
@@ -458,28 +482,21 @@ impl FuncTranslator {
     ///
     /// Otherwise returns `None`.
     fn try_fuse_copy_asc(
-        prev: Option<Op>,
+        prev: Option<FusedCopy>,
         new_results: SlotSpan,
         new_values: SlotSpan,
         new_len: u16,
-    ) -> Option<Op> {
-        let Op::CopySpanAsc {
-            results,
-            values,
-            len,
-        } = prev?
-        else {
-            return None;
-        };
-        let can_fuse_asc = new_results.head() == results.head().next_n(len)
-            && new_values.head() == values.head().next_n(len);
+    ) -> Option<FusedCopy> {
+        let prev = prev?;
+        let can_fuse_asc = new_results.head() == prev.results.head().next_n(prev.len)
+            && new_values.head() == prev.values.head().next_n(prev.len);
         if can_fuse_asc {
             // Case: copy fusion in ascending slot order can be applied.
-            return Some(Op::CopySpanAsc {
-                results,
-                values,
-                len: len + new_len,
-            });
+            return Some(FusedCopy::new(
+                prev.results,
+                prev.values,
+                prev.len + new_len,
+            ));
         }
         None
     }
@@ -488,28 +505,17 @@ impl FuncTranslator {
     ///
     /// Otherwise returns `None`.
     fn try_fuse_copy_des(
-        prev: Option<Op>,
+        prev: Option<FusedCopy>,
         new_results: SlotSpan,
         new_values: SlotSpan,
         new_len: u16,
-    ) -> Option<Op> {
-        let Op::CopySpanAsc {
-            results,
-            values,
-            len,
-        } = prev?
-        else {
-            return None;
-        };
-        let can_fuse_des = new_results.head() == results.head().prev_n(new_len)
-            && new_values.head() == values.head().prev_n(new_len);
+    ) -> Option<FusedCopy> {
+        let prev = prev?;
+        let can_fuse_des = new_results.head() == prev.results.head().prev_n(new_len)
+            && new_values.head() == prev.values.head().prev_n(new_len);
         if can_fuse_des {
             // Case: copy fusion in ascending slot order can be applied.
-            return Some(Op::CopySpanAsc {
-                results: new_results,
-                values: new_values,
-                len: len + new_len,
-            });
+            return Some(FusedCopy::new(new_results, new_values, prev.len + new_len));
         }
         None
     }
@@ -517,30 +523,23 @@ impl FuncTranslator {
     /// Encodes `copy_op` if any as lowered (more efficient) version if possible.
     fn encode_fused_copy_op_if_any(
         &mut self,
-        copy_op: Option<Op>,
+        fused_copy: Option<FusedCopy>,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        let Some(copy_op) = copy_op else {
+        let Some(fused_copy) = fused_copy else {
             return Ok(());
         };
-        // Note: we only care about `CopySpanAsc` and not `CopySpanDes` because during fusion
-        //       we only ever memorize `CopySpanAsc` since we can easily restore slot order here.
-        let copy_op = 'op: {
-            let Op::CopySpanAsc {
-                results,
-                values,
-                len,
-            } = copy_op
-            else {
-                break 'op copy_op;
-            };
-            match len {
-                1 => Op::u64_copy_ss(results.head(), values.head()),
-                #[cfg(feature = "simd")]
-                2 => Op::v128_copy_ss(results.head(), values.head()),
-                _ if results < values => Op::copy_span_asc(results, values, len),
-                _ => Op::copy_span_des(results, values, len),
-            }
+        let FusedCopy {
+            results,
+            values,
+            len,
+        } = fused_copy;
+        let copy_op = match len {
+            1 => Op::u64_copy_ss(results.head(), values.head()),
+            #[cfg(feature = "simd")]
+            2 => Op::v128_copy_ss(results.head(), values.head()),
+            _ if results < values => Op::copy_span_asc(results, values, len),
+            _ => Op::copy_span_des(results, values, len),
         };
         self.instrs
             .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1586,30 +1586,7 @@ impl FuncTranslator {
         let fuel_pos = self.stack.fuel_pos();
         self.preserve_regs(fuel_pos)?;
         let fuel_pos = self.stack.fuel_pos();
-        let params_start = match ty.len_params() {
-            0 => self.stack.next_temp_slots(),
-            n => {
-                let first_param = self.stack.peek(usize::from(n) - 1);
-                first_param.temp_slots().span()
-            }
-        };
-        let mut params_len: u16 = 0;
-        let mut prev = None;
-        for depth in (0..ty.len_params()).rev() {
-            let param = self.stack.peek(depth.into());
-            let temp_slots = param.temp_slots();
-            params_len = params_len
-                .checked_add(temp_slots.len())
-                .ok_or(TranslationError::AllocatedTooManySlots)?;
-            let result = temp_slots.head();
-            let Some(copy_op) = Self::select_copy_sx_op(result, param, &self.layout)? else {
-                continue;
-            };
-            self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
-        }
-        // The `prev` might still contain `Some` at this point, so we have to "flush" it.
-        self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
-        let params = BoundedSlotSpan::new(params_start, params_len);
+        let params = self.copy_operands_to_temp(ty.len_params(), fuel_pos)?;
         for _ in 0..ty.len_params() {
             self.stack.pop();
         }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1167,11 +1167,7 @@ impl FuncTranslator {
     ) -> Result<Op, Error> {
         debug_assert!(len > 1);
         let span = self.copy_operands_to_temp(len, fuel_pos)?;
-        let op = match u16::from(span.head()) {
-            0 => Op::Return {},
-            _ => Op::return_span(span),
-        };
-        Ok(op)
+        Ok(Self::make_return_span(span))
     }
 
     /// Translates the end of a Wasm `block` control frame.

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -763,23 +763,23 @@ impl FuncTranslator {
             return Ok(BoundedSlotSpan::new(self.stack.next_temp_slots(), 0));
         }
         let dst = self.stack.peek(usize::from(len) - 1).temp_slots().span();
-        self.copy_operands_to_dst(dst, len, fuel_pos)
+        self.copy_operands_to_dst(dst, len, 0, fuel_pos)
     }
 
-    /// Copies the top `len` operands on the stack to to `dst` slot span.
+    /// Skips the top `skip` operands and copies the remaining top `len` operands to `dst`.
     ///
-    /// Returns the `dst` slot span extended with the number of copied cells.
+    /// Returns `dst` extended with information about the number of copied cells.
     fn copy_operands_to_dst(
         &mut self,
         dst: SlotSpan,
         len: u16,
+        skip: u16,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<BoundedSlotSpan, Error> {
-        let len = usize::from(len);
         let mut len_cells: u16 = 0;
         let mut prev = None;
-        for depth in (0..len).rev() {
-            let value = self.stack.peek(depth);
+        for depth in (skip..len + skip).rev() {
+            let value = self.stack.peek(depth.into());
             let result = dst.head().next_n(len_cells);
             if let Some(copy_op) = Self::select_copy_sx_op(result, value, &self.layout)? {
                 self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -423,11 +423,11 @@ impl FuncTranslator {
 #[derive(Copy, Clone)]
 struct FusedCopy {
     /// The result slots of the fused copy [`Op`].
-    pub results: SlotSpan,
+    results: SlotSpan,
     /// The value slots of the fused copy [`Op`].
-    pub values: SlotSpan,
+    values: SlotSpan,
     /// The number of copied slots of the fused copy [`Op`].
-    pub len: u16,
+    len: u16,
 }
 
 impl FusedCopy {

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -388,13 +388,107 @@ impl FuncTranslator {
         let mut result = params.temp_slots().head();
         let start = params.len();
         let end = params.len_regs();
+        let mut prev = None;
         for depth in (end..start).rev() {
             let value = self.stack.peek(depth.into());
             let ty = value.ty();
-            self.encode_copy_sx_op(result, value, fuel_pos)?;
-            // TODO: enhance with copy op-fusion and support for `copy_span_{asc,des}`.
+            let copy_if_not_noop = Self::select_copy_sx_op(result, value, &self.layout)?;
             result = result.next_n(required_cells_for_ty(ty));
+            let Some(copy_op) = copy_if_not_noop else {
+                // Case: no-op copy instruction
+                continue;
+            };
+            let (new_prev, copy_op) = Self::copy_branch_params_temps_fuse(prev.take(), copy_op);
+            prev = new_prev;
+            self.copy_branch_params_temps_lower(copy_op, fuel_pos)?;
         }
+        // The `prev` might still contain `Some` at this point, so we have to "flush" it.
+        self.copy_branch_params_temps_lower(prev.take(), fuel_pos)?;
+        Ok(())
+    }
+
+    /// Tries to fuse `prev` and `copy_op` if possible.
+    ///
+    /// Returns a pair of [`Option<Op>`]:
+    ///
+    /// - The first item represents the new `prev` after this operation.
+    /// - The second item represents the [`Op`] to be encoded if any.
+    fn copy_branch_params_temps_fuse(prev: Option<Op>, copy_op: Op) -> (Option<Op>, Option<Op>) {
+        let Op::U64Copy_Ss { result, value } = copy_op else {
+            // Case: only `u64_copy_ss` is fusable, so just return.
+            return (Some(copy_op), prev);
+        };
+        let Some(prev) = prev else {
+            // Case: no previous copy for op-code fusion.
+            return (Some(copy_op), None);
+        };
+        match prev {
+            Op::U64Copy_Ss {
+                result: prev_result,
+                value: prev_value,
+            } => {
+                let can_fuse = result == prev_result.next() && value == prev_value.next();
+                if can_fuse {
+                    let results = SlotSpan::new(prev_result);
+                    let values = SlotSpan::new(prev_value);
+                    let copy_span_op = match result < value {
+                        true => Op::copy_span_asc,
+                        false => Op::copy_span_des,
+                    };
+                    let prev = Some(copy_span_op(results, values, 2));
+                    return (prev, None);
+                }
+            }
+            Op::CopySpanAsc {
+                results,
+                values,
+                len,
+            } => {
+                let can_fuse =
+                    result == results.head().next_n(len) && value == values.head().next_n(len);
+                if can_fuse {
+                    let prev = Some(Op::CopySpanAsc {
+                        results,
+                        values,
+                        len: len + 1,
+                    });
+                    return (prev, None);
+                }
+            }
+            _ => {}
+        };
+        (Some(copy_op), Some(prev))
+    }
+
+    /// Encodes `copy_op` if any as lowered (more efficient) version if possible.
+    fn copy_branch_params_temps_lower(
+        &mut self,
+        copy_op: Option<Op>,
+        fuel_pos: Option<Pos<ir::BlockFuel>>,
+    ) -> Result<(), Error> {
+        let Some(copy_op) = copy_op else {
+            return Ok(());
+        };
+        let lowered_op = match copy_op {
+            Op::CopySpanAsc {
+                results,
+                values,
+                len: 2,
+            }
+            | Op::CopySpanDes {
+                results,
+                values,
+                len: 2,
+            } => {
+                // Note: `copy_span_asc` with `len = 2` is equivalent to `v128_copy_ss` but less efficient.`
+                let result = results.head();
+                let value = values.head();
+                Op::v128_copy_ss(result, value)
+            }
+            op => op,
+        };
+        self.instrs
+            .encode_op(lowered_op, fuel_pos, FuelCostsProvider::base)?;
         Ok(())
     }
 

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -483,39 +483,25 @@ impl FuncTranslator {
         };
         // Note: we only care about `CopySpanAsc` and not `CopySpanDes` because during fusion
         //       we only ever memorize `CopySpanAsc` since we can easily restore slot order here.
-        let lowered_op = match copy_op {
-            Op::CopySpanAsc {
-                results,
-                values,
-                len: 1,
-            } => {
-                let result = results.head();
-                let value = values.head();
-                Op::u64_copy_ss(result, value)
-            }
-            #[cfg(feature = "simd")]
-            Op::CopySpanAsc {
-                results,
-                values,
-                len: 2,
-            } => {
-                // Note: `copy_span_asc` with `len = 2` is equivalent to `v128_copy_ss` but less efficient.
-                let result = results.head();
-                let value = values.head();
-                Op::v128_copy_ss(result, value)
-            }
-            Op::CopySpanAsc {
+        let copy_op = 'op: {
+            let Op::CopySpanAsc {
                 results,
                 values,
                 len,
-            } => match results < values {
-                true => Op::copy_span_asc(results, values, len),
-                false => Op::copy_span_des(results, values, len),
-            },
-            op => op,
+            } = copy_op
+            else {
+                break 'op copy_op;
+            };
+            match len {
+                1 => Op::u64_copy_ss(results.head(), values.head()),
+                #[cfg(feature = "simd")]
+                2 => Op::v128_copy_ss(results.head(), values.head()),
+                _ if results < values => Op::copy_span_asc(results, values, len),
+                _ => Op::copy_span_des(results, values, len),
+            }
         };
         self.instrs
-            .encode_op(lowered_op, fuel_pos, FuelCostsProvider::base)?;
+            .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;
         Ok(())
     }
 

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -431,6 +431,88 @@ struct FusedCopy {
 }
 
 impl FusedCopy {
+    /// Returns `Some` if `op` is a copy [`Op`] that can be fused.
+    ///
+    /// Otherwise returns `None`.
+    pub fn from_op(op: Op) -> Option<Self> {
+        let (results, values, len) = match op {
+            Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
+            #[cfg(feature = "simd")]
+            Op::V128Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 2),
+            Op::CopySpanAsc {
+                results,
+                values,
+                len,
+            }
+            | Op::CopySpanDes {
+                results,
+                values,
+                len,
+            } => (results, values, len),
+            _ => return None,
+        };
+        Some(Self::new(results, values, len))
+    }
+
+    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused.
+    ///
+    /// Otherwise returns `None`.
+    pub fn try_fuse(self, new: Self) -> Option<Self> {
+        if let Some(fused) = self.try_fuse_copy_asc(new) {
+            return Some(fused);
+        }
+        if let Some(fused) = self.try_fuse_copy_des(new) {
+            return Some(fused);
+        }
+        None
+    }
+
+    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
+    ///
+    /// Otherwise returns `None`.
+    fn try_fuse_copy_asc(self, new: Self) -> Option<Self> {
+        let can_fuse = new.results.head() == self.results.head().next_n(self.len)
+            && new.values.head() == self.values.head().next_n(self.len);
+        if can_fuse {
+            // Case: copy fusion in ascending slot order can be applied.
+            return Some(Self::new(self.results, self.values, self.len + new.len));
+        }
+        None
+    }
+
+    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in descending slot-order.
+    ///
+    /// Otherwise returns `None`.
+    fn try_fuse_copy_des(self, new: Self) -> Option<Self> {
+        let can_fuse = new.results.head() == self.results.head().prev_n(new.len)
+            && new.values.head() == self.values.head().prev_n(new.len);
+        if can_fuse {
+            // Case: copy fusion in descending slot order can be applied.
+            return Some(Self::new(new.results, new.values, self.len + new.len));
+        }
+        None
+    }
+
+    /// Lowers `self` back into an [`Op`] for encoding.
+    ///
+    /// This returns the an most efficient [`Op`] that preserve copy semantics.
+    pub fn into_op(self) -> Op {
+        let Self {
+            results,
+            values,
+            len,
+        } = self;
+        match len {
+            1 => Op::u64_copy_ss(results.head(), values.head()),
+            #[cfg(feature = "simd")]
+            2 => Op::v128_copy_ss(results.head(), values.head()),
+            _ if results < values => Op::copy_span_asc(results, values, len),
+            _ => Op::copy_span_des(results, values, len),
+        }
+    }
+}
+
+impl FusedCopy {
     /// Creates a new [`FusedCopy`] from its raw parts.
     pub fn new(results: SlotSpan, values: SlotSpan, len: u16) -> Self {
         Self {
@@ -468,68 +550,15 @@ impl FuncTranslator {
     /// - `Some` if `prev` was `None` and `copy_op` could be fused.
     /// - `None` otherwise.
     fn try_fuse_copy_if_any(prev: Option<FusedCopy>, copy_op: Op) -> Option<FusedCopy> {
-        let (new_results, new_values, new_len) = match copy_op {
-            Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
-            #[cfg(feature = "simd")]
-            Op::V128Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 2),
-            Op::CopySpanAsc {
-                results,
-                values,
-                len,
-            }
-            | Op::CopySpanDes {
-                results,
-                values,
-                len,
-            } => (results, values, len),
-            _ => return None,
-        };
+        let new = FusedCopy::from_op(copy_op)?;
         let Some(prev) = prev else {
-            return Some(FusedCopy::new(new_results, new_values, new_len));
+            // return Some(FusedCopy::new(new_results, new_values, new_len));
+            return Some(new);
         };
-        if let Some(fused) = Self::try_fuse_copy_asc(prev, new_results, new_values, new_len) {
-            return Some(fused);
-        }
-        if let Some(fused) = Self::try_fuse_copy_des(prev, new_results, new_values, new_len) {
+        if let Some(fused) = prev.try_fuse(new) {
             return Some(fused);
         }
         // Case: copy fusion was not applied.
-        None
-    }
-
-    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in ascending slot-order.
-    ///
-    /// Otherwise returns `None`.
-    fn try_fuse_copy_asc(
-        prev: FusedCopy,
-        results: SlotSpan,
-        values: SlotSpan,
-        len: u16,
-    ) -> Option<FusedCopy> {
-        let can_fuse = results.head() == prev.results.head().next_n(prev.len)
-            && values.head() == prev.values.head().next_n(prev.len);
-        if can_fuse {
-            // Case: copy fusion in ascending slot order can be applied.
-            return Some(FusedCopy::new(prev.results, prev.values, prev.len + len));
-        }
-        None
-    }
-
-    /// Returns `Some` if `prev` and the `new` copy-span [`Op`] can be fused in descending slot-order.
-    ///
-    /// Otherwise returns `None`.
-    fn try_fuse_copy_des(
-        prev: FusedCopy,
-        results: SlotSpan,
-        values: SlotSpan,
-        len: u16,
-    ) -> Option<FusedCopy> {
-        let can_fuse = results.head() == prev.results.head().prev_n(len)
-            && values.head() == prev.values.head().prev_n(len);
-        if can_fuse {
-            // Case: copy fusion in descending slot order can be applied.
-            return Some(FusedCopy::new(results, values, prev.len + len));
-        }
         None
     }
 
@@ -539,20 +568,8 @@ impl FuncTranslator {
         fused_copy: Option<FusedCopy>,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        let Some(fused_copy) = fused_copy else {
+        let Some(copy_op) = fused_copy.map(FusedCopy::into_op) else {
             return Ok(());
-        };
-        let FusedCopy {
-            results,
-            values,
-            len,
-        } = fused_copy;
-        let copy_op = match len {
-            1 => Op::u64_copy_ss(results.head(), values.head()),
-            #[cfg(feature = "simd")]
-            2 => Op::v128_copy_ss(results.head(), values.head()),
-            _ if results < values => Op::copy_span_asc(results, values, len),
-            _ => Op::copy_span_des(results, values, len),
         };
         self.instrs
             .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -398,12 +398,23 @@ impl FuncTranslator {
                 // Case: no-op copy instruction
                 continue;
             };
-            let (new_prev, copy_op) = Self::copy_branch_params_temps_fuse(prev.take(), copy_op);
-            prev = new_prev;
-            self.copy_branch_params_temps_lower(copy_op, fuel_pos)?;
+            self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
         }
         // The `prev` might still contain `Some` at this point, so we have to "flush" it.
-        self.copy_branch_params_temps_lower(prev.take(), fuel_pos)?;
+        self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
+        Ok(())
+    }
+
+    /// Encodes `copy_or` or fuses it with `prev` if possible.
+    fn encode_copy_or_fuse_sx(
+        &mut self,
+        prev: &mut Option<Op>,
+        copy_op: Op,
+        fuel_pos: Option<Pos<ir::BlockFuel>>,
+    ) -> Result<(), Error> {
+        let (new_prev, copy_op) = Self::copy_branch_params_temps_fuse(prev.take(), copy_op);
+        *prev = new_prev;
+        self.encode_fused_copy_op_if_any(copy_op, fuel_pos)?;
         Ok(())
     }
 
@@ -473,7 +484,7 @@ impl FuncTranslator {
     }
 
     /// Encodes `copy_op` if any as lowered (more efficient) version if possible.
-    fn copy_branch_params_temps_lower(
+    fn encode_fused_copy_op_if_any(
         &mut self,
         copy_op: Option<Op>,
         fuel_pos: Option<Pos<ir::BlockFuel>>,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -333,32 +333,6 @@ impl FuncTranslator {
         &self.engine
     }
 
-    /// Copy the top-most `len` operands to [`Operand::Temp`] values.
-    ///
-    /// Returns a [`SlotSpan`] to the copied operands.
-    ///
-    /// # Note
-    ///
-    /// - The top-most `len` operands on the [`Stack`] will be [`Operand::Temp`] upon completion.
-    /// - Does nothing if an [`Operand`] is already an [`Operand::Temp`].
-    fn move_operands_to_temp(
-        &mut self,
-        len: usize,
-        fuel_pos: Option<Pos<ir::BlockFuel>>,
-    ) -> Result<BoundedSlotSpan, Error> {
-        debug_assert!(len > 0);
-        let mut copied_cells: u16 = 0;
-        for n in 0..len {
-            let operand = self.stack.operand_to_temp(n);
-            copied_cells = copied_cells
-                .checked_add(operand.temp_slots().len())
-                .ok_or(TranslationError::SlotAccessOutOfBounds)?;
-            self.copy_operand_to_temp(operand, fuel_pos)?;
-        }
-        let first = self.stack.peek(len - 1).temp_slots().head();
-        Ok(BoundedSlotSpan::new(SlotSpan::new(first), copied_cells))
-    }
-
     /// Emits copy operators to copy all operands to satisfy the [`BranchParams`].
     ///
     /// # Note
@@ -1097,23 +1071,19 @@ impl FuncTranslator {
     /// Encodes a generic return operator.
     fn encode_return(&mut self, fuel_pos: Option<Pos<ir::BlockFuel>>) -> Result<Pos<Op>, Error> {
         let len_results = self.func_type_with(FuncType::len_results);
-        let instr = match len_results {
+        let op = match len_results {
             0 => Op::Return {},
-            1 => self.encode_return_value(fuel_pos)?,
-            _ => {
-                let len_results = usize::from(len_results);
-                let results = self.move_operands_to_temp(len_results, fuel_pos)?;
-                Self::make_return_span(results)
-            }
+            1 => self.prepare_return_1_op(fuel_pos)?,
+            n => self.prepare_return_n_op(n.into(), fuel_pos)?,
         };
-        let instr = self
+        let pos = self
             .instrs
-            .encode_op(instr, fuel_pos, FuelCostsProvider::base)?;
-        Ok(instr)
+            .encode_op(op, fuel_pos, FuelCostsProvider::base)?;
+        Ok(pos)
     }
 
-    /// Encodes a return operator that returns a single value.
-    fn encode_return_value(&mut self, fuel_pos: Option<Pos<ir::BlockFuel>>) -> Result<Op, Error> {
+    /// Prepares to encode a return operator returning a single value.
+    fn prepare_return_1_op(&mut self, fuel_pos: Option<Pos<ir::BlockFuel>>) -> Result<Op, Error> {
         let return_slot_for_ty = |ty: ValType, slot: Slot| match ty {
             ValType::V128 => {
                 let returned = BoundedSlotSpan::new(SlotSpan::new(slot), 2);
@@ -1151,6 +1121,45 @@ impl FuncTranslator {
                     Self::make_return_span(returned)
                 }
             },
+        };
+        Ok(op)
+    }
+
+    /// Prepares to encode a return operator returning `n` (`n > 1`) values.
+    ///
+    /// This will attemp to copy the `n` values on top of the stack to the
+    /// stack slots required for returning to teh caller.
+    fn prepare_return_n_op(
+        &mut self,
+        len: usize,
+        fuel_pos: Option<Pos<ir::BlockFuel>>,
+    ) -> Result<Op, Error> {
+        let start = match len {
+            0 => self.stack.next_temp_slots(),
+            n => self.stack.peek(n - 1).temp_slots().span(),
+        };
+        let mut len_cells: u16 = 0;
+        let mut prev = None;
+        for depth in (0..len).rev() {
+            let param = self.stack.peek(depth);
+            let temp_slots = param.temp_slots();
+            len_cells = len_cells
+                .checked_add(temp_slots.len())
+                .ok_or(TranslationError::AllocatedTooManySlots)?;
+            let result = temp_slots.head();
+            let Some(copy_op) = Self::select_copy_sx_op(result, param, &self.layout)? else {
+                continue;
+            };
+            self.encode_copy_or_fuse_sx(&mut prev, copy_op, fuel_pos)?;
+        }
+        // The `prev` might still contain `Some` at this point, so we have to "flush" it.
+        self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
+        let op = match u16::from(start.head()) {
+            0 => Op::Return {},
+            _ => {
+                let span = BoundedSlotSpan::new(start, len_cells);
+                Op::return_span(span)
+            }
         };
         Ok(op)
     }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -414,7 +414,7 @@ impl FuncTranslator {
     /// - The first item represents the new `prev` after this operation.
     /// - The second item represents the [`Op`] to be encoded if any.
     fn copy_branch_params_temps_fuse(prev: Option<Op>, copy_op: Op) -> (Option<Op>, Option<Op>) {
-        let (results, values, len) = match copy_op {
+        let (new_results, new_values, new_len) = match copy_op {
             Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
             #[cfg(feature = "simd")]
             Op::V128Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 2),
@@ -430,38 +430,22 @@ impl FuncTranslator {
             } => (results, values, len),
             _ => return (Some(copy_op), prev),
         };
-        match results < values {
-            true => Self::copy_branch_params_temps_fuse_asc(prev, results, values, len),
-            false => Self::copy_branch_params_temps_fuse_des(prev, results, values, len),
-        }
-    }
-
-    /// Tries to fuse `prev` and `copy_op` in ascending slot order if possible.
-    ///
-    /// Returns a pair of [`Option<Op>`]:
-    ///
-    /// - The first item represents the new `prev` after this operation.
-    /// - The second item represents the [`Op`] to be encoded if any.
-    fn copy_branch_params_temps_fuse_asc(
-        prev: Option<Op>,
-        new_results: SlotSpan,
-        new_values: SlotSpan,
-        new_len: u16,
-    ) -> (Option<Op>, Option<Op>) {
         let copy_span = Op::copy_span_asc(new_results, new_values, new_len);
-        let Some(prev) = prev else {
-            // Case: no previous copy for op-code fusion.
-            return (Some(copy_span), None);
-        };
-        if let Op::CopySpanAsc {
+        let Some(Op::CopySpanAsc {
             results,
             values,
             len,
-        } = prev
+        }) = prev
+        else {
+            // Case: no fusable previous copy for op-code fusion.
+            return (Some(copy_span), None);
+        };
         {
-            let can_fuse = new_results.head() == results.head().next_n(len)
+            // Try to fuse in ascending slot order:
+            let can_fuse_asc = new_results.head() == results.head().next_n(len)
                 && new_values.head() == values.head().next_n(len);
-            if can_fuse {
+            if can_fuse_asc {
+                // Case: copy fusion in ascending slot order can be applied.
                 let prev = Some(Op::CopySpanAsc {
                     results,
                     values,
@@ -470,35 +454,12 @@ impl FuncTranslator {
                 return (prev, None);
             }
         }
-        (Some(copy_span), Some(prev))
-    }
-
-    /// Tries to fuse `prev` and `copy_op` in descending slot order if possible.
-    ///
-    /// Returns a pair of [`Option<Op>`]:
-    ///
-    /// - The first item represents the new `prev` after this operation.
-    /// - The second item represents the [`Op`] to be encoded if any.
-    fn copy_branch_params_temps_fuse_des(
-        prev: Option<Op>,
-        new_results: SlotSpan,
-        new_values: SlotSpan,
-        new_len: u16,
-    ) -> (Option<Op>, Option<Op>) {
-        let copy_span = Op::copy_span_des(new_results, new_values, new_len);
-        let Some(prev) = prev else {
-            // Case: no previous copy for op-code fusion.
-            return (Some(copy_span), None);
-        };
-        if let Op::CopySpanDes {
-            results,
-            values,
-            len,
-        } = prev
         {
-            let can_fuse = new_results.head() == results.head().prev_n(new_len)
+            // Try to fuse in ascending slot order:
+            let can_fuse_des = new_results.head() == results.head().prev_n(new_len)
                 && new_values.head() == values.head().prev_n(new_len);
-            if can_fuse {
+            if can_fuse_des {
+                // Case: copy fusion in descending slot order can be applied.
                 let prev = Some(Op::CopySpanDes {
                     results: new_results,
                     values: new_values,
@@ -507,7 +468,8 @@ impl FuncTranslator {
                 return (prev, None);
             }
         }
-        (Some(copy_span), Some(prev))
+        // Case: copy fusion was not applied.
+        (Some(copy_span), prev)
     }
 
     /// Encodes `copy_op` if any as lowered (more efficient) version if possible.
@@ -524,11 +486,6 @@ impl FuncTranslator {
                 results,
                 values,
                 len: 1,
-            }
-            | Op::CopySpanDes {
-                results,
-                values,
-                len: 1,
             } => {
                 let result = results.head();
                 let value = values.head();
@@ -539,17 +496,20 @@ impl FuncTranslator {
                 results,
                 values,
                 len: 2,
-            }
-            | Op::CopySpanDes {
-                results,
-                values,
-                len: 2,
             } => {
                 // Note: `copy_span_asc` with `len = 2` is equivalent to `v128_copy_ss` but less efficient.
                 let result = results.head();
                 let value = values.head();
                 Op::v128_copy_ss(result, value)
             }
+            Op::CopySpanAsc {
+                results,
+                values,
+                len,
+            } => match results < values {
+                true => Op::copy_span_asc(results, values, len),
+                false => Op::copy_span_des(results, values, len),
+            },
             op => op,
         };
         self.instrs

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -409,7 +409,7 @@ impl FuncTranslator {
         copy_op: Op,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<(), Error> {
-        let (new_prev, copy_op) = Self::copy_branch_params_temps_fuse(prev.take(), copy_op);
+        let (new_prev, copy_op) = Self::try_fuse_copy_if_any(prev.take(), copy_op);
         *prev = new_prev;
         self.encode_fused_copy_op_if_any(copy_op, fuel_pos)?;
         Ok(())
@@ -421,7 +421,7 @@ impl FuncTranslator {
     ///
     /// - The first item represents the new `prev` after this operation.
     /// - The second item represents the [`Op`] to be encoded if any.
-    fn copy_branch_params_temps_fuse(prev: Option<Op>, copy_op: Op) -> (Option<Op>, Option<Op>) {
+    fn try_fuse_copy_if_any(prev: Option<Op>, copy_op: Op) -> (Option<Op>, Option<Op>) {
         let (new_results, new_values, new_len) = match copy_op {
             Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
             #[cfg(feature = "simd")]

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -401,6 +401,22 @@ impl FuncTranslator {
         self.encode_fused_copy_op_if_any(prev.take(), fuel_pos)?;
         Ok(())
     }
+
+    /// Copies the branch params that are expected in their respective registers.
+    ///
+    /// Part of [`Self::copy_branch_params`].
+    fn copy_branch_params_regs(
+        &mut self,
+        params: BranchParams,
+        fuel_pos: Option<Pos<ir::BlockFuel>>,
+    ) -> Result<(), Error> {
+        for (depth, kind) in params.regs().iter().enumerate() {
+            let value = self.stack.peek(depth);
+            debug_assert!(kind.matches_ty(value.ty()));
+            self.encode_copy_rx_op(value, fuel_pos)?;
+        }
+        Ok(())
+    }
 }
 
 /// A memorized fused copy [`Op`] used by [`FuncTranslator::encode_copy_or_fuse_sx`].
@@ -543,22 +559,6 @@ impl FuncTranslator {
         };
         self.instrs
             .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;
-        Ok(())
-    }
-
-    /// Copies the branch params that are expected in their respective registers.
-    ///
-    /// Part of [`Self::copy_branch_params`].
-    fn copy_branch_params_regs(
-        &mut self,
-        params: BranchParams,
-        fuel_pos: Option<Pos<ir::BlockFuel>>,
-    ) -> Result<(), Error> {
-        for (depth, kind) in params.regs().iter().enumerate() {
-            let value = self.stack.peek(depth);
-            debug_assert!(kind.matches_ty(value.ty()));
-            self.encode_copy_rx_op(value, fuel_pos)?;
-        }
         Ok(())
     }
 

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -414,71 +414,99 @@ impl FuncTranslator {
     /// - The first item represents the new `prev` after this operation.
     /// - The second item represents the [`Op`] to be encoded if any.
     fn copy_branch_params_temps_fuse(prev: Option<Op>, copy_op: Op) -> (Option<Op>, Option<Op>) {
-        let Op::U64Copy_Ss { result, value } = copy_op else {
-            // Case: only `u64_copy_ss` is fusable, so just return.
-            return (Some(copy_op), prev);
-        };
-        let Some(prev) = prev else {
-            // Case: no previous copy for op-code fusion.
-            return (Some(copy_op), None);
-        };
-        match prev {
-            Op::U64Copy_Ss {
-                result: prev_result,
-                value: prev_value,
-            } => {
-                let can_fuse_asc =
-                    result < value && result == prev_result.next() && value == prev_value.next();
-                if can_fuse_asc {
-                    let results = SlotSpan::new(prev_result);
-                    let values = SlotSpan::new(prev_value);
-                    let prev = Some(Op::copy_span_asc(results, values, 2));
-                    return (prev, None);
-                }
-                let can_fuse_des =
-                    result > value && result == prev_result.prev() && value == prev_value.prev();
-                if can_fuse_des {
-                    let results = SlotSpan::new(result);
-                    let values = SlotSpan::new(value);
-                    let prev = Some(Op::copy_span_des(results, values, 2));
-                    return (prev, None);
-                }
-            }
+        let (results, values, len) = match copy_op {
+            Op::U64Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 1),
+            Op::V128Copy_Ss { result, value } => (SlotSpan::new(result), SlotSpan::new(value), 2),
             Op::CopySpanAsc {
                 results,
                 values,
                 len,
-            } => {
-                let can_fuse =
-                    result == results.head().next_n(len) && value == values.head().next_n(len);
-                if can_fuse {
-                    let prev = Some(Op::CopySpanAsc {
-                        results,
-                        values,
-                        len: len + 1,
-                    });
-                    return (prev, None);
-                }
             }
-            Op::CopySpanDes {
+            | Op::CopySpanDes {
                 results,
                 values,
                 len,
-            } => {
-                let can_fuse =
-                    result == results.head().prev_n(len) && value == values.head().prev_n(len);
-                if can_fuse {
-                    let prev = Some(Op::CopySpanDes {
-                        results: SlotSpan::new(result),
-                        values: SlotSpan::new(value),
-                        len: len + 1,
-                    });
-                    return (prev, None);
-                }
-            }
-            _ => {}
+            } => (results, values, len),
+            _ => return (Some(copy_op), prev),
         };
-        (Some(copy_op), Some(prev))
+        match results < values {
+            true => Self::copy_branch_params_temps_fuse_asc(prev, results, values, len),
+            false => Self::copy_branch_params_temps_fuse_des(prev, results, values, len),
+        }
+    }
+
+    /// Tries to fuse `prev` and `copy_op` in ascending slot order if possible.
+    ///
+    /// Returns a pair of [`Option<Op>`]:
+    ///
+    /// - The first item represents the new `prev` after this operation.
+    /// - The second item represents the [`Op`] to be encoded if any.
+    fn copy_branch_params_temps_fuse_asc(
+        prev: Option<Op>,
+        new_results: SlotSpan,
+        new_values: SlotSpan,
+        new_len: u16,
+    ) -> (Option<Op>, Option<Op>) {
+        let copy_span = Op::copy_span_asc(new_results, new_values, new_len);
+        let Some(prev) = prev else {
+            // Case: no previous copy for op-code fusion.
+            return (Some(copy_span), None);
+        };
+        if let Op::CopySpanAsc {
+            results,
+            values,
+            len,
+        } = prev
+        {
+            let can_fuse = results.head() == results.head().next_n(len)
+                && values.head() == values.head().next_n(len);
+            if can_fuse {
+                let prev = Some(Op::CopySpanAsc {
+                    results,
+                    values,
+                    len: len + new_len,
+                });
+                return (prev, None);
+            }
+        }
+        (Some(copy_span), Some(prev))
+    }
+
+    /// Tries to fuse `prev` and `copy_op` in descending slot order if possible.
+    ///
+    /// Returns a pair of [`Option<Op>`]:
+    ///
+    /// - The first item represents the new `prev` after this operation.
+    /// - The second item represents the [`Op`] to be encoded if any.
+    fn copy_branch_params_temps_fuse_des(
+        prev: Option<Op>,
+        new_results: SlotSpan,
+        new_values: SlotSpan,
+        new_len: u16,
+    ) -> (Option<Op>, Option<Op>) {
+        let copy_span = Op::copy_span_des(new_results, new_values, new_len);
+        let Some(prev) = prev else {
+            // Case: no previous copy for op-code fusion.
+            return (Some(copy_span), None);
+        };
+        if let Op::CopySpanDes {
+            results,
+            values,
+            len,
+        } = prev
+        {
+            let can_fuse = results.head() == results.head().prev_n(new_len)
+                && values.head() == values.head().prev_n(new_len);
+            if can_fuse {
+                let prev = Some(Op::CopySpanDes {
+                    results: new_results,
+                    values: new_values,
+                    len: len + new_len,
+                });
+                return (prev, None);
+            }
+        }
+        (Some(copy_span), Some(prev))
     }
 
     /// Encodes `copy_op` if any as lowered (more efficient) version if possible.
@@ -491,6 +519,20 @@ impl FuncTranslator {
             return Ok(());
         };
         let lowered_op = match copy_op {
+            Op::CopySpanAsc {
+                results,
+                values,
+                len: 1,
+            }
+            | Op::CopySpanDes {
+                results,
+                values,
+                len: 1,
+            } => {
+                let result = results.head();
+                let value = values.head();
+                Op::u64_copy_ss(result, value)
+            }
             #[cfg(feature = "simd")]
             Op::CopySpanAsc {
                 results,

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -682,21 +682,6 @@ impl Stack {
         self.operands.preserve_all_temp_regs(skip)
     }
 
-    /// Converts and returns the [`Operand`] at `depth` into a [`Operand::Temp`].
-    ///
-    /// # Note
-    ///
-    /// - Returns the [`Operand`] at `depth` before being converted to an [`Operand::Temp`].
-    /// - [`Operand::Temp`] will have their optional `instr` set to `None`.
-    ///
-    /// # Panics
-    ///
-    /// If `depth` is out of bounds for the [`Stack`] of operands.
-    #[must_use]
-    pub fn operand_to_temp(&mut self, depth: usize) -> Operand {
-        self.operands.operand_to_temp(depth)
-    }
-
     /// Returns the current [`Op::ConsumeFuel`] if fuel metering is enabled.
     ///
     /// Returns `None` otherwise.

--- a/crates/wasmi/src/engine/translator/func/stack/operands.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/operands.rs
@@ -598,23 +598,6 @@ impl OperandStack {
         &mut self.operands[usize::from(pos)]
     }
 
-    /// Converts and returns the [`Operand`] at `depth` into a [`Operand::Temp`].
-    ///
-    /// # Note
-    ///
-    /// - Returns the [`Operand`] at `depth` before being converted to an [`Operand::Temp`].
-    /// - [`Operand::Temp`] will have their optional `instr` set to `None`.
-    ///
-    /// # Panics
-    ///
-    /// If `depth` is out of bounds for the [`OperandStack`] of operands.
-    #[must_use]
-    pub fn operand_to_temp(&mut self, depth: usize) -> Operand {
-        let stack_pos = self.depth_to_stack_pos(depth);
-        let operand = self.operand_to_temp_at(stack_pos);
-        self.regs.wrap_operand(stack_pos, operand)
-    }
-
     /// Converts and returns the [`StackOperand`] at `index` into a [`StackOperand::Temp`].
     ///
     /// # Note


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1795

## Possible Applications

- [x] `copy_branch_params`: copies branch parameters for control flow
- [x] `adjust_stack_for_calls`: prepares operand stack for calls
- [x] `translate_return`: prepares operand stack for returns

## Impossible or Unworthy Applications

- `preserve_locals`: single-local: all copies share the same source slot
- `preserve_all_locals`: scattered locals → contiguous runs rare

## Benchmarks

Significant improvements in the `call/nested` test cases:

<img width="950" height="200" alt="image" src="https://github.com/user-attachments/assets/6bb76813-c3fa-4585-b663-9c5be55299ef" />
