### PR TITLE
Use `NonNull<InstanceEntity>` instead of `Inst` where possible

### DIFF
--- a/crates/wasmi/src/engine/executor/handler/args.rs
+++ b/crates/wasmi/src/engine/executor/handler/args.rs
@@ -23,6 +23,7 @@ use crate::{
             utils::{self, GetValue, IntoControl as _, SetValue, get_value, set_value},
         },
     },
+    instance::InstanceEntity,
     ir::{self, BoundedSlotSpan, BranchOffset},
 };
 use core::ptr::NonNull;
@@ -217,7 +218,7 @@ impl Args {
     /// Reloads the data pointer and length of the default memory at index 0 from `state`.
     #[inline]
     pub fn reload_mem0(&mut self, state: &mut VmState) {
-        (self.mem0_ptr, self.mem0_len) = utils::extract_mem0(state.store, self.instance);
+        (self.mem0_ptr, self.mem0_len) = utils::extract_mem0(state.store, self.instance.as_ptr());
     }
 
     /// Calls `func` with `params` on `instance` with `state` using `self`.
@@ -227,7 +228,7 @@ impl Args {
         state: &mut VmState,
         func: &FuncEntry,
         params: BoundedSlotSpan,
-        instance: Option<Inst>,
+        instance: Option<NonNull<InstanceEntity>>,
     ) -> Control<(), Break> {
         (self.ip, self.sp) = utils::call_func_entry(state, self.ip, params, func, instance)?;
         Control::Continue(())
@@ -240,7 +241,7 @@ impl Args {
         state: &mut VmState,
         func: &FuncEntry,
         params: BoundedSlotSpan,
-        instance: Option<Inst>,
+        instance: Option<NonNull<InstanceEntity>>,
     ) -> Control<(), Break> {
         (self.ip, self.sp) = utils::return_call_func_entry(state, params, func, instance)?;
         Control::Continue(())
@@ -270,13 +271,8 @@ impl Args {
         func_entity: NonNull<FuncEntity>,
         params: BoundedSlotSpan,
     ) -> Control<(), Break> {
-        (
-            self.ip,
-            self.sp,
-            self.mem0_ptr,
-            self.mem0_len,
-            self.instance,
-        ) = utils::call_wasm_or_host(
+        let mut instance = self.instance.as_ptr();
+        (self.ip, self.sp, self.mem0_ptr, self.mem0_len, instance) = utils::call_wasm_or_host(
             state,
             self.ip,
             func,
@@ -284,8 +280,9 @@ impl Args {
             params,
             self.mem0_ptr,
             self.mem0_len,
-            self.instance,
+            instance,
         )?;
+        self.instance = instance.into();
         Control::Continue(())
     }
 
@@ -298,32 +295,30 @@ impl Args {
         func_entity: NonNull<FuncEntity>,
         params: BoundedSlotSpan,
     ) -> Control<(), Break> {
-        (
-            self.ip,
-            self.sp,
-            self.mem0_ptr,
-            self.mem0_len,
-            self.instance,
-        ) = utils::return_call_wasm_or_host(
-            state,
-            func,
-            func_entity,
-            params,
-            self.mem0_ptr,
-            self.mem0_len,
-            self.instance,
-        )?;
+        let mut instance = self.instance.as_ptr();
+        (self.ip, self.sp, self.mem0_ptr, self.mem0_len, instance) =
+            utils::return_call_wasm_or_host(
+                state,
+                func,
+                func_entity,
+                params,
+                self.mem0_ptr,
+                self.mem0_len,
+                instance,
+            )?;
+        self.instance = instance.into();
         Control::Continue(())
     }
 
     /// Pops the top-most frame from the call stack.
     #[inline]
     pub fn pop_frame(&mut self, state: &mut VmState) -> Control<(), Break> {
-        let Some((ip, sp, mem0_ptr, mem0_len, instance)) =
-            state
-                .stack
-                .pop_frame(state.store, self.mem0_ptr, self.mem0_len, self.instance)
-        else {
+        let Some((ip, sp, mem0_ptr, mem0_len, instance)) = state.stack.pop_frame(
+            state.store,
+            self.mem0_ptr,
+            self.mem0_len,
+            self.instance.as_ptr(),
+        ) else {
             // No more frames on the call stack -> break out of execution!
             done!(state, DoneReason::Return(self.sp))
         };
@@ -331,7 +326,7 @@ impl Args {
         self.sp = sp;
         self.mem0_ptr = mem0_ptr;
         self.mem0_len = mem0_len;
-        self.instance = instance;
+        self.instance = instance.into();
         Control::Continue(())
     }
 }

--- a/crates/wasmi/src/engine/executor/handler/dispatch/backend/loop.rs
+++ b/crates/wasmi/src/engine/executor/handler/dispatch/backend/loop.rs
@@ -1,11 +1,13 @@
+use core::ptr::NonNull;
+
 use crate::{
     engine::executor::handler::{
         dispatch::{Break, Control, ExecutionOutcome},
         exec,
         state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, VmState},
     },
-    ir,
-    ir::OpCode,
+    instance::InstanceEntity,
+    ir::{self, OpCode},
 };
 
 #[derive(Debug, Copy, Clone)]
@@ -83,11 +85,12 @@ pub fn execute_until_done(
     sp: Sp,
     mem0: Mem0Ptr,
     mem0_len: Mem0Len,
-    instance: Inst,
+    instance: NonNull<InstanceEntity>,
     ireg: Ireg,
     freg32: Freg32,
     freg64: Freg64,
 ) -> Result<Sp, ExecutionOutcome> {
+    let instance = Inst::from(instance);
     let mut executor = Executor {
         ip,
         sp,

--- a/crates/wasmi/src/engine/executor/handler/dispatch/backend/tail.rs
+++ b/crates/wasmi/src/engine/executor/handler/dispatch/backend/tail.rs
@@ -7,6 +7,8 @@ use crate::{
     ir,
     ir::OpCode,
 };
+use crate::instance::InstanceEntity;
+use core::ptr::NonNull;
 
 #[inline(always)]
 pub fn fetch_handler(ip: Ip) -> Handler {
@@ -96,11 +98,12 @@ pub fn execute_until_done(
     sp: Sp,
     mem0: Mem0Ptr,
     mem0_len: Mem0Len,
-    instance: Inst,
+    instance: NonNull<InstanceEntity>,
     ireg: Ireg,
     freg32: Freg32,
     freg64: Freg64,
 ) -> Result<Sp, ExecutionOutcome> {
+    let instance = instance.into();
     let handler = fetch_handler(ip);
     let Control::Break(reason) = handler(
         state, ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64,

--- a/crates/wasmi/src/engine/executor/handler/func.rs
+++ b/crates/wasmi/src/engine/executor/handler/func.rs
@@ -10,15 +10,16 @@ use crate::{
         LowerToCells,
         executor::handler::{
             dispatch::{ExecutionOutcome, execute_until_done},
-            state::{Freg32, Freg64, Inst, Ip, Ireg, Sp, Stack, VmState},
+            state::{Freg32, Freg64, Ip, Ireg, Sp, Stack, VmState},
             utils::{self, resolve_instance},
         },
     },
     func::HostFuncEntity,
+    instance::InstanceEntity,
     ir::{BoundedSlotSpan, Slot, SlotSpan},
     store::{CallHooks, StoreError},
 };
-use core::marker::PhantomData;
+use core::{marker::PhantomData, ptr::NonNull};
 
 pub struct WasmFuncCall<'a, T, State> {
     store: &'a mut Store<T>,
@@ -26,7 +27,7 @@ pub struct WasmFuncCall<'a, T, State> {
     code: CodeView<'a>,
     callee_ip: Ip,
     callee_sp: Sp,
-    instance: Inst,
+    instance: NonNull<InstanceEntity>,
     state: State,
     ireg: Ireg,
     freg32: Freg32,

--- a/crates/wasmi/src/engine/executor/handler/mod.rs
+++ b/crates/wasmi/src/engine/executor/handler/mod.rs
@@ -28,5 +28,5 @@ pub use self::{
     },
     dispatch::{ExecutionOutcome, op_code_to_handler},
     func::{init_host_func_call, init_wasm_func_call, resume_wasm_func_call},
-    state::{Inst, Stack},
+    state::Stack,
 };

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -28,7 +28,14 @@ use crate::{
     store::PrunedStore,
 };
 use alloc::vec::Vec;
-use core::{cmp, marker::PhantomData, mem, ops, ptr, slice};
+use core::{
+    cmp,
+    marker::PhantomData,
+    mem,
+    ops,
+    ptr::{self, NonNull},
+    slice,
+};
 
 pub struct VmState<'vm> {
     pub store: &'vm mut PrunedStore,
@@ -179,7 +186,19 @@ impl From<&'_ InstanceEntity> for Inst {
     #[inline]
     fn from(entity: &'_ InstanceEntity) -> Self {
         let addr = (entity as *const InstanceEntity).expose_provenance();
-        let value = InstRepr::from_ne_bytes((addr).to_ne_bytes());
+        let value = InstRepr::from_ne_bytes(addr.to_ne_bytes());
+        Self {
+            value,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl From<NonNull<InstanceEntity>> for Inst {
+    #[inline]
+    fn from(entity: NonNull<InstanceEntity>) -> Self {
+        let addr = entity.as_ptr().expose_provenance();
+        let value = InstRepr::from_ne_bytes(addr.to_ne_bytes());
         Self {
             value,
             marker: PhantomData,
@@ -190,7 +209,7 @@ impl From<&'_ InstanceEntity> for Inst {
 impl PartialEq for Inst {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        ptr::addr_eq(self.as_ptr(), other.as_ptr())
+        self.as_ptr().addr() == other.as_ptr().addr()
     }
 }
 impl Eq for Inst {}
@@ -198,9 +217,10 @@ impl Eq for Inst {}
 impl Inst {
     /// Converts the underlying representation back into its original pointer value.
     #[inline]
-    fn as_ptr(&self) -> *const InstanceEntity {
+    pub fn as_ptr(&self) -> NonNull<InstanceEntity> {
         let bits = usize::from_ne_bytes(self.value.to_ne_bytes());
-        ptr::with_exposed_provenance::<InstanceEntity>(bits)
+        let ptr = ptr::with_exposed_provenance::<InstanceEntity>(bits);
+        unsafe { NonNull::new_unchecked(ptr as *mut InstanceEntity) }
     }
 
     /// Returns a shared reference to the referenced [`InstanceEntity`].
@@ -216,7 +236,7 @@ impl Inst {
     ///   reference.
     #[inline]
     pub unsafe fn as_ref(&self) -> &InstanceEntity {
-        unsafe { &*self.as_ptr() }
+        unsafe { self.as_ptr().as_ref() }
     }
 }
 
@@ -749,7 +769,7 @@ pub struct Stack {
     freg64: Freg64,
 }
 
-type ReturnCallHost = Control<(Ip, Sp, Inst), Sp>;
+type ReturnCallHost = Control<(Ip, Sp, NonNull<InstanceEntity>), Sp>;
 
 impl Stack {
     /// Creates a new [`Stack`] with the given [`StackConfig`] limits.
@@ -821,7 +841,7 @@ impl Stack {
     /// # Note
     ///
     /// This is useful and required to resume a function execution that yielded back to the host.
-    pub fn restore_frame(&mut self) -> (Ip, Sp, Inst, Ireg, Freg32, Freg64) {
+    pub fn restore_frame(&mut self) -> (Ip, Sp, NonNull<InstanceEntity>, Ireg, Freg32, Freg64) {
         let Some((ip, start, instance)) = self.frames.restore_frame() else {
             panic!("restore_frame: missing top-frame")
         };
@@ -834,7 +854,7 @@ impl Stack {
         &'a mut self,
         callee_params: BoundedSlotSpan,
         results_len: u16,
-        caller_instance: Inst,
+        caller_instance: NonNull<InstanceEntity>,
     ) -> Result<(ReturnCallHost, InOutParams<'a>), TrapCode> {
         let (callee_start, caller) = self.frames.return_prepare_host_frame(caller_instance);
         self.values
@@ -862,7 +882,7 @@ impl Stack {
         callee_params: BoundedSlotSpan,
         callee_locals: u16,
         callee_slots: u16,
-        callee_instance: Option<Inst>,
+        callee_instance: Option<NonNull<InstanceEntity>>,
     ) -> Result<Sp, TrapCode> {
         let start = self
             .frames
@@ -877,8 +897,8 @@ impl Stack {
         store: &mut PrunedStore,
         mem0: Mem0Ptr,
         mem0_len: Mem0Len,
-        instance: Inst,
-    ) -> Option<(Ip, Sp, Mem0Ptr, Mem0Len, Inst)> {
+        instance: NonNull<InstanceEntity>,
+    ) -> Option<(Ip, Sp, Mem0Ptr, Mem0Len, NonNull<InstanceEntity>)> {
         let (ip, start, changed_instance) = self.frames.pop()?;
         let sp = self.values.sp_or_dangling(start);
         let (mem0, mem0_len, instance) = match changed_instance {
@@ -899,7 +919,7 @@ impl Stack {
         callee_params: BoundedSlotSpan,
         callee_locals: u16,
         callee_size: u16,
-        callee_instance: Option<Inst>,
+        callee_instance: Option<NonNull<InstanceEntity>>,
     ) -> Result<Sp, TrapCode> {
         let start = self.frames.replace(callee_ip, callee_instance)?;
         self.values
@@ -1038,7 +1058,7 @@ impl ValueStack {
     /// the caller's caller.
     fn return_prepare_host_frame<'a>(
         &'a mut self,
-        caller: Option<(Ip, SpOffset, Inst)>,
+        caller: Option<(Ip, SpOffset, NonNull<InstanceEntity>)>,
         callee_start: SpOffset,
         callee_params: BoundedSlotSpan,
         results_len: u16,
@@ -1212,7 +1232,7 @@ pub struct CallStack {
     /// The currently used [`Inst`] if any.
     ///
     /// This may be `None`, for example if the [`CallStack`] is empty.
-    instance: Option<Inst>,
+    instance: Option<NonNull<InstanceEntity>>,
     /// The maximum height of the call stack.
     max_height: usize,
 }
@@ -1285,7 +1305,7 @@ impl CallStack {
     /// # Note
     ///
     /// This is useful and required to resume a function execution that yielded back to the host.
-    fn restore_frame(&self) -> Option<(Ip, SpOffset, Inst)> {
+    fn restore_frame(&self) -> Option<(Ip, SpOffset, NonNull<InstanceEntity>)> {
         let instance = self.instance?;
         let top = self.top()?;
         Some((top.ip, top.start, instance))
@@ -1308,8 +1328,8 @@ impl CallStack {
     /// the caller's caller.
     pub fn return_prepare_host_frame(
         &mut self,
-        callee_instance: Inst,
-    ) -> (SpOffset, Option<(Ip, SpOffset, Inst)>) {
+        callee_instance: NonNull<InstanceEntity>,
+    ) -> (SpOffset, Option<(Ip, SpOffset, NonNull<InstanceEntity>)>) {
         let callee_start = self.top_start();
         let caller = match self.pop() {
             Some((ip, start, instance)) => {
@@ -1328,7 +1348,7 @@ impl CallStack {
         caller_ip: Option<Ip>,
         callee_ip: Ip,
         callee_params: BoundedSlotSpan,
-        instance: Option<Inst>,
+        instance: Option<NonNull<InstanceEntity>>,
     ) -> Result<SpOffset, TrapCode> {
         if self.frames.len() == self.max_height {
             return Err(TrapCode::StackOverflow);
@@ -1352,7 +1372,7 @@ impl CallStack {
     }
 
     /// Adjusts `self` after returning from a function.
-    fn pop(&mut self) -> Option<(Ip, SpOffset, Option<Inst>)> {
+    fn pop(&mut self) -> Option<(Ip, SpOffset, Option<NonNull<InstanceEntity>>)> {
         let Some(popped) = self.frames.pop() else {
             unsafe { unreachable_unchecked!("call stack must not be empty") }
         };
@@ -1373,7 +1393,11 @@ impl CallStack {
     ///   which is required to be different from the currently used instance.
     /// - If `instance` is `None` the callee shares the currently used instance.
     #[inline(always)]
-    fn replace(&mut self, callee_ip: Ip, instance: Option<Inst>) -> Result<SpOffset, TrapCode> {
+    fn replace(
+        &mut self,
+        callee_ip: Ip,
+        instance: Option<NonNull<InstanceEntity>>,
+    ) -> Result<SpOffset, TrapCode> {
         let Some(caller_frame) = self.frames.last_mut() else {
             unsafe { unreachable_unchecked!("missing caller frame on the call stack") }
         };
@@ -1406,13 +1430,13 @@ pub struct Frame {
     pub ip: Ip,
     /// The start index on the value stack for this function frame.
     start: SpOffset,
-    /// The [`Inst`] used if any.
+    /// The instance used if any.
     ///
     /// # Note
     ///
     /// This is only `Some` if [`Frame`] and its caller originate from different
-    /// Wasm instances and thus execution needs to change the currently used [`Inst`].
-    instance: Option<Inst>,
+    /// Wasm instances and thus execution needs to change the currently used instance.
+    instance: Option<NonNull<InstanceEntity>>,
 }
 
 /// The offset of an [`Sp`] of a [`Stack`].

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -544,7 +544,7 @@ pub fn is_default_memory(instance: Inst, memory: ir::MemoryAddr) -> bool {
     )
 }
 
-pub fn extract_mem0(_store: &mut PrunedStore, inst: Inst) -> (Mem0Ptr, Mem0Len) {
+pub fn extract_mem0(_store: &mut PrunedStore, inst: NonNull<InstanceEntity>) -> (Mem0Ptr, Mem0Len) {
     let instance = unsafe { inst.as_ref() };
     let Some(addr) = instance.layout().memory_addr(0) else {
         return (Mem0Ptr::from([].as_mut_ptr()), Mem0Len::from(0));
@@ -760,11 +760,11 @@ where
 
 pub fn update_instance(
     store: &mut PrunedStore,
-    instance: Inst,
-    new_instance: Inst,
+    instance: NonNull<InstanceEntity>,
+    new_instance: NonNull<InstanceEntity>,
     mem0: Mem0Ptr,
     mem0_len: Mem0Len,
-) -> (Inst, Mem0Ptr, Mem0Len) {
+) -> (NonNull<InstanceEntity>, Mem0Ptr, Mem0Len) {
     if new_instance == instance {
         return (instance, mem0, mem0_len);
     }
@@ -778,7 +778,7 @@ pub fn call_func_entry(
     caller_ip: Ip,
     params: BoundedSlotSpan,
     func: &FuncEntry,
-    instance: Option<Inst>,
+    instance: Option<NonNull<InstanceEntity>>,
 ) -> Control<(Ip, Sp), Break> {
     let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func_entry!(state, func);
     let callee_sp = state
@@ -800,7 +800,7 @@ pub fn return_call_func_entry(
     state: &mut VmState,
     params: BoundedSlotSpan,
     func: &FuncEntry,
-    instance: Option<Inst>,
+    instance: Option<NonNull<InstanceEntity>>,
 ) -> Control<(Ip, Sp), Break> {
     let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func_entry!(state, func);
     let callee_sp = state
@@ -822,7 +822,7 @@ pub fn call_host(
     caller_ip: Option<Ip>,
     host_func: HostFuncEntity,
     params: BoundedSlotSpan,
-    instance: Option<Inst>,
+    instance: Option<NonNull<InstanceEntity>>,
     call_hooks: CallHooks,
 ) -> Control<Sp, Break> {
     debug_assert_eq!(params.len(), host_func.len_param_cells());
@@ -854,8 +854,8 @@ pub fn return_call_host(
     func: Func,
     host_func: HostFuncEntity,
     params: BoundedSlotSpan,
-    instance: Inst,
-) -> Control<(Ip, Sp, Inst), Break> {
+    instance: NonNull<InstanceEntity>,
+) -> Control<(Ip, Sp, NonNull<InstanceEntity>), Break> {
     debug_assert_eq!(params.len(), host_func.len_param_cells());
     let trampoline = *host_func.trampoline();
     let (control, inout) = state
@@ -899,8 +899,8 @@ pub fn call_wasm_or_host(
     params: BoundedSlotSpan,
     mem0: Mem0Ptr,
     mem0_len: Mem0Len,
-    instance: Inst,
-) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, Inst), Break> {
+    instance: NonNull<InstanceEntity>,
+) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, NonNull<InstanceEntity>), Break> {
     // SAFETY: the pointer is warmed up at instantiation (imported calls) or freshly resolved
     //         (indirect calls); the reference is only used to copy out the callee data below,
     //         before any store mutation, so it never aliases a `&mut` into the funcs arena.
@@ -925,7 +925,8 @@ pub fn call_wasm_or_host(
     };
     // Hot path: calling a Wasm function. Uses the cached `FuncEntry` and the same inlined
     // machinery as `call_internal`, differing only in the possible instance switch.
-    let callee_instance: Inst = resolve_instance(state.store, wasm_func.instance()).into();
+    let callee_instance: NonNull<InstanceEntity> =
+        resolve_instance(state.store, wasm_func.instance()).into();
     let (callee_ip, callee_sp) = call_func_entry(
         state,
         caller_ip,
@@ -947,8 +948,8 @@ pub fn return_call_wasm_or_host(
     params: BoundedSlotSpan,
     mem0: Mem0Ptr,
     mem0_len: Mem0Len,
-    instance: Inst,
-) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, Inst), Break> {
+    instance: NonNull<InstanceEntity>,
+) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, NonNull<InstanceEntity>), Break> {
     // SAFETY: see `call_wasm_or_host`.
     let func_entity = unsafe { func_entity.as_ref() };
     let wasm_func = match func_entity {
@@ -964,7 +965,8 @@ pub fn return_call_wasm_or_host(
         }
     };
     // Hot path: tail-calling a Wasm function. See `call_wasm_or_host` for the shape.
-    let callee_instance: Inst = resolve_instance(state.store, wasm_func.instance()).into();
+    let callee_instance: NonNull<InstanceEntity> =
+        resolve_instance(state.store, wasm_func.instance()).into();
     let changed_instance = (callee_instance != instance).then_some(callee_instance);
     let (callee_ip, callee_sp) =
         return_call_func_entry(state, params, wasm_func.func_entry(), changed_instance)?;

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -5,7 +5,6 @@ pub use self::{
         CellsReader,
         CellsWriter,
         ExecutionOutcome,
-        Inst,
         LiftFromCells,
         LiftFromCellsByValue,
         LoadByVal,

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -19,7 +19,6 @@ pub(crate) use self::{
     executor::{
         InOutParams,
         InOutResults,
-        Inst,
         LiftFromCells,
         LiftFromCellsByValue,
         LoadByVal,

--- a/crates/wasmi/src/func/caller.rs
+++ b/crates/wasmi/src/func/caller.rs
@@ -1,5 +1,6 @@
 use super::super::{AsContext, AsContextMut, StoreContext, StoreContextMut};
-use crate::{Engine, Error, Extern, engine::Inst};
+use crate::{Engine, Error, Extern, instance::InstanceEntity};
+use core::ptr::NonNull;
 
 /// Represents the caller’s context when creating a host function via [`Func::wrap`].
 ///
@@ -10,14 +11,14 @@ pub struct Caller<'a, T> {
     /// This is `Some` if the host function was called from a Wasm function
     /// since all Wasm function are associated to a module instance.
     /// This usually is `None` if the host function was called from the host side.
-    instance: Option<Inst>,
+    instance: Option<NonNull<InstanceEntity>>,
 }
 
 impl<'a, T> Caller<'a, T> {
     /// Creates a new [`Caller`] from the given store context and [`Instance`] handle.
     ///
     /// [`Instance`]: crate::Instance
-    pub(crate) fn new<C>(ctx: &'a mut C, instance: Option<Inst>) -> Self
+    pub(crate) fn new<C>(ctx: &'a mut C, instance: Option<NonNull<InstanceEntity>>) -> Self
     where
         C: AsContextMut<Data = T>,
     {

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -22,11 +22,16 @@ use crate::{
     Engine,
     Error,
     Val,
-    engine::{InOutParams, InOutResults, Inst, ResumableCall, required_cells_for_tys},
+    engine::{InOutParams, InOutResults, ResumableCall, required_cells_for_tys},
+    instance::InstanceEntity,
     store::Stored,
 };
 use alloc::{boxed::Box, sync::Arc};
-use core::{fmt, fmt::Debug, num::NonZero};
+use core::{
+    fmt::{self, Debug},
+    num::NonZero,
+    ptr::NonNull,
+};
 
 define_handle! {
     struct Trampoline(usize, Stored) => TrampolineEntity<Generic>;
@@ -293,7 +298,7 @@ impl<T> TrampolineEntity<T> {
     pub fn call<'a>(
         &self,
         mut ctx: impl AsContextMut<Data = T>,
-        instance: Option<Inst>,
+        instance: Option<NonNull<InstanceEntity>>,
         params: InOutParams<'a>,
     ) -> Result<InOutResults<'a>, Error> {
         let caller = <Caller<T>>::new(&mut ctx, instance);

--- a/crates/wasmi/src/store/mod.rs
+++ b/crates/wasmi/src/store/mod.rs
@@ -23,13 +23,15 @@ use crate::{
     ResourceLimiter,
     collections::arena::{Arena, ArenaError},
     core::{CoreMemory, ResourceLimiterRef},
-    engine::{InOutParams, Inst},
+    engine::InOutParams,
     func::{Trampoline, TrampolineEntity},
+    instance::InstanceEntity,
 };
 use alloc::boxed::Box;
 use core::{
     any::{TypeId, type_name},
     fmt::{self, Debug},
+    ptr::NonNull,
 };
 
 /// The store that owns all data associated to Wasm modules.
@@ -114,7 +116,7 @@ impl<T> Store<T> {
     fn call_host_func(
         &mut self,
         trampoline: Trampoline,
-        instance: Option<Inst>,
+        instance: Option<NonNull<InstanceEntity>>,
         inout: InOutParams,
     ) -> Result<(), StoreError<Error>> {
         let trampoline = self.resolve_trampoline(&trampoline)?.clone();

--- a/crates/wasmi/src/store/pruned.rs
+++ b/crates/wasmi/src/store/pruned.rs
@@ -6,14 +6,16 @@ use crate::{
     Store,
     Table,
     core::{RawRef, hint},
-    engine::{InOutParams, Inst},
+    engine::InOutParams,
     errors::{MemoryError, TableError},
     func::Trampoline,
+    instance::InstanceEntity,
     store::error::{InternalStoreError, StoreError},
 };
 use core::{
     fmt::{self, Debug},
     mem,
+    ptr::NonNull,
 };
 
 #[cfg(test)]
@@ -34,7 +36,7 @@ pub struct PrunedStoreVTable {
     call_host_func: fn(
         store: &mut PrunedStore,
         trampoline: Trampoline,
-        instance: Option<Inst>,
+        instance: Option<NonNull<InstanceEntity>>,
         inout: InOutParams,
         call_hooks: CallHooks,
     ) -> Result<(), StoreError<Error>>,
@@ -54,7 +56,7 @@ impl PrunedStoreVTable {
         Self {
             call_host_func: |pruned: &mut PrunedStore,
                              trampoline: Trampoline,
-                             instance: Option<Inst>,
+                             instance: Option<NonNull<InstanceEntity>>,
                              inout: InOutParams,
                              call_hooks: CallHooks|
              -> Result<(), StoreError<Error>> {
@@ -104,7 +106,7 @@ impl PrunedStoreVTable {
         &self,
         pruned: &mut PrunedStore,
         trampoline: Trampoline,
-        instance: Option<Inst>,
+        instance: Option<NonNull<InstanceEntity>>,
         inout: InOutParams,
         call_hooks: CallHooks,
     ) -> Result<(), StoreError<Error>> {
@@ -194,7 +196,7 @@ impl PrunedStore {
     pub fn call_host_func(
         &mut self,
         trampoline: Trampoline,
-        instance: Option<Inst>,
+        instance: Option<NonNull<InstanceEntity>>,
         inout: InOutParams,
         call_hooks: CallHooks,
     ) -> Result<(), StoreError<Error>> {


### PR DESCRIPTION
the reason `NonNull<InstanceEntity>` is better than `Inst` is because `Inst` might be a float-wrapper and thus not profiting from `Option`'s niche optimization.