### PR TITLE
Add `u64_copy_sNsM` operator variants

### DIFF
--- a/crates/ir/build/isa.rs
+++ b/crates/ir/build/isa.rs
@@ -572,6 +572,20 @@ fn add_copy_ops(isa: &mut Isa) {
     for (ty, result, value) in ops {
         isa.push_op(UnaryOp::new(Ident::Copy, ty, ty, result, value));
     }
+    for result in 0..6 {
+        for value in 0..6 {
+            if result == value {
+                continue;
+            }
+            isa.push_op(UnaryOp::new(
+                Ident::Copy,
+                Ty::U64,
+                Ty::U64,
+                OperandKind::Local(result),
+                OperandKind::Local(value),
+            ));
+        }
+    }
     let reinterpret_ops = [
         (Ty::F32, Ty::I32),
         (Ty::I32, Ty::F32),

--- a/crates/ir/build/mod.rs
+++ b/crates/ir/build/mod.rs
@@ -77,8 +77,8 @@ pub fn generate_code(config: &Config) -> Result<(), Error> {
 
 fn generate_op_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
-        true => 480_000,
-        false => 360_000,
+        true => 490_000,
+        false => 365_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {
         write!(
@@ -99,8 +99,8 @@ fn generate_op_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(
 
 fn generate_op_code_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
-        true => 290_000,
-        false => 230_000,
+        true => 295_000,
+        false => 235_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {
         writeln!(buffer, "{}", DisplayOpCode::new(isa, Indent::default()),)
@@ -111,7 +111,7 @@ fn generate_op_code_rs(config: &Config, isa: &Isa, contents: &mut String) -> Res
 
 fn generate_encode_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
-        true => 205_000,
+        true => 210_000,
         false => 170_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {
@@ -123,7 +123,7 @@ fn generate_encode_rs(config: &Config, isa: &Isa, contents: &mut String) -> Resu
 
 fn generate_decode_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
-        true => 85_000,
+        true => 90_000,
         false => 70_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {

--- a/crates/wasmi/src/engine/executor/handler/exec.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec.rs
@@ -1324,6 +1324,37 @@ impl_branch_table_exec_handler! {
 }
 
 handler_unary! {
+    // specialized copy_sNsM operators
+    fn u64_copy_s0s1(U64Copy_S0s1) = identity::<u64>;
+    fn u64_copy_s0s2(U64Copy_S0s2) = identity::<u64>;
+    fn u64_copy_s0s3(U64Copy_S0s3) = identity::<u64>;
+    fn u64_copy_s0s4(U64Copy_S0s4) = identity::<u64>;
+    fn u64_copy_s0s5(U64Copy_S0s5) = identity::<u64>;
+    fn u64_copy_s1s0(U64Copy_S1s0) = identity::<u64>;
+    fn u64_copy_s1s2(U64Copy_S1s2) = identity::<u64>;
+    fn u64_copy_s1s3(U64Copy_S1s3) = identity::<u64>;
+    fn u64_copy_s1s4(U64Copy_S1s4) = identity::<u64>;
+    fn u64_copy_s1s5(U64Copy_S1s5) = identity::<u64>;
+    fn u64_copy_s2s0(U64Copy_S2s0) = identity::<u64>;
+    fn u64_copy_s2s1(U64Copy_S2s1) = identity::<u64>;
+    fn u64_copy_s2s3(U64Copy_S2s3) = identity::<u64>;
+    fn u64_copy_s2s4(U64Copy_S2s4) = identity::<u64>;
+    fn u64_copy_s2s5(U64Copy_S2s5) = identity::<u64>;
+    fn u64_copy_s3s0(U64Copy_S3s0) = identity::<u64>;
+    fn u64_copy_s3s1(U64Copy_S3s1) = identity::<u64>;
+    fn u64_copy_s3s2(U64Copy_S3s2) = identity::<u64>;
+    fn u64_copy_s3s4(U64Copy_S3s4) = identity::<u64>;
+    fn u64_copy_s3s5(U64Copy_S3s5) = identity::<u64>;
+    fn u64_copy_s4s0(U64Copy_S4s0) = identity::<u64>;
+    fn u64_copy_s4s1(U64Copy_S4s1) = identity::<u64>;
+    fn u64_copy_s4s2(U64Copy_S4s2) = identity::<u64>;
+    fn u64_copy_s4s3(U64Copy_S4s3) = identity::<u64>;
+    fn u64_copy_s4s5(U64Copy_S4s5) = identity::<u64>;
+    fn u64_copy_s5s0(U64Copy_S5s0) = identity::<u64>;
+    fn u64_copy_s5s1(U64Copy_S5s1) = identity::<u64>;
+    fn u64_copy_s5s2(U64Copy_S5s2) = identity::<u64>;
+    fn u64_copy_s5s3(U64Copy_S5s3) = identity::<u64>;
+    fn u64_copy_s5s4(U64Copy_S5s4) = identity::<u64>;
     // specialized copy_sNr operators
     fn u64_copy_s0r(U64Copy_S0r) = identity::<u64>;
     fn u64_copy_s1r(U64Copy_S1r) = identity::<u64>;

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -235,10 +235,21 @@ impl GetValue<f64> for ir::Reg<f64> {
     }
 }
 
+impl<const N: u16, T> GetValue<T> for Local<N>
+where
+    T: LoadFromCellsByValue,
+{
+    #[inline]
+    fn get_value(_src: Self, sp: Sp, ireg: Ireg, freg32: Freg32, freg64: Freg64) -> T {
+        <Slot as GetValue<T>>::get_value(Slot::from(N), sp, ireg, freg32, freg64)
+    }
+}
+
 impl<T> GetValue<T> for Slot
 where
     T: LoadFromCellsByValue,
 {
+    #[inline]
     fn get_value(src: Self, sp: Sp, _ireg: Ireg, _freg32: Freg32, _freg64: Freg64) -> T {
         // # Safety
         //

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -593,9 +593,49 @@ impl FuncTranslator {
         if result == value {
             return None;
         }
-        let op = match ty {
-            #[cfg(feature = "simd")]
-            ValType::V128 => Op::v128_copy_ss(result, value),
+        #[cfg(feature = "simd")]
+        if matches!(ty, ValType::V128) {
+            return Some(Op::v128_copy_ss(result, value));
+        }
+        let r = u16::from(result);
+        let v = u16::from(value);
+        let op = match (r, v) {
+            // s0sN
+            (0, 1) => Op::u64_copy_s0s1(),
+            (0, 2) => Op::u64_copy_s0s2(),
+            (0, 3) => Op::u64_copy_s0s3(),
+            (0, 4) => Op::u64_copy_s0s4(),
+            (0, 5) => Op::u64_copy_s0s5(),
+            // s1sN
+            (1, 0) => Op::u64_copy_s1s0(),
+            (1, 2) => Op::u64_copy_s1s2(),
+            (1, 3) => Op::u64_copy_s1s3(),
+            (1, 4) => Op::u64_copy_s1s4(),
+            (1, 5) => Op::u64_copy_s1s5(),
+            // s2sN
+            (2, 0) => Op::u64_copy_s2s0(),
+            (2, 1) => Op::u64_copy_s2s1(),
+            (2, 3) => Op::u64_copy_s2s3(),
+            (2, 4) => Op::u64_copy_s2s4(),
+            (2, 5) => Op::u64_copy_s2s5(),
+            // s3sN
+            (3, 0) => Op::u64_copy_s3s0(),
+            (3, 1) => Op::u64_copy_s3s1(),
+            (3, 2) => Op::u64_copy_s3s2(),
+            (3, 4) => Op::u64_copy_s3s4(),
+            (3, 5) => Op::u64_copy_s3s5(),
+            // s4sN
+            (4, 0) => Op::u64_copy_s4s0(),
+            (4, 1) => Op::u64_copy_s4s1(),
+            (4, 2) => Op::u64_copy_s4s2(),
+            (4, 3) => Op::u64_copy_s4s3(),
+            (4, 5) => Op::u64_copy_s4s5(),
+            // s5sN
+            (5, 0) => Op::u64_copy_s5s0(),
+            (5, 1) => Op::u64_copy_s5s1(),
+            (5, 2) => Op::u64_copy_s5s2(),
+            (5, 3) => Op::u64_copy_s5s3(),
+            (5, 4) => Op::u64_copy_s5s4(),
             _ => Op::u64_copy_ss(result, value),
         };
         Some(op)


### PR DESCRIPTION
Similar in spirit to https://github.com/wasmi-labs/wasmi/pull/1928 but specialized `u64_copy_ss` ops even further.

With this PR the additional bonus over #1928 is that those specialized ops now no longer have any operands, thus their encoded size is a single op-code or pointer to their execution handler, depending on the crate features. This halfs their encoding size (32-bits -> 16-bit or 128-bit to 64-bit) compared to `u64_copy_ss` on both encoding modes.

With this CoreMark improves from a score of ~2650 to ~2720 (+2.6%).

## Wasmi Benchmarks

<img width="944" height="370" alt="image" src="https://github.com/user-attachments/assets/abb818c9-68ed-49da-9a16-9999ee15e148" />

The other benchmarks improve, but within noise:

<img width="948" height="1090" alt="image" src="https://github.com/user-attachments/assets/df348df8-0f7f-4eb0-b0b9-1f0bbbb40f5b" />
