### PR TITLE
fix: match (ref.func), (ref.extern) and untyped (ref.null) result patterns

### DIFF
--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -424,6 +424,9 @@ impl WastRunner {
                 return v128_matches_or_err(result, expected)
                     .map_err(|error| error.context("evaluation mismatch of `v128` values"));
             }
+            // An untyped `(ref.null)` matches a null reference of any type.
+            (Val::FuncRef(funcref), WastRetCore::RefNull(None)) => funcref.is_null(),
+            (Val::ExternRef(externref), WastRetCore::RefNull(None)) => externref.is_null(),
             (
                 Val::FuncRef(funcref),
                 WastRetCore::RefNull(Some(HeapType::Abstract {
@@ -438,6 +441,10 @@ impl WastRunner {
                     ..
                 })),
             ) => externref.is_null(),
+            // A `(ref.func)` result pattern expects a non-null function reference.
+            // Wasmi's API does not expose the underlying function index, so any
+            // non-null `funcref` is accepted for `(ref.func $f)` as well.
+            (Val::FuncRef(funcref), WastRetCore::RefFunc(_)) => !funcref.is_null(),
             (Val::ExternRef(externref), WastRetCore::RefExtern(Some(expected))) => {
                 let Nullable::Val(value) = externref else {
                     bail!("unexpected null element: {externref:?}");
@@ -447,7 +454,9 @@ impl WastRunner {
                 };
                 value == expected
             }
-            (Val::ExternRef(externref), WastRetCore::RefExtern(None)) => externref.is_null(),
+            // A `(ref.extern)` result pattern expects a non-null external reference
+            // with an unspecified value.
+            (Val::ExternRef(externref), WastRetCore::RefExtern(None)) => !externref.is_null(),
             _ => false,
         };
         if !is_equal {

--- a/crates/wast/tests/mod.rs
+++ b/crates/wast/tests/mod.rs
@@ -627,3 +627,37 @@ fn wasmi_torture() {
         runner_config(apply_spec_config(FuelMetering::Disabled)),
     );
 }
+
+/// Tests the reference result patterns used by `assert_return` directives.
+///
+/// # Background
+///
+/// The official Wasm spec testsuite uses the `(ref.func)`, `(ref.extern)` and
+/// untyped `(ref.null)` result patterns, e.g. in `select.wast`, `table.wast` and
+/// `br_table.wast`. They respectively match any non-null `funcref`, any non-null
+/// `externref` and a null reference of any type.
+#[test]
+fn reference_result_patterns() {
+    let wast = r#"
+        (module
+            (func $f)
+            (elem declare func $f)
+            (func (export "func") (result funcref) (ref.func $f))
+            (func (export "null-func") (result funcref) (ref.null func))
+            (func (export "null-extern") (result externref) (ref.null extern))
+            (func (export "extern") (param externref) (result externref) (local.get 0))
+        )
+        (assert_return (invoke "func") (ref.func))
+        (assert_return (invoke "null-func") (ref.null))
+        (assert_return (invoke "null-func") (ref.null func))
+        (assert_return (invoke "null-extern") (ref.null))
+        (assert_return (invoke "null-extern") (ref.null extern))
+        (assert_return (invoke "extern" (ref.extern 1)) (ref.extern))
+        (assert_return (invoke "extern" (ref.extern 1)) (ref.extern 1))
+    "#;
+    process_wast(
+        "wasmi/tests/reference-result-patterns",
+        wast,
+        runner_config(apply_spec_config(FuelMetering::Disabled)),
+    );
+}


### PR DESCRIPTION
`WastRunner::assert_result_core` doesn't handle three reference result patterns that the spec testsuite uses in `assert_return`. `RefFunc(..)` has no match arm and falls through to `_ => false`, so every `(ref.func)` expectation fails; the untyped `(ref.null)` (`RefNull(None)`) is likewise unhandled; and `RefExtern(None)` checks that the reference *is* null, which is inverted — `(ref.extern)` expects a non-null externref with an unspecified value, so a null `externref` currently compares equal and silently passes.

`gc/extern.wast` shows the intended distinction directly: the null cases are written `(ref.null extern)` (lines 42, 47) while the non-null cases use bare `(ref.extern)` (lines 43-46).

Because of the missing `RefFunc` arm, `select.wast` fails at `(assert_return (invoke "join-funcnull" (i32.const 1)) (ref.func))`:

```
expected RefFunc(None) but found FuncRef(Val(Func(Stored { .. })))
```

With this change, `select.wast` from the `wasm-3.0`, `gc` and `function-references` directories passes.

wasmi's API doesn't expose a `Func`'s index, so `(ref.func $f)` is treated like `(ref.func)` and accepts any non-null `funcref` — the same approach Wasmtime's Wast runner takes. Adds a `reference_result_patterns` regression test.

The inverted `RefExtern(None)` case is worth a closer look than the other two: it was a false pass rather than a false failure, so a null externref was satisfying an assertion that requires a non-null one.

Disclosure: this was AI assisted. An agent ran the spec testsuite against the runner and drafted the patch; I verified the behaviour and the spec citations before submitting.
