### PR TITLE
Experiment: swap float-wrapper between `Inst` and `VmState`

### DIFF
--- a/crates/wasmi/src/engine/executor/handler/args.rs
+++ b/crates/wasmi/src/engine/executor/handler/args.rs
@@ -18,6 +18,7 @@ use crate::{
                 Mem0Len,
                 Mem0Ptr,
                 Sp,
+                Vm,
                 VmState,
             },
             utils::{self, GetValue, IntoControl as _, SetValue, get_value, set_value},
@@ -149,13 +150,14 @@ impl Args {
     #[inline]
     pub fn fetch_memory_bytes<'a>(
         &mut self,
-        state: &'a mut VmState,
+        state: &'a mut Vm<'_, '_>,
         addr: ir::MemoryAddr,
     ) -> &'a mut [u8] {
         if utils::is_default_memory(self.instance, addr) {
             return self.fetch_default_memory_bytes();
         }
-        self.fetch_memory(state, addr).data_mut()
+        // Note: only the non-default memory path resolves the `VmState`.
+        self.fetch_memory(state.get(), addr).data_mut()
     }
 
     /// Returns the bytes of the default memory at index 0.

--- a/crates/wasmi/src/engine/executor/handler/dispatch/backend/loop.rs
+++ b/crates/wasmi/src/engine/executor/handler/dispatch/backend/loop.rs
@@ -2,7 +2,7 @@ use crate::{
     engine::executor::handler::{
         dispatch::{Break, Control, ExecutionOutcome},
         exec,
-        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, VmState},
+        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, Vm, VmState},
     },
     ir,
     ir::OpCode,
@@ -48,7 +48,7 @@ pub fn control_continue(
 
 macro_rules! dispatch {
     ( $state:expr, $args:expr $(,)? ) => {{
-        let _: &mut VmState = $state;
+        let _: Vm<'_, '_> = $state;
         let (ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64) = $args.into_parts();
         return $crate::engine::executor::handler::dispatch::backend::control_continue(
             ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64,
@@ -190,7 +190,7 @@ macro_rules! impl_executor_handlers {
             #[cfg_attr(all(feature = "indirect-dispatch", debug_assertions), inline(never))]
             #[cfg_attr(not(feature = "indirect-dispatch"), inline(never))]
             fn $snake_case(&mut self, state: &mut VmState) -> Control<(), Break> {
-                match exec::$snake_case(state, self.ip, self.sp, self.mem0, self.mem0_len, self.instance, self.ireg, self.freg32, self.freg64) {
+                match exec::$snake_case(Vm::from(&mut *state), self.ip, self.sp, self.mem0, self.mem0_len, self.instance, self.ireg, self.freg32, self.freg64) {
                     Done::Continue(NextState { ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64 }) => {
                         self.ip = ip;
                         self.sp = sp;

--- a/crates/wasmi/src/engine/executor/handler/dispatch/backend/tail.rs
+++ b/crates/wasmi/src/engine/executor/handler/dispatch/backend/tail.rs
@@ -2,7 +2,7 @@ use crate::{
     engine::executor::handler::{
         dispatch::{Break, Control, ExecutionOutcome, decode_handler, decode_op_code},
         exec,
-        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, VmState},
+        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, Vm, VmState},
     },
     ir,
     ir::OpCode,
@@ -24,7 +24,7 @@ pub type Done = Control<Never, Break>;
 
 #[cfg(not(target_arch = "x86_64"))]
 pub type Handler = fn(
-    &mut VmState,
+    state: Vm<'_, '_>,
     ip: Ip,
     sp: Sp,
     mem0: Mem0Ptr,
@@ -38,7 +38,7 @@ pub type Handler = fn(
 #[cfg(target_arch = "x86_64")]
 #[allow(improper_ctypes_definitions)] // not used in FFI
 pub type Handler = extern "sysv64" fn(
-    &mut VmState,
+    state: Vm<'_, '_>,
     ip: Ip,
     sp: Sp,
     mem0: Mem0Ptr,
@@ -103,7 +103,15 @@ pub fn execute_until_done(
 ) -> Result<Sp, ExecutionOutcome> {
     let handler = fetch_handler(ip);
     let Control::Break(reason) = handler(
-        state, ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64,
+        Vm::from(&mut *state),
+        ip,
+        sp,
+        mem0,
+        mem0_len,
+        instance,
+        ireg,
+        freg32,
+        freg64,
     );
     if let Some(trap_code) = reason.trap_code() {
         return Err(ExecutionOutcome::from(trap_code));

--- a/crates/wasmi/src/engine/executor/handler/exec.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec.rs
@@ -10,7 +10,7 @@ pub use self::simd::*;
 use super::{
     Args,
     dispatch::Done,
-    state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, VmState},
+    state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, Vm, VmState},
     utils::fetch_func,
 };
 #[cfg(feature = "simd")]
@@ -41,7 +41,7 @@ fn identity<T>(value: T) -> T {
 
 execution_handler! {
     fn trap(
-        _state: &mut VmState,
+        _state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -59,7 +59,7 @@ execution_handler! {
 
 execution_handler! {
     fn consume_fuel(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -72,13 +72,14 @@ execution_handler! {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::ConsumeFuel { fuel } = unsafe { args.decode_op() };
         let consumption_result = state
+            .get()
             .store
             .inner_mut()
             .fuel_mut()
             .consume_fuel_unchecked(u64::from(fuel));
         if let Err(FuelError::OutOfFuel { required_fuel }) = consumption_result {
             args.set_ip(ip);
-            out_of_fuel!(state, args, required_fuel)
+            out_of_fuel!(state.get(), args, required_fuel)
         }
         dispatch!(state, args)
     }
@@ -86,7 +87,7 @@ execution_handler! {
 
 execution_handler! {
     fn branch(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -115,7 +116,7 @@ macro_rules! global_get_execution_handler {
             $( #[$attr] )*
             execution_handler! {
                 fn $snake_name(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -127,7 +128,7 @@ macro_rules! global_get_execution_handler {
                 ) -> Done = {
                     let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
                     let crate::ir::decode::$camel_name { global, result } = unsafe { args.decode_op() };
-                    let global = args.fetch_global(state, global);
+                    let global = args.fetch_global(state.get(), global);
                     let value: $ty = global.get_raw().read_as();
                     args.set(result, value);
                     dispatch!(state, args)
@@ -156,7 +157,7 @@ macro_rules! global_set_execution_handler {
             $( #[$attr] )*
             execution_handler! {
                 fn $snake_name(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -168,7 +169,7 @@ macro_rules! global_set_execution_handler {
                 ) -> Done = {
                     let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
                     let crate::ir::decode::$camel_name { global, value } = unsafe { args.decode_op() };
-                    let global = args.fetch_global(state, global);
+                    let global = args.fetch_global(state.get(), global);
                     let value: $ty = args.get(value);
                     let mut value_ptr = global.get_raw_ptr();
                     let global_ref = unsafe { value_ptr.as_mut() };
@@ -193,7 +194,7 @@ global_set_execution_handler! {
 
 execution_handler! {
     fn call_internal(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -208,14 +209,14 @@ execution_handler! {
         // SAFETY: `func` is the exposed address of a `FuncEntry` in the engine's append-only
         //         `CodeMap`, baked into the bytecode; it stays valid while this bytecode runs.
         let func = unsafe { FuncEntryPtr::from(usize::from(func)).get() };
-        args.call_func_entry(state, func, params, None)?;
+        args.call_func_entry(state.get(), func, params, None)?;
         dispatch!(state, args)
     }
 }
 
 execution_handler! {
     fn call_imported(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -228,7 +229,7 @@ execution_handler! {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::CallImported { params, func } = unsafe { args.decode_op() };
         let (func, func_entity) = utils::load_func_entry(args.instance, func);
-        args.call_wasm_or_host_func(state, func, func_entity, params)?;
+        args.call_wasm_or_host_func(state.get(), func, func_entity, params)?;
         dispatch!(state, args)
     }
 }
@@ -238,7 +239,7 @@ macro_rules! call_indirect_execution_handler {
         $(
             execution_handler! {
                 fn $snake_name(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -255,8 +256,8 @@ macro_rules! call_indirect_execution_handler {
                         params,
                         index,
                     } = unsafe { args.decode_op() };
-                    let (func, func_entity) = args.resolve_indirect_func(state, index, table, func_type)?;
-                    args.call_wasm_or_host_func(state, func, func_entity, params)?;
+                    let (func, func_entity) = args.resolve_indirect_func(state.get(), index, table, func_type)?;
+                    args.call_wasm_or_host_func(state.get(), func, func_entity, params)?;
                     dispatch!(state, args)
                 }
             }
@@ -270,7 +271,7 @@ call_indirect_execution_handler! {
 
 execution_handler! {
     fn return_call_internal(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -284,14 +285,14 @@ execution_handler! {
         let crate::ir::decode::ReturnCallInternal { params, func } = unsafe { args.decode_op() };
         // SAFETY: see `call_internal`.
         let func = unsafe { FuncEntryPtr::from(usize::from(func)).get() };
-        args.return_call_func_entry(state, func, params, None)?;
+        args.return_call_func_entry(state.get(), func, params, None)?;
         dispatch!(state, args)
     }
 }
 
 execution_handler! {
     fn return_call_imported(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -304,7 +305,7 @@ execution_handler! {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::ReturnCallImported { params, func } = unsafe { args.decode_op() };
         let (func, func_entity) = utils::load_func_entry(instance, func);
-        args.return_call_wasm_or_host_func(state, func, func_entity, params)?;
+        args.return_call_wasm_or_host_func(state.get(), func, func_entity, params)?;
         dispatch!(state, args)
     }
 }
@@ -314,7 +315,7 @@ macro_rules! return_call_indirect_execution_handler {
         $(
             execution_handler! {
                 fn $snake_name(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -331,8 +332,8 @@ macro_rules! return_call_indirect_execution_handler {
                         func_type,
                         table,
                     } = unsafe { args.decode_op() };
-                    let (func, func_entity) = args.resolve_indirect_func(state, index, table, func_type)?;
-                    args.return_call_wasm_or_host_func(state, func, func_entity, params)?;
+                    let (func, func_entity) = args.resolve_indirect_func(state.get(), index, table, func_type)?;
+                    args.return_call_wasm_or_host_func(state.get(), func, func_entity, params)?;
                     dispatch!(state, args)
                 }
             }
@@ -346,7 +347,7 @@ return_call_indirect_execution_handler! {
 
 execution_handler! {
     fn r#return(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -357,14 +358,14 @@ execution_handler! {
         freg64: Freg64,
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
-        args.pop_frame(state)?;
+        args.pop_frame(state.get())?;
         dispatch!(state, args)
     }
 }
 
 execution_handler! {
     fn memory_size(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -376,7 +377,7 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::MemorySize { memory, result } = unsafe { args.decode_op() };
-        let size = args.fetch_memory(state, memory).size();
+        let size = args.fetch_memory(state.get(), memory).size();
         args.set(result, size);
         dispatch!(state, args)
     }
@@ -384,7 +385,7 @@ execution_handler! {
 
 execution_handler! {
     fn memory_grow(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -402,20 +403,20 @@ execution_handler! {
         } = unsafe { args.decode_op() };
         let delta: u64 = args.get(delta);
         let memref = utils::fetch_memory(instance, memory);
-        let return_value = match state.store.grow_memory(&memref, delta) {
+        let return_value = match state.get().store.grow_memory(&memref, delta) {
             Ok(return_value) => {
                 // The `memory.grow` operation might have invalidated the cached
                 // linear memory so we need to reset it in order for the cache to
                 // reload in case it is used again.
                 if utils::is_default_memory(instance, memory) {
-                    args.reload_mem0(state);
+                    args.reload_mem0(state.get());
                 }
                 return_value
             }
             Err(StoreError::External(
                 MemoryError::OutOfBoundsGrowth | MemoryError::OutOfSystemMemory,
             )) => {
-                let memory_ty = utils::resolve_memory(state.store, &memref).ty();
+                let memory_ty = utils::resolve_memory(state.get().store, &memref).ty();
                 match memory_ty.is_64() {
                     true => u64::MAX,
                     false => u64::from(u32::MAX),
@@ -423,7 +424,7 @@ execution_handler! {
             }
             Err(StoreError::External(MemoryError::OutOfFuel { required_fuel })) => {
                 args.set_ip(ip);
-                out_of_fuel!(state, args, required_fuel)
+                out_of_fuel!(state.get(), args, required_fuel)
             }
             Err(StoreError::External(MemoryError::ResourceLimiterDeniedAllocation)) => {
                 trap!(TrapCode::GrowthOperationLimited);
@@ -442,7 +443,7 @@ execution_handler! {
 
 execution_handler! {
     fn memory_copy(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -473,7 +474,7 @@ execution_handler! {
             trap!(TrapCode::MemoryOutOfBounds)
         };
         if dst_memory == src_memory {
-            memory_copy_within(state, &mut args, ip, dst_memory, dst_index, src_index, len)?;
+            memory_copy_within(state.get(), &mut args, ip, dst_memory, dst_index, src_index, len)?;
             dispatch!(state, args)
         }
         let src_ptr = unsafe { utils::load_memory_ptr(instance, src_memory) };
@@ -482,20 +483,20 @@ execution_handler! {
             // Distinct memory indices can still resolve to the same store entity (e.g. the same
             // memory imported under two names), so branch on the resolved entity before forming
             // the aliasing references below.
-            memory_copy_within(state, &mut args, ip, dst_memory, dst_index, src_index, len)?;
+            memory_copy_within(state.get(), &mut args, ip, dst_memory, dst_index, src_index, len)?;
             dispatch!(state, args)
         }
         // SAFETY: `src_ptr != dst_ptr`, so these are distinct entities whose references do not
         //         alias. These accesses just perform the bounds checks required by the Wasm spec.
         let src_memory = unsafe { src_ptr.as_ref() };
         let dst_memory = unsafe { dst_ptr.as_mut() };
-        let fuel = state.store.inner_mut().fuel_mut();
+        let fuel = state.get().store.inner_mut().fuel_mut();
         let src_bytes = utils::memory_slice(src_memory, src_index, len)
             .into_control()?;
         let dst_bytes = utils::memory_slice_mut(dst_memory, dst_index, len)
             .into_control()?;
         consume_fuel!(
-            state,
+            state.get(),
             ip,
             args,
             fuel,
@@ -531,7 +532,7 @@ fn memory_copy_within(
 
 execution_handler! {
     fn memory_fill(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -559,9 +560,9 @@ execution_handler! {
         };
         // SAFETY: `instance` is live and warmed up; `memory` is the only entity accessed here.
         let memory = unsafe { utils::load_memory_ptr(instance, memory).as_mut() };
-        let fuel = state.store.inner_mut().fuel_mut();
+        let fuel = state.get().store.inner_mut().fuel_mut();
         let slice = utils::memory_slice_mut(memory, dst, len).into_control()?;
-        consume_fuel!(state, ip, args, fuel, |costs| costs.fuel_for_copying_values::<u8>(len as u64));
+        consume_fuel!(state.get(), ip, args, fuel, |costs| costs.fuel_for_copying_values::<u8>(len as u64));
         slice.fill(value);
         dispatch!(state, args)
     }
@@ -569,7 +570,7 @@ execution_handler! {
 
 execution_handler! {
     fn memory_init(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -603,7 +604,7 @@ execution_handler! {
         // arenas, so their references are to distinct entities and cannot alias.
         let memory = unsafe { utils::load_memory_ptr(instance, memory).as_mut() };
         let data = unsafe { utils::load_data_ptr(instance, data).as_ref() };
-        let fuel = state.store.inner_mut().fuel_mut();
+        let fuel = state.get().store.inner_mut().fuel_mut();
         let memory = utils::memory_slice_mut(memory, dst_index, len).into_control()?;
         let Some(data) = data
             .bytes()
@@ -612,7 +613,7 @@ execution_handler! {
         else {
             trap!(TrapCode::MemoryOutOfBounds)
         };
-        consume_fuel!(state, ip, args, fuel, |costs| costs.fuel_for_copying_values::<u8>(len as u64));
+        consume_fuel!(state.get(), ip, args, fuel, |costs| costs.fuel_for_copying_values::<u8>(len as u64));
         memory.copy_from_slice(data);
         dispatch!(state, args)
     }
@@ -620,7 +621,7 @@ execution_handler! {
 
 execution_handler! {
     fn data_drop(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -632,14 +633,14 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::DataDrop { data } = unsafe { args.decode_op() };
-        args.fetch_data(state, data).drop_bytes();
+        args.fetch_data(state.get(), data).drop_bytes();
         dispatch!(state, args)
     }
 }
 
 execution_handler! {
     fn table_size(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -651,7 +652,7 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::TableSize { table, result } = unsafe { args.decode_op() };
-        let size = args.fetch_table(state, table).size();
+        let size = args.fetch_table(state.get(), table).size();
         args.set(result, size);
         dispatch!(state, args)
     }
@@ -659,7 +660,7 @@ execution_handler! {
 
 execution_handler! {
     fn table_grow(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -679,17 +680,17 @@ execution_handler! {
         let table = utils::fetch_table(instance, table);
         let delta = args.get(delta);
         let value = args.get(value);
-        let return_value = match state.store.grow_table(&table, delta, value) {
+        let return_value = match state.get().store.grow_table(&table, delta, value) {
             Ok(return_value) => return_value,
             Err(StoreError::External(TableError::GrowOutOfBounds | TableError::OutOfSystemMemory)) => {
-                let table = utils::resolve_table(state.store, &table);
+                let table = utils::resolve_table(state.get().store, &table);
                 match table.ty().is_64() {
                     true => u64::MAX,
                     false => u64::from(u32::MAX),
                 }
             }
             Err(StoreError::External(TableError::OutOfFuel { required_fuel })) => {
-                done!(state, DoneReason::out_of_fuel(required_fuel));
+                done!(state.get(), DoneReason::out_of_fuel(required_fuel));
             }
             Err(StoreError::External(TableError::ResourceLimiterDeniedAllocation)) => {
                 trap!(TrapCode::GrowthOperationLimited);
@@ -708,7 +709,7 @@ execution_handler! {
 
 execution_handler! {
     fn table_copy(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -737,7 +738,7 @@ execution_handler! {
             // Case: copy within the same table.
             // SAFETY: `dst_ptr` is warmed up and is the only entity accessed here.
             let table = unsafe { dst_ptr.as_mut() };
-            let fuel = state.store.inner_mut().fuel_mut();
+            let fuel = state.get().store.inner_mut().fuel_mut();
             table.copy_within(dst, src, len, Some(fuel))
         } else {
             // Case: copy between two distinct tables.
@@ -745,7 +746,7 @@ execution_handler! {
             //         not alias.
             let src_table = unsafe { src_ptr.as_ref() };
             let dst_table = unsafe { dst_ptr.as_mut() };
-            let fuel = state.store.inner_mut().fuel_mut();
+            let fuel = state.get().store.inner_mut().fuel_mut();
             CoreTable::copy(dst_table, dst, src_table, src, len, Some(fuel))
         };
         if let Err(error) = result {
@@ -754,7 +755,7 @@ execution_handler! {
                 TableError::OutOfSystemMemory => TrapCode::OutOfSystemMemory,
                 TableError::OutOfFuel { required_fuel } => {
                     args.set_ip(ip);
-                    out_of_fuel!(state, args, required_fuel)
+                    out_of_fuel!(state.get(), args, required_fuel)
                 }
                 _ => panic!("table.copy: unexpected error: {error}"),
             };
@@ -766,7 +767,7 @@ execution_handler! {
 
 execution_handler! {
     fn table_fill(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -788,14 +789,14 @@ execution_handler! {
         let value: RawRef = args.get(value);
         // SAFETY: `instance` is live and warmed up; `table` is the only entity accessed here.
         let table = unsafe { utils::load_table_ptr(instance, table).as_mut() };
-        let fuel = state.store.inner_mut().fuel_mut();
+        let fuel = state.get().store.inner_mut().fuel_mut();
         if let Err(error) = table.fill_raw(dst, value, len, Some(fuel)) {
             let trap_code = match error {
                 TableError::OutOfSystemMemory => TrapCode::OutOfSystemMemory,
                 TableError::FillOutOfBounds => TrapCode::TableOutOfBounds,
                 TableError::OutOfFuel { required_fuel } => {
                     args.set_ip(ip);
-                    out_of_fuel!(state, args, required_fuel)
+                    out_of_fuel!(state.get(), args, required_fuel)
                 }
                 _ => panic!("table.fill: unexpected error: {error}"),
             };
@@ -807,7 +808,7 @@ execution_handler! {
 
 execution_handler! {
     fn table_init(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -832,14 +833,14 @@ execution_handler! {
         //         arenas, so their references are to distinct entities and cannot alias.
         let table = unsafe { utils::load_table_ptr(args.instance, table).as_mut() };
         let element = unsafe { utils::load_elem_ptr(args.instance, elem).as_ref() };
-        let fuel = state.store.inner_mut().fuel_mut();
+        let fuel = state.get().store.inner_mut().fuel_mut();
         if let Err(error) = table.init(element.as_ref(), dst, src, len, Some(fuel)) {
             let trap_code = match error {
                 TableError::OutOfSystemMemory => TrapCode::OutOfSystemMemory,
                 TableError::InitOutOfBounds => TrapCode::TableOutOfBounds,
                 TableError::OutOfFuel { required_fuel } => {
                     args.set_ip(ip);
-                    out_of_fuel!(state, args, required_fuel)
+                    out_of_fuel!(state.get(), args, required_fuel)
                 }
                 _ => panic!("table.init: unexpected error: {error}"),
             };
@@ -851,7 +852,7 @@ execution_handler! {
 
 execution_handler! {
     fn elem_drop(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -863,7 +864,7 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::ElemDrop { elem } = unsafe { args.decode_op() };
-        args.fetch_elem(state, elem).drop_items();
+        args.fetch_elem(state.get(), elem).drop_items();
         dispatch!(state, args)
     }
 }
@@ -873,7 +874,7 @@ macro_rules! impl_table_get {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -885,7 +886,7 @@ macro_rules! impl_table_get {
                 ) -> Done = {
                     let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
                     let crate::ir::decode::$op { table, result, index } = unsafe { args.decode_op() };
-                    let table = args.fetch_table(state, table);
+                    let table = args.fetch_table(state.get(), table);
                     let index = $ext(args.get(index));
                     let Some(value) = table.get(index) else {
                         trap!(TrapCode::TableOutOfBounds)
@@ -908,7 +909,7 @@ macro_rules! impl_table_set {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -920,7 +921,7 @@ macro_rules! impl_table_set {
                 ) -> Done = {
                     let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
                     let crate::ir::decode::$op { table, index, value } = unsafe { args.decode_op() };
-                    let table = args.fetch_table(state, table);
+                    let table = args.fetch_table(state.get(), table);
                     let index = $ext(args.get(index));
                     let value: u32 = args.get(value);
                     if let Err(TableError::SetOutOfBounds) = table.set_raw(index, RawRef::from(value)) {
@@ -945,7 +946,7 @@ impl_table_set! {
 
 execution_handler! {
     fn ref_func(
-        state: &mut VmState,
+        state: Vm<'_, '_>,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -958,7 +959,7 @@ execution_handler! {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::RefFunc { func, result } = unsafe { args.decode_op() };
         let func = fetch_func(instance, func);
-        let Some(rawref) = func.unwrap_raw(&*state.store) else {
+        let Some(rawref) = func.unwrap_raw(&*state.get().store) else {
             unsafe { unreachable_unchecked!("store mismatch with: {func:?}") }
         };
         args.set(result, rawref);
@@ -973,7 +974,7 @@ macro_rules! impl_i64_binop128 {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -1011,7 +1012,7 @@ macro_rules! impl_i64_mul_wide {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -1099,7 +1100,7 @@ macro_rules! impl_branch_table_exec_handler {
         $(
             execution_handler! {
                 fn $snake_case(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -1804,7 +1805,7 @@ macro_rules! handler_cmp_branch {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -2041,7 +2042,7 @@ macro_rules! handler_select {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -2177,7 +2178,7 @@ macro_rules! handler_load_ri {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -2194,7 +2195,7 @@ macro_rules! handler_load_ri {
                         memory,
                     } = unsafe { args.decode_op() };
                     let address = args.get(address);
-                    let bytes = args.fetch_memory_bytes(state, memory);
+                    let bytes = args.fetch_memory_bytes(&mut state, memory);
                     let loaded = $load(bytes, usize::from(address)).into_control()?;
                     args.set(result, loaded);
                     dispatch!(state, args)
@@ -2335,7 +2336,7 @@ macro_rules! handler_store_ix {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -2353,7 +2354,7 @@ macro_rules! handler_store_ix {
                     } = unsafe { args.decode_op() };
                     let address = args.get(address);
                     let value: $hint = args.get(value);
-                    let bytes = args.fetch_memory_bytes(state, memory);
+                    let bytes = args.fetch_memory_bytes(&mut state, memory);
                     $store(bytes, usize::from(address), value.into()).into_control()?;
                     dispatch!(state, args)
                 }

--- a/crates/wasmi/src/engine/executor/handler/exec/macros.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec/macros.rs
@@ -29,8 +29,9 @@ macro_rules! execution_handler {
         )]
         #[allow(improper_ctypes_definitions)] // not used in FFI
         #[allow(clippy::too_many_arguments)] // extern fns are ignored
+        #[allow(unused_mut)] // most handlers never touch the `VmState`
         pub extern "sysv64" fn $name(
-            $state: $state_ty,
+            mut $state: $state_ty,
             $ip: $ip_ty,
             $sp: $sp_ty,
             $mem0_ptr: $mem0_ptr_ty,
@@ -74,8 +75,9 @@ macro_rules! execution_handler {
         )]
         #[allow(improper_ctypes_definitions)] // not used in FFI
         #[expect(clippy::too_many_arguments)]
+        #[allow(unused_mut)] // most handlers never touch the `VmState`
         pub fn $name(
-            $state: $state_ty,
+            mut $state: $state_ty,
             $ip: $ip_ty,
             $sp: $sp_ty,
             $mem0_ptr: $mem0_ptr_ty,
@@ -93,7 +95,7 @@ macro_rules! handler_unary {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -120,7 +122,7 @@ macro_rules! handler_binary {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -148,7 +150,7 @@ macro_rules! handler_load {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -167,7 +169,7 @@ macro_rules! handler_load {
                     } = unsafe { args.decode_op() };
                     let ptr: u64 = args.get(ptr);
                     let offset: u64 = args.get(offset);
-                    let bytes = args.fetch_memory_bytes(state, memory);
+                    let bytes = args.fetch_memory_bytes(&mut state, memory);
                     let loaded = $load(bytes, ptr, offset).into_control()?;
                     args.set(result, loaded);
                     dispatch!(state, args)
@@ -182,7 +184,7 @@ macro_rules! handler_load_mem0_offset16 {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -215,7 +217,7 @@ macro_rules! handler_store {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -235,7 +237,7 @@ macro_rules! handler_store {
                     let ptr = args.get(ptr);
                     let offset = args.get(offset);
                     let value: $hint = args.get(value);
-                    let bytes = args.fetch_memory_bytes(state, memory);
+                    let bytes = args.fetch_memory_bytes(&mut state, memory);
                     $store(bytes, ptr, offset, value.into()).into_control()?;
                     dispatch!(state, args)
                 }
@@ -249,7 +251,7 @@ macro_rules! handler_store_mem0_offset16 {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,

--- a/crates/wasmi/src/engine/executor/handler/exec/simd.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec/simd.rs
@@ -8,7 +8,7 @@ use crate::{
     engine::executor::handler::{
         Args,
         dispatch::Done,
-        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, VmState},
+        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, Vm},
         utils::IntoControl as _,
     },
 };
@@ -19,7 +19,7 @@ macro_rules! execution_handler_for_v128_select {
         $(
             execution_handler! {
                 fn $snake_name(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -322,7 +322,7 @@ macro_rules! handler_extract_lane {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -382,7 +382,7 @@ macro_rules! handler_extract_lane {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -431,7 +431,7 @@ macro_rules! handler_ternary {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -490,7 +490,7 @@ macro_rules! handler_store_lane_ss {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -505,7 +505,7 @@ macro_rules! handler_store_lane_ss {
                     let ptr = args.get(ptr);
                     let offset = args.get(offset);
                     let value = args.get(value);
-                    let bytes = args.fetch_memory_bytes(state, memory);
+                    let bytes = args.fetch_memory_bytes(&mut state, memory);
                     $eval(bytes, ptr, offset, value, lane).into_control()?;
                     dispatch!(state, args)
                 }
@@ -525,7 +525,7 @@ macro_rules! handler_store_lane_mem0_offset16_ss {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    state: Vm<'_, '_>,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -28,7 +28,14 @@ use crate::{
     store::PrunedStore,
 };
 use alloc::vec::Vec;
-use core::{cmp, marker::PhantomData, mem, ops, ptr, slice};
+use core::{
+    cmp,
+    marker::PhantomData,
+    mem,
+    ops,
+    ptr::{self, NonNull},
+    slice,
+};
 
 pub struct VmState<'vm> {
     pub store: &'vm mut PrunedStore,
@@ -77,6 +84,72 @@ impl<'vm> VmState<'vm> {
 
     pub fn execution_outcome(&mut self) -> Result<Sp, ExecutionOutcome> {
         self.take_done_reason().into_execution_outcome()
+    }
+}
+
+/// An exclusive reference to a [`VmState`] that is passed in a floating point register.
+///
+/// # Note
+///
+/// - This is semantically equivalent to a `&'a mut VmState<'vm>` and only exists to control
+///   how the reference is passed to execution handlers: we use a float representation so that
+///   the compiler puts it into a floating point register. This frees up a general purpose
+///   (integer) register for [`Inst`] which is accessed far more frequently on the hot path,
+///   and integer registers are the scarce resource in the execution handler ABI.
+/// - [`Vm`] is deliberately not [`Copy`] since [`Vm::get`] would otherwise be unsound: two
+///   copies could each hand out an exclusive reference to the same [`VmState`].
+/// - On 32-bit platforms the pointer bit pattern may represent a signaling NaN. This is fine
+///   as long as the value is only ever moved between registers and never used arithmetically.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct Vm<'a, 'vm> {
+    /// The underlying reference to the [`VmState`].
+    value: VmRepr,
+    /// Marks [`Vm`] as what it is: an exclusive borrow of a [`VmState`].
+    marker: PhantomData<&'a mut VmState<'vm>>,
+}
+
+/// The underlying float representation of [`Vm`] for 64-bit platforms.
+#[cfg(target_pointer_width = "64")]
+type VmRepr = f64;
+
+/// The underlying float representation of [`Vm`] for 32-bit platforms.
+#[cfg(target_pointer_width = "32")]
+type VmRepr = f32;
+
+const _: () = {
+    use core::mem::size_of;
+    assert!(size_of::<VmRepr>() == size_of::<usize>());
+};
+
+impl<'a, 'vm> From<&'a mut VmState<'vm>> for Vm<'a, 'vm> {
+    #[inline]
+    fn from(state: &'a mut VmState<'vm>) -> Self {
+        let addr = ptr::from_mut(state).expose_provenance();
+        Self {
+            value: VmRepr::from_ne_bytes(addr.to_ne_bytes()),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'vm> Vm<'_, 'vm> {
+    /// Converts the underlying representation back into its original pointer value.
+    #[inline]
+    fn as_ptr(&self) -> NonNull<VmState<'vm>> {
+        let bits = usize::from_ne_bytes(self.value.to_ne_bytes());
+        let ptr = ptr::with_exposed_provenance_mut::<VmState<'vm>>(bits);
+        // SAFETY: `self` was constructed from a reference and thus is never null.
+        unsafe { NonNull::new_unchecked(ptr) }
+    }
+
+    /// Returns an exclusive reference to the underlying [`VmState`].
+    #[inline]
+    pub fn get(&mut self) -> &mut VmState<'vm> {
+        // SAFETY: `Vm` is not `Copy` and its only constructor consumes a `&'a mut VmState<'vm>`.
+        //         Thus `self` is the unique live handle to that `VmState` and the exclusive
+        //         borrow of `self` properly scopes the returned reference.
+        unsafe { self.as_ptr().as_mut() }
     }
 }
 
@@ -144,65 +217,23 @@ impl DoneReason {
 }
 
 /// A thin-wrapper around a non-owned [`InstanceEntity`].
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Inst {
     /// The underlying reference to the [`InstanceEntity`].
-    ///
-    /// # Note
-    ///
-    /// - We use a float to represent [`Inst`] to avoid using a
-    ///   general purpose (integer) register as they are not as
-    ///   available as floating point registers on most platforms.
-    /// - Since [`Inst`] is only accessed by operators that are
-    ///   considered "slow" anyways an additional conversion between
-    ///   integer and float won't be a terrible trade-off.
-    value: InstRepr,
-    /// Marks `Inst` as logically containing a shared raw pointer.
-    marker: PhantomData<*const InstanceEntity>,
+    value: NonNull<InstanceEntity>,
 }
-
-/// The underlying float representation of `Inst` for 64-bit platforms.
-#[cfg(target_pointer_width = "64")]
-type InstRepr = f64;
-
-/// The underlying float representation of `Inst` for 32-bit platforms.
-#[cfg(target_pointer_width = "32")]
-type InstRepr = f32;
-
-const _: () = {
-    use core::mem::size_of;
-    assert!(size_of::<InstRepr>() == size_of::<usize>());
-};
 
 impl From<&'_ InstanceEntity> for Inst {
     #[inline]
     fn from(entity: &'_ InstanceEntity) -> Self {
-        let addr = (entity as *const InstanceEntity).expose_provenance();
-        let value = InstRepr::from_ne_bytes((addr).to_ne_bytes());
         Self {
-            value,
-            marker: PhantomData,
+            value: NonNull::from(entity),
         }
     }
 }
 
-impl PartialEq for Inst {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        ptr::addr_eq(self.as_ptr(), other.as_ptr())
-    }
-}
-impl Eq for Inst {}
-
 impl Inst {
-    /// Converts the underlying representation back into its original pointer value.
-    #[inline]
-    fn as_ptr(&self) -> *const InstanceEntity {
-        let bits = usize::from_ne_bytes(self.value.to_ne_bytes());
-        ptr::with_exposed_provenance::<InstanceEntity>(bits)
-    }
-
     /// Returns a shared reference to the referenced [`InstanceEntity`].
     ///
     /// # Safety
@@ -216,7 +247,7 @@ impl Inst {
     ///   reference.
     #[inline]
     pub unsafe fn as_ref(&self) -> &InstanceEntity {
-        unsafe { &*self.as_ptr() }
+        unsafe { self.value.as_ref() }
     }
 }
 


### PR DESCRIPTION
This significantly improves the `count/globals` benchmark by ~10%.
However, this also significantly regresses many call-intense benchmarks by at least the same percentage points.

This can only be merged if we can fix the performance regressions.