### PR TITLE
Unbloat Wasmi translator code with minor tweaks

### DIFF
--- a/crates/ir/src/encode.rs
+++ b/crates/ir/src/encode.rs
@@ -217,6 +217,7 @@ macro_rules! for_tuple {
 macro_rules! impl_encode_for_tuple {
     ( $t0:ident $(, $t:ident)* $(,)? ) => {
         impl<$t0: Encode $(, $t: Encode)*> Encode for ($t0, $($t,)*) {
+            #[inline(always)]
             fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<E::Pos, E::Error> {
                 #[allow(non_snake_case)]
                 let ($t0, $($t,)*) = self;

--- a/crates/wasmi/src/engine/translator/driver.rs
+++ b/crates/wasmi/src/engine/translator/driver.rs
@@ -48,7 +48,7 @@ where
         mut self,
         finalize: impl FnOnce(CompiledFuncEntry),
     ) -> Result<T::Allocations, Error> {
-        if self.translator.setup(self.bytes)? {
+        if self.translator.setup(self.bytes)? || T::SETUP_ONLY {
             let allocations = self.translator.finish(finalize)?;
             return Ok(allocations);
         }

--- a/crates/wasmi/src/engine/translator/func/simd/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/simd/mod.rs
@@ -65,6 +65,7 @@ impl FuncTranslator {
     }
 
     /// Generically translate any of the Wasm `simd` splat instructions.
+    #[inline(never)]
     fn translate_simd_splat<T, Wrapped>(
         &mut self,
         op_sr: fn(result: Slot) -> Op,
@@ -94,6 +95,7 @@ impl FuncTranslator {
     }
 
     /// Generically translate any of the Wasm `simd` extract lane instructions.
+    #[inline(never)]
     fn translate_extract_lane<T: IntoLaneIdx, R>(
         &mut self,
         lane: u8,
@@ -123,6 +125,7 @@ impl FuncTranslator {
     }
 
     /// Generically translate a Wasm SIMD replace lane instruction.
+    #[inline(never)]
     fn translate_replace_lane<T: op::SimdReplaceLane>(&mut self, lane: u8) -> Result<(), Error>
     where
         T::Item: IntoLaneIdx + From<RawVal> + Copy,
@@ -155,6 +158,7 @@ impl FuncTranslator {
     }
 
     /// Generically translate a Wasm unary instruction.
+    #[inline(never)]
     fn translate_simd_unary_sx<T>(
         &mut self,
         make_instr: fn(result: Slot, input: Slot) -> Op,
@@ -181,6 +185,7 @@ impl FuncTranslator {
     }
 
     /// Generically translate a Wasm unary instruction.
+    #[inline(never)]
     fn translate_simd_unary_rx<T>(
         &mut self,
         make_instr: fn(input: Slot) -> Op,
@@ -203,6 +208,7 @@ impl FuncTranslator {
     }
 
     /// Generically translate a Wasm binary instruction.
+    #[inline(never)]
     fn translate_simd_binary(
         &mut self,
         make_instr: fn(result: Slot, lhs: Slot, rhs: Slot) -> Op,
@@ -227,6 +233,7 @@ impl FuncTranslator {
     }
 
     /// Generically translate a Wasm ternary instruction.
+    #[inline(never)]
     fn translate_simd_ternary(
         &mut self,
         make_instr: fn(result: Slot, a: Slot, b: Slot, c: Slot) -> Op,
@@ -253,6 +260,7 @@ impl FuncTranslator {
     }
 
     /// Generically translate a Wasm SIMD shift instruction.
+    #[inline(never)]
     fn translate_simd_shift<T>(
         &mut self,
         op_ssr: fn(result: Slot, lhs: Slot) -> Op,
@@ -345,6 +353,7 @@ impl FuncTranslator {
         Ok(())
     }
 
+    #[inline(never)]
     fn translate_v128_load_modify<L: LoadOp>(
         &mut self,
         memarg: MemArg,
@@ -369,6 +378,7 @@ impl FuncTranslator {
         Ok(())
     }
 
+    #[inline(never)]
     fn translate_v128_load_lane<L: LoadOp, T: op::SimdReplaceLane>(
         &mut self,
         memarg: MemArg,
@@ -402,6 +412,7 @@ impl FuncTranslator {
     }
 
     #[expect(clippy::type_complexity, clippy::too_many_arguments)]
+    #[inline(never)]
     fn translate_v128_store_lane<T: IntoLaneIdx>(
         &mut self,
         memarg: MemArg,

--- a/crates/wasmi/src/engine/translator/mod.rs
+++ b/crates/wasmi/src/engine/translator/mod.rs
@@ -83,6 +83,15 @@ pub trait WasmTranslator<'parser>:
     /// in order to avoid frequent memory allocations and deallocations.
     type Allocations: Default;
 
+    /// Is `true` if [`WasmTranslator::setup`] always returns `Ok(true)`.
+    ///
+    /// # Note
+    ///
+    /// This allows the translation driver to statically eliminate
+    /// its Wasm parsing and operator translation code paths that are
+    /// unreachable for setup-only [`WasmTranslator`]s.
+    const SETUP_ONLY: bool = false;
+
     /// Sets up the translation process for the Wasm `bytes` and Wasm `module` header.
     ///
     /// - Returns `true` if the [`WasmTranslator`] is done with the translation process.
@@ -427,6 +436,8 @@ impl LazyFuncTranslator {
 
 impl WasmTranslator<'_> for LazyFuncTranslator {
     type Allocations = ();
+
+    const SETUP_ONLY: bool = true;
 
     fn setup(&mut self, bytes: &[u8]) -> Result<bool, Error> {
         self.module


### PR DESCRIPTION
Reduces binary artifact size by ~66.5 kB.

Translation benchmarks are affects but in both directions within 5% margin.