### PR TITLE
Add option to disallow `start` functions for Wasm modules

### DIFF
--- a/crates/wasmi/src/engine/config.rs
+++ b/crates/wasmi/src/engine/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     consume_fuel: bool,
     /// Is `true` if Wasmi shall ignore Wasm custom sections when parsing Wasm modules.
     ignore_custom_sections: bool,
+    /// Is `true` if Wasmi allows `start` functions in Wasm modules.
+    allow_start_fn: bool,
     /// The configured fuel costs of all Wasmi bytecode instructions.
     fuel_costs: FuelCostsProvider,
     /// The mode of Wasm to Wasmi bytecode compilation.
@@ -53,6 +55,7 @@ impl Default for Config {
             features: Self::default_features(),
             consume_fuel: false,
             ignore_custom_sections: false,
+            allow_start_fn: true,
             fuel_costs: FuelCostsProvider::default(),
             compilation_mode: CompilationMode::default(),
             limits: EnforcedLimits::default(),
@@ -361,6 +364,21 @@ impl Config {
     /// [`Engine`]: crate::Engine
     pub(crate) fn get_consume_fuel(&self) -> bool {
         self.consume_fuel
+    }
+
+    /// Configures whether Wasmi allows Wasm modules with `start` functions.
+    ///
+    /// Enabled by default.
+    pub fn allow_start_fn(&mut self, allow: bool) -> &mut Self {
+        self.allow_start_fn = allow;
+        self
+    }
+
+    /// Returns `true` if the [`Config`] allows Wasm modules with `start` functions.
+    ///
+    /// [`Engine`]: crate::Engine
+    pub(crate) fn get_allow_start_fn(&self) -> bool {
+        self.allow_start_fn
     }
 
     /// Configures whether Wasmi will ignore custom sections when parsing Wasm modules.

--- a/crates/wasmi/src/engine/translator/error.rs
+++ b/crates/wasmi/src/engine/translator/error.rs
@@ -6,6 +6,10 @@ use core::{
 /// An error that may occur upon parsing, validating and translating Wasm.
 #[derive(Debug)]
 pub enum TranslationError {
+    /// A Wasm module defines a `start` function that the [`Config`] disallowed.
+    ///
+    /// [`Config`]: crate::Config
+    DisallowedStartFn,
     /// Encountered an unsupported Wasm block type.
     UnsupportedBlockType(wasmparser::BlockType),
     /// Encountered an unsupported Wasm value type.
@@ -57,6 +61,7 @@ impl Error for TranslationError {}
 impl Display for TranslationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let message = match self {
+            Self::DisallowedStartFn => "configuration disallows start functions but found one",
             Self::UnsupportedBlockType(error) => {
                 return write!(f, "encountered unsupported Wasm block type: {error:?}");
             }

--- a/crates/wasmi/src/module/parser/mod.rs
+++ b/crates/wasmi/src/module/parser/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     FuncType,
     MemoryType,
     TableType,
-    engine::{EnforcedLimitsError, EngineFunc},
+    engine::{EnforcedLimitsError, EngineFunc, TranslationError},
     module::MaybeDebug,
 };
 use alloc::boxed::Box;
@@ -333,6 +333,9 @@ impl ModuleParser {
         #[cfg(feature = "validate")]
         if let Some(validator) = &mut self.validator {
             validator.start_section(func, &range)?;
+        }
+        if !self.engine.config().get_allow_start_fn() {
+            return Err(Error::from(TranslationError::DisallowedStartFn));
         }
         module.set_start(FuncIdx::from(func));
         Ok(())

--- a/crates/wasmi/tests/integration/disallowed_start_fn.rs
+++ b/crates/wasmi/tests/integration/disallowed_start_fn.rs
@@ -16,7 +16,10 @@ fn disallowed_start_fn() {
         Ok(module) => panic!("expected error but found: {module:?}"),
         Err(err) => {
             assert!(matches!(err.kind(), ErrorKind::Translation(_)));
-            assert_eq!(err.to_string(), "configuration disallows start functions but found one".to_string())
+            assert_eq!(
+                err.to_string(),
+                "configuration disallows start functions but found one".to_string()
+            )
         }
     }
 }

--- a/crates/wasmi/tests/integration/disallowed_start_fn.rs
+++ b/crates/wasmi/tests/integration/disallowed_start_fn.rs
@@ -1,0 +1,22 @@
+use wasmi::{Config, Engine, Module, errors::ErrorKind};
+
+#[test]
+fn disallowed_start_fn() {
+    let wasm = r#"
+        (module
+            (start $f)
+            (func $f)
+        )
+    "#;
+    let mut config = Config::default();
+    config.allow_start_fn(false);
+    let engine = Engine::new(&config);
+    let module_or_err = Module::new(&engine, wasm.as_bytes());
+    match module_or_err {
+        Ok(module) => panic!("expected error but found: {module:?}"),
+        Err(err) => {
+            assert!(matches!(err.kind(), ErrorKind::Translation(_)));
+            assert_eq!(err.to_string(), "configuration disallows start functions but found one".to_string())
+        }
+    }
+}

--- a/crates/wasmi/tests/integration/mod.rs
+++ b/crates/wasmi/tests/integration/mod.rs
@@ -1,5 +1,6 @@
 mod call_hook;
 mod call_host_via_engine;
+mod disallowed_start_fn;
 mod fuel_consumption;
 mod fuel_metering;
 mod func;


### PR DESCRIPTION
Closes https://github.com/wasmi-labs/wasmi/issues/1984

cc @pwang200

New API:

<img width="1138" height="202" alt="image" src="https://github.com/user-attachments/assets/c220edb8-60ae-4303-b964-6653f55a93ac" />
