### PR TITLE
Cache `FuncEntry` in `FuncEntity` and make use of this caching in the executor

### DIFF
--- a/crates/wasmi/src/engine/code_map/mod.rs
+++ b/crates/wasmi/src/engine/code_map/mod.rs
@@ -550,6 +550,49 @@ pub struct FuncEntry {
     state: AtomicU8,
 }
 
+/// A stable address of a [`FuncEntry`] in the engine's append-only [`CodeMap`].
+///
+/// Holding this instead of an `EngineFunc` lets callers reach the [`FuncEntry`] directly, skipping
+/// the [`CodeMap`] lookup. It stores the address as an exposed-provenance `usize` (the same
+/// convention the `call_internal` handler uses for its baked pointer) which keeps it `Send + Sync`
+/// without an `unsafe impl`.
+///
+/// [`CodeMap`]: crate::engine::CodeMap
+#[derive(Debug, Copy, Clone)]
+pub struct FuncEntryPtr(usize);
+
+impl From<usize> for FuncEntryPtr {
+    /// Creates a [`FuncEntryPtr`] from a previously exposed [`FuncEntry`] address.
+    ///
+    /// Used by the `call_internal` handlers to recover the address baked into the bytecode.
+    fn from(addr: usize) -> Self {
+        Self(addr)
+    }
+}
+
+impl FuncEntryPtr {
+    /// Creates a [`FuncEntryPtr`] from `entry`, exposing its provenance.
+    pub fn new(entry: &FuncEntry) -> Self {
+        Self(ptr::from_ref(entry).expose_provenance())
+    }
+
+    /// Returns a shared reference to the pointed-to [`FuncEntry`].
+    ///
+    /// # Safety
+    ///
+    /// The engine owning the [`FuncEntry`] must outlive `'a`. This holds for a [`FuncEntryPtr`]
+    /// stored in a [`WasmFuncEntity`] since its [`Func`] cannot outlive the owning engine. The
+    /// [`FuncEntry`] is only ever accessed through shared references (interior mutation is guarded
+    /// by atomics), so no aliasing `&mut` is ever formed.
+    ///
+    /// [`WasmFuncEntity`]: crate::func::WasmFuncEntity
+    /// [`Func`]: crate::Func
+    pub unsafe fn get<'a>(self) -> &'a FuncEntry {
+        // SAFETY: guaranteed by the caller (see above); provenance was exposed in `new`.
+        unsafe { &*ptr::with_exposed_provenance::<FuncEntry>(self.0) }
+    }
+}
+
 impl Drop for FuncEntry {
     fn drop(&mut self) {
         match self.state.load(Ordering::Acquire) {

--- a/crates/wasmi/src/engine/executor/handler/args.rs
+++ b/crates/wasmi/src/engine/executor/handler/args.rs
@@ -221,7 +221,7 @@ impl Args {
     }
 
     /// Calls `func` with `params` on `instance` with `state` using `self`.
-    #[inline]
+    #[inline(always)]
     pub fn call_func_entry(
         &mut self,
         state: &mut VmState,
@@ -234,7 +234,7 @@ impl Args {
     }
 
     /// Tail-calls `func` with `params` on `instance` with `state` using `self`.
-    #[inline]
+    #[inline(always)]
     pub fn return_call_func_entry(
         &mut self,
         state: &mut VmState,

--- a/crates/wasmi/src/engine/executor/handler/exec.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec.rs
@@ -19,7 +19,7 @@ use crate::{
     TrapCode,
     core::{CoreTable, RawRef, ReadAs, WriteAs, wasm},
     engine::{
-        FuncEntry,
+        FuncEntryPtr,
         eval,
         executor::handler::{
             Control,
@@ -33,7 +33,7 @@ use crate::{
     ir::{self, BoundedSlotSpan},
     store::StoreError,
 };
-use core::{cmp, ptr};
+use core::cmp;
 
 fn identity<T>(value: T) -> T {
     value
@@ -205,14 +205,9 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::CallInternal { params, func } = unsafe { args.decode_op() };
-        // Safety:
-        //
-        // `func` is the exposed address of a `FuncEntity` in the engine's append-only `CodeMap`.
-        //
-        //  - the used `with_exposed_provenance` recovers the original provenance.
-        //  - its allocation is never moved or freed while this bytecode runs.
-        //  - the `FuncEntry` type mutates only guarded by lock-free atomics.
-        let func = unsafe { &*ptr::with_exposed_provenance::<FuncEntry>(usize::from(func)) };
+        // SAFETY: `func` is the exposed address of a `FuncEntry` in the engine's append-only
+        //         `CodeMap`, baked into the bytecode; it stays valid while this bytecode runs.
+        let func = unsafe { FuncEntryPtr::from(usize::from(func)).get() };
         args.call_func_entry(state, func, params, None)?;
         dispatch!(state, args)
     }
@@ -287,14 +282,8 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::ReturnCallInternal { params, func } = unsafe { args.decode_op() };
-        // Safety:
-        //
-        // `func` is the exposed address of a `FuncEntity` in the engine's append-only `CodeMap`.
-        //
-        //  - the used `with_exposed_provenance` recovers the original provenance.
-        //  - its allocation is never moved or freed while this bytecode runs.
-        //  - the `FuncEntry` type mutates only guarded by lock-free atomics.
-        let func = unsafe { &*ptr::with_exposed_provenance::<FuncEntry>(usize::from(func)) };
+        // SAFETY: see `call_internal`.
+        let func = unsafe { FuncEntryPtr::from(usize::from(func)).get() };
         args.return_call_func_entry(state, func, params, None)?;
         dispatch!(state, args)
     }

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -772,17 +772,6 @@ pub fn update_instance(
     (new_instance, mem0, mem0_len)
 }
 
-#[inline(never)]
-pub fn call_func_entry_cold(
-    state: &mut VmState,
-    caller_ip: Ip,
-    params: BoundedSlotSpan,
-    func: &FuncEntry,
-    instance: Option<Inst>,
-) -> Control<(Ip, Sp), Break> {
-    call_func_entry(state, caller_ip, params, func, instance)
-}
-
 #[inline(always)]
 pub fn call_func_entry(
     state: &mut VmState,
@@ -804,16 +793,6 @@ pub fn call_func_entry(
         )
         .into_control()?;
     Control::Continue((callee_ip, callee_sp))
-}
-
-#[inline(never)]
-pub fn return_call_func_entry_cold(
-    state: &mut VmState,
-    params: BoundedSlotSpan,
-    func: &FuncEntry,
-    instance: Option<Inst>,
-) -> Control<(Ip, Sp), Break> {
-    return_call_func_entry(state, params, func, instance)
 }
 
 #[inline(always)]
@@ -929,13 +908,25 @@ pub fn call_wasm_or_host(
     let wasm_func = match func_entity {
         FuncEntity::Wasm(wasm_func) => wasm_func,
         FuncEntity::Host(host_func) => {
-            return call_host_cold(state, func, caller_ip, *host_func, params, instance);
+            let sp = call_host(
+                state,
+                func,
+                Some(caller_ip),
+                *host_func,
+                params,
+                Some(instance),
+                CallHooks::Call,
+            )?;
+            // Note: host functions may grow memories, invalidating the cached `(memory 0)`.
+            //       Therefore, it is required to re-extract `(memory 0)` to avoid a stale cache.
+            let (mem0, mem0_len) = extract_mem0(state.store, instance);
+            return Control::Continue((caller_ip, sp, mem0, mem0_len, instance));
         }
     };
     // Hot path: calling a Wasm function. Uses the cached `FuncEntry` and the same inlined
     // machinery as `call_internal`, differing only in the possible instance switch.
     let callee_instance: Inst = resolve_instance(state.store, wasm_func.instance()).into();
-    let (callee_ip, callee_sp) = call_func_entry_cold(
+    let (callee_ip, callee_sp) = call_func_entry(
         state,
         caller_ip,
         params,
@@ -945,33 +936,6 @@ pub fn call_wasm_or_host(
     let (instance, mem0, mem0_len) =
         update_instance(state.store, instance, callee_instance, mem0, mem0_len);
     Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))
-}
-
-/// Out-of-line slow path of [`call_wasm_or_host`] for calling a host function.
-#[cold]
-#[inline(never)]
-fn call_host_cold(
-    state: &mut VmState,
-    func: Func,
-    caller_ip: Ip,
-    host_func: HostFuncEntity,
-    params: BoundedSlotSpan,
-    instance: Inst,
-) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, Inst), Break> {
-    let sp = call_host(
-        state,
-        func,
-        Some(caller_ip),
-        host_func,
-        params,
-        Some(instance),
-        CallHooks::Call,
-    )?;
-    // Host functions may re-enter WASM (e.g. calling cabi_realloc)
-    // which can trigger memory.grow, invalidating the cached mem0
-    // pointer. Re-extract to avoid stale pointer dereference.
-    let (mem0, mem0_len) = extract_mem0(state.store, instance);
-    Control::Continue((caller_ip, sp, mem0, mem0_len, instance))
 }
 
 /// Tail-call (`return_call`) twin of [`call_wasm_or_host`].
@@ -990,35 +954,19 @@ pub fn return_call_wasm_or_host(
     let wasm_func = match func_entity {
         FuncEntity::Wasm(wasm_func) => wasm_func,
         FuncEntity::Host(host_func) => {
-            return return_call_host_cold(
-                state, func, *host_func, params, mem0, mem0_len, instance,
-            );
+            let (callee_ip, sp, new_instance) =
+                return_call_host(state, func, *host_func, params, instance)?;
+            let (instance, mem0, mem0_len) =
+                update_instance(state.store, instance, new_instance, mem0, mem0_len);
+            return Control::Continue((callee_ip, sp, mem0, mem0_len, instance));
         }
     };
     // Hot path: tail-calling a Wasm function. See `call_wasm_or_host` for the shape.
     let callee_instance: Inst = resolve_instance(state.store, wasm_func.instance()).into();
     let changed_instance = (callee_instance != instance).then_some(callee_instance);
     let (callee_ip, callee_sp) =
-        return_call_func_entry_cold(state, params, wasm_func.func_entry(), changed_instance)?;
+        return_call_func_entry(state, params, wasm_func.func_entry(), changed_instance)?;
     let (instance, mem0, mem0_len) =
         update_instance(state.store, instance, callee_instance, mem0, mem0_len);
     Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))
-}
-
-/// Out-of-line slow path of [`return_call_wasm_or_host`] for tail-calling a host function.
-#[cold]
-#[inline(never)]
-fn return_call_host_cold(
-    state: &mut VmState,
-    func: Func,
-    host_func: HostFuncEntity,
-    params: BoundedSlotSpan,
-    mem0: Mem0Ptr,
-    mem0_len: Mem0Len,
-    instance: Inst,
-) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, Inst), Break> {
-    let (callee_ip, sp, new_instance) = return_call_host(state, func, host_func, params, instance)?;
-    let (instance, mem0, mem0_len) =
-        update_instance(state.store, instance, new_instance, mem0, mem0_len);
-    Control::Continue((callee_ip, sp, mem0, mem0_len, instance))
 }

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -772,7 +772,18 @@ pub fn update_instance(
     (new_instance, mem0, mem0_len)
 }
 
-#[inline]
+#[inline(never)]
+pub fn call_func_entry_cold(
+    state: &mut VmState,
+    caller_ip: Ip,
+    params: BoundedSlotSpan,
+    func: &FuncEntry,
+    instance: Option<Inst>,
+) -> Control<(Ip, Sp), Break> {
+    call_func_entry(state, caller_ip, params, func, instance)
+}
+
+#[inline(always)]
 pub fn call_func_entry(
     state: &mut VmState,
     caller_ip: Ip,
@@ -795,7 +806,17 @@ pub fn call_func_entry(
     Control::Continue((callee_ip, callee_sp))
 }
 
-#[inline]
+#[inline(never)]
+pub fn return_call_func_entry_cold(
+    state: &mut VmState,
+    params: BoundedSlotSpan,
+    func: &FuncEntry,
+    instance: Option<Inst>,
+) -> Control<(Ip, Sp), Break> {
+    return_call_func_entry(state, params, func, instance)
+}
+
+#[inline(always)]
 pub fn return_call_func_entry(
     state: &mut VmState,
     params: BoundedSlotSpan,
@@ -914,7 +935,7 @@ pub fn call_wasm_or_host(
     // Hot path: calling a Wasm function. Uses the cached `FuncEntry` and the same inlined
     // machinery as `call_internal`, differing only in the possible instance switch.
     let callee_instance: Inst = resolve_instance(state.store, wasm_func.instance()).into();
-    let (callee_ip, callee_sp) = call_func_entry(
+    let (callee_ip, callee_sp) = call_func_entry_cold(
         state,
         caller_ip,
         params,
@@ -978,7 +999,7 @@ pub fn return_call_wasm_or_host(
     let callee_instance: Inst = resolve_instance(state.store, wasm_func.instance()).into();
     let changed_instance = (callee_instance != instance).then_some(callee_instance);
     let (callee_ip, callee_sp) =
-        return_call_func_entry(state, params, wasm_func.func_entry(), changed_instance)?;
+        return_call_func_entry_cold(state, params, wasm_func.func_entry(), changed_instance)?;
     let (instance, mem0, mem0_len) =
         update_instance(state.store, instance, callee_instance, mem0, mem0_len);
     Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -22,7 +22,6 @@ use crate::{
     },
     engine::{
         DedupFuncType,
-        EngineFunc,
         FuncEntry,
         executor::{
             LoadFromCellsByValue,
@@ -79,22 +78,6 @@ pub fn compile_or_get_func_entry(
 macro_rules! compile_or_get_func_entry {
     ($state:expr, $func:expr) => {{
         match $crate::engine::executor::handler::utils::compile_or_get_func_entry($state, $func) {
-            Ok((ip, len_local_slots, len_stack_slots)) => (ip, len_local_slots, len_stack_slots),
-            Err(error) => done!($state, DoneReason::error(error)),
-        }
-    }};
-}
-
-pub fn compile_or_get_func(state: &mut VmState, func: EngineFunc) -> Result<(Ip, u16, u16), Error> {
-    let Some(func_entry) = state.code.entry(func) else {
-        unreachable!("missing function entry at: {func:?}")
-    };
-    compile_or_get_func_entry(state, func_entry)
-}
-
-macro_rules! compile_or_get_func {
-    ($state:expr, $func:expr) => {{
-        match $crate::engine::executor::handler::utils::compile_or_get_func($state, $func) {
             Ok((ip, len_local_slots, len_stack_slots)) => (ip, len_local_slots, len_stack_slots),
             Err(error) => done!($state, DoneReason::error(error)),
         }
@@ -812,29 +795,6 @@ pub fn call_func_entry(
     Control::Continue((callee_ip, callee_sp))
 }
 
-#[inline(never)]
-pub fn call_wasm(
-    state: &mut VmState,
-    caller_ip: Ip,
-    params: BoundedSlotSpan,
-    func: EngineFunc,
-    instance: Option<Inst>,
-) -> Control<(Ip, Sp), Break> {
-    let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func!(state, func);
-    let callee_sp = state
-        .stack
-        .push_frame(
-            Some(caller_ip),
-            callee_ip,
-            params,
-            len_local_slots,
-            len_stack_slots,
-            instance,
-        )
-        .into_control()?;
-    Control::Continue((callee_ip, callee_sp))
-}
-
 #[inline]
 pub fn return_call_func_entry(
     state: &mut VmState,
@@ -843,27 +803,6 @@ pub fn return_call_func_entry(
     instance: Option<Inst>,
 ) -> Control<(Ip, Sp), Break> {
     let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func_entry!(state, func);
-    let callee_sp = state
-        .stack
-        .replace_frame(
-            callee_ip,
-            params,
-            len_local_slots,
-            len_stack_slots,
-            instance,
-        )
-        .into_control()?;
-    Control::Continue((callee_ip, callee_sp))
-}
-
-#[inline(never)]
-pub fn return_call_wasm(
-    state: &mut VmState,
-    params: BoundedSlotSpan,
-    func: EngineFunc,
-    instance: Option<Inst>,
-) -> Control<(Ip, Sp), Break> {
-    let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func!(state, func);
     let callee_sp = state
         .stack
         .replace_frame(
@@ -950,6 +889,7 @@ pub fn return_call_host(
     }
 }
 
+#[inline]
 #[expect(clippy::too_many_arguments)]
 pub fn call_wasm_or_host(
     state: &mut VmState,
@@ -965,39 +905,56 @@ pub fn call_wasm_or_host(
     //         (indirect calls); the reference is only used to copy out the callee data below,
     //         before any store mutation, so it never aliases a `&mut` into the funcs arena.
     let func_entity = unsafe { func_entity.as_ref() };
-    let next_state = match func_entity {
-        FuncEntity::Wasm(wasm_func) => {
-            let func = wasm_func.func_body();
-            let callee_instance = *wasm_func.instance();
-            let callee_instance: Inst = resolve_instance(state.store, &callee_instance).into();
-            let (callee_ip, callee_sp) =
-                call_wasm(state, caller_ip, params, func, Some(callee_instance))?;
-            let (instance, mem0, mem0_len) =
-                update_instance(state.store, instance, callee_instance, mem0, mem0_len);
-            (callee_ip, callee_sp, mem0, mem0_len, instance)
-        }
+    let wasm_func = match func_entity {
+        FuncEntity::Wasm(wasm_func) => wasm_func,
         FuncEntity::Host(host_func) => {
-            let host_func = *host_func;
-            let sp = call_host(
-                state,
-                func,
-                Some(caller_ip),
-                host_func,
-                params,
-                Some(instance),
-                CallHooks::Call,
-            )?;
-            // Host functions may re-enter WASM (e.g. calling cabi_realloc)
-            // which can trigger memory.grow, invalidating the cached mem0
-            // pointer. Re-extract to avoid stale pointer dereference.
-            let (mem0, mem0_len) = extract_mem0(state.store, instance);
-            (caller_ip, sp, mem0, mem0_len, instance)
+            return call_host_cold(state, func, caller_ip, *host_func, params, instance);
         }
     };
-    Control::Continue(next_state)
+    // Hot path: calling a Wasm function. Uses the cached `FuncEntry` and the same inlined
+    // machinery as `call_internal`, differing only in the possible instance switch.
+    let callee_instance: Inst = resolve_instance(state.store, wasm_func.instance()).into();
+    let (callee_ip, callee_sp) = call_func_entry(
+        state,
+        caller_ip,
+        params,
+        wasm_func.func_entry(),
+        Some(callee_instance),
+    )?;
+    let (instance, mem0, mem0_len) =
+        update_instance(state.store, instance, callee_instance, mem0, mem0_len);
+    Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))
+}
+
+/// Out-of-line slow path of [`call_wasm_or_host`] for calling a host function.
+#[cold]
+#[inline(never)]
+fn call_host_cold(
+    state: &mut VmState,
+    func: Func,
+    caller_ip: Ip,
+    host_func: HostFuncEntity,
+    params: BoundedSlotSpan,
+    instance: Inst,
+) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, Inst), Break> {
+    let sp = call_host(
+        state,
+        func,
+        Some(caller_ip),
+        host_func,
+        params,
+        Some(instance),
+        CallHooks::Call,
+    )?;
+    // Host functions may re-enter WASM (e.g. calling cabi_realloc)
+    // which can trigger memory.grow, invalidating the cached mem0
+    // pointer. Re-extract to avoid stale pointer dereference.
+    let (mem0, mem0_len) = extract_mem0(state.store, instance);
+    Control::Continue((caller_ip, sp, mem0, mem0_len, instance))
 }
 
 /// Tail-call (`return_call`) twin of [`call_wasm_or_host`].
+#[inline]
 pub fn return_call_wasm_or_host(
     state: &mut VmState,
     func: Func,
@@ -1009,24 +966,37 @@ pub fn return_call_wasm_or_host(
 ) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, Inst), Break> {
     // SAFETY: see `call_wasm_or_host`.
     let func_entity = unsafe { func_entity.as_ref() };
-    let (callee_ip, sp, new_instance) = match func_entity {
-        FuncEntity::Wasm(wasm_func) => {
-            let wasm_func_body = wasm_func.func_body();
-            let callee_instance = *wasm_func.instance();
-            let callee_instance: Inst = resolve_instance(state.store, &callee_instance).into();
-            let changed_instance = match callee_instance != instance {
-                true => Some(callee_instance),
-                false => None,
-            };
-            let (callee_ip, callee_sp) =
-                return_call_wasm(state, params, wasm_func_body, changed_instance)?;
-            (callee_ip, callee_sp, callee_instance)
-        }
+    let wasm_func = match func_entity {
+        FuncEntity::Wasm(wasm_func) => wasm_func,
         FuncEntity::Host(host_func) => {
-            let host_func = *host_func;
-            return_call_host(state, func, host_func, params, instance)?
+            return return_call_host_cold(
+                state, func, *host_func, params, mem0, mem0_len, instance,
+            );
         }
     };
+    // Hot path: tail-calling a Wasm function. See `call_wasm_or_host` for the shape.
+    let callee_instance: Inst = resolve_instance(state.store, wasm_func.instance()).into();
+    let changed_instance = (callee_instance != instance).then_some(callee_instance);
+    let (callee_ip, callee_sp) =
+        return_call_func_entry(state, params, wasm_func.func_entry(), changed_instance)?;
+    let (instance, mem0, mem0_len) =
+        update_instance(state.store, instance, callee_instance, mem0, mem0_len);
+    Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))
+}
+
+/// Out-of-line slow path of [`return_call_wasm_or_host`] for tail-calling a host function.
+#[cold]
+#[inline(never)]
+fn return_call_host_cold(
+    state: &mut VmState,
+    func: Func,
+    host_func: HostFuncEntity,
+    params: BoundedSlotSpan,
+    mem0: Mem0Ptr,
+    mem0_len: Mem0Len,
+    instance: Inst,
+) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, Inst), Break> {
+    let (callee_ip, sp, new_instance) = return_call_host(state, func, host_func, params, instance)?;
     let (instance, mem0, mem0_len) =
         update_instance(state.store, instance, new_instance, mem0, mem0_len);
     Control::Continue((callee_ip, sp, mem0, mem0_len, instance))

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -15,6 +15,7 @@ mod utils;
 pub(crate) use self::translator::ValidatingFuncTranslator;
 pub(crate) use self::{
     block_type::BlockType,
+    code_map::{FuncEntry, FuncEntryPtr},
     executor::{
         InOutParams,
         InOutResults,
@@ -61,7 +62,6 @@ use crate::{
     Func,
     FuncType,
     StoreContextMut,
-    engine::code_map::FuncEntry,
     module::{FuncIdx, ModuleHeader},
 };
 use alloc::{

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -16,7 +16,7 @@ use super::{
     AsContextMut,
     Instance,
     StoreContext,
-    engine::{DedupFuncType, EngineFunc},
+    engine::{DedupFuncType, EngineFunc, FuncEntry, FuncEntryPtr},
 };
 use crate::{
     Engine,
@@ -129,16 +129,32 @@ pub struct WasmFuncEntity {
     ty: DedupFuncType,
     /// The compiled function body of the Wasm function.
     body: EngineFunc,
+    /// A cached pointer to the [`FuncEntry`] of `body` in the engine's [`CodeMap`].
+    ///
+    /// Lets the executor reach the compiled code without a [`CodeMap`] lookup.
+    ///
+    /// [`CodeMap`]: crate::engine::CodeMap
+    func_entry: FuncEntryPtr,
     /// The instance associated to the Wasm function.
     instance: Instance,
 }
 
 impl WasmFuncEntity {
     /// Creates a new Wasm function from the given raw parts.
-    pub fn new(signature: DedupFuncType, body: EngineFunc, instance: Instance) -> Self {
+    ///
+    /// `func_entry` must be the [`FuncEntry`] of `body` in the owning engine's [`CodeMap`].
+    ///
+    /// [`CodeMap`]: crate::engine::CodeMap
+    pub fn new(
+        signature: DedupFuncType,
+        body: EngineFunc,
+        func_entry: &FuncEntry,
+        instance: Instance,
+    ) -> Self {
         Self {
             ty: signature,
             body,
+            func_entry: FuncEntryPtr::new(func_entry),
             instance,
         }
     }
@@ -156,6 +172,13 @@ impl WasmFuncEntity {
     /// Returns the Wasm function body of the [`Func`].
     pub fn func_body(&self) -> EngineFunc {
         self.body
+    }
+
+    /// Returns the cached [`FuncEntry`] of the Wasm function.
+    pub fn func_entry(&self) -> &FuncEntry {
+        // SAFETY: the `FuncEntry` lives in the owning engine's `CodeMap`, which outlives this
+        //         `WasmFuncEntity` since a `Func` cannot outlive its engine.
+        unsafe { self.func_entry.get() }
     }
 }
 

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -129,11 +129,11 @@ pub struct WasmFuncEntity {
     ty: DedupFuncType,
     /// The compiled function body of the Wasm function.
     body: EngineFunc,
-    /// A cached pointer to the [`FuncEntry`] of `body` in the engine's [`CodeMap`].
+    /// A cached pointer to the [`FuncEntry`] of `body` in the [`Engine`].
     ///
-    /// Lets the executor reach the compiled code without a [`CodeMap`] lookup.
+    /// Lets the executor reach the compiled code without an [`Engine`] lookup.
     ///
-    /// [`CodeMap`]: crate::engine::CodeMap
+    /// [`Engine`]: crate::Engine
     func_entry: FuncEntryPtr,
     /// The instance associated to the Wasm function.
     instance: Instance,
@@ -142,9 +142,9 @@ pub struct WasmFuncEntity {
 impl WasmFuncEntity {
     /// Creates a new Wasm function from the given raw parts.
     ///
-    /// `func_entry` must be the [`FuncEntry`] of `body` in the owning engine's [`CodeMap`].
+    /// `func_entry` must be the [`FuncEntry`] of `body` in the owning [`Engine`].
     ///
-    /// [`CodeMap`]: crate::engine::CodeMap
+    /// [`Engine`]: crate::Engine
     pub fn new(
         signature: DedupFuncType,
         body: EngineFunc,

--- a/crates/wasmi/src/module/instantiate/mod.rs
+++ b/crates/wasmi/src/module/instantiate/mod.rs
@@ -210,7 +210,10 @@ impl Module {
         handle: Instance,
     ) {
         for (func_type, func_body) in self.internal_funcs() {
-            let wasm_func = WasmFuncEntity::new(func_type, func_body, handle);
+            let Some(func_entry) = self.engine().resolve_func(func_body) else {
+                unreachable!("missing func entry at: {func_body:?}")
+            };
+            let wasm_func = WasmFuncEntity::new(func_type, func_body, func_entry, handle);
             let func = context
                 .as_context_mut()
                 .store


### PR DESCRIPTION
Part of https://github.com/wasmi-labs/wasmi/issues/1940.

Benchmarks look promising:

<img width="954" height="1444" alt="image" src="https://github.com/user-attachments/assets/f7e65ec6-e0b5-41b5-ba5f-c08f6c723eed" />
