### PR TITLE
Make `StableArena::get_disjoint_mut` return `array` instead of `tuple`

### DIFF
--- a/crates/collections/src/arena/stable_arena.rs
+++ b/crates/collections/src/arena/stable_arena.rs
@@ -162,7 +162,7 @@ where
     /// - If `keys[0]` and `keys[1]` refer to the same item, a.k.a. aliasing each other.
     /// - If `keys[0]` or `keys[1]` is out of bounds for the arena.
     #[inline]
-    pub fn get_disjoint_mut(&mut self, keys: [Key; 2]) -> Result<(&mut T, &mut T), ArenaError> {
+    pub fn get_disjoint_mut(&mut self, keys: [Key; 2]) -> Result<[&mut T; 2], ArenaError> {
         let [a, b] = keys;
         self.items
             .get_disjoint_mut([a.into_usize(), b.into_usize()])
@@ -392,7 +392,7 @@ mod tests {
         let mut arena: Arena = (0..10).collect();
         *arena.get_mut(3).unwrap() = 30;
         assert_eq!(arena.get(3).unwrap(), &30);
-        let (a, b) = arena.get_disjoint_mut([1, 8]).unwrap();
+        let [a, b] = arena.get_disjoint_mut([1, 8]).unwrap();
         *a = -1;
         *b = -8;
         assert_eq!((arena[1], arena[8]), (-1, -8));

--- a/crates/collections/src/arena/stable_vec.rs
+++ b/crates/collections/src/arena/stable_vec.rs
@@ -128,10 +128,7 @@ impl<T> StableVec<T> {
     /// - If `indices[0]` and `indices[1]` refer to the same item, a.k.a. aliasing each other.
     /// - If `indices[0]` or `indices[1]` is out of bounds for the arena.
     #[inline]
-    pub fn get_disjoint_mut(
-        &mut self,
-        indices: [usize; 2],
-    ) -> Result<(&mut T, &mut T), ArenaError> {
+    pub fn get_disjoint_mut(&mut self, indices: [usize; 2]) -> Result<[&mut T; 2], ArenaError> {
         let [a, b] = indices;
         if a == b {
             return Err(ArenaError::AliasingPairAccess);
@@ -146,7 +143,7 @@ impl<T> StableVec<T> {
         unsafe {
             let pa = self.buckets[ba].unwrap_unchecked().as_ptr().add(sa);
             let pb = self.buckets[bb].unwrap_unchecked().as_ptr().add(sb);
-            Ok((&mut *pa, &mut *pb))
+            Ok([&mut *pa, &mut *pb])
         }
     }
 
@@ -562,7 +559,7 @@ mod tests {
     #[test]
     fn get_pair_mut_disjoint() {
         let mut vector: StableVec<usize> = (0..100).collect();
-        let (a, b) = vector.get_disjoint_mut([10, 90]).unwrap();
+        let [a, b] = vector.get_disjoint_mut([10, 90]).unwrap();
         *a = 111;
         *b = 999;
         assert_eq!(vector.get(10), Some(&111));


### PR DESCRIPTION
this mirrors Rust's `Vec::get_disjoint_mut` API more closely.