### PR TITLE
Refactor `InOut{Params,Results}` types + host calls

### DIFF
--- a/crates/wasmi/src/engine/executor/handler/func.rs
+++ b/crates/wasmi/src/engine/executor/handler/func.rs
@@ -8,7 +8,7 @@ use crate::{
         LowerToCells,
         executor::handler::{
             dispatch::{ExecutionOutcome, execute_until_done},
-            state::{Freg32, Freg64, Inst, Ip, Ireg, Sp, Stack, VmState},
+            state::{Freg32, Freg64, HostFrame, Inst, Ip, Ireg, Sp, Stack, VmState},
             utils,
         },
     },
@@ -47,7 +47,7 @@ impl<'a, T, State> WasmFuncCall<'a, T, State> {
 }
 
 mod state {
-    use super::Sp;
+    use super::{HostFrame, Sp};
     use crate::{engine::InOutParams, func::Trampoline};
     use core::marker::PhantomData;
 
@@ -63,7 +63,7 @@ mod state {
 
     pub struct UninitHost {
         pub sp: Sp,
-        pub inout: InOutParams,
+        pub frame: HostFrame,
         pub trampoline: Trampoline,
     }
 
@@ -222,12 +222,13 @@ pub fn init_host_func_call<'a, T>(
     let len_result_cells = func.len_result_cells();
     let trampoline = *func.trampoline();
     let callee_params = BoundedSlotSpan::new(SlotSpan::new(Slot::from(0)), len_param_cells);
-    let (sp, inout) = stack.prepare_host_frame(None, callee_params, len_result_cells)?;
+    let (sp, frame) = stack.prepare_host_frame(None, callee_params, len_result_cells)?;
     Ok(HostFuncCall {
         store,
+        stack,
         state: state::UninitHost {
             sp,
-            inout,
+            frame,
             trampoline,
         },
     })
@@ -236,6 +237,7 @@ pub fn init_host_func_call<'a, T>(
 #[derive(Debug)]
 pub struct HostFuncCall<'a, T, State> {
     store: &'a mut Store<T>,
+    stack: &'a mut Stack,
     state: State,
 }
 
@@ -246,15 +248,19 @@ impl<'a, T> HostFuncCall<'a, T, state::UninitHost> {
     {
         let state::UninitHost {
             sp,
-            inout,
+            frame,
             trampoline,
         } = self.state;
         let mut sp_writer = sp;
         let Ok(_) = params.lower_to_cells(&*self.store, &mut sp_writer) else {
             panic!("failed to store parameter values to cells")
         };
+        // Note: the `InOutParams` must be derived _after_ the parameters have been written above,
+        //       since writing through `sp` invalidates its pointer. See `Stack::host_inout`.
+        let inout = self.stack.host_inout(frame);
         HostFuncCall {
             store: self.store,
+            stack: self.stack,
             state: state::InitHost {
                 sp,
                 inout,
@@ -283,6 +289,7 @@ impl<'a, T> HostFuncCall<'a, T, state::InitHost> {
         }
         Ok(HostFuncCall {
             store: self.store,
+            stack: self.stack,
             state: state::Done { sp },
         })
     }

--- a/crates/wasmi/src/engine/executor/handler/func.rs
+++ b/crates/wasmi/src/engine/executor/handler/func.rs
@@ -61,15 +61,15 @@ mod state {
         pub enum Resumed {}
     }
 
-    pub struct UninitHost<'a> {
+    pub struct UninitHost {
         pub sp: Sp,
-        pub inout: InOutParams<'a>,
+        pub inout: InOutParams,
         pub trampoline: Trampoline,
     }
 
-    pub struct InitHost<'a> {
+    pub struct InitHost {
         pub sp: Sp,
-        pub inout: InOutParams<'a>,
+        pub inout: InOutParams,
         pub trampoline: Trampoline,
     }
 
@@ -217,7 +217,7 @@ pub fn init_host_func_call<'a, T>(
     store: &'a mut Store<T>,
     stack: &'a mut Stack,
     func: HostFuncEntity,
-) -> Result<HostFuncCall<'a, T, state::UninitHost<'a>>, Error> {
+) -> Result<HostFuncCall<'a, T, state::UninitHost>, Error> {
     let len_param_cells = func.len_param_cells();
     let len_result_cells = func.len_result_cells();
     let trampoline = *func.trampoline();
@@ -239,8 +239,8 @@ pub struct HostFuncCall<'a, T, State> {
     state: State,
 }
 
-impl<'a, T> HostFuncCall<'a, T, state::UninitHost<'a>> {
-    pub fn write_params<Params>(self, params: Params) -> HostFuncCall<'a, T, state::InitHost<'a>>
+impl<'a, T> HostFuncCall<'a, T, state::UninitHost> {
+    pub fn write_params<Params>(self, params: Params) -> HostFuncCall<'a, T, state::InitHost>
     where
         Params: LowerToCells,
     {
@@ -264,7 +264,7 @@ impl<'a, T> HostFuncCall<'a, T, state::UninitHost<'a>> {
     }
 }
 
-impl<'a, T> HostFuncCall<'a, T, state::InitHost<'a>> {
+impl<'a, T> HostFuncCall<'a, T, state::InitHost> {
     pub fn execute(self) -> Result<HostFuncCall<'a, T, state::Done>, Error> {
         let state::InitHost {
             sp,

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -502,6 +502,50 @@ mod ip_tests {
     };
 }
 
+/// The cells window of a host function call frame on the value stack.
+///
+/// # Note
+///
+/// Produced by [`Stack::prepare_host_frame`] and [`Stack::return_prepare_host_frame`] and turned
+/// into the [`InOutParams`] of the call by [`Stack::host_inout`].
+///
+/// Both steps are separate so that the [`InOutParams`] can be derived _after_ the caller wrote the
+/// call parameters into the frame through its [`Sp`]: writing through an [`Sp`] that was obtained
+/// before the [`InOutParams`] invalidates the latter's pointer.
+#[derive(Debug, Copy, Clone)]
+pub struct HostFrame {
+    /// The start offset of the frame's cells.
+    start: SpOffset,
+    /// The end offset of the frame's cells.
+    end: SpOffset,
+    /// The number of cells used for parameters.
+    len_params: usize,
+    /// The number of cells used for results.
+    len_results: usize,
+}
+
+impl HostFrame {
+    /// Creates a new [`HostFrame`] spanning `cells[start..end]`.
+    fn new(start: SpOffset, end: SpOffset, len_params: usize, len_results: usize) -> Self {
+        Self {
+            start,
+            end,
+            len_params,
+            len_results,
+        }
+    }
+
+    /// Creates a [`HostFrame`] that spans no cells.
+    fn empty() -> Self {
+        Self::new(SpOffset::from(0), SpOffset::from(0), 0, 0)
+    }
+
+    /// Returns `true` if `self` spans no cells.
+    fn is_empty(&self) -> bool {
+        self.len_params == 0 && self.len_results == 0
+    }
+}
+
 /// The stack pointer.
 ///
 /// # Note

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -1235,6 +1235,10 @@ impl ValueStack {
         let Some(cells) = self.cells_from_to(start, end) else {
             unsafe { unreachable_unchecked!("must fit slice after `grow_if_needed` operation") }
         };
+        // SAFETY: the cells are heap allocated by `self.cells` and thus travel along with `self`
+        //         and its owning `Stack`. `Stack::host_inout` requires its caller to leave both
+        //         the cells and the `Stack` alone until the returned `InOutParams` is consumed,
+        //         which happens before the host function call returns.
         let inout_or_err = unsafe { InOutParams::new(cells, len_params, len_results) };
         let Ok(inout) = inout_or_err else {
             unsafe {

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -912,27 +912,51 @@ impl Stack {
     }
 
     /// Prepares `self` for a host function tail call.
+    ///
+    /// Use [`Stack::host_inout`] on the returned [`HostFrame`] to obtain the [`InOutParams`]
+    /// of the call.
     pub fn return_prepare_host_frame(
         &mut self,
         callee_params: BoundedSlotSpan,
         results_len: u16,
         caller_instance: Inst,
-    ) -> Result<(ReturnCallHost, InOutParams), TrapCode> {
+    ) -> Result<(ReturnCallHost, HostFrame), TrapCode> {
         let (callee_start, caller) = self.frames.return_prepare_host_frame(caller_instance);
         self.values
             .return_prepare_host_frame(caller, callee_start, callee_params, results_len)
     }
 
     /// Prepares `self` for a host function call.
+    ///
+    /// Use [`Stack::host_inout`] on the returned [`HostFrame`] to obtain the [`InOutParams`]
+    /// of the call.
     pub fn prepare_host_frame(
         &mut self,
         caller_ip: Option<Ip>,
         callee_params: BoundedSlotSpan,
         results_len: u16,
-    ) -> Result<(Sp, InOutParams), TrapCode> {
+    ) -> Result<(Sp, HostFrame), TrapCode> {
         let caller_start = self.frames.prepare_host_frame(caller_ip);
         self.values
             .prepare_host_frame(caller_start, callee_params, results_len)
+    }
+
+    /// Returns the [`InOutParams`] of the host function call `frame`.
+    ///
+    /// # Warning
+    ///
+    /// The returned [`InOutParams`] aliases the cells of `self` without borrowing them. Until it
+    /// has been consumed the caller must neither
+    ///
+    /// - mutate `self` in any way, since growing the value stack may reallocate its cells, nor
+    /// - write to the `frame`'s cells through an [`Sp`] that was obtained before this call, since
+    ///   that invalidates the pointer of the returned [`InOutParams`].
+    ///
+    /// The latter is why creating the [`HostFrame`] and turning it into [`InOutParams`] are two
+    /// steps: callers that still have to write the call parameters via their [`Sp`] must do so
+    /// before calling this method.
+    pub fn host_inout(&mut self, frame: HostFrame) -> InOutParams {
+        self.values.host_inout(frame)
     }
 
     /// Returns an [`Sp`] pointing at the base of the value stack.
@@ -1208,7 +1232,7 @@ impl ValueStack {
         callee_start: SpOffset,
         callee_params: BoundedSlotSpan,
         results_len: u16,
-    ) -> Result<(ReturnCallHost, InOutParams), TrapCode> {
+    ) -> Result<(ReturnCallHost, HostFrame), TrapCode> {
         let caller_start = caller.map(|(_, start, _)| start).unwrap_or_default();
         let params_offset = usize::from(u16::from(callee_params.span().head()));
         let params_len = usize::from(callee_params.len());
@@ -1219,12 +1243,11 @@ impl ValueStack {
                 Some(_) if caller_start != callee_start => self.sp(caller_start),
                 _ => Sp::dangling(),
             };
-            let inout = InOutParams::empty();
             let control = match caller {
                 Some((ip, _, instance)) => ReturnCallHost::Continue((ip, sp, instance)),
                 None => ReturnCallHost::Break(sp),
             };
-            return Ok((control, inout));
+            return Ok((control, HostFrame::empty()));
         }
         let params_start = callee_start.add(params_offset)?;
         let params_end = params_start.add(params_len)?;
@@ -1232,12 +1255,12 @@ impl ValueStack {
         let callee_end = callee_start.add(callee_size)?;
         self.grow_if_needed(callee_end)?;
         let caller_sp = self.sp(caller_start);
-        let inout = self.host_inout(callee_start, callee_end, params_len, results_len);
+        let frame = HostFrame::new(callee_start, callee_end, params_len, results_len);
         let control = match caller {
             Some((ip, _, instance)) => ReturnCallHost::Continue((ip, caller_sp, instance)),
             None => ReturnCallHost::Break(caller_sp),
         };
-        Ok((control, inout))
+        Ok((control, frame))
     }
 
     /// Prepares `self` for a host function call.
@@ -1246,7 +1269,7 @@ impl ValueStack {
         caller_start: SpOffset,
         callee_params: BoundedSlotSpan,
         results_len: u16,
-    ) -> Result<(Sp, InOutParams), TrapCode> {
+    ) -> Result<(Sp, HostFrame), TrapCode> {
         let params_offset = usize::from(u16::from(callee_params.span().head()));
         let params_len = usize::from(callee_params.len());
         let results_len = usize::from(results_len);
@@ -1255,23 +1278,27 @@ impl ValueStack {
         let callee_end = callee_start.add(callee_size)?;
         self.grow_if_needed(callee_end)?;
         let sp = self.sp(caller_start);
-        let inout = self.host_inout(callee_start, callee_end, params_len, results_len);
-        Ok((sp, inout))
+        let frame = HostFrame::new(callee_start, callee_end, params_len, results_len);
+        Ok((sp, frame))
     }
 
-    /// Returns the [`InOutParams`] window `cells[start..end]` for a host function call.
+    /// Returns the [`InOutParams`] for the host function call `frame`.
     ///
-    /// # Note
+    /// # Warning
     ///
-    /// Both `end - start` and `max(len_params, len_results)` denote the callee size,
-    /// and [`ValueStack::grow_if_needed`] has already been called for `end`.
-    fn host_inout(
-        &mut self,
-        start: SpOffset,
-        end: SpOffset,
-        len_params: usize,
-        len_results: usize,
-    ) -> InOutParams {
+    /// See [`Stack::host_inout`] for what the caller has to uphold.
+    fn host_inout(&mut self, frame: HostFrame) -> InOutParams {
+        let HostFrame {
+            start,
+            end,
+            len_params,
+            len_results,
+        } = frame;
+        if frame.is_empty() {
+            // Note: zero-sized host frames may start past the end of the value stack cells
+            //       since `grow_if_needed` was a no-op for them.
+            return InOutParams::empty();
+        }
         debug_assert_eq!(
             end.into_inner() - start.into_inner(),
             len_params.max(len_results)

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -868,24 +868,24 @@ impl Stack {
     }
 
     /// Prepares `self` for a host function tail call.
-    pub fn return_prepare_host_frame<'a>(
-        &'a mut self,
+    pub fn return_prepare_host_frame(
+        &mut self,
         callee_params: BoundedSlotSpan,
         results_len: u16,
         caller_instance: Inst,
-    ) -> Result<(ReturnCallHost, InOutParams<'a>), TrapCode> {
+    ) -> Result<(ReturnCallHost, InOutParams), TrapCode> {
         let (callee_start, caller) = self.frames.return_prepare_host_frame(caller_instance);
         self.values
             .return_prepare_host_frame(caller, callee_start, callee_params, results_len)
     }
 
     /// Prepares `self` for a host function call.
-    pub fn prepare_host_frame<'a>(
-        &'a mut self,
+    pub fn prepare_host_frame(
+        &mut self,
         caller_ip: Option<Ip>,
         callee_params: BoundedSlotSpan,
         results_len: u16,
-    ) -> Result<(Sp, InOutParams<'a>), TrapCode> {
+    ) -> Result<(Sp, InOutParams), TrapCode> {
         let caller_start = self.frames.prepare_host_frame(caller_ip);
         self.values
             .prepare_host_frame(caller_start, callee_params, results_len)
@@ -1158,13 +1158,13 @@ impl ValueStack {
     /// In the following code, `callee` represents the called host function frame
     /// and `caller` represents the caller of the caller of the host function, a.k.a.
     /// the caller's caller.
-    fn return_prepare_host_frame<'a>(
-        &'a mut self,
+    fn return_prepare_host_frame(
+        &mut self,
         caller: Option<(Ip, SpOffset, Inst)>,
         callee_start: SpOffset,
         callee_params: BoundedSlotSpan,
         results_len: u16,
-    ) -> Result<(ReturnCallHost, InOutParams<'a>), TrapCode> {
+    ) -> Result<(ReturnCallHost, InOutParams), TrapCode> {
         let caller_start = caller.map(|(_, start, _)| start).unwrap_or_default();
         let params_offset = usize::from(u16::from(callee_params.span().head()));
         let params_len = usize::from(callee_params.len());
@@ -1175,7 +1175,7 @@ impl ValueStack {
                 Some(_) if caller_start != callee_start => self.sp(caller_start),
                 _ => Sp::dangling(),
             };
-            let inout = InOutParams::new(&mut [], 0, 0).unwrap();
+            let inout = InOutParams::empty();
             let control = match caller {
                 Some((ip, _, instance)) => ReturnCallHost::Continue((ip, sp, instance)),
                 None => ReturnCallHost::Break(sp),
@@ -1197,12 +1197,12 @@ impl ValueStack {
     }
 
     /// Prepares `self` for a host function call.
-    fn prepare_host_frame<'a>(
-        &'a mut self,
+    fn prepare_host_frame(
+        &mut self,
         caller_start: SpOffset,
         callee_params: BoundedSlotSpan,
         results_len: u16,
-    ) -> Result<(Sp, InOutParams<'a>), TrapCode> {
+    ) -> Result<(Sp, InOutParams), TrapCode> {
         let params_offset = usize::from(u16::from(callee_params.span().head()));
         let params_len = usize::from(callee_params.len());
         let results_len = usize::from(results_len);
@@ -1227,7 +1227,7 @@ impl ValueStack {
         end: SpOffset,
         len_params: usize,
         len_results: usize,
-    ) -> InOutParams<'_> {
+    ) -> InOutParams {
         debug_assert_eq!(
             end.into_inner() - start.into_inner(),
             len_params.max(len_results)
@@ -1235,7 +1235,8 @@ impl ValueStack {
         let Some(cells) = self.cells_from_to(start, end) else {
             unsafe { unreachable_unchecked!("must fit slice after `grow_if_needed` operation") }
         };
-        let Ok(inout) = InOutParams::new(cells, len_params, len_results) else {
+        let inout_or_err = unsafe { InOutParams::new(cells, len_params, len_results) };
+        let Ok(inout) = inout_or_err else {
             unsafe {
                 unreachable_unchecked!("host frame cells are sized as max(len_params, len_results)")
             }

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -897,7 +897,7 @@ fn invoke_host(
     store: &mut PrunedStore,
     trampoline: Trampoline,
     instance: Option<Inst>,
-    inout: InOutParams<'_>,
+    inout: InOutParams,
     call_hooks: CallHooks,
 ) -> Result<(), Error> {
     match store.call_host_func(trampoline, instance, inout, call_hooks) {

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -889,7 +889,8 @@ pub fn return_call_func_entry(
 ///
 /// # Note
 ///
-/// Takes `store` instead of the whole [`VmState`] since `inout` already borrows its [`Stack`].
+/// Takes `store` instead of the whole [`VmState`] so that this cannot touch the [`Stack`] whose
+/// cells `inout` points at: `inout` aliases them without borrowing them.
 ///
 /// [`Stack`]: crate::engine::executor::Stack
 #[inline]
@@ -923,10 +924,13 @@ pub fn call_host(
 ) -> Control<Sp, Break> {
     debug_assert_eq!(params.len(), host_func.len_param_cells());
     let trampoline = *host_func.trampoline();
-    let (sp, inout) = state
+    let (sp, frame) = state
         .stack
         .prepare_host_frame(caller_ip, params, host_func.len_result_cells())
         .into_control()?;
+    // Note: the parameters have already been written by the caller's frame, so the `InOutParams`
+    //       can be derived right away.
+    let inout = state.stack.host_inout(frame);
     if let Err(error) = invoke_host(state.store, trampoline, instance, inout, call_hooks) {
         done!(state, DoneReason::host_error(error, func, params.span()))
     }
@@ -942,10 +946,13 @@ pub fn return_call_host(
 ) -> Control<(Ip, Sp, Inst), Break> {
     debug_assert_eq!(params.len(), host_func.len_param_cells());
     let trampoline = *host_func.trampoline();
-    let (control, inout) = state
+    let (control, frame) = state
         .stack
         .return_prepare_host_frame(params, host_func.len_result_cells(), instance)
         .into_control()?;
+    // Note: the parameters have already been moved into place by `return_prepare_host_frame`,
+    //       so the `InOutParams` can be derived right away.
+    let inout = state.stack.host_inout(frame);
     if let Err(error) = invoke_host(
         state.store,
         trampoline,

--- a/crates/wasmi/src/engine/executor/inout.rs
+++ b/crates/wasmi/src/engine/executor/inout.rs
@@ -157,6 +157,7 @@ impl InOutParams {
 /// Since [`InOutParams::encode_results`] consumes its [`InOutParams`], the only way to obtain an
 /// `InOutResults<'cells>` is to have encoded results into the cells that were handed in. The
 /// trampoline signature uses this to require that a host function actually wrote its results.
+#[derive(Debug)]
 pub struct InOutResults {
     _seal: private::Seal,
 }
@@ -165,5 +166,6 @@ mod private {
     /// Seals [`InOutResults`] by making it unconstructible from its parent scopes.
     ///
     /// [`InOutResults`]: super::InOutResults
+    #[derive(Debug)]
     pub struct Seal;
 }

--- a/crates/wasmi/src/engine/executor/inout.rs
+++ b/crates/wasmi/src/engine/executor/inout.rs
@@ -4,13 +4,16 @@ use crate::{
 };
 use core::{cmp::max, ptr::NonNull, slice};
 
-/// Wrapper around a slice of [`Cell`]s to manage reading parameters and writing results of a function call.
+/// Raw parts of a sequence of [`Cell`]s to manage reading parameters and writing results of a function call.
 ///
 /// # Note
 ///
 /// The [`Cell`]s are referred to by raw parts instead of by a `&mut [Cell]` because they live in the
 /// value stack owned by the [`Store`], while the host function invoked with them requires exclusive
 /// access to that very same [`Store`]. Holding a borrow here would make the two mutually exclusive.
+///
+/// For the same reason `self` is neither [`Send`] nor [`Sync`], in contrast to the `&mut [Cell]`
+/// that it replaces.
 ///
 /// # Invariant
 ///
@@ -26,18 +29,24 @@ pub struct InOutParams {
     ///
     /// # Note
     ///
-    /// Must be less than or equal to `len_cells`.
+    /// Must be less than or equal to the number of [`Cell`]s behind `cells`.
     len_params: usize,
     /// The number of cells used for results.
     ///
     /// # Note
     ///
-    /// Must be less than or equal to `len_cells`.
+    /// Must be less than or equal to the number of [`Cell`]s behind `cells`.
     len_results: usize,
 }
 
 impl InOutParams {
     /// Creates empty [`InOutParams`] that span no cells.
+    ///
+    /// # Note
+    ///
+    /// Used for host function frames that require no cells at all. Both lengths are `0`, thus the
+    /// accessors only ever form empty slices from the aligned and non-null dangling pointer, which
+    /// is sound and keeps the [`InOutParams::new`] invariant vacuously true.
     pub fn empty() -> Self {
         Self {
             cells: <NonNull<[Cell]>>::from(&mut [][..]).cast::<Cell>(),
@@ -52,7 +61,8 @@ impl InOutParams {
     ///
     /// The [`Cell`]s behind `cells` must stay allocated, unmoved and unaliased for as long as the
     /// returned [`InOutParams`] is used. Nothing bounds that value's lifetime, so upholding it is
-    /// the caller's job.
+    /// the caller's job. In particular no write may happen through a pointer to those [`Cell`]s
+    /// that was derived before this call, since that invalidates the pointer returned here.
     ///
     /// # Errors
     ///
@@ -80,8 +90,8 @@ impl InOutParams {
     ///
     /// # Safety
     ///
-    /// The returned lifetime is unbounded: the caller must not let it outlive the invariant
-    /// asserted by [`InOutParams::new`].
+    /// The invariant asserted by [`InOutParams::new`] must still hold: the [`Cell`]s must be live
+    /// and no write may have happened through a pointer that was derived before `self`.
     #[inline]
     unsafe fn params(&self) -> &[Cell] {
         // SAFETY: `self.len_params` is at most the number of cells behind `self.cells` by
@@ -91,11 +101,15 @@ impl InOutParams {
 
     /// Returns the result [`Cell`]s.
     ///
+    /// # Note
+    ///
+    /// The result [`Cell`]s overlap those returned by [`InOutParams::params`]. Both slices can
+    /// never be alive at the same time since this requires exclusive access to `self`.
+    ///
     /// # Safety
     ///
-    /// The returned lifetime is unbounded: the caller must not let it outlive the invariant
-    /// asserted by [`InOutParams::new`], nor overlap it with a slice returned by
-    /// [`InOutParams::params`].
+    /// The invariant asserted by [`InOutParams::new`] must still hold: the [`Cell`]s must be live
+    /// and no write may have happened through a pointer that was derived before `self`.
     #[inline]
     unsafe fn results_mut(&mut self) -> &mut [Cell] {
         // SAFETY: `self.len_results` is at most the number of cells behind `self.cells` by
@@ -155,8 +169,8 @@ impl InOutParams {
 /// # Note
 ///
 /// Since [`InOutParams::encode_results`] consumes its [`InOutParams`], the only way to obtain an
-/// `InOutResults<'cells>` is to have encoded results into the cells that were handed in. The
-/// trampoline signature uses this to require that a host function actually wrote its results.
+/// [`InOutResults`] is to have encoded results into the cells that were handed in. The trampoline
+/// signature uses this to require that a host function actually wrote its results.
 #[derive(Debug)]
 pub struct InOutResults {
     _seal: private::Seal,

--- a/crates/wasmi/src/engine/executor/inout.rs
+++ b/crates/wasmi/src/engine/executor/inout.rs
@@ -2,35 +2,63 @@ use crate::{
     engine::executor::{Cell, CellError, LiftFromCells, LiftFromCellsByValue, LowerToCells},
     store::AsStoreId,
 };
-use core::cmp::max;
+use core::{cmp::max, ptr::NonNull, slice};
 
 /// Wrapper around a slice of [`Cell`]s to manage reading parameters and writing results of a function call.
+///
+/// # Note
+///
+/// The [`Cell`]s are referred to by raw parts instead of by a `&mut [Cell]` because they live in the
+/// value stack owned by the [`Store`], while the host function invoked with them requires exclusive
+/// access to that very same [`Store`]. Holding a borrow here would make the two mutually exclusive.
+///
+/// # Invariant
+///
+/// The [`Cell`]s behind `cells` stay allocated, unmoved and unaliased for as long as `self` is
+/// used. Asserted by [`InOutParams::new`], relied upon by every other method.
+///
+/// [`Store`]: crate::Store
 #[derive(Debug)]
-pub struct InOutParams<'cells> {
-    /// The underlying slice of cells used for both parameters and results.
-    cells: &'cells mut [Cell],
+pub struct InOutParams {
+    /// The underlying [`Cell`]s used for both parameters and results.
+    cells: NonNull<Cell>,
     /// The number of cells used for parameters.
     ///
     /// # Note
     ///
-    /// Must be less than or equal to the length of `cells`.
+    /// Must be less than or equal to `len_cells`.
     len_params: usize,
     /// The number of cells used for results.
     ///
     /// # Note
     ///
-    /// Must be less than or equal to the length of `cells`.
+    /// Must be less than or equal to `len_cells`.
     len_results: usize,
 }
 
-impl<'cells> InOutParams<'cells> {
+impl InOutParams {
+    /// Creates empty [`InOutParams`] that span no cells.
+    pub fn empty() -> Self {
+        Self {
+            cells: <NonNull<[Cell]>>::from(&mut [][..]).cast::<Cell>(),
+            len_params: 0,
+            len_results: 0,
+        }
+    }
+
     /// Creates a new [`InOutParams`] from the given parts.
+    ///
+    /// # Safety
+    ///
+    /// The [`Cell`]s behind `cells` must stay allocated, unmoved and unaliased for as long as the
+    /// returned [`InOutParams`] is used. Nothing bounds that value's lifetime, so upholding it is
+    /// the caller's job.
     ///
     /// # Errors
     ///
     /// If max(len_params, len_results) is not equal to `cells.len()`.
-    pub fn new(
-        cells: &'cells mut [Cell],
+    pub unsafe fn new(
+        cells: &mut [Cell],
         len_params: usize,
         len_results: usize,
     ) -> Result<Self, CellError> {
@@ -42,15 +70,37 @@ impl<'cells> InOutParams<'cells> {
             return Err(CellError::NotEnoughCells);
         }
         Ok(Self {
-            cells,
+            cells: NonNull::from(cells).cast::<Cell>(),
             len_params,
             len_results,
         })
     }
 
-    /// Returns the slice of [`Cell`] parameters.
-    pub fn params(&self) -> &[Cell] {
-        &self.cells[..self.len_params]
+    /// Returns the parameter [`Cell`]s.
+    ///
+    /// # Safety
+    ///
+    /// The returned lifetime is unbounded: the caller must not let it outlive the invariant
+    /// asserted by [`InOutParams::new`].
+    #[inline]
+    unsafe fn params(&self) -> &[Cell] {
+        // SAFETY: `self.len_params` is at most the number of cells behind `self.cells` by
+        //         construction, and those cells are live per the `InOutParams::new` invariant.
+        unsafe { slice::from_raw_parts(self.cells.as_ptr(), self.len_params) }
+    }
+
+    /// Returns the result [`Cell`]s.
+    ///
+    /// # Safety
+    ///
+    /// The returned lifetime is unbounded: the caller must not let it outlive the invariant
+    /// asserted by [`InOutParams::new`], nor overlap it with a slice returned by
+    /// [`InOutParams::params`].
+    #[inline]
+    unsafe fn results_mut(&mut self) -> &mut [Cell] {
+        // SAFETY: `self.len_results` is at most the number of cells behind `self.cells` by
+        //         construction, and those cells are live per the `InOutParams::new` invariant.
+        unsafe { slice::from_raw_parts_mut(self.cells.as_ptr(), self.len_results) }
     }
 
     /// Decodes the parameter slice of [`Cell`]s into `T` if possible.
@@ -60,7 +110,10 @@ impl<'cells> InOutParams<'cells> {
     where
         T: LiftFromCells<Value = ()>,
     {
-        out.lift_from_cells(store, &mut self.params())
+        // SAFETY: the slice does not escape this call, so it stays within the invariant
+        //         asserted by `InOutParams::new`.
+        let mut param_cells = unsafe { self.params() };
+        out.lift_from_cells(store, &mut param_cells)
     }
 
     /// Decodes the parameter slice of [`Cell`]s into `T` if possible.
@@ -70,36 +123,47 @@ impl<'cells> InOutParams<'cells> {
     where
         T: LiftFromCellsByValue,
     {
-        <T as LiftFromCellsByValue>::lift_from_cells_by_value(store, &mut self.params())
+        // SAFETY: the slice does not escape this call, so it stays within the invariant
+        //         asserted by `InOutParams::new`.
+        let mut param_cells = unsafe { self.params() };
+        <T as LiftFromCellsByValue>::lift_from_cells_by_value(store, &mut param_cells)
     }
 
     /// Encodes the `results` of type `T` into the result [`Cell`]s if possible.
     ///
     /// Returns a [`CellError`], otherwise.
     pub fn encode_results<T>(
-        self,
+        mut self,
         store: impl AsStoreId,
         results: T,
-    ) -> Result<InOutResults<'cells>, CellError>
+    ) -> Result<InOutResults, CellError>
     where
         T: LowerToCells,
     {
-        let mut cells = &mut self.cells[..self.len_results];
-        results.lower_to_cells(store, &mut cells)?;
-        Ok(InOutResults { cells })
+        // SAFETY: the slice does not escape this call, so it stays within the invariant asserted
+        //         by `InOutParams::new`. `self` is consumed here, so no parameter slice is alive.
+        let mut result_cells = unsafe { self.results_mut() };
+        results.lower_to_cells(store, &mut result_cells)?;
+        Ok(InOutResults {
+            _seal: private::Seal,
+        })
     }
 }
 
-/// The result [`Cell`]s of a (host) function invocation.
-#[derive(Debug)]
-pub struct InOutResults<'cells> {
-    /// The underlying [`Cell`]s representing the encoded results.
-    cells: &'cells mut [Cell],
+/// Proof that the results of a (host) function invocation have been encoded into its cells.
+///
+/// # Note
+///
+/// Since [`InOutParams::encode_results`] consumes its [`InOutParams`], the only way to obtain an
+/// `InOutResults<'cells>` is to have encoded results into the cells that were handed in. The
+/// trampoline signature uses this to require that a host function actually wrote its results.
+pub struct InOutResults {
+    _seal: private::Seal,
 }
 
-impl<'cells> InOutResults<'cells> {
-    /// Returns the slice of [`Cell`] results.
-    pub fn results(&self) -> &[Cell] {
-        self.cells
-    }
+mod private {
+    /// Seals [`InOutResults`] by making it unconstructible from its parent scopes.
+    ///
+    /// [`InOutResults`]: super::InOutResults
+    pub struct Seal;
 }

--- a/crates/wasmi/src/func/into_func.rs
+++ b/crates/wasmi/src/func/into_func.rs
@@ -78,6 +78,11 @@ macro_rules! impl_into_func {
                     <Self::Params as WasmTyList>::types(),
                     <Self::Results as WasmTyList>::types(),
                 );
+                // Note: `inout` aliases cells of the value stack that is currently executing and
+                //       stays alive across the host function call below. This is sound because a
+                //       re-entrant call from the `Caller` runs on another `Stack` taken from the
+                //       `Engine`'s stack pool, thus the host function cannot grow, reallocate or
+                //       otherwise write to the cells behind `inout`.
                 let trampoline = TrampolineEntity::new(
                     move |caller: Caller<T>, inout: InOutParams| -> Result<InOutResults, Error> {
                         let store_id = caller.as_context().store.inner.id();

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -285,10 +285,8 @@ impl<T> HostFuncTrampolineEntity<T> {
     }
 }
 
-type TrampolineFn<T> = dyn for<'a> Fn(Caller<T>, InOutParams<'a>) -> Result<InOutResults<'a>, Error>
-    + Send
-    + Sync
-    + 'static;
+type TrampolineFn<T> =
+    dyn Fn(Caller<T>, InOutParams) -> Result<InOutResults, Error> + Send + Sync + 'static;
 
 pub struct TrampolineEntity<T> {
     closure: Arc<TrampolineFn<T>>,
@@ -304,10 +302,7 @@ impl<T> TrampolineEntity<T> {
     /// Creates a new [`TrampolineEntity`] from the given host function.
     pub fn new<F>(trampoline: F) -> Self
     where
-        F: for<'a> Fn(Caller<T>, InOutParams<'a>) -> Result<InOutResults<'a>, Error>
-            + Send
-            + Sync
-            + 'static,
+        F: Fn(Caller<T>, InOutParams) -> Result<InOutResults, Error> + Send + Sync + 'static,
     {
         Self {
             closure: Arc::new(trampoline),
@@ -317,12 +312,12 @@ impl<T> TrampolineEntity<T> {
     /// Calls the host function trampoline with the given inputs.
     ///
     /// The result is written back into the `outputs` buffer.
-    pub fn call<'a>(
+    pub fn call(
         &self,
         mut ctx: impl AsContextMut<Data = T>,
         instance: Option<Inst>,
-        params: InOutParams<'a>,
-    ) -> Result<InOutResults<'a>, Error> {
+        params: InOutParams,
+    ) -> Result<InOutResults, Error> {
         let caller = <Caller<T>>::new(&mut ctx, instance);
         (self.closure)(caller, params)
     }

--- a/crates/wasmi/src/func/mod.rs
+++ b/crates/wasmi/src/func/mod.rs
@@ -246,6 +246,11 @@ impl<T> HostFuncTrampolineEntity<T> {
         let results_iter = ty.results().iter().copied().map(Val::default_for_ty);
         let len_params = ty.params().len();
         let params_results: Box<[Val]> = params_iter.chain(results_iter).collect();
+        // Note: `inout` aliases cells of the value stack that is currently executing and stays
+        //       alive across the host function call below. This is sound because a re-entrant call
+        //       from the `Caller` runs on another `Stack` taken from the `Engine`'s stack pool,
+        //       thus the host function cannot grow, reallocate or otherwise write to the cells
+        //       behind `inout`.
         let trampoline = <TrampolineEntity<T>>::new(move |caller, inout| {
             // We are required to clone the buffer because we are operating within a `Fn`.
             // This way the trampoline closure only has to own a single slice buffer.


### PR DESCRIPTION
This fixes a potential UB when calling host functions and removes a lifetime from `InOut{Params,Results}` which is a requirement for planned follow-up PRs.