### PR TITLE
Specialize `u64_copy_ss` operators

### DIFF
--- a/crates/ir/build/isa.rs
+++ b/crates/ir/build/isa.rs
@@ -606,6 +606,24 @@ fn add_copy_ops(isa: &mut Isa) {
         )),
     ];
     isa.push_ops(ops);
+    for index in 0..10 {
+        isa.push_op(UnaryOp::new(
+            Ident::Copy,
+            Ty::U64,
+            Ty::U64,
+            Opd::Local(index),
+            OperandKind::Slot,
+        ));
+    }
+    for index in 0..10 {
+        isa.push_op(UnaryOp::new(
+            Ident::Copy,
+            Ty::U64,
+            Ty::U64,
+            OperandKind::Slot,
+            Opd::Local(index),
+        ));
+    }
     for result_ty in [Ty::U64, Ty::F32, Ty::F64] {
         for index in 0..10 {
             isa.push_op(UnaryOp::new(

--- a/crates/ir/build/mod.rs
+++ b/crates/ir/build/mod.rs
@@ -77,8 +77,8 @@ pub fn generate_code(config: &Config) -> Result<(), Error> {
 
 fn generate_op_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
-        true => 480_000,
-        false => 360_000,
+        true => 485_000,
+        false => 365_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {
         write!(
@@ -99,7 +99,7 @@ fn generate_op_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(
 
 fn generate_op_code_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
-        true => 290_000,
+        true => 295_000,
         false => 230_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {
@@ -111,7 +111,7 @@ fn generate_op_code_rs(config: &Config, isa: &Isa, contents: &mut String) -> Res
 
 fn generate_encode_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
-        true => 205_000,
+        true => 210_000,
         false => 170_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {
@@ -123,7 +123,7 @@ fn generate_encode_rs(config: &Config, isa: &Isa, contents: &mut String) -> Resu
 
 fn generate_decode_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
-        true => 85_000,
+        true => 86_000,
         false => 70_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {

--- a/crates/wasmi/src/engine/executor/handler/exec.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec.rs
@@ -1375,6 +1375,28 @@ impl_branch_table_exec_handler! {
 }
 
 handler_unary! {
+    // specialized copy_sNs operators
+    fn u64_copy_s0s(U64Copy_S0s) = identity::<u64>;
+    fn u64_copy_s1s(U64Copy_S1s) = identity::<u64>;
+    fn u64_copy_s2s(U64Copy_S2s) = identity::<u64>;
+    fn u64_copy_s3s(U64Copy_S3s) = identity::<u64>;
+    fn u64_copy_s4s(U64Copy_S4s) = identity::<u64>;
+    fn u64_copy_s5s(U64Copy_S5s) = identity::<u64>;
+    fn u64_copy_s6s(U64Copy_S6s) = identity::<u64>;
+    fn u64_copy_s7s(U64Copy_S7s) = identity::<u64>;
+    fn u64_copy_s8s(U64Copy_S8s) = identity::<u64>;
+    fn u64_copy_s9s(U64Copy_S9s) = identity::<u64>;
+    // specialized copy_ssN operators
+    fn u64_copy_ss0(U64Copy_Ss0) = identity::<u64>;
+    fn u64_copy_ss1(U64Copy_Ss1) = identity::<u64>;
+    fn u64_copy_ss2(U64Copy_Ss2) = identity::<u64>;
+    fn u64_copy_ss3(U64Copy_Ss3) = identity::<u64>;
+    fn u64_copy_ss4(U64Copy_Ss4) = identity::<u64>;
+    fn u64_copy_ss5(U64Copy_Ss5) = identity::<u64>;
+    fn u64_copy_ss6(U64Copy_Ss6) = identity::<u64>;
+    fn u64_copy_ss7(U64Copy_Ss7) = identity::<u64>;
+    fn u64_copy_ss8(U64Copy_Ss8) = identity::<u64>;
+    fn u64_copy_ss9(U64Copy_Ss9) = identity::<u64>;
     // specialized copy_sNr operators
     fn u64_copy_s0r(U64Copy_S0r) = identity::<u64>;
     fn u64_copy_s1r(U64Copy_S1r) = identity::<u64>;

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -260,6 +260,15 @@ where
     }
 }
 
+impl<const N: u16, T> GetValue<T> for Local<N>
+where
+    T: LoadFromCellsByValue,
+{
+    fn get_value(_src: Self, sp: Sp, ireg: Ireg, freg32: Freg32, freg64: Freg64) -> T {
+        <Slot as GetValue<T>>::get_value(Slot::from(N), sp, ireg, freg32, freg64)
+    }
+}
+
 /// Returns the value at `sp[src]`.
 #[inline]
 pub fn get_slot_value<L>(src: Slot, sp: Sp) -> L

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -642,10 +642,55 @@ impl FuncTranslator {
         if result == value {
             return None;
         }
-        let op = match ty {
-            #[cfg(feature = "simd")]
-            ValType::V128 => Op::v128_copy_ss(result, value),
-            _ => Op::u64_copy_ss(result, value),
+        #[cfg(feature = "simd")]
+        if matches!(ty, ValType::V128) {
+            return Some(Op::v128_copy_ss(result, value));
+        }
+        if let Some(op) = Self::try_select_copy_ssn_op(result, value) {
+            return Some(op);
+        }
+        if let Some(op) = Self::try_select_copy_sns_op(result, value) {
+            return Some(op);
+        }
+        Some(Op::u64_copy_ss(result, value))
+    }
+
+    /// Returns the [`Op`] to copy `value` into `result` if `result` in `0..10`.
+    ///
+    /// Otherwise returns `None`.
+    fn try_select_copy_sns_op(result: Slot, value: Slot) -> Option<Op> {
+        let op = match u16::from(result) {
+            0 => Op::u64_copy_s0s(value),
+            1 => Op::u64_copy_s1s(value),
+            2 => Op::u64_copy_s2s(value),
+            3 => Op::u64_copy_s3s(value),
+            4 => Op::u64_copy_s4s(value),
+            5 => Op::u64_copy_s5s(value),
+            6 => Op::u64_copy_s6s(value),
+            7 => Op::u64_copy_s7s(value),
+            8 => Op::u64_copy_s8s(value),
+            9 => Op::u64_copy_s9s(value),
+            _ => return None,
+        };
+        Some(op)
+    }
+
+    /// Returns the [`Op`] to copy `value` into `result` if `value` in `0..10`.
+    ///
+    /// Otherwise returns `None`.
+    fn try_select_copy_ssn_op(result: Slot, value: Slot) -> Option<Op> {
+        let op = match u16::from(value) {
+            0 => Op::u64_copy_ss0(result),
+            1 => Op::u64_copy_ss1(result),
+            2 => Op::u64_copy_ss2(result),
+            3 => Op::u64_copy_ss3(result),
+            4 => Op::u64_copy_ss4(result),
+            5 => Op::u64_copy_ss5(result),
+            6 => Op::u64_copy_ss6(result),
+            7 => Op::u64_copy_ss7(result),
+            8 => Op::u64_copy_ss8(result),
+            9 => Op::u64_copy_ss9(result),
+            _ => return None,
         };
         Some(op)
     }


### PR DESCRIPTION
This PR resulted after this analysis: https://gist.github.com/Robbepop/ff717b3f92ba536eb45dc939f548697f

CoreMark shows slight improvemetns from ~2650 to ~2700 points.

However, this is only roughly 2% improvement.
Wasmi benchmarks show no or only 2% improvement as well.
I guess this is too narrow of a win to really justify those 20 new Wasmi IR operators.