### PR TITLE
Refactor Wasm module parsing

### DIFF
--- a/crates/wasmi/src/module/builder.rs
+++ b/crates/wasmi/src/module/builder.rs
@@ -33,15 +33,8 @@ use alloc::{boxed::Box, sync::Arc, vec::Vec};
 /// A builder for a WebAssembly [`Module`].
 #[derive(Debug)]
 pub struct ModuleBuilder {
-    pub header: ModuleHeader,
-    pub data_segments: DataSegmentsBuilder,
-    pub custom_sections: CustomSectionsBuilder,
-}
-
-/// A builder for a WebAssembly [`Module`] header.
-#[derive(Debug)]
-pub struct ModuleHeaderBuilder {
     engine: Engine,
+    pub header: Option<ModuleHeader>,
     pub func_types: Vec<DedupFuncType>,
     pub imports: ModuleImportsBuilder,
     pub funcs: Vec<DedupFuncType>,
@@ -53,13 +46,16 @@ pub struct ModuleHeaderBuilder {
     pub start: Option<FuncIdx>,
     pub engine_funcs: EngineFuncSpan,
     pub element_segments: Box<[ElementSegment]>,
+    pub data_segments: DataSegmentsBuilder,
+    pub custom_sections: CustomSectionsBuilder,
 }
 
-impl ModuleHeaderBuilder {
-    /// Creates a new [`ModuleHeaderBuilder`] for the given [`Engine`].
+impl ModuleBuilder {
+    /// Creates a new [`ModuleBuilder`] for the given [`Engine`].
     pub fn new(engine: &Engine) -> Self {
         Self {
             engine: engine.clone(),
+            header: None,
             func_types: Vec::new(),
             imports: ModuleImportsBuilder::default(),
             funcs: Vec::new(),
@@ -71,27 +67,56 @@ impl ModuleHeaderBuilder {
             start: None,
             engine_funcs: EngineFuncSpan::default(),
             element_segments: Box::from([]),
+            data_segments: DataSegments::build(),
+            custom_sections: CustomSectionsBuilder::default(),
         }
     }
 
     /// Finishes construction of [`ModuleHeader`].
-    pub fn finish(self) -> ModuleHeader {
-        ModuleHeader {
-            inner: Arc::new(ModuleHeaderInner {
-                engine: self.engine.weak(),
-                func_types: self.func_types.into(),
-                imports: self.imports.finish(),
-                funcs: self.funcs.into(),
-                tables: self.tables.into(),
-                memories: self.memories.into(),
-                globals: self.globals.into(),
-                globals_init: self.globals_init.into(),
-                exports: self.exports,
-                start: self.start,
-                engine_funcs: self.engine_funcs,
-                element_segments: self.element_segments,
+    pub fn finish(mut self) -> Module {
+        let header = self.header();
+        Module {
+            inner: Arc::new(ModuleInner {
+                engine: self.engine,
+                data_segments: self.data_segments.finish(),
+                custom_sections: self.custom_sections.finish(),
+                header,
             }),
         }
+    }
+
+    pub fn header(&mut self) -> ModuleHeader {
+        use core::mem::take;
+        if let Some(header) = self.header.as_ref() {
+            return header.clone();
+        }
+        let func_types: Box<[DedupFuncType]> = take(&mut self.func_types).into();
+        let header = ModuleHeader {
+            inner: Arc::new(ModuleHeaderInner {
+                engine: self.engine.weak(),
+                func_types: func_types.into(),
+                imports: take(&mut self.imports).finish(),
+                funcs: take(&mut self.funcs).into(),
+                tables: take(&mut self.tables).into(),
+                memories: take(&mut self.memories).into(),
+                globals: take(&mut self.globals).into(),
+                globals_init: take(&mut self.globals_init).into(),
+                exports: take(&mut self.exports),
+                start: self.start,
+                engine_funcs: self.engine_funcs,
+                element_segments: take(&mut self.element_segments),
+            }),
+        };
+        self.header = Some(header.clone());
+        header
+    }
+
+    /// Returns the number of imported functions.
+    pub fn len_funcs_imports(&self) -> usize {
+        if let Some(header) = self.header.as_ref() {
+            return header.inner.imports.len_funcs();
+        }
+        self.imports.funcs.len()
     }
 }
 
@@ -131,17 +156,6 @@ impl ModuleImportsBuilder {
 }
 
 impl ModuleBuilder {
-    /// Creates a new [`ModuleBuilder`] for the given [`Engine`].
-    pub fn new(header: ModuleHeader, custom_sections: CustomSectionsBuilder) -> Self {
-        Self {
-            header,
-            data_segments: DataSegments::build(),
-            custom_sections,
-        }
-    }
-}
-
-impl ModuleHeaderBuilder {
     /// Pushes the given function types to the [`Module`] under construction.
     ///
     /// # Errors
@@ -405,17 +419,5 @@ impl ModuleBuilder {
     /// Push another parsed data segment to the [`ModuleBuilder`].
     pub fn push_data_segment(&mut self, data: wasmparser::Data) -> Result<(), Error> {
         self.data_segments.push_data_segment(data)
-    }
-
-    /// Finishes construction of the WebAssembly [`Module`].
-    pub fn finish(self, engine: &Engine) -> Module {
-        Module {
-            inner: Arc::new(ModuleInner {
-                engine: engine.clone(),
-                header: self.header,
-                data_segments: self.data_segments.finish(),
-                custom_sections: self.custom_sections.finish(),
-            }),
-        }
     }
 }

--- a/crates/wasmi/src/module/parser/buffered.rs
+++ b/crates/wasmi/src/module/parser/buffered.rs
@@ -1,16 +1,9 @@
-use super::{
-    CustomSectionsBuilder,
-    ModuleBuilder,
-    ModuleHeader,
-    ModuleHeaderBuilder,
-    ModuleParser,
-};
+use super::{ModuleBuilder, ModuleParser};
 use crate::{Error, Module};
 #[cfg(feature = "validate")]
 use wasmparser::Validator;
 use wasmparser::{Chunk, Payload};
 
-#[cfg_attr(not(feature = "validate"), allow(unused_mut, unused_variables))]
 impl ModuleParser {
     /// Starts parsing and validating the Wasm bytecode stream.
     ///
@@ -61,11 +54,9 @@ impl ModuleParser {
     ///
     /// If the Wasm bytecode stream fails to validate.
     unsafe fn parse_buffered_impl(mut self, mut buffer: &[u8]) -> Result<Module, Error> {
-        let mut custom_sections = CustomSectionsBuilder::default();
-        let header = Self::parse_buffered_header(&mut self, &mut buffer, &mut custom_sections)?;
-        let builder = Self::parse_buffered_code(&mut self, &mut buffer, header, custom_sections)?;
-        let module = Self::parse_buffered_data(&mut self, &mut buffer, builder)?;
-        Ok(module)
+        let mut builder = ModuleBuilder::new(&self.engine);
+        self.parse_module(&mut buffer, &mut builder)?;
+        Ok(builder.finish())
     }
 
     /// Fetch next Wasm module payload and adust the `buffer`.
@@ -100,12 +91,11 @@ impl ModuleParser {
     /// # Errors
     ///
     /// If the Wasm bytecode stream fails to parse or validate.
-    fn parse_buffered_header(
+    fn parse_module(
         &mut self,
         buffer: &mut &[u8],
-        custom_sections: &mut CustomSectionsBuilder,
-    ) -> Result<ModuleHeader, Error> {
-        let mut header = ModuleHeaderBuilder::new(&self.engine);
+        module: &mut ModuleBuilder,
+    ) -> Result<(), Error> {
         loop {
             let (consumed, payload) = self.next_payload(buffer)?;
             match payload {
@@ -114,99 +104,33 @@ impl ModuleParser {
                     encoding,
                     range,
                 } => self.process_version(num, encoding, range),
-                Payload::TypeSection(section) => self.process_types(section, &mut header),
-                Payload::ImportSection(section) => self.process_imports(section, &mut header),
-                Payload::FunctionSection(section) => self.process_functions(section, &mut header),
-                Payload::TableSection(section) => self.process_tables(section, &mut header),
-                Payload::MemorySection(section) => self.process_memories(section, &mut header),
-                Payload::GlobalSection(section) => self.process_globals(section, &mut header),
-                Payload::ExportSection(section) => self.process_exports(section, &mut header),
-                Payload::StartSection { func, range } => {
-                    self.process_start(func, range, &mut header)
-                }
-                Payload::ElementSection(section) => self.process_element(section, &mut header),
+                Payload::TypeSection(section) => self.process_types(section, module),
+                Payload::ImportSection(section) => self.process_imports(section, module),
+                Payload::FunctionSection(section) => self.process_functions(section, module),
+                Payload::TableSection(section) => self.process_tables(section, module),
+                Payload::MemorySection(section) => self.process_memories(section, module),
+                Payload::GlobalSection(section) => self.process_globals(section, module),
+                Payload::ExportSection(section) => self.process_exports(section, module),
+                Payload::StartSection { func, range } => self.process_start(func, range, module),
+                Payload::ElementSection(section) => self.process_element(section, module),
                 Payload::DataCountSection { count, range } => self.process_data_count(count, range),
                 Payload::CodeSectionStart { count, range, size } => {
-                    self.process_code_start(count, range, size)?;
-                    Self::consume_buffer(consumed, buffer);
-                    break;
+                    self.process_code_start(count, range, size)
                 }
-                Payload::DataSection(_) => break,
-                Payload::End(_) => break,
-                Payload::CustomSection(reader) => {
-                    self.process_custom_section(custom_sections, reader)
-                }
-                unexpected => self.process_invalid_payload(unexpected),
-            }?;
-            Self::consume_buffer(consumed, buffer);
-        }
-        Ok(header.finish())
-    }
-
-    /// Parse the Wasm code section entries.
-    ///
-    /// We separate parsing of the Wasm code section since most of a Wasm module
-    /// is made up of code section entries which we can parse and validate more efficiently
-    /// by serving them with a specialized routine.
-    ///
-    /// # Errors
-    ///
-    /// If the Wasm bytecode stream fails to parse or validate.
-    fn parse_buffered_code(
-        &mut self,
-        buffer: &mut &[u8],
-        header: ModuleHeader,
-        custom_sections: CustomSectionsBuilder,
-    ) -> Result<ModuleBuilder, Error> {
-        loop {
-            let (consumed, payload) = self.next_payload(buffer)?;
-            match payload {
                 Payload::CodeSectionEntry(func_body) => {
-                    // Note: Unfortunately the `wasmparser` crate is missing an API
-                    //       to return the byte slice for the respective code section
-                    //       entry payload. Please remove this work around as soon as
-                    //       such an API becomes available.
-                    Self::consume_buffer(consumed, buffer);
                     let bytes = func_body.as_bytes();
-                    self.process_code_entry(func_body, bytes, &header)?;
+                    self.process_code_entry(func_body, bytes, module)
                 }
-                _ => break,
-            }
-        }
-        Ok(ModuleBuilder::new(header, custom_sections))
-    }
-
-    /// Parse the Wasm data section and finalize parsing.
-    ///
-    /// We separate parsing of the Wasm data section since it is the only Wasm
-    /// section that comes after the Wasm code section that we have to separate
-    /// out for technical reasons.
-    ///
-    /// # Errors
-    ///
-    /// If the Wasm bytecode stream fails to parse or validate.
-    fn parse_buffered_data(
-        &mut self,
-        buffer: &mut &[u8],
-        mut builder: ModuleBuilder,
-    ) -> Result<Module, Error> {
-        loop {
-            let (consumed, payload) = self.next_payload(buffer)?;
-            match payload {
-                Payload::DataSection(section) => {
-                    self.process_data(section, &mut builder)?;
-                }
+                Payload::DataSection(section) => self.process_data(section, module),
                 Payload::End(offset) => {
                     self.process_end(offset)?;
                     break;
                 }
-                Payload::CustomSection(reader) => {
-                    self.process_custom_section(&mut builder.custom_sections, reader)?;
-                }
-                invalid => self.process_invalid_payload(invalid)?,
-            }
+                Payload::CustomSection(reader) => self.process_custom_section(reader, module),
+                unexpected => self.process_invalid_payload(unexpected),
+            }?;
             Self::consume_buffer(consumed, buffer);
         }
-        Ok(builder.finish(&self.engine))
+        Ok(())
     }
 }

--- a/crates/wasmi/src/module/parser/mod.rs
+++ b/crates/wasmi/src/module/parser/mod.rs
@@ -1,10 +1,7 @@
 use super::{
-    CustomSectionsBuilder,
     ElementSegment,
     FuncIdx,
     ModuleBuilder,
-    ModuleHeader,
-    builder::ModuleHeaderBuilder,
     export::ExternIdx,
     global::Global,
     import::{FuncTypeIdx, Import},
@@ -112,7 +109,7 @@ impl ModuleParser {
     fn process_types(
         &mut self,
         section: TypeSectionReader,
-        header: &mut ModuleHeaderBuilder,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
         #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
@@ -136,7 +133,7 @@ impl ModuleParser {
             }
             Ok(FuncType::from_wasmparser(func_ty))
         });
-        header.push_func_types(func_types)?;
+        module.push_func_types(func_types)?;
         Ok(())
     }
 
@@ -153,7 +150,7 @@ impl ModuleParser {
     fn process_imports(
         &mut self,
         section: ImportSectionReader,
-        header: &mut ModuleHeaderBuilder,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
         #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
@@ -162,7 +159,7 @@ impl ModuleParser {
         let imports = section
             .into_iter()
             .map(|import| import.map(Import::from).map_err(Error::from));
-        header.push_imports(imports)?;
+        module.push_imports(imports)?;
         Ok(())
     }
 
@@ -178,7 +175,7 @@ impl ModuleParser {
     fn process_functions(
         &mut self,
         section: FunctionSectionReader,
-        header: &mut ModuleHeaderBuilder,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
         if let Some(limit) = self.engine.config().get_enforced_limits().max_functions {
             if section.count() > limit {
@@ -192,7 +189,7 @@ impl ModuleParser {
         let funcs = section
             .into_iter()
             .map(|func| func.map(FuncTypeIdx::from).map_err(Error::from));
-        header.push_funcs(funcs)?;
+        module.push_funcs(funcs)?;
         Ok(())
     }
 
@@ -208,7 +205,7 @@ impl ModuleParser {
     fn process_tables(
         &mut self,
         section: TableSectionReader,
-        header: &mut ModuleHeaderBuilder,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
         if let Some(limit) = self.engine.config().get_enforced_limits().max_tables {
             if section.count() > limit {
@@ -226,7 +223,7 @@ impl ModuleParser {
             }
             Err(err) => Err(err.into()),
         });
-        header.push_tables(tables)?;
+        module.push_tables(tables)?;
         Ok(())
     }
 
@@ -242,7 +239,7 @@ impl ModuleParser {
     fn process_memories(
         &mut self,
         section: MemorySectionReader,
-        header: &mut ModuleHeaderBuilder,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
         if let Some(limit) = self.engine.config().get_enforced_limits().max_memories {
             if section.count() > limit {
@@ -256,7 +253,7 @@ impl ModuleParser {
         let memories = section
             .into_iter()
             .map(|memory| memory.map(MemoryType::from_wasmparser).map_err(Error::from));
-        header.push_memories(memories)?;
+        module.push_memories(memories)?;
         Ok(())
     }
 
@@ -272,7 +269,7 @@ impl ModuleParser {
     fn process_globals(
         &mut self,
         section: GlobalSectionReader,
-        header: &mut ModuleHeaderBuilder,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
         if let Some(limit) = self.engine.config().get_enforced_limits().max_globals {
             if section.count() > limit {
@@ -286,7 +283,7 @@ impl ModuleParser {
         let globals = section
             .into_iter()
             .map(|global| global.map(Global::from).map_err(Error::from));
-        header.push_globals(globals)?;
+        module.push_globals(globals)?;
         Ok(())
     }
 
@@ -302,7 +299,7 @@ impl ModuleParser {
     fn process_exports(
         &mut self,
         section: ExportSectionReader,
-        header: &mut ModuleHeaderBuilder,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
         #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
@@ -314,7 +311,7 @@ impl ModuleParser {
             let idx = ExternIdx::new(export.kind, export.index)?;
             Ok((field, idx))
         });
-        header.push_exports(exports)?;
+        module.push_exports(exports)?;
         Ok(())
     }
 
@@ -331,13 +328,13 @@ impl ModuleParser {
         &mut self,
         func: u32,
         range: Range<usize>,
-        header: &mut ModuleHeaderBuilder,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
         #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.start_section(func, &range)?;
         }
-        header.set_start(FuncIdx::from(func));
+        module.set_start(FuncIdx::from(func));
         Ok(())
     }
 
@@ -353,7 +350,7 @@ impl ModuleParser {
     fn process_element(
         &mut self,
         section: ElementSectionReader,
-        header: &mut ModuleHeaderBuilder,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
         if let Some(limit) = self
             .engine
@@ -374,7 +371,7 @@ impl ModuleParser {
         let segments = section
             .into_iter()
             .map(|segment| segment.map(ElementSegment::from).map_err(Error::from));
-        header.push_element_segments(segments)?;
+        module.push_element_segments(segments)?;
         Ok(())
     }
 
@@ -482,13 +479,13 @@ impl ModuleParser {
     }
 
     /// Returns the next `FuncIdx` for processing of its function body.
-    fn next_func(&mut self, header: &ModuleHeader) -> (FuncIdx, EngineFunc) {
+    fn next_func(&mut self, module: &ModuleBuilder) -> (FuncIdx, EngineFunc) {
         let index = self.engine_funcs;
-        let engine_func = header.inner.engine_funcs.get_or_panic(index);
+        let engine_func = module.engine_funcs.get_or_panic(index);
         self.engine_funcs += 1;
         // We have to adjust the initial func reference to the first
         // internal function before we process any of the internal functions.
-        let len_func_imports = u32::try_from(header.inner.imports.len_funcs())
+        let len_func_imports = u32::try_from(module.len_funcs_imports())
             .unwrap_or_else(|_| panic!("too many imported functions"));
         let func_idx = FuncIdx::from(index + len_func_imports);
         (func_idx, engine_func)
@@ -509,10 +506,9 @@ impl ModuleParser {
         &mut self,
         func_body: FunctionBody,
         bytes: &[u8],
-        header: &ModuleHeader,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
-        let (func, engine_func) = self.next_func(header);
-        let module = header.clone();
+        let (func, engine_func) = self.next_func(module);
         let offset = func_body.get_binary_reader().original_position();
         let func_to_validate = {
             #[cfg(feature = "validate")]
@@ -527,21 +523,22 @@ impl ModuleParser {
                 None
             }
         };
+        let header = module.header();
         self.engine
-            .translate_func(func, engine_func, offset, bytes, module, func_to_validate)?;
+            .translate_func(func, engine_func, offset, bytes, header, func_to_validate)?;
         Ok(())
     }
 
     /// Process a single Wasm custom section.
     fn process_custom_section(
         &mut self,
-        custom_sections: &mut CustomSectionsBuilder,
         reader: CustomSectionReader,
+        module: &mut ModuleBuilder,
     ) -> Result<(), Error> {
         if self.engine.config().get_ignore_custom_sections() {
             return Ok(());
         }
-        custom_sections.push(reader.name(), reader.data());
+        module.custom_sections.push(reader.name(), reader.data());
         Ok(())
     }
 


### PR DESCRIPTION
Required for https://github.com/wasmi-labs/wasmi/issues/1940 to add a new `InstanceLayout` field to `ModuleHeader`.

- This drops the `ModuleHeaderBuilder` and moves its logic into `ModuleBuilder`.
- This refactoring allows to upgrade `wasmparser` to newer versions.
