### PR TITLE
Resolve `DedupFuncType`s in Wasmi's translator for `[return_]call_indirect`

### DIFF
--- a/crates/ir/src/index.rs
+++ b/crates/ir/src/index.rs
@@ -8,7 +8,13 @@ macro_rules! for_each_index {
         $mac! {
             /// A Wasmi function instance address.
             FuncAddr(pub(crate) u32);
-            /// A Wasm function type index.
+            /// A deduplicated Wasmi function type.
+            ///
+            /// # Note
+            ///
+            /// This is the raw representation of an engine's deduplicated function type and
+            /// not an index into the Wasm module's type section. Its engine association is
+            /// implied by the function body storing it.
             FuncType(pub(crate) u32);
             /// A Wasmi global variable instance address.
             GlobalAddr(pub(crate) u32);

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -22,7 +22,6 @@ use crate::{
     },
     engine::{
         CodeView,
-        DedupFuncType,
         FuncEntry,
         InOutParams,
         executor::{
@@ -704,17 +703,6 @@ impl_fetch_from_instance! {
     fn fetch_table(table: ir::TableAddr) -> Table = get_table;
 }
 
-/// Fetches the [`DedupFuncType`] at `func_type` from the instance's function types.
-#[inline]
-pub fn fetch_func_type(instance: Inst, func_type: ir::FuncType) -> DedupFuncType {
-    let index = u32::from(func_type);
-    // SAFETY: `instance` refers to a live instance for the duration of the call.
-    let Some(func_type) = (unsafe { instance.as_ptr().get_signature(index) }) else {
-        unsafe { unreachable_unchecked!("missing func type at: {index}") }
-    };
-    *func_type
-}
-
 macro_rules! impl_resolve_from_store {
     (
         $( fn $fn:ident($param:ident: $ty:ty) -> $ret:ty = $getter:expr );* $(;)?
@@ -762,9 +750,11 @@ where
     let func = funcref.val().ok_or(TrapCode::IndirectCallToNull)?;
     let func_entity = state.store.inner_mut().resolve_func_ptr(func);
     // SAFETY: freshly resolved from the store; only read here for the signature check.
-    let actual_fnty = unsafe { func_entity.as_ref() }.ty_dedup();
-    let expected_fnty = fetch_func_type(args.instance, func_type);
-    if expected_fnty.ne(actual_fnty) {
+    let actual_fnty = unsafe { func_entity.as_ref() }.ty_dedup().repr_entity();
+    // Note: `func_type` already stores the resolved deduplicated function type, thus the
+    //       engine association dropped by `repr_entity` is implied by both operands
+    //       belonging to the very engine that is executing them.
+    if actual_fnty != u32::from(func_type) {
         return Err(TrapCode::BadSignature);
     }
     Ok((*func, func_entity))

--- a/crates/wasmi/src/engine/func_types.rs
+++ b/crates/wasmi/src/engine/func_types.rs
@@ -25,6 +25,19 @@ define_handle! {
     struct DedupFuncType(u32, EngineOwned) => FuncType;
 }
 
+impl DedupFuncType {
+    /// Returns the raw `u32` representation of `self`, dropping its engine association.
+    ///
+    /// # Note
+    ///
+    /// This is used to encode a [`DedupFuncType`] into Wasmi bytecode where the engine
+    /// association is implied by the function body that stores it.
+    #[inline]
+    pub(crate) fn repr_entity(self) -> u32 {
+        self.0.value.raw()
+    }
+}
+
 /// A [`FuncType`] registry that efficiently deduplicate stored function types.
 ///
 /// Can also be used to later resolve deduplicated function types into their

--- a/crates/wasmi/src/engine/translator/func/mod.rs
+++ b/crates/wasmi/src/engine/translator/func/mod.rs
@@ -350,6 +350,17 @@ impl FuncTranslator {
             .resolve_func_type(dedup_func_type, Clone::clone)
     }
 
+    /// Resolves the deduplicated function type at the given Wasm module `type_index`.
+    ///
+    /// # Note
+    ///
+    /// Resolving this at translation time is what allows the executor to compare function
+    /// types for indirect calls without querying the instance.
+    fn resolve_dedup_type(&self, type_index: u32) -> ir::FuncType {
+        let func_type_idx = FuncTypeIdx::from(type_index);
+        ir::FuncType::from(self.module.get_func_type(func_type_idx).repr_entity())
+    }
+
     /// Returns the [`GlobalAddr`] for the global at `index`.
     ///
     /// [`GlobalAddr`]: crate::instance::GlobalAddr
@@ -1683,7 +1694,7 @@ impl FuncTranslator {
         let callee_ty = self.resolve_type(type_index);
         let index = self.copy_immediate_to_slot(index)?;
         let params = self.adjust_stack_for_call(&callee_ty)?;
-        let func_type = ir::FuncType::from(type_index);
+        let func_type = self.resolve_dedup_type(type_index);
         let op = match index {
             Location::Slot(index) => op_s(table_addr, func_type, params, index),
             Location::Reg(_) => op_r(table_addr, func_type, params),

--- a/crates/wasmi/src/instance/builder.rs
+++ b/crates/wasmi/src/instance/builder.rs
@@ -10,18 +10,16 @@ use crate::{
     Module,
     Table,
     collections::Map,
-    engine::DedupFuncType,
     instance::{AnyHandleAndEntity, InstanceLayout, handle::AnyHandle},
     memory::DataSegment,
     module::FuncIdx,
 };
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use core::iter::FusedIterator;
 
 /// A module instance entity builder.
 #[derive(Debug)]
 pub struct InstanceEntityBuilder {
-    func_types: Arc<[DedupFuncType]>,
     tables: Vec<Table>,
     funcs: Vec<Func>,
     memories: Vec<Memory>,
@@ -63,7 +61,6 @@ impl InstanceEntityBuilder {
         }
         let layout = *module.instance_layout();
         Self {
-            func_types: module.func_types_cloned(),
             tables: vec_with_capacity_exact(len_tables),
             funcs: vec_with_capacity_exact(len_funcs),
             memories: vec_with_capacity_exact(len_memories),
@@ -191,12 +188,7 @@ impl InstanceEntityBuilder {
     /// Finishes constructing the [`InstanceEntity`].
     pub fn finish(self) -> Result<Box<InstanceEntity>, Error> {
         let handles = self.finish_handles();
-        Ok(InstanceEntity::new_init(
-            self.func_types,
-            self.exports,
-            self.layout,
-            handles,
-        ))
+        Ok(InstanceEntity::new_init(self.exports, self.layout, handles))
     }
 
     /// Finishes construction of the [`AnyHandle`] buffer.

--- a/crates/wasmi/src/instance/entity.rs
+++ b/crates/wasmi/src/instance/entity.rs
@@ -21,14 +21,12 @@ use crate::{
     Module,
     Table,
     collections::Map,
-    engine::DedupFuncType,
     memory::DataSegment,
     store::StoreInner,
 };
 use alloc::{
     alloc::{alloc, handle_alloc_error},
     boxed::Box,
-    sync::Arc,
     vec::Vec,
 };
 use core::{
@@ -74,7 +72,6 @@ struct InstanceEntityHeader {
     /// handles than the layout accounts for.
     len_handles: u32,
     state: InstanceState,
-    func_types: Arc<[DedupFuncType]>,
     exports: Map<Box<str>, Extern>,
     layout: InstanceLayout,
 }
@@ -154,12 +151,6 @@ impl InstanceEntityHeader {
     fn layout(&self) -> &InstanceLayout {
         &self.layout
     }
-
-    /// Returns the signature at the `index` if any.
-    #[inline]
-    fn get_signature(&self, index: u32) -> Option<&DedupFuncType> {
-        self.func_types.get(index as usize)
-    }
 }
 
 impl InstanceEntity {
@@ -167,7 +158,6 @@ impl InstanceEntity {
     pub fn new_uninit() -> Box<Self> {
         Self::alloc(
             InstanceState::Uninitialized,
-            Arc::new([]),
             Map::new(),
             InstanceLayout::uninit(),
             [],
@@ -176,7 +166,6 @@ impl InstanceEntity {
 
     /// Creates an initialized [`InstanceEntity`].
     pub(super) fn new_init<I>(
-        func_types: Arc<[DedupFuncType]>,
         exports: Map<Box<str>, Extern>,
         layout: InstanceLayout,
         handles: I,
@@ -184,13 +173,7 @@ impl InstanceEntity {
     where
         I: IntoIterator<Item = AnyHandleAndEntity, IntoIter: ExactSizeIterator>,
     {
-        Self::alloc(
-            InstanceState::Initialized,
-            func_types,
-            exports,
-            layout,
-            handles,
-        )
+        Self::alloc(InstanceState::Initialized, exports, layout, handles)
     }
 
     /// Allocates a new [`InstanceEntity`] with the trailing `handles` buffer.
@@ -200,7 +183,6 @@ impl InstanceEntity {
     /// If `handles` yields more items than fit into a `u32`.
     fn alloc<I>(
         state: InstanceState,
-        func_types: Arc<[DedupFuncType]>,
         exports: Map<Box<str>, Extern>,
         layout: InstanceLayout,
         handles: I,
@@ -216,7 +198,6 @@ impl InstanceEntity {
         let header = InstanceEntityHeader {
             len_handles,
             state,
-            func_types,
             exports,
             layout,
         };
@@ -366,12 +347,6 @@ impl InstanceEntity {
         Some(unsafe { entry.typed_ref::<ElementSegment>() }.handle())
     }
 
-    /// Returns the signature at the `index` if any.
-    #[inline]
-    pub fn get_signature(&self, index: u32) -> Option<&DedupFuncType> {
-        self.header.get_signature(index)
-    }
-
     /// Returns the value exported to the given `name` if any.
     pub fn get_export(&self, name: &str) -> Option<Extern> {
         self.header.exports.get(name).copied()
@@ -498,17 +473,6 @@ impl ThinPtr<InstanceEntity> {
     pub unsafe fn layout<'a>(self) -> &'a InstanceLayout {
         // Safety: guaranteed by the caller.
         unsafe { self.header() }.layout()
-    }
-
-    /// Returns the signature at the `index` of the pointee if any.
-    ///
-    /// # Safety
-    ///
-    /// Same as for [`ThinPtr::as_ref`].
-    #[inline]
-    pub unsafe fn get_signature<'a>(self, index: u32) -> Option<&'a DedupFuncType> {
-        // Safety: guaranteed by the caller.
-        unsafe { self.header() }.get_signature(index)
     }
 
     impl_get_entry! {

--- a/crates/wasmi/src/module/builder.rs
+++ b/crates/wasmi/src/module/builder.rs
@@ -105,12 +105,11 @@ impl ModuleBuilder {
     fn finish_header(&mut self) -> Result<ModuleHeader, Error> {
         use core::mem::take;
         assert!(self.header.is_none());
-        let func_types: Box<[DedupFuncType]> = take(&mut self.func_types).into();
         let layout = self.finish_instance_layout()?;
         let header = ModuleHeader {
             inner: Arc::new(ModuleHeaderInner {
                 engine: self.engine.weak(),
-                func_types: func_types.into(),
+                func_types: take(&mut self.func_types).into(),
                 imports: take(&mut self.imports).finish(),
                 funcs: take(&mut self.funcs).into(),
                 tables: take(&mut self.tables).into(),

--- a/crates/wasmi/src/module/mod.rs
+++ b/crates/wasmi/src/module/mod.rs
@@ -75,7 +75,7 @@ pub struct ModuleHeader {
 #[derive(Debug)]
 struct ModuleHeaderInner {
     engine: EngineWeak,
-    func_types: Arc<[DedupFuncType]>,
+    func_types: Box<[DedupFuncType]>,
     imports: ModuleImports,
     funcs: Box<[DedupFuncType]>,
     tables: Box<[TableType]>,
@@ -330,15 +330,6 @@ impl Module {
     /// Returns the [`InstanceLayout`] shared by all instances of this [`Module`].
     pub(crate) fn instance_layout(&self) -> &InstanceLayout {
         &self.module_header().layout
-    }
-
-    /// Returns a slice to the function types of the [`Module`].
-    ///
-    /// # Note
-    ///
-    /// The slice is stored in a `Arc` so that this operation is very cheap.
-    pub(crate) fn func_types_cloned(&self) -> Arc<[DedupFuncType]> {
-        self.module_header().func_types.clone()
     }
 
     /// Returns an iterator over the imports of the [`Module`].


### PR DESCRIPTION
Performance improvements compared to `main` are nice:

<img width="1130" height="1318" alt="image" src="https://github.com/user-attachments/assets/46817dab-aba8-47d9-bf0e-a512102632ae" />
