### PR TITLE
Use v-table for operator translation to avoid monomorphizations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -334,6 +334,28 @@ jobs:
       - name: Check uDeps
         run: cargo udeps --all-targets
 
+  cfg-policy:
+    name: Cfg Policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install cargo-wasmi-cfg-policy
+        run: |
+          # Note: We use `|| true` because cargo install returns an error
+          #       if cargo-wasmi-cfg-policy was already installed on the CI runner.
+          cargo install cargo-wasmi-cfg-policy || true
+      - name: Check Cfg Policy (default features)
+        run: cargo wasmi-cfg-policy -p wasmi
+      - name: Check Cfg Policy (no default features)
+        run: cargo wasmi-cfg-policy -p wasmi --no-default-features
+      - name: Check Cfg Policy (all features)
+        run: cargo wasmi-cfg-policy -p wasmi --all-features
+
   fuzz:
     name: Fuzz
     runs-on: ubuntu-latest

--- a/crates/wasmi/build.rs
+++ b/crates/wasmi/build.rs
@@ -8,17 +8,17 @@ use std::env;
 ///
 /// - `wasmi_opt_size` (if `opt-level` is "s" or "z")
 /// - `wasmi_opt_speed` (if `opt-level` is 2 or 3)
-/// 
+///
 /// Any other optimization level (e.g. `0` or `1`) does not set
 /// either of the above Wasmi specific `cfg` annotations.
-/// 
+///
 /// Users may combine the above annotations with `cfg_attr` the following built-ins:
-/// 
+///
 /// - `#[inline]`
 /// - `#[inline(never)]`
 /// - `#[inline(always)]`
 /// - `#[cold]`
-/// 
+///
 /// Any other combination is forbidden as it would alter the code paths taken
 /// on different optimization levels which is something we strictly want to avoid
 /// in the Wasmi codebase.

--- a/crates/wasmi/build.rs
+++ b/crates/wasmi/build.rs
@@ -1,0 +1,35 @@
+use std::env;
+
+/// Emits opt-level dependent Rust `cfg`s to steer `#[inline]` annotations.
+///
+/// # Note
+///
+/// This sets the following `cfg` annotations in the Wasmi codebase:
+///
+/// - `wasmi_opt_size` (if `opt-level` is "s" or "z")
+/// - `wasmi_opt_speed` (if `opt-level` is 2 or 3)
+/// 
+/// Any other optimization level (e.g. `0` or `1`) does not set
+/// either of the above Wasmi specific `cfg` annotations.
+/// 
+/// Users may combine the above annotations with `cfg_attr` the following built-ins:
+/// 
+/// - `#[inline]`
+/// - `#[inline(never)]`
+/// - `#[inline(always)]`
+/// - `#[cold]`
+/// 
+/// Any other combination is forbidden as it would alter the code paths taken
+/// on different optimization levels which is something we strictly want to avoid
+/// in the Wasmi codebase.
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rustc-check-cfg=cfg(wasmi_opt_size)");
+    println!("cargo::rustc-check-cfg=cfg(wasmi_opt_speed)");
+    let opt_level = env::var("OPT_LEVEL").unwrap_or_default();
+    match opt_level.as_str() {
+        "s" | "z" => println!("cargo::rustc-cfg=wasmi_opt_size"),
+        "2" | "3" => println!("cargo::rustc-cfg=wasmi_opt_speed"),
+        _ => (),
+    }
+}

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -24,6 +24,7 @@ use self::{
         CommutativeBinaryOp,
         CommutativeBinaryOpVt,
         LoadOpVt,
+        StoreOpVt,
         UnaryOp,
         UnaryOpVt,
     },
@@ -2499,11 +2500,7 @@ impl FuncTranslator {
     /// Used for translating the following Wasm operators to Wasmi bytecode:
     ///
     /// - `{i32, i64}.{store, store8, store16, store32}`
-    fn translate_store<T: op::StoreOp>(&mut self, memarg: MemArg) -> Result<(), Error>
-    where
-        T::Value: Copy + From<TypedRawVal>,
-        T::Immediate: Copy,
-    {
+    fn translate_store<T: op::StoreOp>(&mut self, memarg: MemArg) -> Result<(), Error> {
         bail_unreachable!(self);
         let (ptr, value) = self.stack.pop2();
         self.encode_store::<T>(memarg, ptr, value)
@@ -2514,12 +2511,28 @@ impl FuncTranslator {
         memarg: MemArg,
         ptr: Operand,
         value: Operand,
-    ) -> Result<(), Error>
-    where
-        T::Value: Copy + From<TypedRawVal>,
-        T::Immediate: Copy,
-    {
-        let op = self.choose_store_op::<T>(memarg, ptr, value)?;
+    ) -> Result<(), Error> {
+        self.encode_store_vt(&T::VT, memarg, ptr, value)
+    }
+
+    /// Encodes a Wasm `store` instruction as Wasmi bytecode.
+    ///
+    /// # Note
+    ///
+    /// All types implementing [`StoreOp`] share this single monomorphization
+    /// via their [`StoreOp::VT`] virtual table to avoid codegen bloat.
+    ///
+    /// [`StoreOp`]: op::StoreOp
+    /// [`StoreOp::VT`]: op::StoreOp::VT
+    #[inline(never)]
+    fn encode_store_vt(
+        &mut self,
+        vt: &StoreOpVt,
+        memarg: MemArg,
+        ptr: Operand,
+        value: Operand,
+    ) -> Result<(), Error> {
+        let op = self.choose_store_op_vt(vt, memarg, ptr, value)?;
         if let Op::Trap { trap_code } = op {
             return self.translate_trap(trap_code);
         }
@@ -2527,17 +2540,14 @@ impl FuncTranslator {
         Ok(())
     }
 
-    /// Selects which store operator to encode based on type `T`.
-    fn choose_store_op<T: op::StoreOp>(
+    /// Selects which store operator to encode based on the given `vt`.
+    fn choose_store_op_vt(
         &mut self,
+        vt: &StoreOpVt,
         memarg: MemArg,
         ptr: Operand,
         value: Operand,
-    ) -> Result<Op, Error>
-    where
-        T::Value: Copy + From<TypedRawVal>,
-        T::Immediate: Copy,
-    {
+    ) -> Result<Op, Error> {
         use ResolvedOperand as Opd;
         let Some((memory, offset)) = Self::decode_memarg(memarg)? else {
             return Ok(Op::trap(TrapCode::MemoryOutOfBounds));
@@ -2549,25 +2559,25 @@ impl FuncTranslator {
         else {
             return Ok(Op::trap(TrapCode::MemoryOutOfBounds));
         };
-        if let Some(op) = self.choose_store_mem0_offset16_op::<T>(ptr, offset, memory, value)? {
+        if let Some(op) = self.choose_store_mem0_offset16_op_vt(vt, ptr, offset, memory, value)? {
             return Ok(op);
         }
-        let value = self
-            .resolve_operand::<T::Value>(value)?
-            .map(T::into_immediate);
+        let value = self.resolve_operand::<TypedRawVal>(value)?;
         let op = match (ptr, value) {
-            (Opd::Reg(_), Opd::Reg(_)) => match T::store_rr(offset, memory) {
+            (Opd::Reg(_), Opd::Reg(_)) => match (vt.store_rr)(offset, memory) {
                 Some(op) => op,
                 None => unreachable!(),
             },
-            (Opd::Reg(_), Opd::Slot(value)) => T::store_rs(offset, value, memory),
-            (Opd::Reg(_), Opd::Immediate(value)) => T::store_ri(offset, value, memory),
-            (Opd::Slot(ptr), Opd::Reg(_)) => T::store_sr(ptr, offset, memory),
-            (Opd::Slot(ptr), Opd::Slot(value)) => T::store_ss(ptr, offset, value, memory),
-            (Opd::Slot(ptr), Opd::Immediate(value)) => T::store_si(ptr, offset, value, memory),
-            (Opd::Immediate(address), Opd::Reg(_)) => T::store_ir(address, memory),
-            (Opd::Immediate(address), Opd::Slot(value)) => T::store_is(address, value, memory),
-            (Opd::Immediate(address), Opd::Immediate(value)) => T::store_ii(address, value, memory),
+            (Opd::Reg(_), Opd::Slot(value)) => (vt.store_rs)(offset, value, memory),
+            (Opd::Reg(_), Opd::Immediate(value)) => (vt.store_ri)(offset, value, memory),
+            (Opd::Slot(ptr), Opd::Reg(_)) => (vt.store_sr)(ptr, offset, memory),
+            (Opd::Slot(ptr), Opd::Slot(value)) => (vt.store_ss)(ptr, offset, value, memory),
+            (Opd::Slot(ptr), Opd::Immediate(value)) => (vt.store_si)(ptr, offset, value, memory),
+            (Opd::Immediate(address), Opd::Reg(_)) => (vt.store_ir)(address, memory),
+            (Opd::Immediate(address), Opd::Slot(value)) => (vt.store_is)(address, value, memory),
+            (Opd::Immediate(address), Opd::Immediate(value)) => {
+                (vt.store_ii)(address, value, memory)
+            }
         };
         Ok(op)
     }
@@ -2579,17 +2589,14 @@ impl FuncTranslator {
     /// - Returns `Ok(true)` if encoding is available.
     /// - Returns `Ok(false)` if encoding is not available.
     /// - Returns `Err(_)` if an error occurred.
-    fn choose_store_mem0_offset16_op<T: op::StoreOp>(
+    fn choose_store_mem0_offset16_op_vt(
         &mut self,
+        vt: &StoreOpVt,
         ptr: ResolvedOperand<Address>,
         offset: Offset,
         memory: index::Memory,
         value: Operand,
-    ) -> Result<Option<Op>, Error>
-    where
-        T::Value: Copy + From<TypedRawVal>,
-        T::Immediate: Copy,
-    {
+    ) -> Result<Option<Op>, Error> {
         use Location as Loc;
         use ResolvedOperand as Opd;
         if !memory.is_default() {
@@ -2603,23 +2610,21 @@ impl FuncTranslator {
             Opd::Slot(ptr) => Loc::Slot(ptr),
             Opd::Immediate(_) => return Ok(None),
         };
-        let resolved_value = self
-            .resolve_operand::<T::Value>(value)?
-            .map(T::into_immediate);
+        let resolved_value = self.resolve_operand::<TypedRawVal>(value)?;
         let op = match (ptr, resolved_value) {
-            (Loc::Reg(_), Opd::Reg(_)) => match T::store_mem0_offset16_rr(offset) {
+            (Loc::Reg(_), Opd::Reg(_)) => match (vt.store_mem0_offset16_rr)(offset) {
                 Some(op) => op,
                 None => {
                     let value = self.reg_operand_to_slot(value)?;
-                    T::store_mem0_offset16_rs(offset, value)
+                    (vt.store_mem0_offset16_rs)(offset, value)
                 }
             },
-            (Loc::Reg(_), Opd::Slot(value)) => T::store_mem0_offset16_rs(offset, value),
-            (Loc::Reg(_), Opd::Immediate(value)) => T::store_mem0_offset16_ri(offset, value),
-            (Loc::Slot(ptr), Opd::Reg(_)) => T::store_mem0_offset16_sr(ptr, offset),
-            (Loc::Slot(ptr), Opd::Slot(value)) => T::store_mem0_offset16_ss(ptr, offset, value),
+            (Loc::Reg(_), Opd::Slot(value)) => (vt.store_mem0_offset16_rs)(offset, value),
+            (Loc::Reg(_), Opd::Immediate(value)) => (vt.store_mem0_offset16_ri)(offset, value),
+            (Loc::Slot(ptr), Opd::Reg(_)) => (vt.store_mem0_offset16_sr)(ptr, offset),
+            (Loc::Slot(ptr), Opd::Slot(value)) => (vt.store_mem0_offset16_ss)(ptr, offset, value),
             (Loc::Slot(ptr), Opd::Immediate(value)) => {
-                T::store_mem0_offset16_si(ptr, offset, value)
+                (vt.store_mem0_offset16_si)(ptr, offset, value)
             }
         };
         Ok(Some(op))

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1673,7 +1673,8 @@ impl FuncTranslator {
     ///
     /// All types implementing [`UnaryOp`] share this single monomorphization
     /// via their [`UnaryOp::VT`] virtual table to avoid codegen bloat.
-    #[inline(never)]
+    #[cfg_attr(wasmi_opt_size, inline(never))]
+    #[cfg_attr(wasmi_opt_speed, inline(always))]
     fn translate_unary_vt(
         &mut self,
         vt: &UnaryOpVt,
@@ -1852,7 +1853,8 @@ impl FuncTranslator {
     /// All types implementing [`CommutativeBinaryOp`] share this single
     /// monomorphization via their [`CommutativeBinaryOp::VT`] virtual table
     /// to avoid codegen bloat.
-    #[inline(never)]
+    #[cfg_attr(wasmi_opt_size, inline(never))]
+    #[cfg_attr(wasmi_opt_speed, inline(always))]
     fn translate_binary_commutative_vt(
         &mut self,
         vt: &CommutativeBinaryOpVt,
@@ -1908,7 +1910,8 @@ impl FuncTranslator {
     ///
     /// All types implementing [`BinaryOp`] share this single monomorphization
     /// via their [`BinaryOp::VT`] virtual table to avoid codegen bloat.
-    #[inline(never)]
+    #[cfg_attr(wasmi_opt_size, inline(never))]
+    #[cfg_attr(wasmi_opt_speed, inline(always))]
     fn translate_binary_vt(
         &mut self,
         vt: &BinaryOpVt,
@@ -2419,7 +2422,8 @@ impl FuncTranslator {
     ///
     /// [`LoadOp`]: op::LoadOp
     /// [`LoadOp::VT`]: op::LoadOp::VT
-    #[inline(never)]
+    #[cfg_attr(wasmi_opt_size, inline(never))]
+    #[cfg_attr(wasmi_opt_speed, inline(always))]
     fn translate_load_vt(&mut self, vt: &LoadOpVt, memarg: MemArg) -> Result<(), Error> {
         bail_unreachable!(self);
         let ptr = self.stack.pop();
@@ -2450,6 +2454,7 @@ impl FuncTranslator {
     ///
     /// This chooses the right encoding for the given `load` instruction.
     /// If `ptr+offset` is a constant value the address is pre-calculated.
+    #[cfg_attr(wasmi_opt_speed, inline(always))]
     fn select_load_op_vt(
         &mut self,
         vt: &LoadOpVt,
@@ -2524,7 +2529,8 @@ impl FuncTranslator {
     ///
     /// [`StoreOp`]: op::StoreOp
     /// [`StoreOp::VT`]: op::StoreOp::VT
-    #[inline(never)]
+    #[cfg_attr(wasmi_opt_size, inline(never))]
+    #[cfg_attr(wasmi_opt_speed, inline(always))]
     fn encode_store_vt(
         &mut self,
         vt: &StoreOpVt,
@@ -2541,6 +2547,7 @@ impl FuncTranslator {
     }
 
     /// Selects which store operator to encode based on the given `vt`.
+    #[cfg_attr(wasmi_opt_speed, inline(always))]
     fn choose_store_op_vt(
         &mut self,
         vt: &StoreOpVt,

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -23,6 +23,7 @@ use self::{
         BinaryOpVt,
         CommutativeBinaryOp,
         CommutativeBinaryOpVt,
+        LoadOpVt,
         UnaryOp,
         UnaryOpVt,
     },
@@ -2405,13 +2406,25 @@ impl FuncTranslator {
     /// - `i32.{load8_s, load8_u, load16_s, load16_u}`
     /// - `i64.{load8_s, load8_u, load16_s, load16_u load32_s, load32_u}`
     fn translate_load<T: op::LoadOp>(&mut self, memarg: MemArg) -> Result<(), Error> {
+        self.translate_load_vt(&T::VT, memarg)
+    }
+
+    /// Translates a Wasm `load` instruction to Wasmi bytecode.
+    ///
+    /// # Note
+    ///
+    /// All [`LoadOp`]s share the single monomorphization of this method
+    /// via their [`LoadOp::VT`] virtual table to avoid codegen bloat.
+    ///
+    /// [`LoadOp`]: op::LoadOp
+    /// [`LoadOp::VT`]: op::LoadOp::VT
+    #[inline(never)]
+    fn translate_load_vt(&mut self, vt: &LoadOpVt, memarg: MemArg) -> Result<(), Error> {
         bail_unreachable!(self);
         let ptr = self.stack.pop();
-        match self.select_load_op::<T>(ptr, memarg)? {
+        match self.select_load_op_vt(vt, ptr, memarg)? {
             Op::Trap { trap_code } => self.translate_trap(trap_code),
-            op => {
-                self.stage_op_with_result_reg(<T::Result as Typed>::TY, op, FuelCostsProvider::load)
-            }
+            op => self.stage_op_with_result_reg(vt.result_ty, op, FuelCostsProvider::load),
         }
     }
 
@@ -2423,7 +2436,25 @@ impl FuncTranslator {
     ///
     /// This chooses the right encoding for the given `load` instruction.
     /// If `ptr+offset` is a constant value the address is pre-calculated.
+    #[cfg(feature = "simd")]
     fn select_load_op<T: op::LoadOp>(&mut self, ptr: Operand, memarg: MemArg) -> Result<Op, Error> {
+        self.select_load_op_vt(&T::VT, ptr, memarg)
+    }
+
+    /// Returns a Wasmi `load` operator for `memarg` and `ptr` if any.
+    ///
+    /// Returns [`Op::Trap`] if `ptr` is known to be out of bounds for the linear memory.
+    ///
+    /// # Note
+    ///
+    /// This chooses the right encoding for the given `load` instruction.
+    /// If `ptr+offset` is a constant value the address is pre-calculated.
+    fn select_load_op_vt(
+        &mut self,
+        vt: &LoadOpVt,
+        ptr: Operand,
+        memarg: MemArg,
+    ) -> Result<Op, Error> {
         let Some((memory, offset)) = Self::decode_memarg(memarg)? else {
             return Ok(Op::trap(TrapCode::MemoryOutOfBounds));
         };
@@ -2438,8 +2469,8 @@ impl FuncTranslator {
                 None => break 'opt,
             };
             let op = match ptr {
-                ResolvedOperand::Reg(_) => T::op_rr_mem0_offset16(offset),
-                ResolvedOperand::Slot(ptr) => T::op_rs_mem0_offset16(ptr, offset),
+                ResolvedOperand::Reg(_) => (vt.op_rr_mem0_offset16)(offset),
+                ResolvedOperand::Slot(ptr) => (vt.op_rs_mem0_offset16)(ptr, offset),
                 ResolvedOperand::Immediate(_) => break 'opt,
             };
             return Ok(op);
@@ -2449,9 +2480,9 @@ impl FuncTranslator {
             return Ok(Op::trap(TrapCode::MemoryOutOfBounds));
         };
         let op = match ptr {
-            ResolvedOperand::Reg(_) => T::op_rr(offset, memory),
-            ResolvedOperand::Slot(ptr) => T::op_rs(ptr, offset, memory),
-            ResolvedOperand::Immediate(address) => T::op_ri(address, memory),
+            ResolvedOperand::Reg(_) => (vt.op_rr)(offset, memory),
+            ResolvedOperand::Slot(ptr) => (vt.op_rs)(ptr, offset, memory),
+            ResolvedOperand::Immediate(address) => (vt.op_ri)(address, memory),
         };
         Ok(op)
     }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -18,7 +18,7 @@ use self::{
     labels::{LabelRef, LabelRegistry},
     layout::{StackLayout, StackSpace},
     locals::{LocalIdx, LocalsRegistry},
-    op::{BinaryOp, CommutativeBinaryOp, UnaryOp},
+    op::{BinaryOp, CommutativeBinaryOp, UnaryOp, UnaryOpVt},
     stack::{
         BlockControlFrame,
         ControlFrame,
@@ -1654,22 +1654,33 @@ impl FuncTranslator {
     fn translate_unary_with_opt<Op: UnaryOp>(
         &mut self,
         try_opt: fn(&mut FuncTranslator, value: Operand) -> Result<bool, Error>,
-    ) -> Result<(), Error>
-    where
-        Op::Value: From<TypedRawVal>,
-        Op::Result: Into<TypedRawVal> + Typed,
-    {
+    ) -> Result<(), Error> {
+        self.translate_unary_vt(&Op::VT, try_opt)
+    }
+
+    /// Translates a unary Wasm instruction to Wasmi bytecode.
+    ///
+    /// # Note
+    ///
+    /// All types implementing [`UnaryOp`] share this single monomorphization
+    /// via their [`UnaryOp::VT`] virtual table to avoid codegen bloat.
+    #[inline(never)]
+    fn translate_unary_vt(
+        &mut self,
+        vt: &UnaryOpVt,
+        try_opt: fn(&mut FuncTranslator, value: Operand) -> Result<bool, Error>,
+    ) -> Result<(), Error> {
         bail_unreachable!(self);
         let input = self.stack.pop();
         if try_opt(self, input)? {
             // Case: custom optimization took effect, return early.
             return Ok(());
         }
-        let op = match self.resolve_operand::<Op::Value>(input)? {
-            ResolvedOperand::Reg(_) => Op::op_rr(),
-            ResolvedOperand::Slot(input) => Op::op_rs(input),
+        let op = match self.resolve_operand::<TypedRawVal>(input)? {
+            ResolvedOperand::Reg(_) => (vt.op_rr)(),
+            ResolvedOperand::Slot(input) => (vt.op_rs)(input),
             ResolvedOperand::Immediate(input) => {
-                match Op::consteval(input) {
+                match (vt.consteval)(input) {
                     Ok(result) => {
                         self.stack.push_immediate(result)?;
                     }
@@ -1680,16 +1691,12 @@ impl FuncTranslator {
                 return Ok(());
             }
         };
-        self.stage_op_with_result_reg(<Op::Result>::TY, op, FuelCostsProvider::base)?;
+        self.stage_op_with_result_reg(vt.result_ty, op, FuelCostsProvider::base)?;
         Ok(())
     }
 
     /// Translates a unary Wasm instruction to Wasmi bytecode.
-    fn translate_unary<Op: UnaryOp>(&mut self) -> Result<(), Error>
-    where
-        Op::Value: From<TypedRawVal>,
-        Op::Result: Into<TypedRawVal> + Typed,
-    {
+    fn translate_unary<Op: UnaryOp>(&mut self) -> Result<(), Error> {
         self.translate_unary_with_opt::<Op>(|_, _| Ok(false))
     }
 

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -18,7 +18,14 @@ use self::{
     labels::{LabelRef, LabelRegistry},
     layout::{StackLayout, StackSpace},
     locals::{LocalIdx, LocalsRegistry},
-    op::{BinaryOp, CommutativeBinaryOp, UnaryOp, UnaryOpVt},
+    op::{
+        BinaryOp,
+        BinaryOpVt,
+        CommutativeBinaryOp,
+        CommutativeBinaryOpVt,
+        UnaryOp,
+        UnaryOpVt,
+    },
     stack::{
         BlockControlFrame,
         ControlFrame,
@@ -1762,7 +1769,7 @@ impl FuncTranslator {
     }
 
     /// Convenience method to tell that there is no custom optimization.
-    fn no_opt_ri<T>(&mut self, _lhs: Operand, _rhs: T) -> Result<bool, Error> {
+    fn no_opt_ri(&mut self, _lhs: Operand, _rhs: TypedRawVal) -> Result<bool, Error> {
         Ok(false)
     }
 
@@ -1824,29 +1831,37 @@ impl FuncTranslator {
     }
 
     /// Translates a non-commutative binary Wasm operator to Wasmi bytecode.
-    fn translate_binary_commutative<T: CommutativeBinaryOp>(&mut self) -> Result<(), Error>
-    where
-        T::Input: From<TypedRawVal> + Copy,
-        T::Result: Into<TypedRawVal>,
-    {
+    fn translate_binary_commutative<T: CommutativeBinaryOp>(&mut self) -> Result<(), Error> {
         self.translate_binary_commutative_with_opt::<T>(Self::no_opt_ri)
     }
 
     /// Translates a commutative binary Wasm operator to Wasmi bytecode.
     fn translate_binary_commutative_with_opt<T: CommutativeBinaryOp>(
         &mut self,
-        opt_rhs_imm: fn(this: &mut Self, lhs: Operand, rhs: T::Input) -> Result<bool, Error>,
-    ) -> Result<(), Error>
-    where
-        T::Input: From<TypedRawVal> + Copy,
-        T::Result: Into<TypedRawVal>,
-    {
+        opt_rhs_imm: fn(this: &mut Self, lhs: Operand, rhs: TypedRawVal) -> Result<bool, Error>,
+    ) -> Result<(), Error> {
+        self.translate_binary_commutative_vt(&T::VT, opt_rhs_imm)
+    }
+
+    /// Translates a commutative binary Wasm operator to Wasmi bytecode.
+    ///
+    /// # Note
+    ///
+    /// All types implementing [`CommutativeBinaryOp`] share this single
+    /// monomorphization via their [`CommutativeBinaryOp::VT`] virtual table
+    /// to avoid codegen bloat.
+    #[inline(never)]
+    fn translate_binary_commutative_vt(
+        &mut self,
+        vt: &CommutativeBinaryOpVt,
+        opt_rhs_imm: fn(this: &mut Self, lhs: Operand, rhs: TypedRawVal) -> Result<bool, Error>,
+    ) -> Result<(), Error> {
         bail_unreachable!(self);
         let (lhs, rhs) = self.stack.pop2();
-        let l = self.resolve_operand::<T::Input>(lhs)?;
-        let r = self.resolve_operand::<T::Input>(rhs)?;
+        let l = self.resolve_operand::<TypedRawVal>(lhs)?;
+        let r = self.resolve_operand::<TypedRawVal>(rhs)?;
         if let (ResolvedOperand::Immediate(lhs), ResolvedOperand::Immediate(rhs)) = (l, r) {
-            return self.translate_binary_consteval(lhs, rhs, T::consteval);
+            return self.translate_binary_consteval(lhs, rhs, vt.consteval);
         }
         let (l, r) = ResolvedOperand::sort(l, r);
         if let (_, ResolvedOperand::Immediate(rhs)) = (l, r) {
@@ -1855,51 +1870,56 @@ impl FuncTranslator {
             }
         }
         let operator = match (l, r) {
-            (ResolvedOperand::Reg(_), ResolvedOperand::Reg(_)) => match T::op_rrr() {
+            (ResolvedOperand::Reg(_), ResolvedOperand::Reg(_)) => match (vt.op_rrr)() {
                 Some(op) => op,
                 None => {
                     let rhs_slot = self.reg_operand_to_slot(rhs)?;
-                    T::op_rrs(rhs_slot)
+                    (vt.op_rrs)(rhs_slot)
                 }
             },
-            (ResolvedOperand::Reg(_), ResolvedOperand::Slot(rhs)) => T::op_rrs(rhs),
-            (ResolvedOperand::Reg(_), ResolvedOperand::Immediate(rhs)) => T::op_rri(rhs),
-            (ResolvedOperand::Slot(lhs), ResolvedOperand::Slot(rhs)) => T::op_rss(lhs, rhs),
-            (ResolvedOperand::Slot(lhs), ResolvedOperand::Immediate(rhs)) => T::op_rsi(lhs, rhs),
+            (ResolvedOperand::Reg(_), ResolvedOperand::Slot(rhs)) => (vt.op_rrs)(rhs),
+            (ResolvedOperand::Reg(_), ResolvedOperand::Immediate(rhs)) => (vt.op_rri)(rhs),
+            (ResolvedOperand::Slot(lhs), ResolvedOperand::Slot(rhs)) => (vt.op_rss)(lhs, rhs),
+            (ResolvedOperand::Slot(lhs), ResolvedOperand::Immediate(rhs)) => (vt.op_rsi)(lhs, rhs),
             _ => Self::unsupported_operand_pair(lhs, rhs),
         };
-        self.stage_op_with_result_reg(<T::Result as Typed>::TY, operator, FuelCostsProvider::base)?;
+        self.stage_op_with_result_reg(vt.result_ty, operator, FuelCostsProvider::base)?;
         Ok(())
     }
 
     /// Translates a non-commutative binary Wasm operator to Wasmi bytecode.
-    fn translate_binary<T: BinaryOp>(&mut self) -> Result<(), Error>
-    where
-        T::Lhs: From<TypedRawVal> + Copy,
-        T::Rhs: Copy,
-        T::Result: Into<TypedRawVal>,
-    {
+    fn translate_binary<T: BinaryOp>(&mut self) -> Result<(), Error> {
         self.translate_binary_with_opt::<T>(Self::no_opt_ri)
     }
 
     /// Translates a non-commutative binary Wasm operator to Wasmi bytecode.
     fn translate_binary_with_opt<T: BinaryOp>(
         &mut self,
-        opt_rhs_imm: fn(this: &mut Self, lhs: Operand, rhs: T::Rhs) -> Result<bool, Error>,
-    ) -> Result<(), Error>
-    where
-        T::Lhs: From<TypedRawVal> + Copy,
-        T::Rhs: Copy,
-        T::Result: Into<TypedRawVal>,
-    {
+        opt_rhs_imm: fn(this: &mut Self, lhs: Operand, rhs: TypedRawVal) -> Result<bool, Error>,
+    ) -> Result<(), Error> {
+        self.translate_binary_vt(&T::VT, opt_rhs_imm)
+    }
+
+    /// Translates a non-commutative binary Wasm operator to Wasmi bytecode.
+    ///
+    /// # Note
+    ///
+    /// All types implementing [`BinaryOp`] share this single monomorphization
+    /// via their [`BinaryOp::VT`] virtual table to avoid codegen bloat.
+    #[inline(never)]
+    fn translate_binary_vt(
+        &mut self,
+        vt: &BinaryOpVt,
+        opt_rhs_imm: fn(this: &mut Self, lhs: Operand, rhs: TypedRawVal) -> Result<bool, Error>,
+    ) -> Result<(), Error> {
         bail_unreachable!(self);
         let (lhs, rhs) = self.stack.pop2();
-        let l = self.resolve_operand::<T::Lhs>(lhs)?;
-        let r = self.resolve_operand::<RawVal>(rhs)?;
+        let l = self.resolve_operand::<TypedRawVal>(lhs)?;
+        let r = self.resolve_operand::<TypedRawVal>(rhs)?;
         let r = match r {
             ResolvedOperand::Reg(ty) => ResolvedOperand::Reg(ty),
             ResolvedOperand::Slot(rhs) => ResolvedOperand::Slot(rhs),
-            ResolvedOperand::Immediate(rhs) => match T::decode_rhs(rhs) {
+            ResolvedOperand::Immediate(rhs) => match (vt.decode_rhs)(rhs) {
                 BinaryOpRhs::Value(rhs) => ResolvedOperand::Immediate(rhs),
                 BinaryOpRhs::Trap(trap_code) => return self.translate_trap(trap_code),
                 BinaryOpRhs::ReturnLhs => {
@@ -1909,7 +1929,7 @@ impl FuncTranslator {
             },
         };
         if let (ResolvedOperand::Immediate(lhs), ResolvedOperand::Immediate(rhs)) = (l, r) {
-            return self.translate_binary_consteval(lhs, rhs, T::consteval);
+            return self.translate_binary_consteval(lhs, rhs, vt.consteval);
         }
         if let (_, ResolvedOperand::Immediate(rhs)) = (l, r) {
             if opt_rhs_imm(self, lhs, rhs)? {
@@ -1917,36 +1937,33 @@ impl FuncTranslator {
             }
         }
         let operator = match (l, r) {
-            (ResolvedOperand::Reg(_), ResolvedOperand::Reg(_)) => match T::op_rrr() {
+            (ResolvedOperand::Reg(_), ResolvedOperand::Reg(_)) => match (vt.op_rrr)() {
                 Some(op) => op,
                 None => {
                     let rhs_slot = self.reg_operand_to_slot(rhs)?;
-                    T::op_rrs(rhs_slot)
+                    (vt.op_rrs)(rhs_slot)
                 }
             },
-            (ResolvedOperand::Reg(_), ResolvedOperand::Slot(rhs)) => T::op_rrs(rhs),
-            (ResolvedOperand::Reg(_), ResolvedOperand::Immediate(rhs)) => T::op_rri(rhs),
-            (ResolvedOperand::Slot(lhs), ResolvedOperand::Reg(_)) => T::op_rsr(lhs),
-            (ResolvedOperand::Slot(lhs), ResolvedOperand::Slot(rhs)) => T::op_rss(lhs, rhs),
-            (ResolvedOperand::Slot(lhs), ResolvedOperand::Immediate(rhs)) => T::op_rsi(lhs, rhs),
-            (ResolvedOperand::Immediate(lhs), ResolvedOperand::Reg(_)) => T::op_rir(lhs),
-            (ResolvedOperand::Immediate(lhs), ResolvedOperand::Slot(rhs)) => T::op_ris(lhs, rhs),
+            (ResolvedOperand::Reg(_), ResolvedOperand::Slot(rhs)) => (vt.op_rrs)(rhs),
+            (ResolvedOperand::Reg(_), ResolvedOperand::Immediate(rhs)) => (vt.op_rri)(rhs),
+            (ResolvedOperand::Slot(lhs), ResolvedOperand::Reg(_)) => (vt.op_rsr)(lhs),
+            (ResolvedOperand::Slot(lhs), ResolvedOperand::Slot(rhs)) => (vt.op_rss)(lhs, rhs),
+            (ResolvedOperand::Slot(lhs), ResolvedOperand::Immediate(rhs)) => (vt.op_rsi)(lhs, rhs),
+            (ResolvedOperand::Immediate(lhs), ResolvedOperand::Reg(_)) => (vt.op_rir)(lhs),
+            (ResolvedOperand::Immediate(lhs), ResolvedOperand::Slot(rhs)) => (vt.op_ris)(lhs, rhs),
             _ => Self::unsupported_operand_pair(lhs, rhs),
         };
-        self.stage_op_with_result_reg(<T::Result as Typed>::TY, operator, FuelCostsProvider::base)?;
+        self.stage_op_with_result_reg(vt.result_ty, operator, FuelCostsProvider::base)?;
         Ok(())
     }
 
     /// Evaluates `consteval(lhs, rhs)` and pushed either its result or tranlates a `trap`.
-    fn translate_binary_consteval<Lhs, Rhs, Res>(
+    fn translate_binary_consteval(
         &mut self,
-        lhs: Lhs,
-        rhs: Rhs,
-        consteval: impl FnOnce(Lhs, Rhs) -> Result<Res, TrapCode>,
-    ) -> Result<(), Error>
-    where
-        Res: Into<TypedRawVal>,
-    {
+        lhs: TypedRawVal,
+        rhs: TypedRawVal,
+        consteval: fn(TypedRawVal, TypedRawVal) -> Result<TypedRawVal, TrapCode>,
+    ) -> Result<(), Error> {
         match consteval(lhs, rhs) {
             Ok(value) => {
                 self.stack.push_immediate(value)?;
@@ -2309,7 +2326,7 @@ impl FuncTranslator {
     /// - `Ok(true)` if the intruction fusion was successful.
     /// - `Ok(false)` if instruction fusion could not be applied.
     /// - `Err(_)` if an error occurred.
-    pub fn fuse_eqz<T: WasmInteger>(&mut self, lhs: Operand, rhs: T) -> Result<bool, Error> {
+    pub fn fuse_eqz(&mut self, lhs: Operand, rhs: TypedRawVal) -> Result<bool, Error> {
         self.fuse_commutative_cmp_with(lhs, rhs, NegateCmpInstr::negate_cmp_instr)
     }
 
@@ -2320,7 +2337,7 @@ impl FuncTranslator {
     /// - `Ok(true)` if the intruction fusion was successful.
     /// - `Ok(false)` if instruction fusion could not be applied.
     /// - `Err(_)` if an error occurred.
-    pub fn fuse_nez<T: WasmInteger>(&mut self, lhs: Operand, rhs: T) -> Result<bool, Error> {
+    pub fn fuse_nez(&mut self, lhs: Operand, rhs: TypedRawVal) -> Result<bool, Error> {
         self.fuse_commutative_cmp_with(lhs, rhs, LogicalizeCmpInstr::logicalize_cmp_instr)
     }
 
@@ -2333,13 +2350,18 @@ impl FuncTranslator {
     /// - `Ok(true)` if the intruction fusion was successful.
     /// - `Ok(false)` if instruction fusion could not be applied.
     /// - `Err(_)` if an error occurred.
-    fn fuse_commutative_cmp_with<T: WasmInteger>(
+    fn fuse_commutative_cmp_with(
         &mut self,
         lhs: Operand,
-        rhs: T,
+        rhs: TypedRawVal,
         try_fuse: fn(cmp: &Op) -> Option<Op>,
     ) -> Result<bool, Error> {
-        if !rhs.is_zero() {
+        let is_zero = match rhs.ty() {
+            ValType::I32 => i32::from(rhs).is_zero(),
+            ValType::I64 => i64::from(rhs).is_zero(),
+            _ => false,
+        };
+        if !is_zero {
             // Case: cannot fuse with non-zero `rhs`
             return Ok(false);
         }

--- a/crates/wasmi/src/engine/translator/func/op/binary.rs
+++ b/crates/wasmi/src/engine/translator/func/op/binary.rs
@@ -3,15 +3,32 @@
 use super::IntoResult as _;
 use crate::{
     TrapCode,
-    core::{IntoShiftAmount, RawVal, ShiftAmount, Typed, wasm},
+    ValType,
+    core::{IntoShiftAmount, ShiftAmount, Typed, TypedRawVal, wasm},
     engine::eval,
     ir::{Op, Slot},
 };
 use core::num::NonZero;
 
-pub trait CommutativeBinaryOp {
-    type Result: Typed;
-    type Input: Typed;
+pub trait CommutativeBinaryOp: Sized {
+    type Result: Typed + Into<TypedRawVal>;
+    type Input: Typed + From<TypedRawVal>;
+
+    /// The virtual table of `Self`'s associated methods.
+    ///
+    /// Passing this to the generic translation routines instead of `Self`
+    /// allows all [`CommutativeBinaryOp`]s to share a single monomorphization,
+    /// avoiding codegen bloat. Immediates cross the vtable boundary as
+    /// [`TypedRawVal`] which type-checks all conversions in debug mode.
+    const VT: CommutativeBinaryOpVt = CommutativeBinaryOpVt {
+        result_ty: <Self::Result as Typed>::TY,
+        consteval: commutative_consteval_vt::<Self>,
+        op_rrr: Self::op_rrr,
+        op_rrs: Self::op_rrs,
+        op_rri: commutative_op_rri_vt::<Self>,
+        op_rss: Self::op_rss,
+        op_rsi: commutative_op_rsi_vt::<Self>,
+    };
 
     fn consteval(lhs: Self::Input, rhs: Self::Input) -> Result<Self::Result, TrapCode>;
 
@@ -24,12 +41,61 @@ pub trait CommutativeBinaryOp {
     fn op_rsi(lhs: Slot, rhs: Self::Input) -> Op;
 }
 
-pub trait BinaryOp {
-    type Result: Typed;
-    type Lhs: Typed;
-    type Rhs: Typed;
+/// Virtual table for a [`CommutativeBinaryOp`]. See [`CommutativeBinaryOp::VT`].
+pub struct CommutativeBinaryOpVt {
+    pub result_ty: ValType,
+    pub consteval: fn(lhs: TypedRawVal, rhs: TypedRawVal) -> Result<TypedRawVal, TrapCode>,
+    pub op_rrr: fn() -> Option<Op>,
+    pub op_rrs: fn(rhs: Slot) -> Op,
+    pub op_rri: fn(rhs: TypedRawVal) -> Op,
+    pub op_rss: fn(lhs: Slot, rhs: Slot) -> Op,
+    pub op_rsi: fn(lhs: Slot, rhs: TypedRawVal) -> Op,
+}
 
-    fn decode_rhs(rhs: RawVal) -> BinaryOpRhs<Self::Rhs>;
+/// Adapts [`CommutativeBinaryOp::consteval`] for [`CommutativeBinaryOpVt`].
+fn commutative_consteval_vt<T: CommutativeBinaryOp>(
+    lhs: TypedRawVal,
+    rhs: TypedRawVal,
+) -> Result<TypedRawVal, TrapCode> {
+    T::consteval(lhs.into(), rhs.into()).map(Into::into)
+}
+
+/// Adapts [`CommutativeBinaryOp::op_rri`] for [`CommutativeBinaryOpVt`].
+fn commutative_op_rri_vt<T: CommutativeBinaryOp>(rhs: TypedRawVal) -> Op {
+    T::op_rri(rhs.into())
+}
+
+/// Adapts [`CommutativeBinaryOp::op_rsi`] for [`CommutativeBinaryOpVt`].
+fn commutative_op_rsi_vt<T: CommutativeBinaryOp>(lhs: Slot, rhs: TypedRawVal) -> Op {
+    T::op_rsi(lhs, rhs.into())
+}
+
+pub trait BinaryOp: Sized {
+    type Result: Typed + Into<TypedRawVal>;
+    type Lhs: Typed + From<TypedRawVal>;
+    type Rhs: Typed + RhsImmediate;
+
+    /// The virtual table of `Self`'s associated methods.
+    ///
+    /// Passing this to the generic translation routines instead of `Self`
+    /// allows all [`BinaryOp`]s to share a single monomorphization,
+    /// avoiding codegen bloat. Immediates cross the vtable boundary as
+    /// [`TypedRawVal`] which type-checks all conversions in debug mode.
+    const VT: BinaryOpVt = BinaryOpVt {
+        result_ty: <Self::Result as Typed>::TY,
+        decode_rhs: binary_decode_rhs_vt::<Self>,
+        consteval: binary_consteval_vt::<Self>,
+        op_rrr: Self::op_rrr,
+        op_rrs: Self::op_rrs,
+        op_rri: binary_op_rri_vt::<Self>,
+        op_rsr: Self::op_rsr,
+        op_rss: Self::op_rss,
+        op_rsi: binary_op_rsi_vt::<Self>,
+        op_rir: binary_op_rir_vt::<Self>,
+        op_ris: binary_op_ris_vt::<Self>,
+    };
+
+    fn decode_rhs(rhs: TypedRawVal) -> BinaryOpRhs<Self::Rhs>;
     fn consteval(lhs: Self::Lhs, rhs: Self::Rhs) -> Result<Self::Result, TrapCode>;
 
     fn op_rrr() -> Option<Op> {
@@ -42,6 +108,115 @@ pub trait BinaryOp {
     fn op_rsi(lhs: Slot, rhs: Self::Rhs) -> Op;
     fn op_rir(lhs: Self::Lhs) -> Op;
     fn op_ris(lhs: Self::Lhs, rhs: Slot) -> Op;
+}
+
+/// Virtual table for a [`BinaryOp`]. See [`BinaryOp::VT`].
+///
+/// # Note
+///
+/// Immediate `rhs` values are the *decoded* [`BinaryOp::Rhs`] values
+/// re-encoded as [`TypedRawVal`] via [`RhsImmediate`].
+pub struct BinaryOpVt {
+    pub result_ty: ValType,
+    pub decode_rhs: fn(rhs: TypedRawVal) -> BinaryOpRhs<TypedRawVal>,
+    pub consteval: fn(lhs: TypedRawVal, rhs: TypedRawVal) -> Result<TypedRawVal, TrapCode>,
+    pub op_rrr: fn() -> Option<Op>,
+    pub op_rrs: fn(rhs: Slot) -> Op,
+    pub op_rri: fn(rhs: TypedRawVal) -> Op,
+    pub op_rsr: fn(lhs: Slot) -> Op,
+    pub op_rss: fn(lhs: Slot, rhs: Slot) -> Op,
+    pub op_rsi: fn(lhs: Slot, rhs: TypedRawVal) -> Op,
+    pub op_rir: fn(lhs: TypedRawVal) -> Op,
+    pub op_ris: fn(lhs: TypedRawVal, rhs: Slot) -> Op,
+}
+
+/// Adapts [`BinaryOp::decode_rhs`] for [`BinaryOpVt`].
+fn binary_decode_rhs_vt<T: BinaryOp>(rhs: TypedRawVal) -> BinaryOpRhs<TypedRawVal> {
+    match T::decode_rhs(rhs) {
+        BinaryOpRhs::Value(rhs) => BinaryOpRhs::Value(rhs.into_typed()),
+        BinaryOpRhs::Trap(trap_code) => BinaryOpRhs::Trap(trap_code),
+        BinaryOpRhs::ReturnLhs => BinaryOpRhs::ReturnLhs,
+    }
+}
+
+/// Adapts [`BinaryOp::consteval`] for [`BinaryOpVt`].
+fn binary_consteval_vt<T: BinaryOp>(
+    lhs: TypedRawVal,
+    rhs: TypedRawVal,
+) -> Result<TypedRawVal, TrapCode> {
+    T::consteval(lhs.into(), <T::Rhs as RhsImmediate>::from_typed(rhs)).map(Into::into)
+}
+
+/// Adapts [`BinaryOp::op_rri`] for [`BinaryOpVt`].
+fn binary_op_rri_vt<T: BinaryOp>(rhs: TypedRawVal) -> Op {
+    T::op_rri(<T::Rhs as RhsImmediate>::from_typed(rhs))
+}
+
+/// Adapts [`BinaryOp::op_rsi`] for [`BinaryOpVt`].
+fn binary_op_rsi_vt<T: BinaryOp>(lhs: Slot, rhs: TypedRawVal) -> Op {
+    T::op_rsi(lhs, <T::Rhs as RhsImmediate>::from_typed(rhs))
+}
+
+/// Adapts [`BinaryOp::op_rir`] for [`BinaryOpVt`].
+fn binary_op_rir_vt<T: BinaryOp>(lhs: TypedRawVal) -> Op {
+    T::op_rir(lhs.into())
+}
+
+/// Adapts [`BinaryOp::op_ris`] for [`BinaryOpVt`].
+fn binary_op_ris_vt<T: BinaryOp>(lhs: TypedRawVal, rhs: Slot) -> Op {
+    T::op_ris(lhs.into(), rhs)
+}
+
+/// Decoded [`BinaryOp::Rhs`] immediates crossing the [`BinaryOpVt`] boundary as [`TypedRawVal`].
+pub trait RhsImmediate: Sized {
+    /// Re-encodes the decoded `self` as [`TypedRawVal`].
+    fn into_typed(self) -> TypedRawVal;
+    /// Decodes `value` that was encoded via [`RhsImmediate::into_typed`].
+    fn from_typed(value: TypedRawVal) -> Self;
+}
+
+macro_rules! impl_rhs_immediate_for {
+    ( $($ty:ty),* $(,)? ) => {
+        $(
+            impl RhsImmediate for $ty {
+                fn into_typed(self) -> TypedRawVal {
+                    self.into()
+                }
+                fn from_typed(value: TypedRawVal) -> Self {
+                    value.into()
+                }
+            }
+        )*
+    };
+}
+impl_rhs_immediate_for!(i32, u32, i64, u64, f32, f64);
+
+macro_rules! impl_rhs_immediate_for_nonzero {
+    ( $($ty:ty),* $(,)? ) => {
+        $(
+            impl RhsImmediate for NonZero<$ty> {
+                fn into_typed(self) -> TypedRawVal {
+                    self.into()
+                }
+                fn from_typed(value: TypedRawVal) -> Self {
+                    match Self::new(<$ty>::from(value)) {
+                        Some(value) => value,
+                        None => unreachable!(),
+                    }
+                }
+            }
+        )*
+    };
+}
+impl_rhs_immediate_for_nonzero!(i32, u32, i64, u64);
+
+impl RhsImmediate for ShiftAmount {
+    fn into_typed(self) -> TypedRawVal {
+        u8::from(self).into()
+    }
+    fn from_typed(value: TypedRawVal) -> Self {
+        Self::from(u8::from(value))
+    }
 }
 
 macro_rules! impl_commutative_binary_op_for {
@@ -126,7 +301,7 @@ macro_rules! impl_binary_op_for {
                 type Lhs = $lhs_ty;
                 type Rhs = $rhs_ty;
 
-                fn decode_rhs(rhs: RawVal) -> BinaryOpRhs<Self::Rhs> {
+                fn decode_rhs(rhs: TypedRawVal) -> BinaryOpRhs<Self::Rhs> {
                     $decode_rhs(rhs)
                 }
 
@@ -1220,7 +1395,7 @@ macro_rules! impl_cmp_op_for {
                 type Lhs = <$binop as BinaryOp>::Lhs;
                 type Rhs = <$binop as BinaryOp>::Rhs;
 
-                fn decode_rhs(rhs: RawVal) -> BinaryOpRhs<<$binop as BinaryOp>::Rhs> {
+                fn decode_rhs(rhs: TypedRawVal) -> BinaryOpRhs<<$binop as BinaryOp>::Rhs> {
                     <$binop as BinaryOp>::decode_rhs(rhs)
                 }
 
@@ -1284,26 +1459,26 @@ pub enum BinaryOpRhs<T> {
     ReturnLhs,
 }
 
-fn decode_rhs_as_value<T>(value: RawVal) -> BinaryOpRhs<T>
+fn decode_rhs_as_value<T>(value: TypedRawVal) -> BinaryOpRhs<T>
 where
-    T: From<RawVal>,
+    T: From<TypedRawVal>,
 {
     BinaryOpRhs::Value(T::from(value))
 }
 
-fn decode_rhs_as_divisor<T: DecodeRhsAsDivisor>(value: RawVal) -> BinaryOpRhs<T> {
+fn decode_rhs_as_divisor<T: DecodeRhsAsDivisor>(value: TypedRawVal) -> BinaryOpRhs<T> {
     DecodeRhsAsDivisor::decode_rhs_as_divisor(value)
 }
 
 trait DecodeRhsAsDivisor: Sized {
-    fn decode_rhs_as_divisor(value: RawVal) -> BinaryOpRhs<Self>;
+    fn decode_rhs_as_divisor(value: TypedRawVal) -> BinaryOpRhs<Self>;
 }
 
 macro_rules! impl_decode_rhs_as_divisor_for {
     ( $($ty:ty),* $(,)? ) => {
         $(
             impl DecodeRhsAsDivisor for NonZero<$ty> {
-                fn decode_rhs_as_divisor(value: RawVal) -> BinaryOpRhs<Self> {
+                fn decode_rhs_as_divisor(value: TypedRawVal) -> BinaryOpRhs<Self> {
                     match Self::new(<$ty>::from(value)) {
                         Some(value) => BinaryOpRhs::Value(value),
                         None => BinaryOpRhs::Trap(TrapCode::IntegerDivisionByZero),
@@ -1315,9 +1490,9 @@ macro_rules! impl_decode_rhs_as_divisor_for {
 }
 impl_decode_rhs_as_divisor_for!(i32, i64, u32, u64);
 
-fn decode_rhs_as_shift_amount<T>(value: RawVal) -> BinaryOpRhs<ShiftAmount>
+fn decode_rhs_as_shift_amount<T>(value: TypedRawVal) -> BinaryOpRhs<ShiftAmount>
 where
-    T: IntoShiftAmount<ShiftSource: From<RawVal>>,
+    T: IntoShiftAmount<ShiftSource: From<TypedRawVal>>,
 {
     let shift_source = <<T as IntoShiftAmount>::ShiftSource>::from(value);
     match <T as IntoShiftAmount>::into_shift_amount(shift_source) {

--- a/crates/wasmi/src/engine/translator/func/op/load.rs
+++ b/crates/wasmi/src/engine/translator/func/op/load.rs
@@ -1,4 +1,5 @@
 use crate::{
+    ValType,
     core::Typed,
     ir::{Address, Offset, Offset16, Op, Slot, index::Memory},
 };
@@ -8,11 +9,35 @@ pub trait LoadOp {
     /// The type of the loaded value.
     type Result: Typed;
 
+    /// The virtual table of `Self`'s associated methods.
+    ///
+    /// Passing this to the generic translation routines instead of `Self`
+    /// allows all [`LoadOp`]s to share a single monomorphization,
+    /// avoiding codegen bloat.
+    const VT: LoadOpVt = LoadOpVt {
+        result_ty: <Self::Result as Typed>::TY,
+        op_rr: Self::op_rr,
+        op_rs: Self::op_rs,
+        op_ri: Self::op_ri,
+        op_rr_mem0_offset16: Self::op_rr_mem0_offset16,
+        op_rs_mem0_offset16: Self::op_rs_mem0_offset16,
+    };
+
     fn op_rr(offset: Offset, memory: Memory) -> Op;
     fn op_rs(ptr: Slot, offset: Offset, memory: Memory) -> Op;
     fn op_ri(address: Address, memory: Memory) -> Op;
     fn op_rr_mem0_offset16(offset: Offset16) -> Op;
     fn op_rs_mem0_offset16(ptr: Slot, offset: Offset16) -> Op;
+}
+
+/// Virtual table for a [`LoadOp`]. See [`LoadOp::VT`].
+pub struct LoadOpVt {
+    pub result_ty: ValType,
+    pub op_rr: fn(offset: Offset, memory: Memory) -> Op,
+    pub op_rs: fn(ptr: Slot, offset: Offset, memory: Memory) -> Op,
+    pub op_ri: fn(address: Address, memory: Memory) -> Op,
+    pub op_rr_mem0_offset16: fn(offset: Offset16) -> Op,
+    pub op_rs_mem0_offset16: fn(ptr: Slot, offset: Offset16) -> Op,
 }
 
 macro_rules! impl_load_extend {

--- a/crates/wasmi/src/engine/translator/func/op/store.rs
+++ b/crates/wasmi/src/engine/translator/func/op/store.rs
@@ -1,15 +1,40 @@
 use crate::{
-    core::Typed,
+    core::{Typed, TypedRawVal},
     engine::translator::utils::{ToBits, Wrap},
     ir::{Address, Offset, Offset16, Op, Slot, index::Memory},
 };
 
 /// Trait implemented by all Wasm operators that can be translated as wrapping store instructions.
-pub trait StoreOp {
+pub trait StoreOp: Sized {
     /// The type of the value to the stored.
-    type Value: Typed;
+    type Value: Typed + From<TypedRawVal>;
     /// The type of immediate values.
     type Immediate;
+
+    /// The virtual table of `Self`'s associated methods.
+    ///
+    /// Passing this to the generic translation routines instead of `Self`
+    /// allows all [`StoreOp`]s to share a single monomorphization,
+    /// avoiding codegen bloat. Immediates cross the vtable boundary as
+    /// [`TypedRawVal`] which type-checks all conversions in debug mode;
+    /// [`StoreOp::into_immediate`] is applied inside the adapted constructors.
+    const VT: StoreOpVt = StoreOpVt {
+        store_rr: Self::store_rr,
+        store_rs: Self::store_rs,
+        store_ri: store_ri_vt::<Self>,
+        store_sr: Self::store_sr,
+        store_ss: Self::store_ss,
+        store_si: store_si_vt::<Self>,
+        store_ir: Self::store_ir,
+        store_is: Self::store_is,
+        store_ii: store_ii_vt::<Self>,
+        store_mem0_offset16_rr: Self::store_mem0_offset16_rr,
+        store_mem0_offset16_rs: Self::store_mem0_offset16_rs,
+        store_mem0_offset16_ri: store_mem0_offset16_ri_vt::<Self>,
+        store_mem0_offset16_sr: Self::store_mem0_offset16_sr,
+        store_mem0_offset16_ss: Self::store_mem0_offset16_ss,
+        store_mem0_offset16_si: store_mem0_offset16_si_vt::<Self>,
+    };
 
     /// Converts the value into the immediate value type.
     ///
@@ -41,6 +66,50 @@ pub trait StoreOp {
     fn store_mem0_offset16_sr(ptr: Slot, offset: Offset16) -> Op;
     fn store_mem0_offset16_ss(ptr: Slot, offset: Offset16, value: Slot) -> Op;
     fn store_mem0_offset16_si(ptr: Slot, offset: Offset16, value: Self::Immediate) -> Op;
+}
+
+/// Virtual table for a [`StoreOp`]. See [`StoreOp::VT`].
+pub struct StoreOpVt {
+    pub store_rr: fn(offset: Offset, memory: Memory) -> Option<Op>,
+    pub store_rs: fn(offset: Offset, value: Slot, memory: Memory) -> Op,
+    pub store_ri: fn(offset: Offset, value: TypedRawVal, memory: Memory) -> Op,
+    pub store_sr: fn(ptr: Slot, offset: Offset, memory: Memory) -> Op,
+    pub store_ss: fn(ptr: Slot, offset: Offset, value: Slot, memory: Memory) -> Op,
+    pub store_si: fn(ptr: Slot, offset: Offset, value: TypedRawVal, memory: Memory) -> Op,
+    pub store_ir: fn(address: Address, memory: Memory) -> Op,
+    pub store_is: fn(address: Address, value: Slot, memory: Memory) -> Op,
+    pub store_ii: fn(address: Address, value: TypedRawVal, memory: Memory) -> Op,
+    pub store_mem0_offset16_rr: fn(offset: Offset16) -> Option<Op>,
+    pub store_mem0_offset16_rs: fn(offset: Offset16, value: Slot) -> Op,
+    pub store_mem0_offset16_ri: fn(offset: Offset16, value: TypedRawVal) -> Op,
+    pub store_mem0_offset16_sr: fn(ptr: Slot, offset: Offset16) -> Op,
+    pub store_mem0_offset16_ss: fn(ptr: Slot, offset: Offset16, value: Slot) -> Op,
+    pub store_mem0_offset16_si: fn(ptr: Slot, offset: Offset16, value: TypedRawVal) -> Op,
+}
+
+/// Adapts [`StoreOp::store_ri`] for [`StoreOpVt`].
+fn store_ri_vt<T: StoreOp>(offset: Offset, value: TypedRawVal, memory: Memory) -> Op {
+    T::store_ri(offset, T::into_immediate(value.into()), memory)
+}
+
+/// Adapts [`StoreOp::store_si`] for [`StoreOpVt`].
+fn store_si_vt<T: StoreOp>(ptr: Slot, offset: Offset, value: TypedRawVal, memory: Memory) -> Op {
+    T::store_si(ptr, offset, T::into_immediate(value.into()), memory)
+}
+
+/// Adapts [`StoreOp::store_ii`] for [`StoreOpVt`].
+fn store_ii_vt<T: StoreOp>(address: Address, value: TypedRawVal, memory: Memory) -> Op {
+    T::store_ii(address, T::into_immediate(value.into()), memory)
+}
+
+/// Adapts [`StoreOp::store_mem0_offset16_ri`] for [`StoreOpVt`].
+fn store_mem0_offset16_ri_vt<T: StoreOp>(offset: Offset16, value: TypedRawVal) -> Op {
+    T::store_mem0_offset16_ri(offset, T::into_immediate(value.into()))
+}
+
+/// Adapts [`StoreOp::store_mem0_offset16_si`] for [`StoreOpVt`].
+fn store_mem0_offset16_si_vt<T: StoreOp>(ptr: Slot, offset: Offset16, value: TypedRawVal) -> Op {
+    T::store_mem0_offset16_si(ptr, offset, T::into_immediate(value.into()))
 }
 
 macro_rules! impl_store_wrap {

--- a/crates/wasmi/src/engine/translator/func/op/unary.rs
+++ b/crates/wasmi/src/engine/translator/func/op/unary.rs
@@ -1,18 +1,45 @@
 use super::IntoResult as _;
 use crate::{
     TrapCode,
-    core::{Typed, wasm},
+    ValType,
+    core::{Typed, TypedRawVal, wasm},
     ir::{Op, Slot},
 };
 
-pub trait UnaryOp {
-    type Result;
-    type Value: Typed;
+pub trait UnaryOp: Sized {
+    type Result: Typed + Into<TypedRawVal>;
+    type Value: Typed + From<TypedRawVal>;
+
+    /// The virtual table of `Self`'s associated methods.
+    ///
+    /// Passing this to the generic translation routines instead of `Self`
+    /// allows all [`UnaryOp`]s to share a single monomorphization,
+    /// avoiding codegen bloat. Immediates cross the vtable boundary as
+    /// [`TypedRawVal`] which type-checks all conversions in debug mode.
+    const VT: UnaryOpVt = UnaryOpVt {
+        result_ty: <Self::Result as Typed>::TY,
+        consteval: unary_consteval_vt::<Self>,
+        op_rs: Self::op_rs,
+        op_rr: Self::op_rr,
+    };
 
     fn consteval(value: Self::Value) -> Result<Self::Result, TrapCode>;
 
     fn op_rs(value: Slot) -> Op;
     fn op_rr() -> Op;
+}
+
+/// Virtual table for a [`UnaryOp`]. See [`UnaryOp::VT`].
+pub struct UnaryOpVt {
+    pub result_ty: ValType,
+    pub consteval: fn(value: TypedRawVal) -> Result<TypedRawVal, TrapCode>,
+    pub op_rs: fn(value: Slot) -> Op,
+    pub op_rr: fn() -> Op,
+}
+
+/// Adapts [`UnaryOp::consteval`] for [`UnaryOpVt`].
+fn unary_consteval_vt<T: UnaryOp>(value: TypedRawVal) -> Result<TypedRawVal, TrapCode> {
+    T::consteval(value.into()).map(Into::into)
 }
 
 macro_rules! impl_unary_op_for {


### PR DESCRIPTION
Prior to using the `strip` tool on the final binary we actually see an file size increase.
It is only after using the `strip` tool that we see a 48.1 kB file size reduction which is nice.
The unstripped file size is increased by roughly 143 kB.

With the new `build.rs` based Wasmi specific `cfg` guards we were able to get the best for both worlds:

- on `opt-level = {2,3}` we use `inline(always)` in some key places to improve performance
- on `opt-level = "{s,z}"` we use `inline(never)` in some key places to improve the binary artifact size.

Benchmarks show no real translation performance regressions on either mode compared to `main`.

We still need a CI check or a test to assert that the new Wasmi specific `cfg` flags are not misused.
Basically we want to assert that they are only used in `cfg_attr` contexts with one of the following hints:

- `#[inline]`
- `#[inline(never)]`
- `#[inline(always)]`
- `#[cold]`

The new [`wasmi-cfg-policy` Cargo plugin](https://github.com/wasmi-labs/cargo-wasmi-cfg-policy/tree/main) is going to assert via Wasmi's GitHub CI that the new `wasmi_opt_{size,speed}` flags are not misused within the Wasmi codebase.