### PR TITLE
Add fused `load`+`copy_sr` ops

### DIFF
--- a/crates/ir/build/display/result.rs
+++ b/crates/ir/build/display/result.rs
@@ -1,5 +1,9 @@
 use crate::build::{
-    display::{Indent, ident::DisplayIdent, utils::{DisplayConcat, DisplaySequence}},
+    display::{
+        Indent,
+        ident::DisplayIdent,
+        utils::{DisplayConcat, DisplaySequence},
+    },
     ident::Ident,
     isa::Isa,
     op::{GenericOp, Op, OperandKind},
@@ -58,7 +62,10 @@ impl Display for DisplayResultMut<&'_ Isa> {
                 .iter()
                 .filter(|op| op.has_result_slot_and_reg())
                 .map(|op| {
-                    (DisplayResultMut::new(op, indent.inc_by(3)), " => &result.slot,")
+                    (
+                        DisplayResultMut::new(op, indent.inc_by(3)),
+                        " => &result.slot,",
+                    )
                 })
                 .map(DisplayConcat),
         );
@@ -69,7 +76,10 @@ impl Display for DisplayResultMut<&'_ Isa> {
                 .iter()
                 .filter(|op| op.has_result_slot_and_reg())
                 .map(|op| {
-                    (DisplayResultMut::new(op, indent.inc_by(3)), " => &mut result.slot,")
+                    (
+                        DisplayResultMut::new(op, indent.inc_by(3)),
+                        " => &mut result.slot,",
+                    )
                 })
                 .map(DisplayConcat),
         );

--- a/crates/ir/build/display/result.rs
+++ b/crates/ir/build/display/result.rs
@@ -1,5 +1,5 @@
 use crate::build::{
-    display::{Indent, ident::DisplayIdent, utils::DisplaySequence},
+    display::{Indent, ident::DisplayIdent, utils::{DisplayConcat, DisplaySequence}},
     ident::Ident,
     isa::Isa,
     op::{GenericOp, Op, OperandKind},
@@ -51,13 +51,27 @@ impl Display for DisplayResultMut<&'_ Isa> {
                 .filter(|op| op.has_result_slot())
                 .map(|op| DisplayResultMut::new(op, indent.inc_by(3))),
         );
-        let variants_slot_and_reg = DisplaySequence::new(
+        let variants_slot_and_reg_ref = DisplaySequence::new(
             "\n",
             self.value
                 .ops
                 .iter()
                 .filter(|op| op.has_result_slot_and_reg())
-                .map(|op| DisplayResultMut::new(op, indent.inc_by(3))),
+                .map(|op| {
+                    (DisplayResultMut::new(op, indent.inc_by(3)), " => &result.slot,")
+                })
+                .map(DisplayConcat),
+        );
+        let variants_slot_and_reg_mut = DisplaySequence::new(
+            "\n",
+            self.value
+                .ops
+                .iter()
+                .filter(|op| op.has_result_slot_and_reg())
+                .map(|op| {
+                    (DisplayResultMut::new(op, indent.inc_by(3)), " => &mut result.slot,")
+                })
+                .map(DisplayConcat),
         );
         let variants_loc = DisplaySequence::new(
             "\n",
@@ -83,7 +97,7 @@ impl Display for DisplayResultMut<&'_ Isa> {
             {indent}    pub fn result_ref(&self) -> Option<&Slot> {{\n\
             {indent}        let res = match self {{\n\
                                 {variants_slot} => result,\n\
-                                {variants_slot_and_reg} => &result.slot,\n\
+                                {variants_slot_and_reg_ref}\n\
             {indent}            _ => return None,\n\
             {indent}        }};\n\
             {indent}        Some(res)\n\
@@ -93,7 +107,7 @@ impl Display for DisplayResultMut<&'_ Isa> {
             {indent}    pub fn result_mut(&mut self) -> Option<&mut Slot> {{\n\
             {indent}        let res = match self {{\n\
                                 {variants_slot} => result,\n\
-                                {variants_slot_and_reg} => &mut result.slot,\n\
+                                {variants_slot_and_reg_mut}\n\
             {indent}            _ => return None,\n\
             {indent}        }};\n\
             {indent}        Some(res)\n\

--- a/crates/ir/build/isa.rs
+++ b/crates/ir/build/isa.rs
@@ -437,14 +437,16 @@ fn add_load_ops(isa: &mut Isa) {
                 OffsetOperand::Offset,
             ));
             if matches!(ptr, OperandKind::Reg | OperandKind::Slot) {
-                isa.push_op(LoadOp::new(
-                    kind,
-                    result_ty,
-                    OperandKind::Reg,
-                    ptr,
-                    MemoryOperand::Mem0,
-                    OffsetOperand::Offset16,
-                ));
+                for result in [OperandKind::Reg, OperandKind::SlotAndReg] {
+                    isa.push_op(LoadOp::new(
+                        kind,
+                        result_ty,
+                        result,
+                        ptr,
+                        MemoryOperand::Mem0,
+                        OffsetOperand::Offset16,
+                    ));
+                }
             }
         }
     }

--- a/crates/ir/build/mod.rs
+++ b/crates/ir/build/mod.rs
@@ -77,8 +77,8 @@ pub fn generate_code(config: &Config) -> Result<(), Error> {
 
 fn generate_op_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
-        true => 490_000,
-        false => 370_000,
+        true => 505_000,
+        false => 385_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {
         write!(
@@ -111,8 +111,8 @@ fn generate_op_code_rs(config: &Config, isa: &Isa, contents: &mut String) -> Res
 
 fn generate_encode_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
-        true => 210_000,
-        false => 170_000,
+        true => 215_000,
+        false => 175_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {
         write!(buffer, "{}", DisplayEncode::new(isa, Indent::default()))
@@ -124,7 +124,7 @@ fn generate_encode_rs(config: &Config, isa: &Isa, contents: &mut String) -> Resu
 fn generate_decode_rs(config: &Config, isa: &Isa, contents: &mut String) -> Result<(), Error> {
     let expected_size = match config.simd {
         true => 90_000,
-        false => 70_000,
+        false => 75_000,
     };
     write_to_buffer(contents, expected_size, |buffer| {
         write!(buffer, "{}", DisplayDecode::new(isa, Indent::default()))

--- a/crates/wasmi/src/engine/executor/handler/exec.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec.rs
@@ -2326,6 +2326,7 @@ handler_load_ri! {
 }
 
 handler_load_mem0_offset16_ss! {
+    // reg results
     fn u32_load_mem0_offset16_rr(U32LoadMem0Offset16_Rr) = wasm::load_u32;
     fn u32_load_mem0_offset16_rs(U32LoadMem0Offset16_Rs) = wasm::load_u32;
     fn u64_load_mem0_offset16_rr(U64LoadMem0Offset16_Rr) = wasm::load_u64;
@@ -2354,6 +2355,35 @@ handler_load_mem0_offset16_ss! {
     fn i64_load_extend32_mem0_offset16_rs(I64LoadExtend32Mem0Offset16_Rs) = wasm::i64_load32_s;
     fn u64_load_extend32_mem0_offset16_rr(U64LoadExtend32Mem0Offset16_Rr) = wasm::i64_load32_u;
     fn u64_load_extend32_mem0_offset16_rs(U64LoadExtend32Mem0Offset16_Rs) = wasm::i64_load32_u;
+    // reg + slot results
+    fn u32_load_mem0_offset16_rs_r(U32LoadMem0Offset16_Rs_r) = wasm::load_u32;
+    fn u32_load_mem0_offset16_rs_s(U32LoadMem0Offset16_Rs_s) = wasm::load_u32;
+    fn u64_load_mem0_offset16_rs_r(U64LoadMem0Offset16_Rs_r) = wasm::load_u64;
+    fn u64_load_mem0_offset16_rs_s(U64LoadMem0Offset16_Rs_s) = wasm::load_u64;
+    fn f32_load_mem0_offset16_rs_r(F32LoadMem0Offset16_Rs_r) = wasm::load_f32;
+    fn f32_load_mem0_offset16_rs_s(F32LoadMem0Offset16_Rs_s) = wasm::load_f32;
+    fn f64_load_mem0_offset16_rs_r(F64LoadMem0Offset16_Rs_r) = wasm::load_f64;
+    fn f64_load_mem0_offset16_rs_s(F64LoadMem0Offset16_Rs_s) = wasm::load_f64;
+    fn i32_load_extend8_mem0_offset16_rs_r(I32LoadExtend8Mem0Offset16_Rs_r) = wasm::i32_load8_s;
+    fn i32_load_extend8_mem0_offset16_rs_s(I32LoadExtend8Mem0Offset16_Rs_s) = wasm::i32_load8_s;
+    fn i32_load_extend16_mem0_offset16_rs_r(I32LoadExtend16Mem0Offset16_Rs_r) = wasm::i32_load8_u;
+    fn i32_load_extend16_mem0_offset16_rs_s(I32LoadExtend16Mem0Offset16_Rs_s) = wasm::i32_load8_u;
+    fn u32_load_extend8_mem0_offset16_rs_r(U32LoadExtend8Mem0Offset16_Rs_r) = wasm::i32_load16_s;
+    fn u32_load_extend8_mem0_offset16_rs_s(U32LoadExtend8Mem0Offset16_Rs_s) = wasm::i32_load16_s;
+    fn u32_load_extend16_mem0_offset16_rs_r(U32LoadExtend16Mem0Offset16_Rs_r) = wasm::i32_load16_u;
+    fn u32_load_extend16_mem0_offset16_rs_s(U32LoadExtend16Mem0Offset16_Rs_s) = wasm::i32_load16_u;
+    fn i64_load_extend8_mem0_offset16_rs_r(I64LoadExtend8Mem0Offset16_Rs_r) = wasm::i64_load8_s;
+    fn i64_load_extend8_mem0_offset16_rs_s(I64LoadExtend8Mem0Offset16_Rs_s) = wasm::i64_load8_s;
+    fn i64_load_extend16_mem0_offset16_rs_r(I64LoadExtend16Mem0Offset16_Rs_r) = wasm::i64_load8_u;
+    fn i64_load_extend16_mem0_offset16_rs_s(I64LoadExtend16Mem0Offset16_Rs_s) = wasm::i64_load8_u;
+    fn i64_load_extend32_mem0_offset16_rs_r(I64LoadExtend32Mem0Offset16_Rs_r) = wasm::i64_load16_s;
+    fn i64_load_extend32_mem0_offset16_rs_s(I64LoadExtend32Mem0Offset16_Rs_s) = wasm::i64_load16_s;
+    fn u64_load_extend8_mem0_offset16_rs_r(U64LoadExtend8Mem0Offset16_Rs_r) = wasm::i64_load16_u;
+    fn u64_load_extend8_mem0_offset16_rs_s(U64LoadExtend8Mem0Offset16_Rs_s) = wasm::i64_load16_u;
+    fn u64_load_extend16_mem0_offset16_rs_r(U64LoadExtend16Mem0Offset16_Rs_r) = wasm::i64_load32_s;
+    fn u64_load_extend16_mem0_offset16_rs_s(U64LoadExtend16Mem0Offset16_Rs_s) = wasm::i64_load32_s;
+    fn u64_load_extend32_mem0_offset16_rs_r(U64LoadExtend32Mem0Offset16_Rs_r) = wasm::i64_load32_u;
+    fn u64_load_extend32_mem0_offset16_rs_s(U64LoadExtend32Mem0Offset16_Rs_s) = wasm::i64_load32_u;
 }
 
 handler_store_sx! {

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -835,14 +835,14 @@ impl FuncTranslator {
     ///
     /// Returns `None` otherwise.
     fn fuse_copy_sr(&self, result: Slot, input_ty: ValType) -> Option<Op> {
-        if !RegKind::Ireg.matches_ty(input_ty) {
-            // This check is required to filter out incorrect fusions
-            // where input is not originating from the staged operator.
-            //
-            // Today, all fused operators have an `ireg` result.
-            // We need to change this logic if we add more fused operators later.
-            return None;
+        match RegKind::new(input_ty)? {
+            RegKind::Ireg => self.fuse_copy_sr_ireg(result),
+            RegKind::Freg32 => self.fuse_copy_sr_freg32(result),
+            RegKind::Freg64 => self.fuse_copy_sr_freg64(result),
         }
+    }
+
+    fn fuse_copy_sr_ireg(&self, result: Slot) -> Option<Op> {
         let result = SlotAndReg::from(result);
         let staged_op = self.instrs.peek_staged()?;
         let op = match staged_op {
@@ -856,6 +856,53 @@ impl FuncTranslator {
             Op::I64Add_Rri { rhs, .. } => Op::i64_add_rs_ri(result, rhs),
             Op::I64Add_Rss { lhs, rhs, .. } => Op::i64_add_rs_ss(result, lhs, rhs),
             Op::I64Add_Rsi { lhs, rhs, .. } => Op::i64_add_rs_si(result, lhs, rhs),
+            // load
+            Op::U32LoadMem0Offset16_Rr { offset, .. } => Op::u32_load_mem0_offset16_rs_r(result, offset),
+            Op::U32LoadMem0Offset16_Rs { ptr, offset, .. } => Op::u32_load_mem0_offset16_rs_s(result, ptr, offset),
+            Op::U64LoadMem0Offset16_Rr { offset, .. } => Op::u64_load_mem0_offset16_rs_r(result, offset),
+            Op::U64LoadMem0Offset16_Rs { ptr, offset, .. } => Op::u64_load_mem0_offset16_rs_s(result, ptr, offset),
+            Op::I32LoadExtend8Mem0Offset16_Rr { offset, .. } => Op::i32_load_extend8_mem0_offset16_rs_r(result, offset),
+            Op::I32LoadExtend8Mem0Offset16_Rs { ptr, offset, .. } => Op::i32_load_extend8_mem0_offset16_rs_s(result, ptr, offset),
+            Op::U32LoadExtend8Mem0Offset16_Rr { offset, .. } => Op::i32_load_extend16_mem0_offset16_rs_r(result, offset),
+            Op::U32LoadExtend8Mem0Offset16_Rs { ptr, offset, .. } => Op::i32_load_extend16_mem0_offset16_rs_s(result, ptr, offset),
+            Op::I32LoadExtend16Mem0Offset16_Rr { offset, .. } => Op::u32_load_extend8_mem0_offset16_rs_r(result, offset),
+            Op::I32LoadExtend16Mem0Offset16_Rs { ptr, offset, .. } => Op::u32_load_extend8_mem0_offset16_rs_s(result, ptr, offset),
+            Op::U32LoadExtend16Mem0Offset16_Rr { offset, .. } => Op::u32_load_extend16_mem0_offset16_rs_r(result, offset),
+            Op::U32LoadExtend16Mem0Offset16_Rs { ptr, offset, .. } => Op::u32_load_extend16_mem0_offset16_rs_s(result, ptr, offset),
+            Op::I64LoadExtend8Mem0Offset16_Rr { offset, .. } => Op::i64_load_extend8_mem0_offset16_rs_r(result, offset),
+            Op::I64LoadExtend8Mem0Offset16_Rs { ptr, offset, .. } => Op::i64_load_extend8_mem0_offset16_rs_s(result, ptr, offset),
+            Op::U64LoadExtend8Mem0Offset16_Rr { offset, .. } => Op::i64_load_extend16_mem0_offset16_rs_r(result, offset),
+            Op::U64LoadExtend8Mem0Offset16_Rs { ptr, offset, .. } => Op::i64_load_extend16_mem0_offset16_rs_s(result, ptr, offset),
+            Op::I64LoadExtend16Mem0Offset16_Rr { offset, .. } => Op::i64_load_extend32_mem0_offset16_rs_r(result, offset),
+            Op::I64LoadExtend16Mem0Offset16_Rs { ptr, offset, .. } => Op::i64_load_extend32_mem0_offset16_rs_s(result, ptr, offset),
+            Op::U64LoadExtend16Mem0Offset16_Rr { offset, .. } => Op::u64_load_extend8_mem0_offset16_rs_r(result, offset),
+            Op::U64LoadExtend16Mem0Offset16_Rs { ptr, offset, .. } => Op::u64_load_extend8_mem0_offset16_rs_s(result, ptr, offset),
+            Op::I64LoadExtend32Mem0Offset16_Rr { offset, .. } => Op::u64_load_extend16_mem0_offset16_rs_r(result, offset),
+            Op::I64LoadExtend32Mem0Offset16_Rs { ptr, offset, .. } => Op::u64_load_extend16_mem0_offset16_rs_s(result, ptr, offset),
+            Op::U64LoadExtend32Mem0Offset16_Rr { offset, .. } => Op::u64_load_extend32_mem0_offset16_rs_r(result, offset),
+            Op::U64LoadExtend32Mem0Offset16_Rs { ptr, offset, .. } => Op::u64_load_extend32_mem0_offset16_rs_s(result, ptr, offset),
+            _ => return None,
+        };
+        Some(op)
+    }
+
+    fn fuse_copy_sr_freg32(&self, result: Slot) -> Option<Op> {
+        let result = SlotAndReg::from(result);
+        let staged_op = self.instrs.peek_staged()?;
+        let op = match staged_op {
+            Op::F32LoadMem0Offset16_Rr { offset, .. } => Op::f32_load_mem0_offset16_rs_r(result, offset),
+            Op::F32LoadMem0Offset16_Rs { ptr, offset, .. } => Op::f32_load_mem0_offset16_rs_s(result, ptr, offset),
+            _ => return None,
+        };
+        Some(op)
+    }
+
+    fn fuse_copy_sr_freg64(&self, result: Slot) -> Option<Op> {
+        let result = SlotAndReg::from(result);
+        let staged_op = self.instrs.peek_staged()?;
+        let op = match staged_op {
+            Op::F64LoadMem0Offset16_Rr { offset, .. } => Op::f64_load_mem0_offset16_rs_r(result, offset),
+            Op::F64LoadMem0Offset16_Rs { ptr, offset, .. } => Op::f64_load_mem0_offset16_rs_s(result, ptr, offset),
             _ => return None,
         };
         Some(op)

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -845,6 +845,7 @@ impl FuncTranslator {
     fn fuse_copy_sr_ireg(&self, result: Slot) -> Option<Op> {
         let result = SlotAndReg::from(result);
         let staged_op = self.instrs.peek_staged()?;
+        #[rustfmt::skip]
         let op = match staged_op {
             // i32
             Op::I32Add_Rrs { rhs, .. } => Op::i32_add_rs_rs(result, rhs),
@@ -890,8 +891,12 @@ impl FuncTranslator {
         let result = SlotAndReg::from(result);
         let staged_op = self.instrs.peek_staged()?;
         let op = match staged_op {
-            Op::F32LoadMem0Offset16_Rr { offset, .. } => Op::f32_load_mem0_offset16_rs_r(result, offset),
-            Op::F32LoadMem0Offset16_Rs { ptr, offset, .. } => Op::f32_load_mem0_offset16_rs_s(result, ptr, offset),
+            Op::F32LoadMem0Offset16_Rr { offset, .. } => {
+                Op::f32_load_mem0_offset16_rs_r(result, offset)
+            }
+            Op::F32LoadMem0Offset16_Rs { ptr, offset, .. } => {
+                Op::f32_load_mem0_offset16_rs_s(result, ptr, offset)
+            }
             _ => return None,
         };
         Some(op)
@@ -901,8 +906,12 @@ impl FuncTranslator {
         let result = SlotAndReg::from(result);
         let staged_op = self.instrs.peek_staged()?;
         let op = match staged_op {
-            Op::F64LoadMem0Offset16_Rr { offset, .. } => Op::f64_load_mem0_offset16_rs_r(result, offset),
-            Op::F64LoadMem0Offset16_Rs { ptr, offset, .. } => Op::f64_load_mem0_offset16_rs_s(result, ptr, offset),
+            Op::F64LoadMem0Offset16_Rr { offset, .. } => {
+                Op::f64_load_mem0_offset16_rs_r(result, offset)
+            }
+            Op::F64LoadMem0Offset16_Rs { ptr, offset, .. } => {
+                Op::f64_load_mem0_offset16_rs_s(result, ptr, offset)
+            }
             _ => return None,
         };
         Some(op)


### PR DESCRIPTION
Those are similar to the fused `i{32,64}.add` ops previously added.
In total 28 new fused operator variants are added this way.

Execution traces showed that `load` + `copy_rs` was a very common pattern in Wasmi IR codegen and thus this was implemented.

CoreMark improves from ~2720 to ~2800 points (+3%).

<img width="632" height="1364" alt="image" src="https://github.com/user-attachments/assets/1e050454-0229-4d67-9f2d-10de91b020a1" />
