### PR TITLE
Revert unnecessary spills

### DIFF
--- a/crates/ir/src/primitive.rs
+++ b/crates/ir/src/primitive.rs
@@ -187,6 +187,18 @@ impl BlockFuel {
             .ok_or(Error::BlockFuelOutOfBounds)?;
         Ok(())
     }
+
+    /// Reduce the fuel by `amount` if possible.
+    ///
+    /// # Errors
+    ///
+    /// If the new fuel amount after this operation would underflow.
+    pub fn reduce_by(&mut self, amount: u64) -> Result<(), Error> {
+        self.0 = u64::from(*self)
+            .checked_sub(amount)
+            .ok_or(Error::BlockFuelOutOfBounds)?;
+        Ok(())
+    }
 }
 
 /// A 64-bit memory address used for some load and store instructions.

--- a/crates/wasmi/src/engine/translator/func/encoder.rs
+++ b/crates/wasmi/src/engine/translator/func/encoder.rs
@@ -1,4 +1,4 @@
-use super::{Reset, ReusableAllocations};
+use super::{Reset, ReusableAllocations, stack::StackPos};
 use crate::{
     Engine,
     Error,
@@ -197,6 +197,38 @@ pub struct OpEncoder {
     labels: LabelRegistry,
 }
 
+/// A register spill that was emitted right before staging an [`Op`].
+///
+/// # Note
+///
+/// Staging an [`Op`] whose result occupies a register may evict a resident operand by
+/// emitting a standalone `copy_sr` spill operator. If the staged [`Op`] is later dropped
+/// (e.g. fused into a result-less branch) this spill turns out to be unnecessary and can
+/// be reverted: the `copy_sr` bytes are truncated and the spilled operand is restored into
+/// its register.
+#[derive(Debug, Copy, Clone)]
+pub struct Spill {
+    /// The position of the emitted `copy_sr` spill [`Op`] in the encoded buffer.
+    copy_pos: Pos<Op>,
+    /// The stack position of the spilled operand.
+    stack_pos: StackPos,
+}
+
+impl Spill {
+    /// Creates a new [`Spill`] from the spill `copy_pos` and the spilled operand `stack_pos`.
+    pub fn new(copy_pos: Pos<Op>, stack_pos: StackPos) -> Self {
+        Self {
+            copy_pos,
+            stack_pos,
+        }
+    }
+
+    /// Returns the stack position of the spilled operand.
+    pub fn stack_pos(&self) -> StackPos {
+        self.stack_pos
+    }
+}
+
 /// The staged [`Op`] and information about its fuel consumption.
 #[derive(Debug, Copy, Clone)]
 pub struct StagedOp {
@@ -209,19 +241,31 @@ pub struct StagedOp {
     /// - The [`Op::ConsumeFuel`] operator associated to the staged [`Op`] if any.
     /// - The fuel required by the staged [`Op`].
     fuel: Option<(Pos<BlockFuel>, FuelUsed)>,
+    /// The unnecessary spill caused by staging this [`Op`] if any.
+    spill: Option<Spill>,
 }
 
 impl StagedOp {
-    /// Creates a new [`StagedOp`] from `op` and `fuel`.
-    pub fn new(op: Op, pos: Pos<Op>, fuel: Option<(Pos<BlockFuel>, FuelUsed)>) -> Self {
-        Self { op, pos, fuel }
+    /// Creates a new [`StagedOp`] from `op`, `fuel` and the optional `spill` it caused.
+    pub fn new(
+        op: Op,
+        pos: Pos<Op>,
+        fuel: Option<(Pos<BlockFuel>, FuelUsed)>,
+        spill: Option<Spill>,
+    ) -> Self {
+        Self {
+            op,
+            pos,
+            fuel,
+            spill,
+        }
     }
 
     /// Updates the current [`Op`] of `self` with `op`.
     ///
     /// # Note
     ///
-    /// There is no need to update `pos` or `fuel` since both stay
+    /// There is no need to update `pos`, `fuel` or `spill` since all stay
     /// the same given that the staged [`Op`] is always last.
     pub fn update(&mut self, op: Op) {
         self.op = op;
@@ -339,6 +383,7 @@ impl OpEncoder {
         new_staged: Op,
         fuel_op: Option<Pos<BlockFuel>>,
         fuel_selector: impl FuelCostsSelector,
+        spill: Option<Spill>,
     ) -> Result<(), Error> {
         self.commit_staged_if_any()?;
         self.pad_to_op_alignment()?;
@@ -348,7 +393,7 @@ impl OpEncoder {
             (Some(fuel_op), Some(fuel_costs)) => Some((fuel_op, fuel_selector.select(fuel_costs))),
             _ => unreachable!(),
         };
-        self.staged = Some(StagedOp::new(new_staged, pos, fuel));
+        self.staged = Some(StagedOp::new(new_staged, pos, fuel, spill));
         Ok(())
     }
 
@@ -385,12 +430,18 @@ impl OpEncoder {
 
     /// Drops the staged [`Op`] without encoding it.
     ///
-    /// Returns the staged [`Op`]'s fuel information or `None` if fuel metering is disabled.
+    /// Returns the staged [`Op`]'s fuel information (or `None` if fuel metering is disabled)
+    /// and the [`Spill`] it caused (if any).
+    ///
+    /// # Note
+    ///
+    /// The caller may revert the returned [`Spill`] via [`OpEncoder::revert_spill`] when it
+    /// knows that the now-dropped staged [`Op`] made the spill unnecessary.
     ///
     /// # Panics
     ///
     /// If there was no staged [`Op`].
-    pub fn drop_staged(&mut self) -> (Option<Pos<BlockFuel>>, FuelUsed) {
+    pub fn drop_staged(&mut self) -> (Option<Pos<BlockFuel>>, FuelUsed, Option<Spill>) {
         let Some(staged) = self.staged.take() else {
             panic!("could not drop staged `Op` since there was none")
         };
@@ -398,7 +449,33 @@ impl OpEncoder {
         self.ops.truncate(staged.pos);
         let fuel_pos = staged.fuel.map(|(pos, _)| pos);
         let fuel_used = staged.fuel.map(|(_, used)| used).unwrap_or(0);
-        (fuel_pos, fuel_used)
+        (fuel_pos, fuel_used, staged.spill)
+    }
+
+    /// Reverts the `spill` that was caused by a now-dropped staged [`Op`].
+    ///
+    /// # Note
+    ///
+    /// - Truncates the encoded `copy_sr` spill operator from the buffer.
+    /// - Reverses the fuel consumption that was bumped for the `copy_sr` spill operator.
+    ///
+    /// The caller is responsible for restoring the spilled operand into its register
+    /// (e.g. via `Stack::restore_reg_temp`).
+    ///
+    /// # Panics (Debug)
+    ///
+    /// If there currently is a staged [`Op`].
+    pub fn revert_spill(
+        &mut self,
+        spill: Spill,
+        fuel_pos: Option<Pos<BlockFuel>>,
+    ) -> Result<(), Error> {
+        debug_assert!(self.staged.is_none());
+        // The `copy_sr` spill was emitted via `encode_op` which already bumped its base
+        // fuel costs, hence we have to reverse that here before truncating the operator.
+        self.reduce_fuel_consumption(fuel_pos, FuelCostsProvider::base)?;
+        self.ops.truncate(spill.copy_pos);
+        Ok(())
     }
 
     /// Replaces the staged [`Op`] with `new_staged`.
@@ -568,6 +645,55 @@ impl OpEncoder {
         self.ops
             .update_encoded(fuel_pos, |mut fuel| -> Option<BlockFuel> {
                 fuel.bump_by(delta).ok()?;
+                Some(fuel)
+            });
+        Ok(())
+    }
+
+    /// Reduces consumed fuel for the [`Op::ConsumeFuel`] at `fuel_pos`.
+    ///
+    /// Does nothing if fuel metering is disabled.
+    ///
+    /// # Errors
+    ///
+    /// If consumed fuel is out of bounds after this operation.
+    fn reduce_fuel_consumption(
+        &mut self,
+        fuel_pos: Option<Pos<BlockFuel>>,
+        fuel_selector: impl FuelCostsSelector,
+    ) -> Result<(), Error> {
+        debug_assert_eq!(fuel_pos.is_some(), self.fuel_costs.is_some());
+        let fuel_used = self
+            .fuel_costs
+            .as_ref()
+            .map(|costs| fuel_selector.select(costs))
+            .unwrap_or(0);
+        if fuel_used == 0 {
+            return Ok(());
+        }
+        self.reduce_fuel_consumption_by(fuel_pos, fuel_used)
+    }
+
+    /// Reduces consumed fuel for [`Op::ConsumeFuel`] at `fuel_pos` by `delta`.
+    ///
+    /// Does nothing if fuel metering is disabled.
+    ///
+    /// # Errors
+    ///
+    /// If consumed fuel is out of bounds after this operation.
+    fn reduce_fuel_consumption_by(
+        &mut self,
+        fuel_pos: Option<Pos<BlockFuel>>,
+        delta: FuelUsed,
+    ) -> Result<(), Error> {
+        debug_assert_eq!(fuel_pos.is_some(), self.fuel_costs.is_some());
+        let fuel_pos = match fuel_pos {
+            None => return Ok(()),
+            Some(fuel_pos) => fuel_pos,
+        };
+        self.ops
+            .update_encoded(fuel_pos, |mut fuel| -> Option<BlockFuel> {
+                fuel.reduce_by(delta).ok()?;
                 Some(fuel)
             });
         Ok(())

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -14,7 +14,7 @@ mod visit;
 use self::stack::ImmediateOperand;
 
 use self::{
-    encoder::{OpEncoder, OpEncoderAllocations, Pos},
+    encoder::{OpEncoder, OpEncoderAllocations, Pos, Spill},
     labels::{LabelRef, LabelRegistry},
     layout::{StackLayout, StackSpace},
     locals::{LocalIdx, LocalsRegistry},
@@ -837,22 +837,37 @@ impl FuncTranslator {
     /// If a register operand of an equivalent type is already on the stack
     /// a copy operator is encoded to turn the existing register operand into
     /// a temporary operand.
-    fn push_result_reg(&mut self, ty: ValType) -> Result<(), Error> {
+    ///
+    /// Returns the [`Spill`] that was caused if a standalone `copy_sr` spill operator was
+    /// emitted. The caller may use it to revert the spill if the staged operator whose result
+    /// occupies the register ends up being dropped (e.g. fused into a result-less branch).
+    fn push_result_reg(&mut self, ty: ValType) -> Result<Option<Spill>, Error> {
         let fuel_pos = self.stack.fuel_pos();
+        let mut spill = None;
         if let Some(operand) = self.stack.dealloc_reg(ty) {
             let result = operand.temp_slots().head();
-            let op = match self.fuse_copy_sr(result, ty) {
+            match self.fuse_copy_sr(result, ty) {
                 Some(fused_op) => {
+                    // Case: the spill was fused into the staged producer operator (which writes
+                    //       its result to both `slot` and register) so there is no standalone
+                    //       `copy_sr` operator to revert later.
                     self.instrs.drop_staged();
-                    fused_op
+                    self.instrs
+                        .encode_op(fused_op, fuel_pos, FuelCostsProvider::base)?;
                 }
-                None => Self::select_copy_sr_op(result, operand.ty()),
-            };
-            self.instrs
-                .encode_op(op, fuel_pos, FuelCostsProvider::base)?;
+                None => {
+                    // Case: a standalone `copy_sr` spill operator is emitted. Record it so that
+                    //       a later fusion of the staged operator can revert this spill.
+                    let copy_op = Self::select_copy_sr_op(result, operand.ty());
+                    let copy_pos =
+                        self.instrs
+                            .encode_op(copy_op, fuel_pos, FuelCostsProvider::base)?;
+                    spill = Some(Spill::new(copy_pos, operand.stack_pos()));
+                }
+            }
         };
         self.stack.push_temp(ty, Allocation::Reg)?;
-        Ok(())
+        Ok(spill)
     }
 
     /// Pushes the `instr` to the function with the associated `fuel_costs`.
@@ -863,9 +878,9 @@ impl FuncTranslator {
         fuel_costs: impl FnOnce(&FuelCostsProvider) -> u64,
     ) -> Result<(), Error> {
         debug_assert_eq!(op.result_loc().map(|loc| loc.is_reg()), Some(true));
-        self.push_result_reg(result_ty)?;
+        let spill = self.push_result_reg(result_ty)?;
         let fuel_pos = self.stack.fuel_pos();
-        self.instrs.stage_op(op, fuel_pos, fuel_costs)?;
+        self.instrs.stage_op(op, fuel_pos, fuel_costs, spill)?;
         Ok(())
     }
 
@@ -899,7 +914,7 @@ impl FuncTranslator {
             .head();
         let op = make_instr(result);
         debug_assert!(op.result_ref().is_some());
-        self.instrs.stage_op(op, fuel_pos, fuel_costs)?;
+        self.instrs.stage_op(op, fuel_pos, fuel_costs, None)?;
         Ok(())
     }
 
@@ -920,7 +935,7 @@ impl FuncTranslator {
             .temp_slots()
             .head();
         if let Some(op) = make_op(result) {
-            self.instrs.stage_op(op, fuel_pos, fuel_costs)?;
+            self.instrs.stage_op(op, fuel_pos, fuel_costs, None)?;
         }
         Ok(())
     }
@@ -1264,7 +1279,7 @@ impl FuncTranslator {
         let fused_op = self.fused_local_set(result, input)?;
         let staged_fuel = match fused_op {
             Some(_) => {
-                let (_, fuel_used) = self.instrs.drop_staged();
+                let (_, fuel_used, _) = self.instrs.drop_staged();
                 Some(fuel_used)
             }
             None => None,
@@ -1407,7 +1422,14 @@ impl FuncTranslator {
         branch_eqz: bool,
     ) -> Result<(), Error> {
         if let Some(fused_op) = self.fused_cmp_branch(condition, branch_eqz)? {
-            let (fuel_pos, _) = self.instrs.drop_staged();
+            let (fuel_pos, _, spill) = self.instrs.drop_staged();
+            if let Some(spill) = spill {
+                // The dropped compare operator made an earlier register spill unnecessary:
+                // the register still holds the spilled value, so revert the spill operator
+                // and restore the operand into its register.
+                self.instrs.revert_spill(spill, fuel_pos)?;
+                self.stack.restore_reg_temp(spill.stack_pos());
+            }
             self.encode_branch_op(
                 label,
                 |offset| fused_op.with_branch_offset(offset),

--- a/crates/wasmi/src/engine/translator/func/stack/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/mod.rs
@@ -6,7 +6,7 @@ mod operands;
 use self::{
     control::ControlStack,
     locals::LocalsHead,
-    operands::{OperandStack, StackOperand, StackPos},
+    operands::{OperandStack, StackOperand},
 };
 pub use self::{
     control::{
@@ -25,7 +25,7 @@ pub use self::{
         RegKind,
     },
     operand::{ImmediateOperand, LocalOperand, Location, Operand, ResolvedOperand, TempOperand},
-    operands::{Allocation, PreservedAllLocalsIter, PreservedLocalsIter, PreservedRegs},
+    operands::{Allocation, PreservedAllLocalsIter, PreservedLocalsIter, PreservedRegs, StackPos},
 };
 use super::{Reset, ReusableAllocations};
 use crate::{
@@ -520,6 +520,16 @@ impl Stack {
     /// and `None` is returned as no copy operator is required.
     pub fn dealloc_reg(&mut self, ty: ValType) -> Option<TempOperand> {
         self.operands.dealloc_reg(ty)
+    }
+
+    /// Restores the temporary operand at `stack_pos` back into its register.
+    ///
+    /// # Note
+    ///
+    /// This is the inverse of [`Stack::dealloc_reg`] and is used to undo an unnecessary
+    /// register spill after the spilling operator has been dropped.
+    pub fn restore_reg_temp(&mut self, stack_pos: StackPos) {
+        self.operands.restore_reg_temp(stack_pos)
     }
 
     /// Pushes the [`Operand`] back to the [`Stack`].

--- a/crates/wasmi/src/engine/translator/func/stack/operand.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/operand.rs
@@ -315,7 +315,7 @@ impl TempOperand {
     }
 
     /// Returns the stack position of the [`TempOperand`].
-    fn stack_pos(&self) -> StackPos {
+    pub fn stack_pos(&self) -> StackPos {
         self.stack_pos
     }
 

--- a/crates/wasmi/src/engine/translator/func/stack/operands.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/operands.rs
@@ -335,6 +335,29 @@ impl OperandStack {
         Some(returned)
     }
 
+    /// Restores the temporary operand at `stack_pos` back into its register.
+    ///
+    /// # Note
+    ///
+    /// This is the inverse of [`OperandStack::dealloc_reg`] and is used to undo an
+    /// unnecessary register spill after the spilling operator has been dropped.
+    ///
+    /// # Panics (Debug)
+    ///
+    /// - If the operand at `stack_pos` is not a [`StackOperand::Temp`].
+    /// - If the operand at `stack_pos` is already linked to its register.
+    pub fn restore_reg_temp(&mut self, stack_pos: StackPos) {
+        let operand = self.get_at_mut(stack_pos);
+        let StackOperand::Temp { ty, in_reg, .. } = operand else {
+            unreachable!("can only restore a temporary operand into its register")
+        };
+        debug_assert!(!*in_reg);
+        *in_reg = true;
+        let ty = *ty;
+        let prev = self.regs.alloc(ty, RegisterLink::Temp(stack_pos));
+        debug_assert!(prev.is_none());
+    }
+
     /// Returns the current [`RegisterMap`] state.
     pub fn get_registers(&self) -> RegisterMap {
         self.regs

--- a/crates/wasmi/tests/integration/mod.rs
+++ b/crates/wasmi/tests/integration/mod.rs
@@ -12,3 +12,4 @@ mod multi_memory;
 mod reextract_memory;
 mod resource_limiter;
 mod resumable_call;
+mod unspill;

--- a/crates/wasmi/tests/integration/unspill.rs
+++ b/crates/wasmi/tests/integration/unspill.rs
@@ -1,0 +1,114 @@
+//! Regression tests for the "avoid unnecessary register spill" translation optimization.
+//!
+//! When a value `A` resides in the accumulator register and the next operator `B` (a compare)
+//! is fused into a `br_if`, the spill of `A` that was emitted to make room for `B` becomes
+//! unnecessary. The translator reverts that spill and keeps `A` in its register. These tests
+//! make sure the reverted value is preserved correctly on both edges of the fused branch.
+
+use wasmi::{Config, Engine, Module, Store};
+
+/// Compiles `wat`, runs the exported `test(a, b, c, d) -> i32` function and returns its result.
+fn run(wat: &str, fuel: bool, params: (i32, i32, i32, i32)) -> i32 {
+    let mut config = Config::default();
+    config.consume_fuel(fuel);
+    let engine = Engine::new(&config);
+    let mut store = Store::new(&engine, ());
+    if fuel {
+        // Plenty of fuel: we only care that execution succeeds and yields the right value.
+        store.set_fuel(1_000_000).unwrap();
+    }
+    let module = Module::new(&engine, wat.as_bytes()).unwrap();
+    let instance = wasmi::Linker::new(&engine)
+        .instantiate_and_start(&mut store, &module)
+        .unwrap();
+    let func = instance
+        .get_typed_func::<(i32, i32, i32, i32), i32>(&store, "test")
+        .unwrap();
+    func.call(&mut store, params).unwrap()
+}
+
+/// Asserts that `test(a, b, c, d)` equals `expected(a, b, c, d)` for a matrix of inputs that
+/// exercises both the taken and not-taken edges of the fused `br_if`, with and without fuel.
+fn assert_matches_oracle(wat: &str, expected: impl Fn(i32, i32, i32, i32) -> i32) {
+    let inputs = [-3i32, -1, 0, 1, 5, 7];
+    for &a in &inputs {
+        for &b in &inputs {
+            // `c, d` drive whether the fused `c < d` branch is taken (true) or not (false).
+            for (c, d) in [(0, 1), (1, 0), (2, 2), (-1, 1)] {
+                let want = expected(a, b, c, d);
+                for fuel in [false, true] {
+                    let got = run(wat, fuel, (a, b, c, d));
+                    assert_eq!(
+                        got, want,
+                        "test({a}, {b}, {c}, {d}) with fuel={fuel} returned {got}, expected {want}",
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// `A = a & b` is produced into the accumulator register by a non-`add` producer, so the spill
+/// caused by the following `c < d` compare is a standalone `copy_sr` operator. The `br_if` fuses
+/// the compare and the spill is reverted. The result differs between the taken edge (returns `A`,
+/// which is only correct if the un-spilled register still holds `a & b`) and the not-taken edge
+/// (returns `-1`), so a corrupted un-spill is observable.
+#[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
+fn unspill_standalone_copy() {
+    let wat = r#"
+    (module
+        (func (export "test") (param i32 i32 i32 i32) (result i32)
+            (block (result i32)
+                (i32.and (local.get 0) (local.get 1)) ;; A = a & b, into `ireg`
+                (i32.lt_s (local.get 2) (local.get 3)) ;; cond = c < d, spills A via `copy_sr`
+                (br_if 0)         ;; fuses `lt_s`; taken => block result = A
+                (drop)            ;; not taken => drop A ...
+                (i32.const -1)    ;; ... and return -1 instead
+            )
+        )
+    )"#;
+    assert_matches_oracle(wat, |a, b, c, d| if c < d { a & b } else { -1 });
+}
+
+/// Control case: `A = a + b` uses the `fuse_copy_sr` producer path (the producer writes both
+/// `slot` and register, no standalone `copy_sr`), so no spill is reverted. Execution must still
+/// be correct on both edges.
+#[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
+fn unspill_fused_producer_control() {
+    let wat = r#"
+    (module
+        (func (export "test") (param i32 i32 i32 i32) (result i32)
+            (block (result i32)
+                (i32.add (local.get 0) (local.get 1)) ;; A = a + b, fused producer
+                (i32.lt_s (local.get 2) (local.get 3)) ;; cond = c < d
+                (br_if 0)
+                (drop)
+                (i32.const -1)
+            )
+        )
+    )"#;
+    assert_matches_oracle(wat, |a, b, c, d| if c < d { a.wrapping_add(b) } else { -1 });
+}
+
+/// Exercises the negated (`br_if` via `i32.eqz`) fusion: `(i32.eqz (i32.lt_s ..))` is fused into
+/// an inverted compare-branch, again after spilling `A`. Confirms the reverted value survives the
+/// negated path too.
+#[test]
+#[cfg_attr(not(feature = "wat"), ignore)]
+fn unspill_negated_branch() {
+    let wat = r#"
+    (module
+        (func (export "test") (param i32 i32 i32 i32) (result i32)
+            (block (result i32)
+                (i32.and (local.get 0) (local.get 1))         ;; A = a & b, into `ireg`
+                (i32.eqz (i32.lt_s (local.get 2) (local.get 3))) ;; cond = !(c < d), spills A
+                (br_if 0)
+                (drop)
+                (i32.const -1)
+            )
+        )
+    )"#;
+    assert_matches_oracle(wat, |a, b, c, d| if c < d { -1 } else { a & b });
+}


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1900.

Benchmarks show absolutely no difference between `main` and this PR.
Therefore I conclude that this additional complexity is not worth the gains.