### PR TITLE
Fix bug in `multi-value` `br_table` translation

### DIFF
--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1092,11 +1092,10 @@ impl FuncTranslator {
         &mut self,
         table: wasmparser::BrTable,
         index: Location,
-        default_branch_params: BranchParams,
+        values: BoundedSlotSpan,
     ) -> Result<(), Error> {
         let len_targets = table.len() + 1;
         debug_assert_eq!(self.immediates.len(), len_targets as usize);
-        let values = default_branch_params.temp_slots();
         let op = match index {
             Location::Reg(_) => Op::branch_table_span_r(len_targets, values),
             Location::Slot(index) => Op::branch_table_span_s(len_targets, index, values),

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -730,13 +730,18 @@ impl FuncTranslator {
     fn copy_operands_to_temp(
         &mut self,
         len: u16,
+        skip: u16,
         fuel_pos: Option<Pos<ir::BlockFuel>>,
     ) -> Result<BoundedSlotSpan, Error> {
         if len == 0 {
             return Ok(BoundedSlotSpan::new(self.stack.next_temp_slots(), 0));
         }
-        let dst = self.stack.peek(usize::from(len) - 1).temp_slots().span();
-        self.copy_operands_to_dst(dst, len, 0, fuel_pos)
+        let dst = self
+            .stack
+            .peek(usize::from(len + skip) - 1)
+            .temp_slots()
+            .span();
+        self.copy_operands_to_dst(dst, len, skip, fuel_pos)
     }
 
     /// Skips the top `skip` operands and copies the remaining top `len` operands to `dst`.
@@ -1615,8 +1620,7 @@ impl FuncTranslator {
     fn adjust_stack_for_call(&mut self, ty: &FuncType) -> Result<BoundedSlotSpan, Error> {
         let fuel_pos = self.stack.fuel_pos();
         self.preserve_regs(fuel_pos)?;
-        let fuel_pos = self.stack.fuel_pos();
-        let params = self.copy_operands_to_temp(ty.len_params(), fuel_pos)?;
+        let params = self.copy_operands_to_temp(ty.len_params(), 0, fuel_pos)?;
         for _ in 0..ty.len_params() {
             self.stack.pop();
         }

--- a/crates/wasmi/src/engine/translator/func/stack/operands.rs
+++ b/crates/wasmi/src/engine/translator/func/stack/operands.rs
@@ -616,8 +616,7 @@ impl OperandStack {
     ///
     /// # Note
     ///
-    /// - Returns the [`Operand`] at `depth` before being converted to an [`Operand::Temp`].
-    /// - [`Operand::Temp`] will have their optional `instr` set to `None`.
+    /// Returns the [`Operand`] at `depth` before being converted to an [`Operand::Temp`].
     ///
     /// # Panics
     ///

--- a/crates/wasmi/src/engine/translator/func/visit.rs
+++ b/crates/wasmi/src/engine/translator/func/visit.rs
@@ -378,12 +378,15 @@ impl<'a> VisitOperator<'a> for FuncTranslator {
                 }
             }
         };
-        self.copy_branch_params(default_branch_params, fuel_pos)?;
-        let required_temp_copies = default_branch_params.len_temps() != 0;
-        let requires_branch_copies = required_temp_copies && equal_heights;
+        let len_temps = default_branch_params.len_temps();
+        let len_regs = default_branch_params.len_regs();
+        let values = self.copy_operands_to_temp(len_temps, len_regs, fuel_pos)?;
+        self.copy_branch_params_regs(default_branch_params, fuel_pos)?;
+        let required_temp_copies = len_temps != 0;
+        let requires_branch_copies = required_temp_copies && !equal_heights;
         match requires_branch_copies {
             false => self.encode_br_table_0(table, index_loc)?,
-            true => self.encode_br_table_n(table, index_loc, default_branch_params)?,
+            true => self.encode_br_table_n(table, index_loc, values)?,
         };
         self.reachable = false;
         Ok(())


### PR DESCRIPTION
The problem was two-fold:

1. The `requires_branch_copies` flag had an incorrectly non-negated `equal_heights` part.
    - This caused translation to incorrectly pick `branch_table` operators instead of `branch_table_span` operator for some `multi-value` cases.
2. When translating a `multi-value` Wasm `br_table` Wasmi copies all non-register branch operands to some temporary stack slots. The old translation chose the branch parameter destination of the default target. However, this can lead to problems (incorrect overwrites) if the default target has a lower stack height than other targets. Thus the new translation now copies the branch operands to their respective temporary stack slots which is always safe to do.