### PR TITLE
fix `u64` overflow computing `memory64` max size in `effective_address`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Additionally we have an `Internal` section for changes that are of interest to d
 
 Dates in this file are formattes as `YYYY-MM-DD`.
 
+## Unreleased
+
+### Fixed
+
+- Fixed a `u64` overflow when sizing a 64-bit memory's maximum during translation. [#1964]
+  - A `memory64` declared with the largest allowed maximum (`2^48` pages) turned every
+    non-zero constant load/store address into an unconditional `MemoryOutOfBounds` trap.
+
 ## `2.0.0-beta.4` - 2026-07-01
 
 ### Added
@@ -68,6 +76,7 @@ Dates in this file are formattes as `YYYY-MM-DD`.
 - Add `cfg`-guard badges to docs rendered at `docs.rs`. [#1913]
 - Update the `nightly` Rust toolchain used for the Wasmi CI. [#1936]
 
+[#1964]: https://github.com/wasmi-labs/wasmi/pull/1964
 [#1952]: https://github.com/wasmi-labs/wasmi/pull/1952
 [#1950]: https://github.com/wasmi-labs/wasmi/pull/1950
 [#1946]: https://github.com/wasmi-labs/wasmi/pull/1946

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -2589,8 +2589,11 @@ impl FuncTranslator {
         };
         if let Some(max) = memory_type.maximum() {
             // The memory's maximum size in bytes.
-            let max_size = max << memory_type.page_size_log2();
-            if address > max_size {
+            //
+            // Computed as `u128` because `max << page_size_log2` can exceed `u64`
+            // for 64-bit memories, matching how `wasmi_core` sizes its memories.
+            let max_size = u128::from(max) << memory_type.page_size_log2();
+            if u128::from(address) > max_size {
                 // Case: address overflows the memory's maximum size.
                 return None;
             }

--- a/crates/wasmi/tests/integration/memory64.rs
+++ b/crates/wasmi/tests/integration/memory64.rs
@@ -1,0 +1,30 @@
+use wasmi::{Engine, Instance, Module, Store};
+
+/// A 64-bit memory whose maximum equals the largest allowed value (`2^48` pages)
+/// must still translate in-bounds constant-address accesses to real load/store ops.
+///
+/// Regression test: the translator sized the memory's maximum via `max << page_size_log2`
+/// in `u64`, which overflows to `0` for `max == 2^48`, folding every non-zero constant
+/// address into an unconditional `MemoryOutOfBounds` trap.
+#[test]
+fn mem64_max_size_constant_access_does_not_trap() {
+    let engine = Engine::default();
+    let mut store = Store::new(&engine, ());
+    let wasm = r#"
+        (module
+            (memory i64 1 0x1000000000000)
+            (func (export "test") (result i64)
+                (i64.store (i64.const 8) (i64.const 42))
+                (i64.load (i64.const 8))
+            )
+        )
+    "#;
+    let module = Module::new(&engine, wasm).unwrap();
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+    let test = instance
+        .get_func(&store, "test")
+        .unwrap()
+        .typed::<(), i64>(&store)
+        .unwrap();
+    assert_eq!(test.call(&mut store, ()).unwrap(), 42);
+}

--- a/crates/wasmi/tests/integration/mod.rs
+++ b/crates/wasmi/tests/integration/mod.rs
@@ -8,6 +8,7 @@ mod host_call_error;
 mod host_call_instantiation;
 mod host_calls_wasm;
 mod instantitation;
+mod memory64;
 mod multi_memory;
 mod reextract_memory;
 mod resource_limiter;


### PR DESCRIPTION
Spotted while auditing the `memory64` load/store translation path. A 64-bit memory declared with the largest allowed maximum traps on a plainly in-bounds constant store:

    (memory i64 1 0x1000000000000)   ;; min 1 page, max 2^48 pages
    (i64.store (i64.const 8) (i64.const 42))  ;; -> MemoryOutOfBounds

The trap comes from translation, not runtime. `effective_address` sizes the memory maximum as `max << page_size_log2()` in `u64`. For `max == 2^48` pages and the default 64 KiB page size (`log2 = 16`) the shift is `2^48 << 16 == 2^64`, which wraps `u64` to `0`, so `address > max_size` holds for every non-zero constant address and the access is folded into an unconditional trap.

`wasmi_core` already does this same byte-size calculation in `u128` (see `crates/core/src/memory/mod.rs` and `ty.rs`); the translator is the one spot still doing it in `u64`. Widened it to match. Added a regression test under `tests/integration/memory64.rs`.
