### PR TITLE
Lower `v128_store{32,64}_lane` translation

### DIFF
--- a/crates/ir/build/isa.rs
+++ b/crates/ir/build/isa.rs
@@ -1223,8 +1223,6 @@ fn add_simd_store_ops(isa: &mut Isa) {
         (StoreKind::Value, Ty::V128),
         (StoreKind::Lane { width: LaneWidth::W8 }, Ty::V128),
         (StoreKind::Lane { width: LaneWidth::W16 }, Ty::V128),
-        (StoreKind::Lane { width: LaneWidth::W32 }, Ty::V128),
-        (StoreKind::Lane { width: LaneWidth::W64 }, Ty::V128),
     ];
     for (kind, value_ty) in kinds {
         for ptr in [OperandKind::Reg, OperandKind::Slot] {

--- a/crates/wasmi/src/engine/executor/handler/exec/simd.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec/simd.rs
@@ -518,10 +518,6 @@ handler_store_lane_ss! {
     fn v128_store_lane8_ss(V128StoreLane8_Ss) = simd::v128_store8_lane;
     fn v128_store_lane16_rs(V128StoreLane16_Rs) = simd::v128_store16_lane;
     fn v128_store_lane16_ss(V128StoreLane16_Ss) = simd::v128_store16_lane;
-    fn v128_store_lane32_rs(V128StoreLane32_Rs) = simd::v128_store32_lane;
-    fn v128_store_lane32_ss(V128StoreLane32_Ss) = simd::v128_store32_lane;
-    fn v128_store_lane64_rs(V128StoreLane64_Rs) = simd::v128_store64_lane;
-    fn v128_store_lane64_ss(V128StoreLane64_Ss) = simd::v128_store64_lane;
 }
 
 macro_rules! handler_store_lane_mem0_offset16_ss {
@@ -557,8 +553,4 @@ handler_store_lane_mem0_offset16_ss! {
     fn v128_store_lane8_mem0_offset16_ss(V128StoreLane8Mem0Offset16_Ss) = simd::v128_store8_lane;
     fn v128_store_lane16_mem0_offset16_rs(V128StoreLane16Mem0Offset16_Rs) = simd::v128_store16_lane;
     fn v128_store_lane16_mem0_offset16_ss(V128StoreLane16Mem0Offset16_Ss) = simd::v128_store16_lane;
-    fn v128_store_lane32_mem0_offset16_rs(V128StoreLane32Mem0Offset16_Rs) = simd::v128_store32_lane;
-    fn v128_store_lane32_mem0_offset16_ss(V128StoreLane32Mem0Offset16_Ss) = simd::v128_store32_lane;
-    fn v128_store_lane64_mem0_offset16_rs(V128StoreLane64Mem0Offset16_Rs) = simd::v128_store64_lane;
-    fn v128_store_lane64_mem0_offset16_ss(V128StoreLane64Mem0Offset16_Ss) = simd::v128_store64_lane;
 }

--- a/crates/wasmi/src/engine/translator/func/simd/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/simd/visit.rs
@@ -157,35 +157,13 @@ impl VisitSimdOperator<'_> for FuncTranslator {
     }
 
     fn visit_v128_store32_lane(&mut self, memarg: MemArg, lane: u8) -> Self::Output {
-        self.translate_v128_store_lane::<i32>(
-            memarg,
-            lane,
-            Op::v128_store_lane32_rs,
-            Op::v128_store_lane32_ss,
-            Op::v128_store_lane32_mem0_offset16_rs,
-            Op::v128_store_lane32_mem0_offset16_ss,
-            |this, memarg, ptr, lane, v128| {
-                let value = simd::i32x4_extract_lane(v128, lane);
-                let value = this.immediate_to_operand(value)?;
-                this.encode_store::<op::I32Store>(memarg, ptr, value)
-            },
-        )
+        self.visit_f32x4_extract_lane(lane)?;
+        self.visit_f32_store(memarg)
     }
 
     fn visit_v128_store64_lane(&mut self, memarg: MemArg, lane: u8) -> Self::Output {
-        self.translate_v128_store_lane::<i64>(
-            memarg,
-            lane,
-            Op::v128_store_lane64_rs,
-            Op::v128_store_lane64_ss,
-            Op::v128_store_lane64_mem0_offset16_rs,
-            Op::v128_store_lane64_mem0_offset16_ss,
-            |this, memarg, ptr, lane, v128| {
-                let value = simd::i64x2_extract_lane(v128, lane);
-                let value = this.immediate_to_operand(value)?;
-                this.encode_store::<op::I64Store>(memarg, ptr, value)
-            },
-        )
+        self.visit_f64x2_extract_lane(lane)?;
+        self.visit_f64_store(memarg)
     }
 
     fn visit_v128_const(&mut self, value: wasmparser::V128) -> Self::Output {


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1703. (the remaining and trivial `store` part)

Lowering was deliberately _not_ applied for `v128_store{8,16}_lane` ops since there is the possibility of a clash with the `ptr` operators as described [in this comment](https://github.com/wasmi-labs/wasmi/issues/1703#issuecomment-4844361795).