### PR TITLE
Fix overly strict `fused_cmp_branch` condition

### DIFF
--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -1471,14 +1471,13 @@ impl FuncTranslator {
             //  - immediates cannot be the result of a previous instruction.
             return Ok(None);
         };
-        if staged_ty != condition_ty {
-            // Case: cannot fuse if staged type and condition type do not match.
-            return Ok(None);
+        match (RegKind::new(staged_ty), RegKind::new(condition_ty)) {
+            (Some(RegKind::Ireg), Some(RegKind::Ireg)) => {}
+            _ => {
+                // Case: cannot fuse if staged and condition accumulators do not match.
+                return Ok(None);
+            }
         }
-        debug_assert!(
-            RegKind::Ireg.matches_ty(condition_ty),
-            "unexpected condition type: {condition_ty:?}"
-        );
         let cmp_op = match negate {
             false => staged_op,
             true => match staged_op.negate_cmp_instr() {


### PR DESCRIPTION
I was wondering about a drop in Wasmi's CoreMark score from `v2.0.0-beta.5` to `v2.0.0-beta.6`.

Investigations showed that it was due to https://github.com/wasmi-labs/wasmi/pull/1973.
The issue is that `staged_ty != condition_ty` is overly strict and forbids many legal fusions.

This PR fixes that issue.

Benchmarks for `prime_sieve` and `regex_redux` show that we are back to `v2.0.0-beta.5` performance.