### PR TITLE
Fix unfused simd `load` ops translation

### DIFF
--- a/crates/wasmi/src/engine/translator/func/simd/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/simd/mod.rs
@@ -393,11 +393,9 @@ impl FuncTranslator {
                 return Ok(());
             }
             op => {
-                self.push_op_with_result_reg(
-                    <L as LoadOp>::Result::TY,
-                    op,
-                    FuelCostsProvider::load,
-                )?;
+                let fuel_pos = self.stack.fuel_pos();
+                self.instrs
+                    .encode_op(op, fuel_pos, FuelCostsProvider::load)?;
             }
         }
         let v128 = self.copy_operand_to_slot(v128)?;

--- a/crates/wasmi/src/engine/translator/func/simd/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/simd/mod.rs
@@ -368,7 +368,8 @@ impl FuncTranslator {
             }
             op => {
                 let fuel_pos = self.stack.fuel_pos();
-                self.instrs.encode_op(op, fuel_pos, FuelCostsProvider::load)?;
+                self.instrs
+                    .encode_op(op, fuel_pos, FuelCostsProvider::load)?;
             }
         }
         self.push_op_with_result_slot(ValType::V128, op_sr, FuelCostsProvider::simd)?;

--- a/crates/wasmi/src/engine/translator/func/simd/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/simd/mod.rs
@@ -367,11 +367,8 @@ impl FuncTranslator {
                 return Ok(());
             }
             op => {
-                self.push_op_with_result_reg(
-                    <L as LoadOp>::Result::TY,
-                    op,
-                    FuelCostsProvider::load,
-                )?;
+                let fuel_pos = self.stack.fuel_pos();
+                self.instrs.encode_op(op, fuel_pos, FuelCostsProvider::load)?;
             }
         }
         self.push_op_with_result_slot(ValType::V128, op_sr, FuelCostsProvider::simd)?;


### PR DESCRIPTION
The bug was that multiple results were pushed onto the stack instead of just 1.