### PR TITLE
Add imported function name to mismatch error

### DIFF
--- a/crates/wasmi/src/module/instantiate/error.rs
+++ b/crates/wasmi/src/module/instantiate/error.rs
@@ -7,6 +7,7 @@ use crate::{
     Table,
     TableType,
     errors::{MemoryError, TableError},
+    module::ImportName,
 };
 use core::{
     error::Error,
@@ -41,6 +42,8 @@ pub enum InstantiationError {
     },
     /// Returned when a function has a mismatching type.
     FuncTypeMismatch {
+        /// Name and module of the function import.
+        import_name: ImportName,
         /// The expected function type of the function import.
         expected: FuncType,
         /// The actual function type of the function import.
@@ -103,9 +106,15 @@ impl Display for InstantiationError {
                 f,
                 "imported global type mismatch. expected {expected:?} but found {actual:?}"
             ),
-            Self::FuncTypeMismatch { expected, actual } => write!(
+            Self::FuncTypeMismatch {
+                import_name,
+                expected,
+                actual,
+            } => write!(
                 f,
-                "imported function type mismatch. expected {expected:?} but found {actual:?}"
+                "imported function \"{}#{}\" type mismatch. expected {expected:?} but found {actual:?}",
+                import_name.module(),
+                import_name.name()
             ),
             Self::TableTypeMismatch { expected, actual } => write!(
                 f,

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -141,6 +141,7 @@ impl Module {
                     let actual_signature = func.ty(&store);
                     if &actual_signature != expected_signature {
                         return Err(InstantiationError::FuncTypeMismatch {
+                            import_name: import.import_name().clone(),
                             actual: actual_signature,
                             expected: expected_signature.clone(),
                         });


### PR DESCRIPTION
Adding the name of the function that has the bad signature is a complete lifesaver, and a little string copying on the error path is well worth it.