### PR TITLE
Fold `VmState` into `PrunedStore`

### DIFF
--- a/crates/wasmi/src/engine/executor/handler/args.rs
+++ b/crates/wasmi/src/engine/executor/handler/args.rs
@@ -12,23 +12,12 @@ use crate::{
         code_map::FuncEntry,
         executor::handler::{
             dispatch::{Break, Control},
-            state::{
-                self,
-                DoneReason,
-                Freg32,
-                Freg64,
-                Inst,
-                Ip,
-                Ireg,
-                Mem0Len,
-                Mem0Ptr,
-                Sp,
-                VmState,
-            },
+            state::{self, DoneReason, Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp},
             utils::{self, GetValue, IntoControl as _, LoadEntity, SetValue, get_value, set_value},
         },
     },
     ir::{self, BoundedSlotSpan, BranchOffset},
+    store::PrunedStore,
 };
 use core::ptr::NonNull;
 
@@ -152,7 +141,7 @@ impl Args {
 
     /// Returns the bytes of the default memory at index 0.
     #[inline]
-    pub fn fetch_default_memory_bytes<'a>(&mut self, _state: &'a mut VmState) -> &'a mut [u8] {
+    pub fn fetch_default_memory_bytes<'a>(&mut self, _store: &'a mut PrunedStore) -> &'a mut [u8] {
         state::mem0_bytes::<'a>(self.mem0_ptr, self.mem0_len)
     }
 
@@ -160,7 +149,7 @@ impl Args {
     #[inline]
     pub fn fetch_memory<'a, Addr>(
         &mut self,
-        state: &'a mut VmState,
+        store: &'a mut PrunedStore,
         addr: Addr,
     ) -> &'a mut MemoryEntity
     where
@@ -169,14 +158,14 @@ impl Args {
         // SAFETY: `addr` stems from a Wasmi IR operator and thus addresses a memory entry of
         //         `self.instance` whose cache was warmed at instantiation. The `state` borrow
         //         scopes the returned reference.
-        unsafe { self.instance.load_entity_mut(state.store, addr) }
+        unsafe { self.instance.load_entity_mut(store, addr) }
     }
 
     /// Returns an exclusive reference to the global at `index`.
     #[inline]
     pub fn fetch_global<'a, Addr>(
         &mut self,
-        state: &'a mut VmState,
+        store: &'a mut PrunedStore,
         addr: Addr,
     ) -> &'a mut GlobalEntity
     where
@@ -185,14 +174,14 @@ impl Args {
         // SAFETY: `addr` stems from a Wasmi IR operator and thus addresses a global entry of
         //         `self.instance` whose cache was warmed at instantiation. The `state` borrow
         //         scopes the returned reference.
-        unsafe { self.instance.load_entity_mut(state.store, addr) }
+        unsafe { self.instance.load_entity_mut(store, addr) }
     }
 
     /// Returns an exclusive reference to the table at `index`.
     #[inline]
     pub fn fetch_table<'a, Addr>(
         &mut self,
-        state: &'a mut VmState,
+        store: &'a mut PrunedStore,
         addr: Addr,
     ) -> &'a mut TableEntity
     where
@@ -201,14 +190,14 @@ impl Args {
         // SAFETY: `addr` stems from a Wasmi IR operator and thus addresses a table entry of
         //         `self.instance` whose cache was warmed at instantiation. The `state` borrow
         //         scopes the returned reference.
-        unsafe { self.instance.load_entity_mut(state.store, addr) }
+        unsafe { self.instance.load_entity_mut(store, addr) }
     }
 
     /// Returns an exclusive reference to the element segment at `index`.
     #[inline]
     pub fn fetch_elem<'a, Addr>(
         &mut self,
-        state: &'a mut VmState,
+        store: &'a mut PrunedStore,
         addr: Addr,
     ) -> &'a mut ElementSegmentEntity
     where
@@ -217,14 +206,14 @@ impl Args {
         // SAFETY: `addr` stems from a Wasmi IR operator and thus addresses an element segment
         //         entry of `self.instance` whose cache was warmed at instantiation. The `state`
         //         borrow scopes the returned reference.
-        unsafe { self.instance.load_entity_mut(state.store, addr) }
+        unsafe { self.instance.load_entity_mut(store, addr) }
     }
 
     /// Returns an exclusive reference to the data segment at `index`.
     #[inline]
     pub fn fetch_data<'a, Addr>(
         &mut self,
-        state: &'a mut VmState,
+        store: &'a mut PrunedStore,
         addr: Addr,
     ) -> &'a mut DataSegmentEntity
     where
@@ -233,26 +222,26 @@ impl Args {
         // SAFETY: `addr` stems from a Wasmi IR operator and thus addresses a data segment entry
         //         of `self.instance` whose cache was warmed at instantiation. The `state` borrow
         //         scopes the returned reference.
-        unsafe { self.instance.load_entity_mut(state.store, addr) }
+        unsafe { self.instance.load_entity_mut(store, addr) }
     }
 
     /// Reloads the data pointer and length of the default memory at index 0 from `state`.
     #[inline]
-    pub fn reload_mem0(&mut self, state: &mut VmState) {
-        (self.mem0_ptr, self.mem0_len) = utils::extract_mem0(state.store, self.instance);
+    pub fn reload_mem0(&mut self, store: &mut PrunedStore) {
+        (self.mem0_ptr, self.mem0_len) = utils::extract_mem0(store, self.instance);
     }
 
     /// Calls `func` with `params` on `instance` with `state` using `self`.
     #[inline(always)]
     pub fn call_func_entry(
         &mut self,
-        state: &mut VmState,
+        store: &mut PrunedStore,
         func: &FuncEntry,
         params: BoundedSlotSpan,
         instance: Option<Inst>,
     ) -> Control<(), Break> {
         (self.ip, self.sp) =
-            utils::call_func_entry(state, self.ip, self.sp, params, func, instance)?;
+            utils::call_func_entry(store, self.ip, self.sp, params, func, instance)?;
         Control::Continue(())
     }
 
@@ -260,12 +249,12 @@ impl Args {
     #[inline(always)]
     pub fn return_call_func_entry(
         &mut self,
-        state: &mut VmState,
+        store: &mut PrunedStore,
         func: &FuncEntry,
         params: BoundedSlotSpan,
         instance: Option<Inst>,
     ) -> Control<(), Break> {
-        (self.ip, self.sp) = utils::return_call_func_entry(state, self.sp, params, func, instance)?;
+        (self.ip, self.sp) = utils::return_call_func_entry(store, self.sp, params, func, instance)?;
         Control::Continue(())
     }
 
@@ -273,7 +262,7 @@ impl Args {
     #[inline]
     pub fn resolve_indirect_func<Idx, Table>(
         &mut self,
-        state: &mut VmState<'_>,
+        store: &mut PrunedStore,
         index: Idx,
         table: Table,
         func_type: ir::FuncType,
@@ -282,14 +271,14 @@ impl Args {
         Idx: GetValue<u64>,
         Inst: LoadEntity<Table, Entity = TableEntity>,
     {
-        utils::resolve_indirect_func(index, table, func_type, state, self).into_control()
+        utils::resolve_indirect_func(index, table, func_type, store, self).into_control()
     }
 
     /// Calls `func` with `params` with `state` using `self`.
     #[inline]
     pub fn call_wasm_or_host_func(
         &mut self,
-        state: &mut VmState,
+        store: &mut PrunedStore,
         func: Func,
         func_entity: NonNull<FuncEntity>,
         params: BoundedSlotSpan,
@@ -301,7 +290,7 @@ impl Args {
             self.mem0_len,
             self.instance,
         ) = utils::call_wasm_or_host(
-            state,
+            store,
             self.ip,
             self.sp,
             func,
@@ -318,7 +307,7 @@ impl Args {
     #[inline]
     pub fn return_call_wasm_or_host_func(
         &mut self,
-        state: &mut VmState,
+        store: &mut PrunedStore,
         func: Func,
         func_entity: NonNull<FuncEntity>,
         params: BoundedSlotSpan,
@@ -330,7 +319,7 @@ impl Args {
             self.mem0_len,
             self.instance,
         ) = utils::return_call_wasm_or_host(
-            state,
+            store,
             self.sp,
             func,
             func_entity,
@@ -344,14 +333,14 @@ impl Args {
 
     /// Pops the top-most frame from the call stack.
     #[inline]
-    pub fn pop_frame(&mut self, state: &mut VmState) -> Control<(), Break> {
+    pub fn pop_frame(&mut self, store: &mut PrunedStore) -> Control<(), Break> {
         let Some((ip, sp, mem0_ptr, mem0_len, instance)) =
-            state
-                .stack
-                .pop_frame(state.store, self.mem0_ptr, self.mem0_len, self.instance)
+            store
+                .stack_mut()
+                .pop_frame(store, self.mem0_ptr, self.mem0_len, self.instance)
         else {
             // No more frames on the call stack -> break out of execution!
-            done!(state, DoneReason::Return(self.sp))
+            done!(store, DoneReason::Return(self.sp))
         };
         self.ip = ip;
         self.sp = sp;

--- a/crates/wasmi/src/engine/executor/handler/args.rs
+++ b/crates/wasmi/src/engine/executor/handler/args.rs
@@ -227,8 +227,8 @@ impl Args {
 
     /// Reloads the data pointer and length of the default memory at index 0 from `state`.
     #[inline]
-    pub fn reload_mem0(&mut self, store: &mut PrunedStore) {
-        (self.mem0_ptr, self.mem0_len) = utils::extract_mem0(store, self.instance);
+    pub fn reload_mem0(&mut self) {
+        (self.mem0_ptr, self.mem0_len) = utils::extract_mem0(self.instance);
     }
 
     /// Calls `func` with `params` on `instance` with `state` using `self`.
@@ -337,7 +337,7 @@ impl Args {
         let Some((ip, sp, mem0_ptr, mem0_len, instance)) =
             store
                 .stack_mut()
-                .pop_frame(store, self.mem0_ptr, self.mem0_len, self.instance)
+                .pop_frame(self.mem0_ptr, self.mem0_len, self.instance)
         else {
             // No more frames on the call stack -> break out of execution!
             done!(store, DoneReason::Return(self.sp))

--- a/crates/wasmi/src/engine/executor/handler/dispatch/backend/loop.rs
+++ b/crates/wasmi/src/engine/executor/handler/dispatch/backend/loop.rs
@@ -151,7 +151,7 @@ impl Executor {
                         match op_code {
                             $(
                                 OpCode::$camel_case => {
-                                    self.$snake_case(state)?;
+                                    self.$snake_case(store)?;
                                     op_code = super::decode_op_code(self.ip);
                                     break 'next op_code
                                 },

--- a/crates/wasmi/src/engine/executor/handler/dispatch/backend/loop.rs
+++ b/crates/wasmi/src/engine/executor/handler/dispatch/backend/loop.rs
@@ -2,10 +2,11 @@ use crate::{
     engine::executor::handler::{
         dispatch::{Break, Control, ExecutionOutcome},
         exec,
-        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, VmState},
+        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp},
     },
     ir,
     ir::OpCode,
+    store::PrunedStore,
 };
 
 #[derive(Debug, Copy, Clone)]
@@ -47,8 +48,8 @@ pub fn control_continue(
 }
 
 macro_rules! dispatch {
-    ( $state:expr, $args:expr $(,)? ) => {{
-        let _: &mut VmState = $state;
+    ( $store:expr, $args:expr $(,)? ) => {{
+        let _: &mut $crate::store::PrunedStore = $store;
         let (ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64) = $args.into_parts();
         return $crate::engine::executor::handler::dispatch::backend::control_continue(
             ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64,
@@ -56,7 +57,7 @@ macro_rules! dispatch {
     }};
 }
 
-pub type Handler = fn(&mut Executor, state: &mut VmState) -> Control<(), Break>;
+pub type Handler = fn(&mut Executor, store: &mut PrunedStore) -> Control<(), Break>;
 
 macro_rules! expand_op_code_to_handler {
     ( $( $snake_case:ident => $camel_case:ident ),* $(,)? ) => {
@@ -78,7 +79,7 @@ ir::for_each_op!(expand_op_code_to_handler);
 
 #[expect(clippy::too_many_arguments)]
 pub fn execute_until_done(
-    state: &mut VmState,
+    store: &mut PrunedStore,
     ip: Ip,
     sp: Sp,
     mem0: Mem0Ptr,
@@ -98,7 +99,7 @@ pub fn execute_until_done(
         freg32,
         freg64,
     };
-    executor.execute_until_done(state)
+    executor.execute_until_done(store)
 }
 
 #[derive(Debug)]
@@ -115,17 +116,17 @@ pub struct Executor {
 
 impl Executor {
     #[inline(always)]
-    fn execute_until_done(&mut self, state: &mut VmState) -> Result<Sp, ExecutionOutcome> {
-        let Control::Break(reason) = self.execute_until_break(state);
-        Self::handle_break(state, reason)
+    fn execute_until_done(&mut self, store: &mut PrunedStore) -> Result<Sp, ExecutionOutcome> {
+        let Control::Break(reason) = self.execute_until_break(store);
+        Self::handle_break(store, reason)
     }
 
     #[inline(never)]
-    fn handle_break(state: &mut VmState, reason: Break) -> Result<Sp, ExecutionOutcome> {
+    fn handle_break(store: &mut PrunedStore, reason: Break) -> Result<Sp, ExecutionOutcome> {
         if let Some(trap_code) = reason.trap_code() {
             return Err(ExecutionOutcome::from(trap_code));
         }
-        state.execution_outcome()
+        store.inner_mut().exec_mut().execution_outcome()
     }
 
     #[cold]
@@ -141,7 +142,7 @@ pub enum Never {}
 #[cfg(feature = "indirect-dispatch")]
 impl Executor {
     #[inline(always)]
-    fn execute_until_break(&mut self, state: &mut VmState) -> Control<Never, Break> {
+    fn execute_until_break(&mut self, store: &mut PrunedStore) -> Control<Never, Break> {
         macro_rules! impl_body {
             ( $( $snake_case:ident => $camel_case:ident ),* $(,)? ) => {
                 let mut op_code = super::decode_op_code(self.ip);
@@ -166,16 +167,16 @@ impl Executor {
 
 #[cfg(not(feature = "indirect-dispatch"))]
 impl Executor {
-    fn execute_until_break(&mut self, state: &mut VmState) -> Control<Never, Break> {
+    fn execute_until_break(&mut self, store: &mut PrunedStore) -> Control<Never, Break> {
         loop {
-            self.dispatch_handler(state)?
+            self.dispatch_handler(store)?
         }
     }
 
     #[inline(always)]
-    fn dispatch_handler(&mut self, state: &mut VmState) -> Control<(), Break> {
+    fn dispatch_handler(&mut self, store: &mut PrunedStore) -> Control<(), Break> {
         let handler = super::decode_handler(self.ip);
-        handler(self, state)
+        handler(self, store)
     }
 }
 
@@ -189,8 +190,8 @@ macro_rules! impl_executor_handlers {
             #[cfg_attr(all(feature = "indirect-dispatch", not(debug_assertions)), inline(always))]
             #[cfg_attr(all(feature = "indirect-dispatch", debug_assertions), inline(never))]
             #[cfg_attr(not(feature = "indirect-dispatch"), inline(never))]
-            fn $snake_case(&mut self, state: &mut VmState) -> Control<(), Break> {
-                match exec::$snake_case(state, self.ip, self.sp, self.mem0, self.mem0_len, self.instance, self.ireg, self.freg32, self.freg64) {
+            fn $snake_case(&mut self, store: &mut PrunedStore) -> Control<(), Break> {
+                match exec::$snake_case(store, self.ip, self.sp, self.mem0, self.mem0_len, self.instance, self.ireg, self.freg32, self.freg64) {
                     Done::Continue(NextState { ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64 }) => {
                         self.ip = ip;
                         self.sp = sp;

--- a/crates/wasmi/src/engine/executor/handler/dispatch/backend/tail.rs
+++ b/crates/wasmi/src/engine/executor/handler/dispatch/backend/tail.rs
@@ -2,10 +2,11 @@ use crate::{
     engine::executor::handler::{
         dispatch::{Break, Control, ExecutionOutcome, decode_handler, decode_op_code},
         exec,
-        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, VmState},
+        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp},
     },
     ir,
     ir::OpCode,
+    store::PrunedStore,
 };
 
 #[inline(always)]
@@ -24,7 +25,7 @@ pub type Done = Control<Never, Break>;
 
 #[cfg(not(target_arch = "x86_64"))]
 pub type Handler = fn(
-    &mut VmState,
+    &mut PrunedStore,
     ip: Ip,
     sp: Sp,
     mem0: Mem0Ptr,
@@ -38,7 +39,7 @@ pub type Handler = fn(
 #[cfg(target_arch = "x86_64")]
 #[allow(improper_ctypes_definitions)] // not used in FFI
 pub type Handler = extern "sysv64" fn(
-    &mut VmState,
+    &mut PrunedStore,
     ip: Ip,
     sp: Sp,
     mem0: Mem0Ptr,
@@ -69,22 +70,22 @@ ir::for_each_op!(expand_op_code_to_handler);
 
 #[cfg(not(all(feature = "unstable", not(feature = "stable"))))]
 macro_rules! dispatch {
-    ( $state:expr, $args:expr $(,)? ) => {{
+    ( $store:expr, $args:expr $(,)? ) => {{
         let (ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64) = $args.into_parts();
         let handler = $crate::engine::executor::handler::dispatch::backend::fetch_handler(ip);
         return handler(
-            $state, ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64,
+            $store, ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64,
         );
     }};
 }
 
 #[cfg(all(feature = "unstable", not(feature = "stable")))]
 macro_rules! dispatch {
-    ( $state:expr, $args:expr $(,)? ) => {{
+    ( $store:expr, $args:expr $(,)? ) => {{
         let (ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64) = $args.into_parts();
         let handler = $crate::engine::executor::handler::dispatch::backend::fetch_handler(ip);
         become handler(
-            $state, ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64,
+            $store, ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64,
         );
     }};
 }
@@ -103,10 +104,10 @@ pub fn execute_until_done(
 ) -> Result<Sp, ExecutionOutcome> {
     let handler = fetch_handler(ip);
     let Control::Break(reason) = handler(
-        state, ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64,
+        store, ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64,
     );
     if let Some(trap_code) = reason.trap_code() {
         return Err(ExecutionOutcome::from(trap_code));
     }
-    state.execution_outcome()
+    store.inner_mut().exec_mut().execution_outcome()
 }

--- a/crates/wasmi/src/engine/executor/handler/dispatch/backend/tail.rs
+++ b/crates/wasmi/src/engine/executor/handler/dispatch/backend/tail.rs
@@ -91,7 +91,7 @@ macro_rules! dispatch {
 
 #[expect(clippy::too_many_arguments)]
 pub fn execute_until_done(
-    state: &mut VmState,
+    store: &mut PrunedStore,
     ip: Ip,
     sp: Sp,
     mem0: Mem0Ptr,

--- a/crates/wasmi/src/engine/executor/handler/exec.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec.rs
@@ -10,7 +10,7 @@ pub use self::simd::*;
 use super::{
     Args,
     dispatch::Done,
-    state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, VmState},
+    state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp},
 };
 #[cfg(feature = "simd")]
 use crate::V128;
@@ -30,7 +30,7 @@ use crate::{
     },
     errors::{FuelError, MemoryError, TableError},
     ir::{self, BoundedSlotSpan},
-    store::StoreError,
+    store::{PrunedStore, StoreError},
 };
 use core::cmp;
 
@@ -40,7 +40,7 @@ fn identity<T>(value: T) -> T {
 
 execution_handler! {
     fn trap(
-        _state: &mut VmState,
+        _store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -58,7 +58,7 @@ execution_handler! {
 
 execution_handler! {
     fn consume_fuel(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -70,22 +70,21 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::ConsumeFuel { fuel } = unsafe { args.decode_op() };
-        let consumption_result = state
-            .store
+        let consumption_result = store
             .inner_mut()
             .fuel_mut()
             .consume_fuel_unchecked(u64::from(fuel));
         if let Err(FuelError::OutOfFuel { required_fuel }) = consumption_result {
             args.set_ip(ip);
-            out_of_fuel!(state, args, required_fuel)
+            out_of_fuel!(store, args, required_fuel)
         }
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn branch(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -99,7 +98,7 @@ execution_handler! {
         let crate::ir::decode::Branch { offset } = unsafe { args.decode_op() };
         args.set_ip(ip);
         args.offset_ip(offset);
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
@@ -114,7 +113,7 @@ macro_rules! global_get_execution_handler {
             $( #[$attr] )*
             execution_handler! {
                 fn $snake_name(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -126,10 +125,10 @@ macro_rules! global_get_execution_handler {
                 ) -> Done = {
                     let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
                     let crate::ir::decode::$camel_name { global, result } = unsafe { args.decode_op() };
-                    let global = args.fetch_global(state, global);
+                    let global = args.fetch_global(store, global);
                     let value: $ty = global.get_raw().read_as();
                     args.set(result, value);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -155,7 +154,7 @@ macro_rules! global_set_execution_handler {
             $( #[$attr] )*
             execution_handler! {
                 fn $snake_name(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -167,12 +166,12 @@ macro_rules! global_set_execution_handler {
                 ) -> Done = {
                     let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
                     let crate::ir::decode::$camel_name { global, value } = unsafe { args.decode_op() };
-                    let global = args.fetch_global(state, global);
+                    let global = args.fetch_global(store, global);
                     let value: $ty = args.get(value);
                     let mut value_ptr = global.get_raw_ptr();
                     let global_ref = unsafe { value_ptr.as_mut() };
                     global_ref.write_as(value);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -192,7 +191,7 @@ global_set_execution_handler! {
 
 execution_handler! {
     fn r#return(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -203,14 +202,14 @@ execution_handler! {
         freg64: Freg64,
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
-        args.pop_frame(state)?;
-        dispatch!(state, args)
+        args.pop_frame(store)?;
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn call_internal(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -225,14 +224,14 @@ execution_handler! {
         // SAFETY: `func` is the exposed address of a `FuncEntry` in the engine's append-only
         //         `CodeMap`, baked into the bytecode; it stays valid while this bytecode runs.
         let func = unsafe { FuncEntryPtr::from(usize::from(func)).get() };
-        args.call_func_entry(state, func, params, None)?;
-        dispatch!(state, args)
+        args.call_func_entry(store, func, params, None)?;
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn call_imported(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -245,8 +244,8 @@ execution_handler! {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::CallImported { params, func } = unsafe { args.decode_op() };
         let (func, func_entity) = utils::load_func_entry(args.instance, func);
-        args.call_wasm_or_host_func(state, func, func_entity, params)?;
-        dispatch!(state, args)
+        args.call_wasm_or_host_func(store, func, func_entity, params)?;
+        dispatch!(store, args)
     }
 }
 
@@ -255,7 +254,7 @@ macro_rules! call_indirect_execution_handler {
         $(
             execution_handler! {
                 fn $snake_name(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -272,9 +271,9 @@ macro_rules! call_indirect_execution_handler {
                         params,
                         index,
                     } = unsafe { args.decode_op() };
-                    let (func, func_entity) = args.resolve_indirect_func(state, index, table, func_type)?;
-                    args.call_wasm_or_host_func(state, func, func_entity, params)?;
-                    dispatch!(state, args)
+                    let (func, func_entity) = args.resolve_indirect_func(store, index, table, func_type)?;
+                    args.call_wasm_or_host_func(store, func, func_entity, params)?;
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -289,7 +288,7 @@ call_indirect_execution_handler! {
 
 execution_handler! {
     fn return_call_internal(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -303,14 +302,14 @@ execution_handler! {
         let crate::ir::decode::ReturnCallInternal { params, func } = unsafe { args.decode_op() };
         // SAFETY: see `call_internal`.
         let func = unsafe { FuncEntryPtr::from(usize::from(func)).get() };
-        args.return_call_func_entry(state, func, params, None)?;
-        dispatch!(state, args)
+        args.return_call_func_entry(store, func, params, None)?;
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn return_call_imported(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -323,8 +322,8 @@ execution_handler! {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::ReturnCallImported { params, func } = unsafe { args.decode_op() };
         let (func, func_entity) = utils::load_func_entry(instance, func);
-        args.return_call_wasm_or_host_func(state, func, func_entity, params)?;
-        dispatch!(state, args)
+        args.return_call_wasm_or_host_func(store, func, func_entity, params)?;
+        dispatch!(store, args)
     }
 }
 
@@ -333,7 +332,7 @@ macro_rules! return_call_indirect_execution_handler {
         $(
             execution_handler! {
                 fn $snake_name(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -350,9 +349,9 @@ macro_rules! return_call_indirect_execution_handler {
                         func_type,
                         table,
                     } = unsafe { args.decode_op() };
-                    let (func, func_entity) = args.resolve_indirect_func(state, index, table, func_type)?;
-                    args.return_call_wasm_or_host_func(state, func, func_entity, params)?;
-                    dispatch!(state, args)
+                    let (func, func_entity) = args.resolve_indirect_func(store, index, table, func_type)?;
+                    args.return_call_wasm_or_host_func(store, func, func_entity, params)?;
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -367,7 +366,7 @@ return_call_indirect_execution_handler! {
 
 execution_handler! {
     fn memory_size(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -379,15 +378,15 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::MemorySize { memory, result } = unsafe { args.decode_op() };
-        let size = args.fetch_memory(state, memory).size();
+        let size = args.fetch_memory(store, memory).size();
         args.set(result, size);
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn memory_grow(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -405,20 +404,20 @@ execution_handler! {
         } = unsafe { args.decode_op() };
         let delta: u64 = args.get(delta);
         let memref = unsafe { instance.load_handle(memory) };
-        let return_value = match state.store.grow_memory(&memref, delta) {
+        let return_value = match store.grow_memory(&memref, delta) {
             Ok(return_value) => {
                 // The `memory.grow` operation might have invalidated the cached
                 // linear memory so we need to reset it in order for the cache to
                 // reload in case it is used again.
                 if utils::is_default_memory(instance, memory) {
-                    args.reload_mem0(state);
+                    args.reload_mem0(store);
                 }
                 return_value
             }
             Err(StoreError::External(
                 MemoryError::OutOfBoundsGrowth | MemoryError::OutOfSystemMemory,
             )) => {
-                let memory = unsafe { instance.load_entity_mut(state.store, memory) };
+                let memory = unsafe { instance.load_entity_mut(store, memory) };
                 let memory_ty = memory.ty();
                 match memory_ty.is_64() {
                     true => u64::MAX,
@@ -427,7 +426,7 @@ execution_handler! {
             }
             Err(StoreError::External(MemoryError::OutOfFuel { required_fuel })) => {
                 args.set_ip(ip);
-                out_of_fuel!(state, args, required_fuel)
+                out_of_fuel!(store, args, required_fuel)
             }
             Err(StoreError::External(MemoryError::ResourceLimiterDeniedAllocation)) => {
                 trap!(TrapCode::GrowthOperationLimited);
@@ -440,13 +439,13 @@ execution_handler! {
             }
         };
         args.set(result, return_value);
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn memory_copy(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -477,8 +476,8 @@ execution_handler! {
             trap!(TrapCode::MemoryOutOfBounds)
         };
         if dst_memory == src_memory {
-            memory_copy_within(state, &mut args, ip, dst_memory, dst_index, src_index, len)?;
-            dispatch!(state, args)
+            memory_copy_within(store, &mut args, ip, dst_memory, dst_index, src_index, len)?;
+            dispatch!(store, args)
         }
         let src_ptr = unsafe { instance.load_entity_ptr(src_memory) };
         let mut dst_ptr = unsafe { instance.load_entity_ptr(dst_memory) };
@@ -486,32 +485,32 @@ execution_handler! {
             // Distinct memory indices can still resolve to the same store entity (e.g. the same
             // memory imported under two names), so branch on the resolved entity before forming
             // the aliasing references below.
-            memory_copy_within(state, &mut args, ip, dst_memory, dst_index, src_index, len)?;
-            dispatch!(state, args)
+            memory_copy_within(store, &mut args, ip, dst_memory, dst_index, src_index, len)?;
+            dispatch!(store, args)
         }
         // SAFETY: `src_ptr != dst_ptr`, so these are distinct entities whose references do not
         //         alias. These accesses just perform the bounds checks required by the Wasm spec.
         let src_memory = unsafe { src_ptr.as_ref() };
         let dst_memory = unsafe { dst_ptr.as_mut() };
-        let fuel = state.store.inner_mut().fuel_mut();
+        let fuel = store.inner_mut().fuel_mut();
         let src_bytes = utils::memory_slice(src_memory, src_index, len)
             .into_control()?;
         let dst_bytes = utils::memory_slice_mut(dst_memory, dst_index, len)
             .into_control()?;
         consume_fuel!(
-            state,
+            store,
             ip,
             args,
             fuel,
             |costs| costs.fuel_for_copying_values::<u8>(len as u64),
         );
         dst_bytes.copy_from_slice(src_bytes);
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 fn memory_copy_within(
-    state: &mut VmState<'_>,
+    store: &mut PrunedStore,
     args: &mut Args,
     ip: Ip,
     dst_memory: ir::MemoryAddr,
@@ -521,11 +520,11 @@ fn memory_copy_within(
 ) -> Control<(), Break> {
     // SAFETY: `args.instance` is live and warmed up; `memory` is the only entity accessed here.
     let memory = unsafe { args.instance.load_entity_ptr(dst_memory).as_mut() };
-    let fuel = state.store.inner_mut().fuel_mut();
+    let fuel = store.inner_mut().fuel_mut();
     // These accesses just perform the bounds checks required by the Wasm spec.
     utils::memory_slice(memory, src_index, len).into_control()?;
     utils::memory_slice(memory, dst_index, len).into_control()?;
-    consume_fuel!(state, ip, args, fuel, |costs| costs
+    consume_fuel!(store, ip, args, fuel, |costs| costs
         .fuel_for_copying_values::<u8>(len as u64));
     memory
         .data_mut()
@@ -535,7 +534,7 @@ fn memory_copy_within(
 
 execution_handler! {
     fn memory_fill(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -563,17 +562,17 @@ execution_handler! {
         };
         // SAFETY: `instance` is live and warmed up; `memory` is the only entity accessed here.
         let memory = unsafe { instance.load_entity_ptr(memory).as_mut() };
-        let fuel = state.store.inner_mut().fuel_mut();
+        let fuel = store.inner_mut().fuel_mut();
         let slice = utils::memory_slice_mut(memory, dst, len).into_control()?;
-        consume_fuel!(state, ip, args, fuel, |costs| costs.fuel_for_copying_values::<u8>(len as u64));
+        consume_fuel!(store, ip, args, fuel, |costs| costs.fuel_for_copying_values::<u8>(len as u64));
         slice.fill(value);
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn memory_init(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -607,7 +606,7 @@ execution_handler! {
         // arenas, so their references are to distinct entities and cannot alias.
         let memory = unsafe { instance.load_entity_ptr(memory).as_mut() };
         let data = unsafe { instance.load_entity_ptr(data).as_ref() };
-        let fuel = state.store.inner_mut().fuel_mut();
+        let fuel = store.inner_mut().fuel_mut();
         let memory = utils::memory_slice_mut(memory, dst_index, len).into_control()?;
         let Some(data) = data
             .bytes()
@@ -616,15 +615,15 @@ execution_handler! {
         else {
             trap!(TrapCode::MemoryOutOfBounds)
         };
-        consume_fuel!(state, ip, args, fuel, |costs| costs.fuel_for_copying_values::<u8>(len as u64));
+        consume_fuel!(store, ip, args, fuel, |costs| costs.fuel_for_copying_values::<u8>(len as u64));
         memory.copy_from_slice(data);
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn data_drop(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -636,14 +635,14 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::DataDrop { data } = unsafe { args.decode_op() };
-        args.fetch_data(state, data).drop_bytes();
-        dispatch!(state, args)
+        args.fetch_data(store, data).drop_bytes();
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn table_size(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -655,15 +654,15 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::TableSize { table, result } = unsafe { args.decode_op() };
-        let size = args.fetch_table(state, table).size();
+        let size = args.fetch_table(store, table).size();
         args.set(result, size);
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn table_grow(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -683,17 +682,17 @@ execution_handler! {
         let table_ref = unsafe { instance.load_handle(table) };
         let delta = args.get(delta);
         let value = args.get(value);
-        let return_value = match state.store.grow_table(&table_ref, delta, value) {
+        let return_value = match store.grow_table(&table_ref, delta, value) {
             Ok(return_value) => return_value,
             Err(StoreError::External(TableError::GrowOutOfBounds | TableError::OutOfSystemMemory)) => {
-                let table = unsafe { instance.load_entity_mut(state.store, table) };
+                let table = unsafe { instance.load_entity_mut(store, table) };
                 match table.ty().is_64() {
                     true => u64::MAX,
                     false => u64::from(u32::MAX),
                 }
             }
             Err(StoreError::External(TableError::OutOfFuel { required_fuel })) => {
-                done!(state, DoneReason::out_of_fuel(required_fuel));
+                done!(store, DoneReason::out_of_fuel(required_fuel));
             }
             Err(StoreError::External(TableError::ResourceLimiterDeniedAllocation)) => {
                 trap!(TrapCode::GrowthOperationLimited);
@@ -706,13 +705,13 @@ execution_handler! {
             }
         };
         args.set(result, return_value);
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn table_copy(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -741,7 +740,7 @@ execution_handler! {
             // Case: copy within the same table.
             // SAFETY: `dst_ptr` is warmed up and is the only entity accessed here.
             let table = unsafe { dst_ptr.as_mut() };
-            let fuel = state.store.inner_mut().fuel_mut();
+            let fuel = store.inner_mut().fuel_mut();
             table.copy_within(dst, src, len, Some(fuel))
         } else {
             // Case: copy between two distinct tables.
@@ -749,7 +748,7 @@ execution_handler! {
             //         not alias.
             let src_table = unsafe { src_ptr.as_ref() };
             let dst_table = unsafe { dst_ptr.as_mut() };
-            let fuel = state.store.inner_mut().fuel_mut();
+            let fuel = store.inner_mut().fuel_mut();
             CoreTable::copy(dst_table, dst, src_table, src, len, Some(fuel))
         };
         if let Err(error) = result {
@@ -758,19 +757,19 @@ execution_handler! {
                 TableError::OutOfSystemMemory => TrapCode::OutOfSystemMemory,
                 TableError::OutOfFuel { required_fuel } => {
                     args.set_ip(ip);
-                    out_of_fuel!(state, args, required_fuel)
+                    out_of_fuel!(store, args, required_fuel)
                 }
                 _ => panic!("table.copy: unexpected error: {error}"),
             };
             trap!(trap_code)
         }
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn table_fill(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -792,26 +791,26 @@ execution_handler! {
         let value: RawRef = args.get(value);
         // SAFETY: `instance` is live and warmed up; `table` is the only entity accessed here.
         let table = unsafe { instance.load_entity_ptr(table).as_mut() };
-        let fuel = state.store.inner_mut().fuel_mut();
+        let fuel = store.inner_mut().fuel_mut();
         if let Err(error) = table.fill_raw(dst, value, len, Some(fuel)) {
             let trap_code = match error {
                 TableError::OutOfSystemMemory => TrapCode::OutOfSystemMemory,
                 TableError::FillOutOfBounds => TrapCode::TableOutOfBounds,
                 TableError::OutOfFuel { required_fuel } => {
                     args.set_ip(ip);
-                    out_of_fuel!(state, args, required_fuel)
+                    out_of_fuel!(store, args, required_fuel)
                 }
                 _ => panic!("table.fill: unexpected error: {error}"),
             };
             trap!(trap_code)
         }
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn table_init(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -836,26 +835,26 @@ execution_handler! {
         //         arenas, so their references are to distinct entities and cannot alias.
         let table = unsafe { args.instance.load_entity_ptr(table).as_mut() };
         let element = unsafe { args.instance.load_entity_ptr(elem).as_ref() };
-        let fuel = state.store.inner_mut().fuel_mut();
+        let fuel = store.inner_mut().fuel_mut();
         if let Err(error) = table.init(element.as_ref(), dst, src, len, Some(fuel)) {
             let trap_code = match error {
                 TableError::OutOfSystemMemory => TrapCode::OutOfSystemMemory,
                 TableError::InitOutOfBounds => TrapCode::TableOutOfBounds,
                 TableError::OutOfFuel { required_fuel } => {
                     args.set_ip(ip);
-                    out_of_fuel!(state, args, required_fuel)
+                    out_of_fuel!(store, args, required_fuel)
                 }
                 _ => panic!("table.init: unexpected error: {error}"),
             };
             trap!(trap_code)
         }
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
 execution_handler! {
     fn elem_drop(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -867,8 +866,8 @@ execution_handler! {
     ) -> Done = {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::ElemDrop { elem } = unsafe { args.decode_op() };
-        args.fetch_elem(state, elem).drop_items();
-        dispatch!(state, args)
+        args.fetch_elem(store, elem).drop_items();
+        dispatch!(store, args)
     }
 }
 
@@ -877,7 +876,7 @@ macro_rules! impl_table_get {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -889,13 +888,13 @@ macro_rules! impl_table_get {
                 ) -> Done = {
                     let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
                     let crate::ir::decode::$op { table, result, index } = unsafe { args.decode_op() };
-                    let table = args.fetch_table(state, table);
+                    let table = args.fetch_table(store, table);
                     let index = $ext(args.get(index));
                     let Some(value) = table.get(index) else {
                         trap!(TrapCode::TableOutOfBounds)
                     };
                     args.set(result, value.raw());
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -912,7 +911,7 @@ macro_rules! impl_table_set {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -924,13 +923,13 @@ macro_rules! impl_table_set {
                 ) -> Done = {
                     let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
                     let crate::ir::decode::$op { table, index, value } = unsafe { args.decode_op() };
-                    let table = args.fetch_table(state, table);
+                    let table = args.fetch_table(store, table);
                     let index = $ext(args.get(index));
                     let value: u32 = args.get(value);
                     if let Err(TableError::SetOutOfBounds) = table.set_raw(index, RawRef::from(value)) {
                         trap!(TrapCode::TableOutOfBounds)
                     };
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -949,7 +948,7 @@ impl_table_set! {
 
 execution_handler! {
     fn ref_func(
-        state: &mut VmState,
+        store: &mut PrunedStore,
         ip: Ip,
         sp: Sp,
         mem0: Mem0Ptr,
@@ -962,11 +961,11 @@ execution_handler! {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::RefFunc { func, result } = unsafe { args.decode_op() };
         let func = unsafe { instance.load_handle(func) };
-        let Some(rawref) = func.unwrap_raw(&*state.store) else {
+        let Some(rawref) = func.unwrap_raw(&*store) else {
             unsafe { unreachable_unchecked!("store mismatch with: {func:?}") }
         };
         args.set(result, rawref);
-        dispatch!(state, args)
+        dispatch!(store, args)
     }
 }
 
@@ -977,7 +976,7 @@ macro_rules! impl_i64_binop128 {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -997,7 +996,7 @@ macro_rules! impl_i64_binop128 {
                     let (result_lo, result_hi) = $eval(lhs_lo, lhs_hi, rhs_lo, rhs_hi);
                     args.set(results[0], result_lo);
                     args.set(results[1], result_hi);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -1015,7 +1014,7 @@ macro_rules! impl_i64_mul_wide {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -1033,7 +1032,7 @@ macro_rules! impl_i64_mul_wide {
                     let results = results.to_array();
                     args.set(results[0], result_lo);
                     args.set(results[1], result_hi);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -1103,7 +1102,7 @@ macro_rules! impl_branch_table_exec_handler {
         $(
             execution_handler! {
                 fn $snake_case(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -1116,7 +1115,7 @@ macro_rules! impl_branch_table_exec_handler {
                     let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
                     let crate::ir::decode::$camel_case { len_targets, index, values } = unsafe { args.decode() };
                     $exec(&mut args, index, len_targets, values);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -1808,7 +1807,7 @@ macro_rules! handler_cmp_branch {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -1826,7 +1825,7 @@ macro_rules! handler_cmp_branch {
                         args.set_ip(ip);
                         args.offset_ip(offset);
                     }
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -2045,7 +2044,7 @@ macro_rules! handler_select {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -2068,7 +2067,7 @@ macro_rules! handler_select {
                     let selected = if condition != 0 { true_val } else { false_val };
                     let selected = args.get(selected);
                     args.set(result, selected);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -2181,7 +2180,7 @@ macro_rules! handler_load_ri {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -2198,10 +2197,10 @@ macro_rules! handler_load_ri {
                         memory,
                     } = unsafe { args.decode_op() };
                     let address = args.get(address);
-                    let bytes = args.fetch_memory(state, memory).data();
+                    let bytes = args.fetch_memory(store, memory).data();
                     let loaded = $load(bytes, usize::from(address)).into_control()?;
                     args.set(result, loaded);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -2339,7 +2338,7 @@ macro_rules! handler_store_ix {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -2357,9 +2356,9 @@ macro_rules! handler_store_ix {
                     } = unsafe { args.decode_op() };
                     let address = args.get(address);
                     let value: $hint = args.get(value);
-                    let bytes = args.fetch_memory(state, memory).data_mut();
+                    let bytes = args.fetch_memory(store, memory).data_mut();
                     $store(bytes, usize::from(address), value.into()).into_control()?;
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*

--- a/crates/wasmi/src/engine/executor/handler/exec.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec.rs
@@ -410,7 +410,7 @@ execution_handler! {
                 // linear memory so we need to reset it in order for the cache to
                 // reload in case it is used again.
                 if utils::is_default_memory(instance, memory) {
-                    args.reload_mem0(store);
+                    args.reload_mem0();
                 }
                 return_value
             }

--- a/crates/wasmi/src/engine/executor/handler/exec/macros.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec/macros.rs
@@ -93,7 +93,7 @@ macro_rules! handler_unary {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -108,7 +108,7 @@ macro_rules! handler_unary {
                     let value = args.get(value);
                     let value = $eval(value).into_control()?;
                     args.set(result, value);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -120,7 +120,7 @@ macro_rules! handler_binary {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -136,7 +136,7 @@ macro_rules! handler_binary {
                     let rhs = args.get(rhs);
                     let value = $eval(lhs, rhs).into_control()?;
                     args.set(result, value);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -148,7 +148,7 @@ macro_rules! handler_load {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -167,10 +167,10 @@ macro_rules! handler_load {
                     } = unsafe { args.decode_op() };
                     let ptr: u64 = args.get(ptr);
                     let offset: u64 = args.get(offset);
-                    let bytes = args.fetch_memory(state, memory).data();
+                    let bytes = args.fetch_memory(store, memory).data();
                     let loaded = $load(bytes, ptr, offset).into_control()?;
                     args.set(result, loaded);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -182,7 +182,7 @@ macro_rules! handler_load_mem0_offset16 {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -200,10 +200,10 @@ macro_rules! handler_load_mem0_offset16 {
                     } = unsafe { args.decode_op() };
                     let ptr = args.get(ptr);
                     let offset = args.get(offset);
-                    let bytes = args.fetch_default_memory_bytes(state);
+                    let bytes = args.fetch_default_memory_bytes(store);
                     let loaded = $load(bytes, ptr, u64::from(offset)).into_control()?;
                     args.set(result, loaded);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -215,7 +215,7 @@ macro_rules! handler_store {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -235,9 +235,9 @@ macro_rules! handler_store {
                     let ptr = args.get(ptr);
                     let offset = args.get(offset);
                     let value: $hint = args.get(value);
-                    let bytes = args.fetch_memory(state, memory).data_mut();
+                    let bytes = args.fetch_memory(store, memory).data_mut();
                     $store(bytes, ptr, offset, value.into()).into_control()?;
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -249,7 +249,7 @@ macro_rules! handler_store_mem0_offset16 {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -268,9 +268,9 @@ macro_rules! handler_store_mem0_offset16 {
                     let ptr = args.get(ptr);
                     let offset = args.get(offset);
                     let value: $hint = args.get(value);
-                    let bytes = args.fetch_default_memory_bytes(state);
+                    let bytes = args.fetch_default_memory_bytes(store);
                     $store(bytes, ptr, u64::from(offset), value.into()).into_control()?;
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*

--- a/crates/wasmi/src/engine/executor/handler/exec/simd.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec/simd.rs
@@ -8,9 +8,10 @@ use crate::{
     engine::executor::handler::{
         Args,
         dispatch::Done,
-        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, VmState},
+        state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp},
         utils::IntoControl as _,
     },
+    store::PrunedStore,
 };
 use core::convert::identity;
 
@@ -19,7 +20,7 @@ macro_rules! execution_handler_for_v128_select {
         $(
             execution_handler! {
                 fn $snake_name(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -43,7 +44,7 @@ macro_rules! execution_handler_for_v128_select {
                     };
                     let selected: V128 = args.get(selected);
                     args.set(result, selected);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -322,7 +323,7 @@ macro_rules! handler_extract_lane {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -341,7 +342,7 @@ macro_rules! handler_extract_lane {
                     let value = args.get(value);
                     let extracted = $eval(value, lane);
                     args.set(result, extracted);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -382,7 +383,7 @@ macro_rules! handler_extract_lane {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -403,7 +404,7 @@ macro_rules! handler_extract_lane {
                     let value = args.get(value);
                     let replaced = $eval(v128, lane, value);
                     args.set(result, replaced);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -431,7 +432,7 @@ macro_rules! handler_ternary {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -448,7 +449,7 @@ macro_rules! handler_ternary {
                     let $v2 = args.get($v2);
                     let value = $eval($v0, $v1, $v2).into_control()?;
                     args.set(result, value);
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -490,7 +491,7 @@ macro_rules! handler_store_lane_ss {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -505,9 +506,9 @@ macro_rules! handler_store_lane_ss {
                     let ptr = args.get(ptr);
                     let offset = args.get(offset);
                     let value = args.get(value);
-                    let bytes = args.fetch_memory(state, memory).data_mut();
+                    let bytes = args.fetch_memory(store, memory).data_mut();
                     $eval(bytes, ptr, offset, value, lane).into_control()?;
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*
@@ -525,7 +526,7 @@ macro_rules! handler_store_lane_mem0_offset16_ss {
         $(
             execution_handler! {
                 fn $handler(
-                    state: &mut VmState,
+                    store: &mut PrunedStore,
                     ip: Ip,
                     sp: Sp,
                     mem0: Mem0Ptr,
@@ -540,9 +541,9 @@ macro_rules! handler_store_lane_mem0_offset16_ss {
                     let ptr = args.get(ptr);
                     let offset = args.get(offset);
                     let value = args.get(value);
-                    let bytes = args.fetch_default_memory_bytes(state);
+                    let bytes = args.fetch_default_memory_bytes(store);
                     $eval(bytes, ptr, u64::from(offset), value, lane).into_control()?;
-                    dispatch!(state, args)
+                    dispatch!(store, args)
                 }
             }
         )*

--- a/crates/wasmi/src/engine/executor/handler/func.rs
+++ b/crates/wasmi/src/engine/executor/handler/func.rs
@@ -122,7 +122,7 @@ impl<'a, T, State: state::Execute> WasmFuncCall<'a, T, State> {
             self.freg32,
             self.freg64,
         );
-        core::mem::replace(self.store.inner.exec_mut().stack_mut(), stack);
+        _ = core::mem::replace(self.store.inner.exec_mut().stack_mut(), stack);
         outcome
     }
 }

--- a/crates/wasmi/src/engine/executor/handler/func.rs
+++ b/crates/wasmi/src/engine/executor/handler/func.rs
@@ -6,10 +6,9 @@ use crate::{
         FuncEntryPtr,
         LiftFromCells,
         LowerToCells,
-        Stack,
         executor::handler::{
             dispatch::{ExecutionOutcome, execute_until_done},
-            state::{Freg32, Freg64, Inst, Ip, Ireg, Sp, VmState},
+            state::{Freg32, Freg64, Inst, Ip, Ireg, Sp},
             utils,
         },
     },
@@ -107,12 +106,10 @@ impl<'a, T, State: state::Execute> WasmFuncCall<'a, T, State> {
 
     fn execute_until_done(&mut self) -> Result<Sp, ExecutionOutcome> {
         // TODO: get rid of `VmState` entirely
-        let mut stack = core::mem::replace(self.store.inner.exec_mut().stack_mut(), Stack::empty());
         let pruned = self.store.prune();
         let (mem0, mem0_len) = utils::extract_mem0(pruned, self.instance);
-        let mut state = VmState::new(pruned, &mut stack);
-        let outcome = execute_until_done(
-            &mut state,
+        execute_until_done(
+            pruned,
             self.callee_ip,
             self.callee_sp,
             mem0,
@@ -121,9 +118,7 @@ impl<'a, T, State: state::Execute> WasmFuncCall<'a, T, State> {
             self.ireg,
             self.freg32,
             self.freg64,
-        );
-        _ = core::mem::replace(self.store.inner.exec_mut().stack_mut(), stack);
-        outcome
+        )
     }
 }
 

--- a/crates/wasmi/src/engine/executor/handler/func.rs
+++ b/crates/wasmi/src/engine/executor/handler/func.rs
@@ -6,9 +6,10 @@ use crate::{
         FuncEntryPtr,
         LiftFromCells,
         LowerToCells,
+        Stack,
         executor::handler::{
             dispatch::{ExecutionOutcome, execute_until_done},
-            state::{Freg32, Freg64, HostFrame, Inst, Ip, Ireg, Sp, Stack, VmState},
+            state::{Freg32, Freg64, Inst, Ip, Ireg, Sp, VmState},
             utils,
         },
     },
@@ -20,7 +21,6 @@ use core::marker::PhantomData;
 
 pub struct WasmFuncCall<'a, T, State> {
     store: &'a mut Store<T>,
-    stack: &'a mut Stack,
     callee_ip: Ip,
     callee_sp: Sp,
     instance: Inst,
@@ -34,7 +34,6 @@ impl<'a, T, State> WasmFuncCall<'a, T, State> {
     fn new_state<NewState>(self, state: NewState) -> WasmFuncCall<'a, T, NewState> {
         WasmFuncCall {
             store: self.store,
-            stack: self.stack,
             callee_ip: self.callee_ip,
             callee_sp: self.callee_sp,
             instance: self.instance,
@@ -47,8 +46,11 @@ impl<'a, T, State> WasmFuncCall<'a, T, State> {
 }
 
 mod state {
-    use super::{HostFrame, Sp};
-    use crate::{engine::InOutParams, func::Trampoline};
+    use super::Sp;
+    use crate::{
+        engine::{InOutParams, executor::handler::state::HostFrame},
+        func::Trampoline,
+    };
     use core::marker::PhantomData;
 
     pub type Uninit = PhantomData<marker::Uninit>;
@@ -104,10 +106,12 @@ impl<'a, T, State: state::Execute> WasmFuncCall<'a, T, State> {
     }
 
     fn execute_until_done(&mut self) -> Result<Sp, ExecutionOutcome> {
-        let store = self.store.prune();
-        let (mem0, mem0_len) = utils::extract_mem0(store, self.instance);
-        let mut state = VmState::new(store, self.stack);
-        execute_until_done(
+        // TODO: get rid of `VmState` entirely
+        let mut stack = core::mem::replace(self.store.inner.exec_mut().stack_mut(), Stack::empty());
+        let pruned = self.store.prune();
+        let (mem0, mem0_len) = utils::extract_mem0(pruned, self.instance);
+        let mut state = VmState::new(pruned, &mut stack);
+        let outcome = execute_until_done(
             &mut state,
             self.callee_ip,
             self.callee_sp,
@@ -117,7 +121,9 @@ impl<'a, T, State: state::Execute> WasmFuncCall<'a, T, State> {
             self.ireg,
             self.freg32,
             self.freg64,
-        )
+        );
+        core::mem::replace(self.store.inner.exec_mut().stack_mut(), stack);
+        outcome
     }
 }
 
@@ -151,12 +157,18 @@ impl<'a, T> WasmFuncCall<'a, T, state::Done> {
     }
 }
 
-pub fn init_wasm_func_call<'a, T>(
-    store: &'a mut Store<T>,
-    stack: &'a mut Stack,
+/// Initializes a call to the Wasm function behind `func_entry`.
+///
+/// # Note
+///
+/// Uses the [`Stack`] installed in `store`, see `with_stack`.
+///
+/// [`Stack`]: crate::engine::Stack
+pub fn init_wasm_func_call<T>(
+    store: &mut Store<T>,
     func_entry: FuncEntryPtr,
     instance: Inst,
-) -> Result<WasmFuncCall<'a, T, state::Uninit>, Error> {
+) -> Result<WasmFuncCall<'_, T, state::Uninit>, Error> {
     // SAFETY: `func_entry` stems from a `WasmFuncEntity` owned by `store`, thus the engine
     //         owning the `FuncEntry` outlives this call.
     let func_entry = unsafe { func_entry.get() };
@@ -170,6 +182,7 @@ pub fn init_wasm_func_call<'a, T>(
     //       an easy and efficient way to get the number of parameter cells at this point
     //       so we simply default to 0.
     let callee_params = BoundedSlotSpan::new(SlotSpan::new(Slot::from(0)), 0);
+    let stack = store.inner.exec_mut().stack_mut();
     // Note: the call stack is empty here, so the first frame starts at the value stack base.
     let caller_sp = stack.base_sp();
     let callee_sp = stack.push_frame(
@@ -184,7 +197,6 @@ pub fn init_wasm_func_call<'a, T>(
     let (ireg, freg32, freg64) = stack.regs();
     Ok(WasmFuncCall {
         store,
-        stack,
         callee_ip,
         callee_sp,
         instance,
@@ -195,14 +207,13 @@ pub fn init_wasm_func_call<'a, T>(
     })
 }
 
-pub fn resume_wasm_func_call<'a, T>(
-    store: &'a mut Store<T>,
-    stack: &'a mut Stack,
-) -> Result<WasmFuncCall<'a, T, state::Resumed>, Error> {
-    let (callee_ip, callee_sp, instance, ireg, freg32, freg64) = stack.restore_frame();
+pub fn resume_wasm_func_call<T>(
+    store: &mut Store<T>,
+) -> Result<WasmFuncCall<'_, T, state::Resumed>, Error> {
+    let (callee_ip, callee_sp, instance, ireg, freg32, freg64) =
+        store.inner.exec_mut().stack_mut().restore_frame();
     Ok(WasmFuncCall {
         store,
-        stack,
         callee_ip,
         callee_sp,
         instance,
@@ -215,17 +226,19 @@ pub fn resume_wasm_func_call<'a, T>(
 
 pub fn init_host_func_call<'a, T>(
     store: &'a mut Store<T>,
-    stack: &'a mut Stack,
     func: HostFuncEntity,
 ) -> Result<HostFuncCall<'a, T, state::UninitHost>, Error> {
     let len_param_cells = func.len_param_cells();
     let len_result_cells = func.len_result_cells();
     let trampoline = *func.trampoline();
     let callee_params = BoundedSlotSpan::new(SlotSpan::new(Slot::from(0)), len_param_cells);
-    let (sp, frame) = stack.prepare_host_frame(None, callee_params, len_result_cells)?;
+    let (sp, frame) = store.inner.exec_mut().stack_mut().prepare_host_frame(
+        None,
+        callee_params,
+        len_result_cells,
+    )?;
     Ok(HostFuncCall {
         store,
-        stack,
         state: state::UninitHost {
             sp,
             frame,
@@ -237,7 +250,6 @@ pub fn init_host_func_call<'a, T>(
 #[derive(Debug)]
 pub struct HostFuncCall<'a, T, State> {
     store: &'a mut Store<T>,
-    stack: &'a mut Stack,
     state: State,
 }
 
@@ -257,10 +269,9 @@ impl<'a, T> HostFuncCall<'a, T, state::UninitHost> {
         };
         // Note: the `InOutParams` must be derived _after_ the parameters have been written above,
         //       since writing through `sp` invalidates its pointer. See `Stack::host_inout`.
-        let inout = self.stack.host_inout(frame);
+        let inout = self.store.inner.exec_mut().stack_mut().host_inout(frame);
         HostFuncCall {
             store: self.store,
-            stack: self.stack,
             state: state::InitHost {
                 sp,
                 inout,
@@ -289,7 +300,6 @@ impl<'a, T> HostFuncCall<'a, T, state::InitHost> {
         }
         Ok(HostFuncCall {
             store: self.store,
-            stack: self.stack,
             state: state::Done { sp },
         })
     }

--- a/crates/wasmi/src/engine/executor/handler/func.rs
+++ b/crates/wasmi/src/engine/executor/handler/func.rs
@@ -105,9 +105,8 @@ impl<'a, T, State: state::Execute> WasmFuncCall<'a, T, State> {
     }
 
     fn execute_until_done(&mut self) -> Result<Sp, ExecutionOutcome> {
-        // TODO: get rid of `VmState` entirely
         let pruned = self.store.prune();
-        let (mem0, mem0_len) = utils::extract_mem0(pruned, self.instance);
+        let (mem0, mem0_len) = utils::extract_mem0(self.instance);
         execute_until_done(
             pruned,
             self.callee_ip,

--- a/crates/wasmi/src/engine/executor/handler/mod.rs
+++ b/crates/wasmi/src/engine/executor/handler/mod.rs
@@ -28,5 +28,5 @@ pub use self::{
     },
     dispatch::{ExecutionOutcome, op_code_to_handler},
     func::{init_host_func_call, init_wasm_func_call, resume_wasm_func_call},
-    state::{Inst, Stack},
+    state::{ExecContext, Inst, Stack},
 };

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -77,6 +77,117 @@ impl<'vm> VmState<'vm> {
     }
 }
 
+/// The execution context of a [`Store`](crate::Store).
+///
+/// # Note
+///
+/// This is stored inline in the [`StoreInner`](crate::store::StoreInner) so that execution
+/// handlers reach both the store and the [`Stack`] with a single load from their `state`
+/// parameter. Its contents are private to the executor.
+#[derive(Debug)]
+pub struct ExecContext {
+    /// The value and call stack of the currently running execution.
+    stack: Stack,
+    /// The reason why the current execution halted, if any.
+    done_reason: Option<DoneReason>,
+}
+
+impl Default for ExecContext {
+    #[inline]
+    fn default() -> Self {
+        Self::new(Stack::empty())
+    }
+}
+
+// # Safety
+//
+// `ExecContext` is neither automatically `Send` nor `Sync` because of the raw pointers
+// reachable from its fields:
+//
+// - `Stack`'s `CallStack` stores `Frame`s holding an `Ip`, a raw pointer into an `Op`
+//   buffer owned by the [`Engine`]. The `StoreInner` owning this `ExecContext` owns the
+//   [`Engine`] as well, thus those buffers cannot be outlived and are immutable.
+// - `DoneReason` may hold an `Sp`, a raw pointer into the cells of this very `Stack`.
+//   Those cells are heap allocated and thus travel along with the `ExecContext`.
+//
+// Both fields are private and only ever handed out via `&mut self`, so a shared reference
+// to an `ExecContext` provides no access to either of them.
+//
+// This mirrors the reasoning behind the `Send`/`Sync` of `ResumableCallCommon`, which owns
+// a `Stack` for the same reasons.
+//
+// [`Engine`]: crate::Engine
+unsafe impl Send for ExecContext {}
+// # Safety
+//
+// See the `Send` impl above.
+unsafe impl Sync for ExecContext {}
+
+impl ExecContext {
+    /// Creates a new [`ExecContext`] with the `stack`.
+    #[inline]
+    pub fn new(stack: Stack) -> Self {
+        Self {
+            stack,
+            done_reason: None,
+        }
+    }
+
+    /// Returns an exclusive reference to the [`Stack`].
+    #[inline]
+    pub fn stack_mut(&mut self) -> &mut Stack {
+        &mut self.stack
+    }
+
+    /// Consumes `self` and returns its [`Stack`].
+    #[inline]
+    pub fn into_stack(self) -> Stack {
+        self.stack
+    }
+
+    /// Halts the current execution with `reason`.
+    ///
+    /// # Note
+    ///
+    /// Must be inlined: every `done!` site sits on the cold arm of a hot handler, and an
+    /// out-of-line call there forces the handler to spill all of its argument registers on
+    /// entry. Only `err` below is meant to stay out of line.
+    #[inline]
+    pub fn done_with(&mut self, reason: impl FnOnce() -> DoneReason) {
+        #[cold]
+        #[inline(never)]
+        fn err(prev: &DoneReason, reason: impl FnOnce() -> DoneReason) -> ! {
+            panic!(
+                "\
+                tried to done with reason while reason already exists:\n\
+                \t- new reason: {:?},\n\
+                \t- old reason: {:?},\
+                ",
+                reason(),
+                prev,
+            )
+        }
+
+        if let Some(prev) = &self.done_reason {
+            err(prev, reason)
+        }
+        self.done_reason = Some(reason());
+    }
+
+    #[inline]
+    pub fn take_done_reason(&mut self) -> DoneReason {
+        let Some(reason) = self.done_reason.take() else {
+            panic!("missing break reason")
+        };
+        reason
+    }
+
+    #[inline]
+    pub fn execution_outcome(&mut self) -> Result<Sp, ExecutionOutcome> {
+        self.take_done_reason().into_execution_outcome()
+    }
+}
+
 /// The reason why a Wasmi execution has halted.
 ///
 /// # Note

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -1124,7 +1124,6 @@ impl Stack {
     #[inline(always)]
     pub fn pop_frame(
         &mut self,
-        store: &mut PrunedStore,
         mem0: Mem0Ptr,
         mem0_len: Mem0Len,
         instance: Inst,
@@ -1133,7 +1132,7 @@ impl Stack {
         let sp = self.values.sp(start);
         let (mem0, mem0_len, instance) = match changed_instance {
             Some(instance) => {
-                let (mem0, mem0_len) = extract_mem0(store, instance);
+                let (mem0, mem0_len) = extract_mem0(instance);
                 (mem0, mem0_len, instance)
             }
             None => (mem0, mem0_len, instance),

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -143,10 +143,12 @@ impl ExecContext {
 ///
 /// # Note
 ///
-/// This type lives in the [`VmState`] type and in case of a halt needs to be
+/// This type lives in the [`PrunedStore`] type and in case of a halt needs to be
 /// updated manually which is a bit costly which is why the most common reason
 /// which is a raised [`TrapCode`] is not included in this `enum` and was put
 /// into the return type of execution handlers directly, instead.
+/// 
+/// [`PrunedStore`]: crate::store::PrunedStore
 #[derive(Debug)]
 pub enum DoneReason {
     /// The execution finished successfully with a result found at the [`Sp`].

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -147,7 +147,7 @@ impl ExecContext {
 /// updated manually which is a bit costly which is why the most common reason
 /// which is a raised [`TrapCode`] is not included in this `enum` and was put
 /// into the return type of execution handlers directly, instead.
-/// 
+///
 /// [`PrunedStore`]: crate::store::PrunedStore
 #[derive(Debug)]
 pub enum DoneReason {

--- a/crates/wasmi/src/engine/executor/handler/state.rs
+++ b/crates/wasmi/src/engine/executor/handler/state.rs
@@ -24,58 +24,9 @@ use crate::{
     },
     instance::{InstanceEntity, ThinPtr},
     ir::{self, BoundedSlotSpan, Slot, SlotSpan},
-    store::PrunedStore,
 };
 use alloc::vec::Vec;
 use core::{cmp, marker::PhantomData, mem, ops, ptr, slice};
-
-pub struct VmState<'vm> {
-    pub store: &'vm mut PrunedStore,
-    pub stack: &'vm mut Stack,
-    done_reason: Option<DoneReason>,
-}
-
-impl<'vm> VmState<'vm> {
-    pub fn new(store: &'vm mut PrunedStore, stack: &'vm mut Stack) -> Self {
-        Self {
-            store,
-            stack,
-            done_reason: None,
-        }
-    }
-
-    pub fn done_with(&mut self, reason: impl FnOnce() -> DoneReason) {
-        #[cold]
-        #[inline(never)]
-        fn err(prev: &DoneReason, reason: impl FnOnce() -> DoneReason) -> ! {
-            panic!(
-                "\
-                tried to done with reason while reason already exists:\n\
-                \t- new reason: {:?},\n\
-                \t- old reason: {:?},\
-                ",
-                reason(),
-                prev,
-            )
-        }
-
-        if let Some(prev) = &self.done_reason {
-            err(prev, reason)
-        }
-        self.done_reason = Some(reason());
-    }
-
-    pub fn take_done_reason(&mut self) -> DoneReason {
-        let Some(reason) = self.done_reason.take() else {
-            panic!("missing break reason")
-        };
-        reason
-    }
-
-    pub fn execution_outcome(&mut self) -> Result<Sp, ExecutionOutcome> {
-        self.take_done_reason().into_execution_outcome()
-    }
-}
 
 /// The execution context of a [`Store`](crate::Store).
 ///

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -1,4 +1,4 @@
-use super::state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp, VmState};
+use super::state::{Freg32, Freg64, Inst, Ip, Ireg, Mem0Len, Mem0Ptr, Sp};
 #[cfg(feature = "simd")]
 use crate::core::simd::ImmLaneIdx;
 #[cfg(doc)]
@@ -46,13 +46,13 @@ use crate::{
 use core::{num::NonZero, ptr::NonNull};
 
 macro_rules! out_of_fuel {
-    ($state:expr, $args:expr, $required_fuel:expr) => {{
-        $state.stack.sync_ip($args.ip);
-        $state
-            .stack
+    ($store:expr, $args:expr, $required_fuel:expr) => {{
+        $store.stack_mut().sync_ip($args.ip);
+        $store
+            .stack_mut()
             .sync_regs($args.ireg, $args.freg32, $args.freg64);
         done!(
-            $state,
+            $store,
             $crate::engine::executor::handler::DoneReason::out_of_fuel($required_fuel),
         )
     }};
@@ -70,10 +70,10 @@ macro_rules! consume_fuel {
 }
 
 pub fn compile_or_get_func_entry(
-    state: &mut VmState,
+    store: &mut PrunedStore,
     func: &FuncEntry,
 ) -> Result<(Ip, u16, u16), Error> {
-    let (fuel, features) = state.store.inner_mut().fuel_and_features();
+    let (fuel, features) = store.inner_mut().fuel_and_features();
     let compiled_func = func.get_or_compile(Some(fuel), features)?;
     let ip = Ip::from(compiled_func.ops());
     let len_local_slots = compiled_func.len_local_slots();
@@ -99,8 +99,8 @@ macro_rules! trap {
 }
 
 macro_rules! done {
-    ($state:expr, $reason:expr $(,)? ) => {{
-        $state.done_with(move || {
+    ($store:expr, $reason:expr $(,)? ) => {{
+        $store.inner_mut().exec_mut().done_with(move || {
             <_ as ::core::convert::Into<$crate::engine::executor::handler::DoneReason>>::into(
                 $reason,
             )
@@ -796,7 +796,7 @@ pub fn resolve_indirect_func<Idx, Table>(
     index: Idx,
     table: Table,
     func_type: ir::FuncType,
-    state: &mut VmState<'_>,
+    store: &mut PrunedStore,
     args: &mut Args,
 ) -> Result<(Func, NonNull<FuncEntity>), TrapCode>
 where
@@ -804,12 +804,12 @@ where
     Inst: LoadEntity<Table, Entity = TableEntity>,
 {
     let index = get_value(index, args.sp, args.ireg, args.freg32, args.freg64);
-    let table = args.fetch_table(state, table);
+    let table = args.fetch_table(store, table);
     let rawref = table.get(index).ok_or(TrapCode::TableOutOfBounds)?;
     debug_assert!(matches!(rawref.ty(), RefType::Func));
-    let funcref = <Nullable<Func>>::from_raw_parts(rawref.raw(), &*state.store);
+    let funcref = <Nullable<Func>>::from_raw_parts(rawref.raw(), &*store);
     let func = funcref.val().ok_or(TrapCode::IndirectCallToNull)?;
-    let func_entity = state.store.inner_mut().resolve_func_ptr(func);
+    let func_entity = store.inner_mut().resolve_func_ptr(func);
     // SAFETY: freshly resolved from the store; only read here for the signature check.
     let actual_fnty = unsafe { func_entity.as_ref() }.ty_dedup().repr_entity();
     // Note: `func_type` already stores the resolved deduplicated function type, thus the
@@ -837,16 +837,16 @@ pub fn update_instance(
 
 #[inline(always)]
 pub fn call_func_entry(
-    state: &mut VmState,
+    store: &mut PrunedStore,
     caller_ip: Ip,
     caller_sp: Sp,
     params: BoundedSlotSpan,
     func: &FuncEntry,
     instance: Option<Inst>,
 ) -> Control<(Ip, Sp), Break> {
-    let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func_entry!(state, func);
-    let callee_sp = state
-        .stack
+    let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func_entry!(store, func);
+    let callee_sp = store
+        .stack_mut()
         .push_frame(
             caller_sp,
             Some(caller_ip),
@@ -862,15 +862,15 @@ pub fn call_func_entry(
 
 #[inline(always)]
 pub fn return_call_func_entry(
-    state: &mut VmState,
+    store: &mut PrunedStore,
     caller_sp: Sp,
     params: BoundedSlotSpan,
     func: &FuncEntry,
     instance: Option<Inst>,
 ) -> Control<(Ip, Sp), Break> {
-    let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func_entry!(state, func);
-    let callee_sp = state
-        .stack
+    let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func_entry!(store, func);
+    let callee_sp = store
+        .stack_mut()
         .replace_frame(
             caller_sp,
             callee_ip,
@@ -914,7 +914,7 @@ fn invoke_host(
 }
 
 pub fn call_host(
-    state: &mut VmState,
+    store: &mut PrunedStore,
     func: Func,
     caller_ip: Option<Ip>,
     host_func: HostFuncEntity,
@@ -924,21 +924,21 @@ pub fn call_host(
 ) -> Control<Sp, Break> {
     debug_assert_eq!(params.len(), host_func.len_param_cells());
     let trampoline = *host_func.trampoline();
-    let (sp, frame) = state
-        .stack
+    let (sp, frame) = store
+        .stack_mut()
         .prepare_host_frame(caller_ip, params, host_func.len_result_cells())
         .into_control()?;
     // Note: the parameters have already been written by the caller's frame, so the `InOutParams`
     //       can be derived right away.
-    let inout = state.stack.host_inout(frame);
-    if let Err(error) = invoke_host(state.store, trampoline, instance, inout, call_hooks) {
-        done!(state, DoneReason::host_error(error, func, params.span()))
+    let inout = store.stack_mut().host_inout(frame);
+    if let Err(error) = invoke_host(store, trampoline, instance, inout, call_hooks) {
+        done!(store, DoneReason::host_error(error, func, params.span()))
     }
     Control::Continue(sp)
 }
 
 pub fn return_call_host(
-    state: &mut VmState,
+    store: &mut PrunedStore,
     func: Func,
     host_func: HostFuncEntity,
     params: BoundedSlotSpan,
@@ -946,38 +946,32 @@ pub fn return_call_host(
 ) -> Control<(Ip, Sp, Inst), Break> {
     debug_assert_eq!(params.len(), host_func.len_param_cells());
     let trampoline = *host_func.trampoline();
-    let (control, frame) = state
-        .stack
+    let (control, frame) = store
+        .stack_mut()
         .return_prepare_host_frame(params, host_func.len_result_cells(), instance)
         .into_control()?;
     // Note: the parameters have already been moved into place by `return_prepare_host_frame`,
     //       so the `InOutParams` can be derived right away.
-    let inout = state.stack.host_inout(frame);
-    if let Err(error) = invoke_host(
-        state.store,
-        trampoline,
-        Some(instance),
-        inout,
-        CallHooks::Call,
-    ) {
+    let inout = store.stack_mut().host_inout(frame);
+    if let Err(error) = invoke_host(store, trampoline, Some(instance), inout, CallHooks::Call) {
         // Note: we won't allow resumption in case the execution would
         //       have returned with this the host function tail call.
         let reason = match control {
             Control::Continue(_) => DoneReason::host_error(error, func, params.span()),
             Control::Break(_) => DoneReason::error(error),
         };
-        done!(state, reason)
+        done!(store, reason)
     }
     match control {
         Control::Continue((ip, sp, instance)) => Control::Continue((ip, sp, instance)),
-        Control::Break(sp) => done!(state, DoneReason::Return(sp)),
+        Control::Break(sp) => done!(store, DoneReason::Return(sp)),
     }
 }
 
 #[inline]
 #[expect(clippy::too_many_arguments)]
 pub fn call_wasm_or_host(
-    state: &mut VmState,
+    store: &mut PrunedStore,
     caller_ip: Ip,
     caller_sp: Sp,
     func: Func,
@@ -995,7 +989,7 @@ pub fn call_wasm_or_host(
         FuncEntity::Wasm(wasm_func) => wasm_func,
         FuncEntity::Host(host_func) => {
             let sp = call_host(
-                state,
+                store,
                 func,
                 Some(caller_ip),
                 *host_func,
@@ -1005,7 +999,7 @@ pub fn call_wasm_or_host(
             )?;
             // Note: host functions may grow memories, invalidating the cached `(memory 0)`.
             //       Therefore, it is required to re-extract `(memory 0)` to avoid a stale cache.
-            let (mem0, mem0_len) = extract_mem0(state.store, instance);
+            let (mem0, mem0_len) = extract_mem0(store, instance);
             return Control::Continue((caller_ip, sp, mem0, mem0_len, instance));
         }
     };
@@ -1013,7 +1007,7 @@ pub fn call_wasm_or_host(
     // machinery as `call_internal`, differing only in the possible instance switch.
     let callee_instance: Inst = wasm_func.instance();
     let (callee_ip, callee_sp) = call_func_entry(
-        state,
+        store,
         caller_ip,
         caller_sp,
         params,
@@ -1021,7 +1015,7 @@ pub fn call_wasm_or_host(
         Some(callee_instance),
     )?;
     let (instance, mem0, mem0_len) =
-        update_instance(state.store, instance, callee_instance, mem0, mem0_len);
+        update_instance(store, instance, callee_instance, mem0, mem0_len);
     Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))
 }
 
@@ -1029,7 +1023,7 @@ pub fn call_wasm_or_host(
 #[inline]
 #[expect(clippy::too_many_arguments)]
 pub fn return_call_wasm_or_host(
-    state: &mut VmState,
+    store: &mut PrunedStore,
     caller_sp: Sp,
     func: Func,
     func_entity: NonNull<FuncEntity>,
@@ -1044,24 +1038,24 @@ pub fn return_call_wasm_or_host(
         FuncEntity::Wasm(wasm_func) => wasm_func,
         FuncEntity::Host(host_func) => {
             let (callee_ip, sp, new_instance) =
-                return_call_host(state, func, *host_func, params, instance)?;
+                return_call_host(store, func, *host_func, params, instance)?;
             // Note: host functions may grow memories, invalidating the cached `(memory 0)`.
             //       Therefore, it is required to re-extract `(memory 0)` to avoid a stale
             //       cache - even if the tail call returned into the very same instance.
-            let (mem0, mem0_len) = extract_mem0(state.store, new_instance);
+            let (mem0, mem0_len) = extract_mem0(store, new_instance);
             return Control::Continue((callee_ip, sp, mem0, mem0_len, new_instance));
         }
     };
     // Hot path: tail-calling a Wasm function. See `call_wasm_or_host` for the shape.
     let callee_instance: Inst = wasm_func.instance();
     let (callee_ip, callee_sp) = return_call_func_entry(
-        state,
+        store,
         caller_sp,
         params,
         wasm_func.func_entry(),
         Some(callee_instance),
     )?;
     let (instance, mem0, mem0_len) =
-        update_instance(state.store, instance, callee_instance, mem0, mem0_len);
+        update_instance(store, instance, callee_instance, mem0, mem0_len);
     Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))
 }

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -892,11 +892,6 @@ pub fn return_call_func_entry(
 ///
 /// Returns the host provided error if the host function trapped.
 ///
-/// # Note
-///
-/// Takes `store` instead of the whole [`VmState`] so that this cannot touch the [`Stack`] whose
-/// cells `inout` points at: `inout` aliases them without borrowing them.
-///
 /// [`Stack`]: crate::engine::executor::Stack
 #[inline]
 fn invoke_host(

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -545,7 +545,13 @@ pub fn is_default_memory(_instance: Inst, memory: ir::MemoryAddr) -> bool {
     u32::from(memory) == 0
 }
 
-pub fn extract_mem0(_store: &mut PrunedStore, inst: Inst) -> (Mem0Ptr, Mem0Len) {
+/// Extracts the data pointer and length of `(memory 0)`.
+///
+/// # Note (Safety)
+///
+/// The caller must ensure that `inst` refers to a live instance
+/// that contains a linear memory and thus `(memory 0)`.
+pub fn extract_mem0(inst: Inst) -> (Mem0Ptr, Mem0Len) {
     // SAFETY: `inst` refers to a live instance for the duration of the call.
     let Some(addr) = (unsafe { inst.as_ptr().layout() }).memory_addr(0) else {
         return (Mem0Ptr::from([].as_mut_ptr()), Mem0Len::from(0));
@@ -559,7 +565,7 @@ pub fn extract_mem0(_store: &mut PrunedStore, inst: Inst) -> (Mem0Ptr, Mem0Len) 
     //         does not outlive this function.
     let mem0 = unsafe { mem0.as_ref() };
     let mem0 = mem0.entity();
-    // SAFETY: warmed at instantiation; the `_store` borrow scopes exclusive memory access.
+    // SAFETY: entity cache is ensured to have warmed at instantiation.
     let mem0 = unsafe { &mut *mem0.as_ptr() }.data_mut();
     let mem0_ptr = mem0.as_mut_ptr();
     let mem0_len = mem0.len();
@@ -822,7 +828,6 @@ where
 }
 
 pub fn update_instance(
-    store: &mut PrunedStore,
     instance: Inst,
     new_instance: Inst,
     mem0: Mem0Ptr,
@@ -831,7 +836,7 @@ pub fn update_instance(
     if new_instance == instance {
         return (instance, mem0, mem0_len);
     }
-    let (mem0, mem0_len) = extract_mem0(store, new_instance);
+    let (mem0, mem0_len) = extract_mem0(new_instance);
     (new_instance, mem0, mem0_len)
 }
 
@@ -999,7 +1004,7 @@ pub fn call_wasm_or_host(
             )?;
             // Note: host functions may grow memories, invalidating the cached `(memory 0)`.
             //       Therefore, it is required to re-extract `(memory 0)` to avoid a stale cache.
-            let (mem0, mem0_len) = extract_mem0(store, instance);
+            let (mem0, mem0_len) = extract_mem0(instance);
             return Control::Continue((caller_ip, sp, mem0, mem0_len, instance));
         }
     };
@@ -1014,8 +1019,7 @@ pub fn call_wasm_or_host(
         wasm_func.func_entry(),
         Some(callee_instance),
     )?;
-    let (instance, mem0, mem0_len) =
-        update_instance(store, instance, callee_instance, mem0, mem0_len);
+    let (instance, mem0, mem0_len) = update_instance(instance, callee_instance, mem0, mem0_len);
     Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))
 }
 
@@ -1042,7 +1046,7 @@ pub fn return_call_wasm_or_host(
             // Note: host functions may grow memories, invalidating the cached `(memory 0)`.
             //       Therefore, it is required to re-extract `(memory 0)` to avoid a stale
             //       cache - even if the tail call returned into the very same instance.
-            let (mem0, mem0_len) = extract_mem0(store, new_instance);
+            let (mem0, mem0_len) = extract_mem0(new_instance);
             return Control::Continue((callee_ip, sp, mem0, mem0_len, new_instance));
         }
     };
@@ -1055,7 +1059,6 @@ pub fn return_call_wasm_or_host(
         wasm_func.func_entry(),
         Some(callee_instance),
     )?;
-    let (instance, mem0, mem0_len) =
-        update_instance(store, instance, callee_instance, mem0, mem0_len);
+    let (instance, mem0, mem0_len) = update_instance(instance, callee_instance, mem0, mem0_len);
     Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))
 }

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -19,7 +19,6 @@ pub use self::{
     },
     inout::{InOutParams, InOutResults},
 };
-use core::mem::{self, ManuallyDrop};
 use crate::{
     Error,
     Func,
@@ -32,9 +31,11 @@ use crate::{
         ResumableCallHostTrap,
         ResumableCallOutOfFuel,
         executor::handler::{init_host_func_call, init_wasm_func_call},
+        resumable::ResumableCallCommon,
     },
     ir::SlotSpan,
 };
+use core::mem::{self, ManuallyDrop};
 
 mod handler;
 mod inout;
@@ -58,11 +59,10 @@ impl EngineInner {
         Params: LowerToCells,
         Results: LiftFromCells,
     {
-        let mut stack = self.stacks.lock().reuse_or_new();
-        let value = EngineExecutor::new(&mut stack)
-            .execute_root_func(ctx.store, func, params, results)
-            .map_err(ExecutionOutcome::into_non_resumable)?;
+        let stack = self.stacks.lock().reuse_or_new();
+        let (outcome, stack) = execute_root_func(ctx.store, stack, func, params, results);
         self.stacks.lock().recycle(stack);
+        let value = outcome.map_err(ExecutionOutcome::into_non_resumable)?;
         Ok(value)
     }
 
@@ -85,9 +85,8 @@ impl EngineInner {
         Results: LiftFromCells,
     {
         let store = ctx.store;
-        let mut stack = self.stacks.lock().reuse_or_new();
-        let outcome =
-            EngineExecutor::new(&mut stack).execute_root_func(store, func, params, results);
+        let stack = self.stacks.lock().reuse_or_new();
+        let (outcome, stack) = execute_root_func(store, stack, func, params, results);
         let value = match outcome {
             Ok(value) => value,
             Err(ExecutionOutcome::Host(error)) => {
@@ -140,8 +139,17 @@ impl EngineInner {
         Results: LiftFromCells,
     {
         let caller_results = invocation.caller_results();
-        let mut executor = EngineExecutor::new(invocation.common.stack_mut());
-        let outcome = executor.resume_func_host_trap(ctx.store, params, caller_results, results);
+        let outcome = resume_func(
+            ctx.store,
+            &mut invocation.common,
+            |store: &mut Store<T>| -> Result<<Results as LiftFromCells>::Value, ExecutionOutcome> {
+                let value = resume_wasm_func_call(store)?
+                    .provide_host_results(params, caller_results)
+                    .execute()?
+                    .write_results(results);
+                Ok(value)
+            },
+        );
         let results = match outcome {
             Ok(results) => results,
             Err(ExecutionOutcome::Host(error)) => {
@@ -180,8 +188,12 @@ impl EngineInner {
     where
         Results: LiftFromCells,
     {
-        let mut executor = EngineExecutor::new(invocation.common.stack_mut());
-        let outcome = executor.resume_func_out_of_fuel(ctx.store, results);
+        let outcome = resume_func(ctx.store, &mut invocation.common, |store| {
+            let value = resume_wasm_func_call(store)?
+                .execute()?
+                .write_results(results);
+            Ok(value)
+        });
         let results = match outcome {
             Ok(results) => results,
             Err(ExecutionOutcome::Host(error)) => {
@@ -244,7 +256,7 @@ impl<'engine> EngineExecutor<'engine> {
                 // We reserve space on the stack to write the results of the root function execution.
                 let instance = wasm_func.instance();
                 let func_entry = wasm_func.func_entry_ptr();
-                let call = init_wasm_func_call(store, self.stack, func_entry, instance)?;
+                let call = init_wasm_func_call(store, func_entry, instance)?;
                 call.write_params(params).execute()?.write_results(results)
             }
             FuncEntity::Host(host_func) => {
@@ -253,7 +265,7 @@ impl<'engine> EngineExecutor<'engine> {
                 // In case the host function returns more values than it takes
                 // we are required to extend the value stack.
                 let host_func = *host_func;
-                let call = init_host_func_call(store, self.stack, host_func)?;
+                let call = init_host_func_call(store, host_func)?;
                 call.write_params(params).execute()?.write_results(results)
             }
         };
@@ -280,7 +292,7 @@ impl<'engine> EngineExecutor<'engine> {
         Params: LowerToCells,
         Results: LiftFromCells,
     {
-        let value = resume_wasm_func_call(store, self.stack)?
+        let value = resume_wasm_func_call(store)?
             .provide_host_results(params, params_slots)
             .execute()?
             .write_results(results);
@@ -303,10 +315,71 @@ impl<'engine> EngineExecutor<'engine> {
     where
         Results: LiftFromCells,
     {
-        let value = resume_wasm_func_call(store, self.stack)?
+        let value = resume_wasm_func_call(store)?
             .execute()?
             .write_results(results);
         Ok(value)
+    }
+}
+
+/// Resumes a function from `handle` using `f`.
+///
+/// This properly reuses and recycles the [`Stack`] of `handle` and feeds back the
+/// original [`Stack`] once the resumable execution via `f` has finished.
+fn resume_func<T, R>(
+    store: &mut Store<T>,
+    handle: &mut ResumableCallCommon,
+    f: impl FnOnce(&mut Store<T>) -> R,
+) -> R {
+    let stack = handle.take_stack();
+    let (outcome, stack) = with_stack(store, stack, |store| f(store));
+    *handle.stack_mut() = stack;
+    outcome
+}
+
+/// Executes the given [`Func`] on `stack` using the given `params`.
+///
+/// Stores the execution result into `results` upon a successful execution and returns the
+/// [`Stack`] for recycling.
+///
+/// # Errors
+///
+/// - If the given `params` do not match the expected parameters of `func`.
+/// - If the given `results` do not match the length of the expected results of `func`.
+/// - When encountering a Wasm or host trap during the execution of `func`.
+fn execute_root_func<T, Params, Results>(
+    store: &mut Store<T>,
+    mut stack: Stack,
+    func: &Func,
+    params: Params,
+    results: Results,
+) -> (Result<Results::Value, ExecutionOutcome>, Stack)
+where
+    Params: LowerToCells,
+    Results: LiftFromCells,
+{
+    stack.reset();
+    match store.inner.resolve_func(func) {
+        FuncEntity::Wasm(wasm_func) => {
+            // We reserve space on the stack to write the results of the root function execution.
+            let instance = wasm_func.instance();
+            let func_entry = wasm_func.func_entry_ptr();
+            with_stack(store, stack, move |store| {
+                let call = init_wasm_func_call(store, func_entry, instance)?;
+                Ok(call.write_params(params).execute()?.write_results(results))
+            })
+        }
+        FuncEntity::Host(host_func) => {
+            // The host function signature is required for properly
+            // adjusting, inspecting and manipulating the value stack.
+            // In case the host function returns more values than it takes
+            // we are required to extend the value stack.
+            let host_func = *host_func;
+            with_stack(store, stack, move |store| {
+                let call = init_host_func_call(store, host_func)?;
+                Ok(call.write_params(params).execute()?.write_results(results))
+            })
+        }
     }
 }
 

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -19,6 +19,7 @@ pub use self::{
     },
     inout::{InOutParams, InOutResults},
 };
+use core::mem::{self, ManuallyDrop};
 use crate::{
     Error,
     Func,
@@ -307,4 +308,52 @@ impl<'engine> EngineExecutor<'engine> {
             .write_results(results);
         Ok(value)
     }
+}
+
+/// Runs `f` with `stack` installed as the execution [`Stack`] of `store`.
+///
+/// Returns the outcome of `f` together with the [`Stack`] it used and re-installs the
+/// [`ExecContext`] that was installed before.
+///
+/// # Note
+///
+/// The [`ExecContext`] of an enclosing execution is parked in this very stack frame for the
+/// duration of `f`. This is what hands a host function that re-enters Wasm a [`Stack`] and a
+/// halt reason of its own instead of letting it share the enclosing ones. Only the [`Stack`]
+/// itself is moved, its heap allocated cells stay in place, which keeps the enclosing `Sp`
+/// and [`InOutParams`] valid across the nested execution.
+///
+/// The `Parked` guard restores on the unwinding path, too: a host function may catch a panic
+/// raised by a nested execution - the C API wraps every call in `catch_unwind` - and without
+/// it the enclosing [`ExecContext`] would be dropped here while its cells are still in use.
+fn with_stack<T, R>(
+    store: &mut Store<T>,
+    stack: Stack,
+    f: impl FnOnce(&mut Store<T>) -> R,
+) -> (R, Stack) {
+    /// Re-installs the parked [`ExecContext`] on both the normal and the unwinding path.
+    struct Parked<'a, T> {
+        store: &'a mut Store<T>,
+        context: ExecContext,
+    }
+    impl<T> Drop for Parked<'_, T> {
+        fn drop(&mut self) {
+            self.revert();
+        }
+    }
+    impl<'a, T> Parked<'a, T> {
+        fn revert(&mut self) -> ExecContext {
+            let parked = mem::take(&mut self.context);
+            mem::replace(self.store.inner.exec_mut(), parked)
+        }
+    }
+    let parked = mem::replace(store.inner.exec_mut(), ExecContext::new(stack));
+    let guard = Parked {
+        store,
+        context: parked,
+    };
+    let result = f(guard.store);
+    let mut guard = ManuallyDrop::new(guard);
+    let used = guard.revert().into_stack();
+    (result, used)
 }

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -138,17 +138,13 @@ impl EngineInner {
         Results: LiftFromCells,
     {
         let caller_results = invocation.caller_results();
-        let outcome = resume_func(
-            ctx.store,
-            &mut invocation.common,
-            |store: &mut Store<T>| -> Result<<Results as LiftFromCells>::Value, ExecutionOutcome> {
-                let value = resume_wasm_func_call(store)?
-                    .provide_host_results(params, caller_results)
-                    .execute()?
-                    .write_results(results);
-                Ok(value)
-            },
-        );
+        let outcome = resume_func(ctx.store, &mut invocation.common, |store| {
+            let value = resume_wasm_func_call(store)?
+                .provide_host_results(params, caller_results)
+                .execute()?
+                .write_results(results);
+            Ok(value)
+        });
         let results = match outcome {
             Ok(results) => results,
             Err(ExecutionOutcome::Host(error)) => {

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -4,6 +4,7 @@ pub use self::{
         CellError,
         CellsReader,
         CellsWriter,
+        ExecContext,
         ExecutionOutcome,
         Inst,
         LiftFromCells,

--- a/crates/wasmi/src/engine/executor/mod.rs
+++ b/crates/wasmi/src/engine/executor/mod.rs
@@ -33,7 +33,6 @@ use crate::{
         executor::handler::{init_host_func_call, init_wasm_func_call},
         resumable::ResumableCallCommon,
     },
-    ir::SlotSpan,
 };
 use core::mem::{self, ManuallyDrop};
 
@@ -214,111 +213,6 @@ impl EngineInner {
         };
         self.stacks.lock().recycle(invocation.common.take_stack());
         Ok(ResumableCallBase::Finished(results))
-    }
-}
-
-/// The internal state of the Wasmi engine.
-#[derive(Debug)]
-pub struct EngineExecutor<'engine> {
-    /// The value and call stacks.
-    stack: &'engine mut Stack,
-}
-
-impl<'engine> EngineExecutor<'engine> {
-    /// Creates a new [`EngineExecutor`] for the given [`Stack`].
-    fn new(stack: &'engine mut Stack) -> Self {
-        Self { stack }
-    }
-
-    /// Executes the given [`Func`] using the given `params`.
-    ///
-    /// Stores the execution result into `results` upon a successful execution.
-    ///
-    /// # Errors
-    ///
-    /// - If the given `params` do not match the expected parameters of `func`.
-    /// - If the given `results` do not match the length of the expected results of `func`.
-    /// - When encountering a Wasm or host trap during the execution of `func`.
-    fn execute_root_func<T, Params, Results>(
-        &mut self,
-        store: &mut Store<T>,
-        func: &Func,
-        params: Params,
-        results: Results,
-    ) -> Result<Results::Value, ExecutionOutcome>
-    where
-        Params: LowerToCells,
-        Results: LiftFromCells,
-    {
-        self.stack.reset();
-        let results = match store.inner.resolve_func(func) {
-            FuncEntity::Wasm(wasm_func) => {
-                // We reserve space on the stack to write the results of the root function execution.
-                let instance = wasm_func.instance();
-                let func_entry = wasm_func.func_entry_ptr();
-                let call = init_wasm_func_call(store, func_entry, instance)?;
-                call.write_params(params).execute()?.write_results(results)
-            }
-            FuncEntity::Host(host_func) => {
-                // The host function signature is required for properly
-                // adjusting, inspecting and manipulating the value stack.
-                // In case the host function returns more values than it takes
-                // we are required to extend the value stack.
-                let host_func = *host_func;
-                let call = init_host_func_call(store, host_func)?;
-                call.write_params(params).execute()?.write_results(results)
-            }
-        };
-        Ok(results)
-    }
-
-    /// Resumes the execution of the given [`Func`] using `params` after a host function trapped.
-    ///
-    /// Stores the execution result into `results` upon a successful execution.
-    ///
-    /// # Errors
-    ///
-    /// - If the given `params` do not match the expected parameters of `func`.
-    /// - If the given `results` do not match the length of the expected results of `func`.
-    /// - When encountering a Wasm or host trap during the execution of `func`.
-    fn resume_func_host_trap<T, Params, Results>(
-        &mut self,
-        store: &mut Store<T>,
-        params: Params,
-        params_slots: SlotSpan,
-        results: Results,
-    ) -> Result<Results::Value, ExecutionOutcome>
-    where
-        Params: LowerToCells,
-        Results: LiftFromCells,
-    {
-        let value = resume_wasm_func_call(store)?
-            .provide_host_results(params, params_slots)
-            .execute()?
-            .write_results(results);
-        Ok(value)
-    }
-
-    /// Resumes the execution of the given [`Func`] using `params` after running out of fuel.
-    ///
-    /// Stores the execution result into `results` upon a successful execution.
-    ///
-    /// # Errors
-    ///
-    /// - If the given `results` do not match the length of the expected results of `func`.
-    /// - When encountering a Wasm or host trap during the execution of `func`.
-    fn resume_func_out_of_fuel<T, Results>(
-        &mut self,
-        store: &mut Store<T>,
-        results: Results,
-    ) -> Result<Results::Value, ExecutionOutcome>
-    where
-        Results: LiftFromCells,
-    {
-        let value = resume_wasm_func_call(store)?
-            .execute()?
-            .write_results(results);
-        Ok(value)
     }
 }
 

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use self::{
     block_type::BlockType,
     code_map::{FuncEntry, FuncEntryPtr},
     executor::{
+        ExecContext,
         InOutParams,
         InOutResults,
         Inst,
@@ -25,7 +26,6 @@ pub(crate) use self::{
         LoadByVal,
         LowerToCells,
         Stack,
-        ExecContext,
     },
     func_types::DedupFuncType,
     translator::{

--- a/crates/wasmi/src/engine/mod.rs
+++ b/crates/wasmi/src/engine/mod.rs
@@ -25,6 +25,7 @@ pub(crate) use self::{
         LoadByVal,
         LowerToCells,
         Stack,
+        ExecContext,
     },
     func_types::DedupFuncType,
     translator::{

--- a/crates/wasmi/src/store/inner.rs
+++ b/crates/wasmi/src/store/inner.rs
@@ -197,11 +197,13 @@ impl StoreInner {
     }
 
     /// Returns an exclusive reference to the [`Fuel`] counters.
+    #[inline]
     pub fn fuel_mut(&mut self) -> &mut Fuel {
         &mut self.fuel
     }
 
     /// Returns the [`Fuel`] counters and the [`WasmFeatures`] required for lazy compilation.
+    #[inline]
     pub fn fuel_and_features(&mut self) -> (&mut Fuel, &WasmFeatures) {
         (&mut self.fuel, &self.features)
     }

--- a/crates/wasmi/src/store/inner.rs
+++ b/crates/wasmi/src/store/inner.rs
@@ -25,6 +25,7 @@ use crate::{
         handle_arena_err,
         id::StoreId,
     },
+    engine::ExecContext,
 };
 use alloc::boxed::Box;
 use core::{fmt::Debug, ptr::NonNull};
@@ -103,6 +104,15 @@ where
 /// The inner store that owns all data not associated to the host state.
 #[derive(Debug)]
 pub struct StoreInner {
+    /// The execution context in use by the Wasmi executor.
+    ///
+    /// # Note
+    ///
+    /// This is an opaque black-box owned by the executor. It is stored inline so that
+    /// execution handlers reach both the store and the [`Stack`] with a single load.
+    ///
+    /// [`Stack`]: crate::engine::Stack
+    exec: ExecContext,
     /// The unique store index.
     ///
     /// Used to protect against invalid entity indices.
@@ -154,6 +164,7 @@ impl StoreInner {
         let fuel = Fuel::new(fuel_enabled, fuel_costs);
         let features = config.wasm_features();
         StoreInner {
+            exec: ExecContext::default(),
             engine: engine.clone(),
             id: StoreId::new(),
             funcs: StableArena::new(),
@@ -177,6 +188,12 @@ impl StoreInner {
     /// Returns the [`StoreId`] of `self`.
     pub(crate) fn id(&self) -> StoreId {
         self.id
+    }
+
+    /// Returns an exclusive reference to the [`ExecContext`].
+    #[inline]
+    pub fn exec_mut(&mut self) -> &mut ExecContext {
+        &mut self.exec
     }
 
     /// Returns an exclusive reference to the [`Fuel`] counters.

--- a/crates/wasmi/src/store/inner.rs
+++ b/crates/wasmi/src/store/inner.rs
@@ -13,7 +13,7 @@ use crate::{
     Table,
     collections::arena::{Arena, ArenaError, ArenaKey, StableArena},
     core::{CoreElementSegment, CoreGlobal, CoreMemory, CoreTable, Fuel},
-    engine::{DedupFuncType, Inst},
+    engine::{DedupFuncType, ExecContext, Inst},
     memory::DataSegment,
     reftype::{ExternRef, ExternRefEntity},
     store::{
@@ -25,7 +25,6 @@ use crate::{
         handle_arena_err,
         id::StoreId,
     },
-    engine::ExecContext,
 };
 use alloc::boxed::Box;
 use core::{fmt::Debug, ptr::NonNull};

--- a/crates/wasmi/src/store/pruned.rs
+++ b/crates/wasmi/src/store/pruned.rs
@@ -6,7 +6,7 @@ use crate::{
     Store,
     Table,
     core::{RawRef, hint},
-    engine::{InOutParams, Inst},
+    engine::{ExecContext, InOutParams, Inst, Stack},
     errors::{MemoryError, TableError},
     func::Trampoline,
     store::error::{InternalStoreError, StoreError},
@@ -183,6 +183,18 @@ impl PrunedStore {
     #[inline]
     pub fn inner_mut(&mut self) -> &mut StoreInner {
         &mut self.pruned.inner
+    }
+
+    /// Returns an exclusive reference to the [`ExecContext`] of the executor.
+    #[inline]
+    pub fn exec_mut(&mut self) -> &mut ExecContext {
+        self.pruned.inner.exec_mut()
+    }
+
+    /// Returns an exclusive reference to the [`Stack`] in use by the executor.
+    #[inline]
+    pub fn stack_mut(&mut self) -> &mut Stack {
+        self.exec_mut().stack_mut()
     }
 
     /// Calls a host `func` at `instance` with `params_results` buffer.


### PR DESCRIPTION
This remove indirections for each access of `state.store` by embedding the execution context (`Stack` and `DoneReason`) into the `PrunedStore`'s `StoreInner` directly.

This way Wasmi execution handlers no longer take `state: &mut VmState` but `store: &mut PrunedStore`.

Benchmarks for call-intense workloads show massive improvements:

<img width="480" height="1346" alt="image" src="https://github.com/user-attachments/assets/740701db-0857-4445-8d3e-36f346c6a3d4" />
