### PR TITLE
Fix fused `f{32,64}.abs` + `f{32,64}.neg` translation

### DIFF
--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -2272,7 +2272,7 @@ impl FuncTranslator {
             return Ok(false);
         };
         let val = self.resolve_operand::<f64>(value)?;
-        if matches!(val, ResolvedOperand::Reg(ValType::F64)) {
+        if !matches!(val, ResolvedOperand::Reg(ValType::F64)) {
             // Case: input/output does not match with staged `Op`
             return Ok(false);
         }

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -2245,7 +2245,7 @@ impl FuncTranslator {
     /// Tries to lower a staged `f32.abs` and a `f32.neg` operator into a `f32.nabs` operator.
     ///
     /// Returns `true` if lowering was successful.
-    fn try_lower_f32_copysign(&mut self, value: Operand) -> Result<bool, Error> {
+    fn try_lower_f32_abs_neg(&mut self, value: Operand) -> Result<bool, Error> {
         let Some(staged_op) = self.instrs.peek_staged() else {
             // Case: no staged `Op` to lower
             return Ok(false);
@@ -2267,7 +2267,7 @@ impl FuncTranslator {
     /// Tries to lower a staged `f64.abs` and a `f64.neg` operator into a `f64.nabs` operator.
     ///
     /// Returns `true` if lowering was successful.
-    fn try_lower_f64_copysign(&mut self, value: Operand) -> Result<bool, Error> {
+    fn try_lower_f64_abs_neg(&mut self, value: Operand) -> Result<bool, Error> {
         let Some(staged_op) = self.instrs.peek_staged() else {
             // Case: no staged `Op` to lower
             return Ok(false);

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1684,6 +1684,7 @@ impl FuncTranslator {
         let input = self.stack.pop();
         if try_opt(self, input)? {
             // Case: custom optimization took effect, return early.
+            self.stack.push_temp(vt.result_ty, Allocation::Reg)?;
             return Ok(());
         }
         let op = match self.resolve_operand::<TypedRawVal>(input)? {

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -2250,7 +2250,7 @@ impl FuncTranslator {
             return Ok(false);
         };
         let val = self.resolve_operand::<f32>(value)?;
-        if matches!(val, ResolvedOperand::Reg(ValType::F32)) {
+        if !matches!(val, ResolvedOperand::Reg(ValType::F32)) {
             // Case: input/output does not match with staged `Op`
             return Ok(false);
         }

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -1147,7 +1147,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_f32_neg(&mut self) -> Self::Output {
-        self.translate_unary_with_opt::<op::F32Neg>(Self::try_lower_f32_copysign)
+        self.translate_unary_with_opt::<op::F32Neg>(Self::try_lower_f32_abs_neg)
     }
 
     #[inline(never)]
@@ -1217,7 +1217,7 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
 
     #[inline(never)]
     fn visit_f64_neg(&mut self) -> Self::Output {
-        self.translate_unary_with_opt::<op::F64Neg>(Self::try_lower_f64_copysign)
+        self.translate_unary_with_opt::<op::F64Neg>(Self::try_lower_f64_abs_neg)
     }
 
     #[inline(never)]


### PR DESCRIPTION
- Bug 1: Fuse condition accidentally was inverted.
- Bug 2: Translation did not push back a register to the stack upon successful fusion.