### PR TITLE
Make out-of-fuel resumable when lazily translating a callee

### DIFF
--- a/crates/wasmi/src/engine/executor/handler/args.rs
+++ b/crates/wasmi/src/engine/executor/handler/args.rs
@@ -236,13 +236,12 @@ impl Args {
     pub fn call_func_entry(
         &mut self,
         store: &mut PrunedStore,
+        op_ip: Ip,
         func: &FuncEntry,
         params: BoundedSlotSpan,
         instance: Option<Inst>,
     ) -> Control<(), Break> {
-        (self.ip, self.sp) =
-            utils::call_func_entry(store, self.ip, self.sp, params, func, instance)?;
-        Control::Continue(())
+        utils::call_func_entry(store, self, op_ip, params, func, instance)
     }
 
     /// Tail-calls `func` with `params` on `instance` with `state` using `self`.
@@ -250,12 +249,12 @@ impl Args {
     pub fn return_call_func_entry(
         &mut self,
         store: &mut PrunedStore,
+        op_ip: Ip,
         func: &FuncEntry,
         params: BoundedSlotSpan,
         instance: Option<Inst>,
     ) -> Control<(), Break> {
-        (self.ip, self.sp) = utils::return_call_func_entry(store, self.sp, params, func, instance)?;
-        Control::Continue(())
+        utils::return_call_func_entry(store, self, op_ip, params, func, instance)
     }
 
     /// Resolves the [`Func`] at `table[index]` of type `func_type` using `state`.
@@ -279,28 +278,12 @@ impl Args {
     pub fn call_wasm_or_host_func(
         &mut self,
         store: &mut PrunedStore,
+        op_ip: Ip,
         func: Func,
         func_entity: NonNull<FuncEntity>,
         params: BoundedSlotSpan,
     ) -> Control<(), Break> {
-        (
-            self.ip,
-            self.sp,
-            self.mem0_ptr,
-            self.mem0_len,
-            self.instance,
-        ) = utils::call_wasm_or_host(
-            store,
-            self.ip,
-            self.sp,
-            func,
-            func_entity,
-            params,
-            self.mem0_ptr,
-            self.mem0_len,
-            self.instance,
-        )?;
-        Control::Continue(())
+        utils::call_wasm_or_host(store, self, op_ip, func, func_entity, params)
     }
 
     /// Tail-calls `func` with `params` with `state` using `self`.
@@ -308,27 +291,12 @@ impl Args {
     pub fn return_call_wasm_or_host_func(
         &mut self,
         store: &mut PrunedStore,
+        op_ip: Ip,
         func: Func,
         func_entity: NonNull<FuncEntity>,
         params: BoundedSlotSpan,
     ) -> Control<(), Break> {
-        (
-            self.ip,
-            self.sp,
-            self.mem0_ptr,
-            self.mem0_len,
-            self.instance,
-        ) = utils::return_call_wasm_or_host(
-            store,
-            self.sp,
-            func,
-            func_entity,
-            params,
-            self.mem0_ptr,
-            self.mem0_len,
-            self.instance,
-        )?;
-        Control::Continue(())
+        utils::return_call_wasm_or_host(store, self, op_ip, func, func_entity, params)
     }
 
     /// Pops the top-most frame from the call stack.

--- a/crates/wasmi/src/engine/executor/handler/exec.rs
+++ b/crates/wasmi/src/engine/executor/handler/exec.rs
@@ -224,7 +224,7 @@ execution_handler! {
         // SAFETY: `func` is the exposed address of a `FuncEntry` in the engine's append-only
         //         `CodeMap`, baked into the bytecode; it stays valid while this bytecode runs.
         let func = unsafe { FuncEntryPtr::from(usize::from(func)).get() };
-        args.call_func_entry(store, func, params, None)?;
+        args.call_func_entry(store, ip, func, params, None)?;
         dispatch!(store, args)
     }
 }
@@ -244,7 +244,7 @@ execution_handler! {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::CallImported { params, func } = unsafe { args.decode_op() };
         let (func, func_entity) = utils::load_func_entry(args.instance, func);
-        args.call_wasm_or_host_func(store, func, func_entity, params)?;
+        args.call_wasm_or_host_func(store, ip, func, func_entity, params)?;
         dispatch!(store, args)
     }
 }
@@ -272,7 +272,7 @@ macro_rules! call_indirect_execution_handler {
                         index,
                     } = unsafe { args.decode_op() };
                     let (func, func_entity) = args.resolve_indirect_func(store, index, table, func_type)?;
-                    args.call_wasm_or_host_func(store, func, func_entity, params)?;
+                    args.call_wasm_or_host_func(store, ip, func, func_entity, params)?;
                     dispatch!(store, args)
                 }
             }
@@ -302,7 +302,7 @@ execution_handler! {
         let crate::ir::decode::ReturnCallInternal { params, func } = unsafe { args.decode_op() };
         // SAFETY: see `call_internal`.
         let func = unsafe { FuncEntryPtr::from(usize::from(func)).get() };
-        args.return_call_func_entry(store, func, params, None)?;
+        args.return_call_func_entry(store, ip, func, params, None)?;
         dispatch!(store, args)
     }
 }
@@ -322,7 +322,7 @@ execution_handler! {
         let mut args = Args::from_parts(ip, sp, mem0, mem0_len, instance, ireg, freg32, freg64);
         let crate::ir::decode::ReturnCallImported { params, func } = unsafe { args.decode_op() };
         let (func, func_entity) = utils::load_func_entry(instance, func);
-        args.return_call_wasm_or_host_func(store, func, func_entity, params)?;
+        args.return_call_wasm_or_host_func(store, ip, func, func_entity, params)?;
         dispatch!(store, args)
     }
 }
@@ -350,7 +350,7 @@ macro_rules! return_call_indirect_execution_handler {
                         table,
                     } = unsafe { args.decode_op() };
                     let (func, func_entity) = args.resolve_indirect_func(store, index, table, func_type)?;
-                    args.return_call_wasm_or_host_func(store, func, func_entity, params)?;
+                    args.return_call_wasm_or_host_func(store, ip, func, func_entity, params)?;
                     dispatch!(store, args)
                 }
             }

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -982,7 +982,6 @@ pub fn return_call_host(
 }
 
 #[inline]
-#[expect(clippy::too_many_arguments)]
 pub fn call_wasm_or_host(
     store: &mut PrunedStore,
     args: &mut Args,
@@ -1032,7 +1031,6 @@ pub fn call_wasm_or_host(
 
 /// Tail-call (`return_call`) twin of [`call_wasm_or_host`].
 #[inline]
-#[expect(clippy::too_many_arguments)]
 pub fn return_call_wasm_or_host(
     store: &mut PrunedStore,
     args: &mut Args,

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -1025,12 +1025,8 @@ pub fn call_wasm_or_host(
         wasm_func.func_entry(),
         Some(callee_instance),
     )?;
-    (args.instance, args.mem0_ptr, args.mem0_len) = update_instance(
-        args.instance,
-        callee_instance,
-        args.mem0_ptr,
-        args.mem0_len,
-    );
+    (args.instance, args.mem0_ptr, args.mem0_len) =
+        update_instance(args.instance, callee_instance, args.mem0_ptr, args.mem0_len);
     Control::Continue(())
 }
 
@@ -1072,11 +1068,7 @@ pub fn return_call_wasm_or_host(
         wasm_func.func_entry(),
         Some(callee_instance),
     )?;
-    (args.instance, args.mem0_ptr, args.mem0_len) = update_instance(
-        args.instance,
-        callee_instance,
-        args.mem0_ptr,
-        args.mem0_len,
-    );
+    (args.instance, args.mem0_ptr, args.mem0_len) =
+        update_instance(args.instance, callee_instance, args.mem0_ptr, args.mem0_len);
     Control::Continue(())
 }

--- a/crates/wasmi/src/engine/executor/handler/utils.rs
+++ b/crates/wasmi/src/engine/executor/handler/utils.rs
@@ -82,10 +82,16 @@ pub fn compile_or_get_func_entry(
 }
 
 macro_rules! compile_or_get_func_entry {
-    ($state:expr, $func:expr) => {{
+    ($state:expr, $ip:expr, $args:expr, $func:expr) => {{
         match $crate::engine::executor::handler::utils::compile_or_get_func_entry($state, $func) {
             Ok((ip, len_local_slots, len_stack_slots)) => (ip, len_local_slots, len_stack_slots),
-            Err(error) => done!($state, DoneReason::error(error)),
+            Err(error) => match error.resumable_required_fuel() {
+                Some(required_fuel) => {
+                    $args.set_ip($ip);
+                    out_of_fuel!($state, $args, required_fuel)
+                }
+                None => done!($state, DoneReason::error(error)),
+            },
         }
     }};
 }
@@ -843,18 +849,19 @@ pub fn update_instance(
 #[inline(always)]
 pub fn call_func_entry(
     store: &mut PrunedStore,
-    caller_ip: Ip,
-    caller_sp: Sp,
+    args: &mut Args,
+    op_ip: Ip,
     params: BoundedSlotSpan,
     func: &FuncEntry,
     instance: Option<Inst>,
-) -> Control<(Ip, Sp), Break> {
-    let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func_entry!(store, func);
+) -> Control<(), Break> {
+    let (callee_ip, len_local_slots, len_stack_slots) =
+        compile_or_get_func_entry!(store, op_ip, args, func);
     let callee_sp = store
         .stack_mut()
         .push_frame(
-            caller_sp,
-            Some(caller_ip),
+            args.sp,
+            Some(args.ip),
             callee_ip,
             params,
             len_local_slots,
@@ -862,22 +869,26 @@ pub fn call_func_entry(
             instance,
         )
         .into_control()?;
-    Control::Continue((callee_ip, callee_sp))
+    args.ip = callee_ip;
+    args.sp = callee_sp;
+    Control::Continue(())
 }
 
 #[inline(always)]
 pub fn return_call_func_entry(
     store: &mut PrunedStore,
-    caller_sp: Sp,
+    args: &mut Args,
+    op_ip: Ip,
     params: BoundedSlotSpan,
     func: &FuncEntry,
     instance: Option<Inst>,
-) -> Control<(Ip, Sp), Break> {
-    let (callee_ip, len_local_slots, len_stack_slots) = compile_or_get_func_entry!(store, func);
+) -> Control<(), Break> {
+    let (callee_ip, len_local_slots, len_stack_slots) =
+        compile_or_get_func_entry!(store, op_ip, args, func);
     let callee_sp = store
         .stack_mut()
         .replace_frame(
-            caller_sp,
+            args.sp,
             callee_ip,
             params,
             len_local_slots,
@@ -885,7 +896,9 @@ pub fn return_call_func_entry(
             instance,
         )
         .into_control()?;
-    Control::Continue((callee_ip, callee_sp))
+    args.ip = callee_ip;
+    args.sp = callee_sp;
+    Control::Continue(())
 }
 
 /// Invokes the host function behind `trampoline`.
@@ -972,15 +985,12 @@ pub fn return_call_host(
 #[expect(clippy::too_many_arguments)]
 pub fn call_wasm_or_host(
     store: &mut PrunedStore,
-    caller_ip: Ip,
-    caller_sp: Sp,
+    args: &mut Args,
+    op_ip: Ip,
     func: Func,
     func_entity: NonNull<FuncEntity>,
     params: BoundedSlotSpan,
-    mem0: Mem0Ptr,
-    mem0_len: Mem0Len,
-    instance: Inst,
-) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, Inst), Break> {
+) -> Control<(), Break> {
     // SAFETY: the pointer is warmed up at instantiation (imported calls) or freshly resolved
     //         (indirect calls); the reference is only used to copy out the callee data below,
     //         before any store mutation, so it never aliases a `&mut` into the funcs arena.
@@ -991,31 +1001,37 @@ pub fn call_wasm_or_host(
             let sp = call_host(
                 store,
                 func,
-                Some(caller_ip),
+                Some(args.ip),
                 *host_func,
                 params,
-                Some(instance),
+                Some(args.instance),
                 CallHooks::Call,
             )?;
+            args.sp = sp;
             // Note: host functions may grow memories, invalidating the cached `(memory 0)`.
             //       Therefore, it is required to re-extract `(memory 0)` to avoid a stale cache.
-            let (mem0, mem0_len) = extract_mem0(instance);
-            return Control::Continue((caller_ip, sp, mem0, mem0_len, instance));
+            (args.mem0_ptr, args.mem0_len) = extract_mem0(args.instance);
+            return Control::Continue(());
         }
     };
     // Hot path: calling a Wasm function. Uses the cached `FuncEntry` and the same inlined
     // machinery as `call_internal`, differing only in the possible instance switch.
     let callee_instance: Inst = wasm_func.instance();
-    let (callee_ip, callee_sp) = call_func_entry(
+    call_func_entry(
         store,
-        caller_ip,
-        caller_sp,
+        args,
+        op_ip,
         params,
         wasm_func.func_entry(),
         Some(callee_instance),
     )?;
-    let (instance, mem0, mem0_len) = update_instance(instance, callee_instance, mem0, mem0_len);
-    Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))
+    (args.instance, args.mem0_ptr, args.mem0_len) = update_instance(
+        args.instance,
+        callee_instance,
+        args.mem0_ptr,
+        args.mem0_len,
+    );
+    Control::Continue(())
 }
 
 /// Tail-call (`return_call`) twin of [`call_wasm_or_host`].
@@ -1023,37 +1039,44 @@ pub fn call_wasm_or_host(
 #[expect(clippy::too_many_arguments)]
 pub fn return_call_wasm_or_host(
     store: &mut PrunedStore,
-    caller_sp: Sp,
+    args: &mut Args,
+    op_ip: Ip,
     func: Func,
     func_entity: NonNull<FuncEntity>,
     params: BoundedSlotSpan,
-    mem0: Mem0Ptr,
-    mem0_len: Mem0Len,
-    instance: Inst,
-) -> Control<(Ip, Sp, Mem0Ptr, Mem0Len, Inst), Break> {
+) -> Control<(), Break> {
     // SAFETY: see `call_wasm_or_host`.
     let func_entity = unsafe { func_entity.as_ref() };
     let wasm_func = match func_entity {
         FuncEntity::Wasm(wasm_func) => wasm_func,
         FuncEntity::Host(host_func) => {
             let (callee_ip, sp, new_instance) =
-                return_call_host(store, func, *host_func, params, instance)?;
+                return_call_host(store, func, *host_func, params, args.instance)?;
+            args.ip = callee_ip;
+            args.sp = sp;
+            args.instance = new_instance;
             // Note: host functions may grow memories, invalidating the cached `(memory 0)`.
             //       Therefore, it is required to re-extract `(memory 0)` to avoid a stale
             //       cache - even if the tail call returned into the very same instance.
-            let (mem0, mem0_len) = extract_mem0(new_instance);
-            return Control::Continue((callee_ip, sp, mem0, mem0_len, new_instance));
+            (args.mem0_ptr, args.mem0_len) = extract_mem0(new_instance);
+            return Control::Continue(());
         }
     };
     // Hot path: tail-calling a Wasm function. See `call_wasm_or_host` for the shape.
     let callee_instance: Inst = wasm_func.instance();
-    let (callee_ip, callee_sp) = return_call_func_entry(
+    return_call_func_entry(
         store,
-        caller_sp,
+        args,
+        op_ip,
         params,
         wasm_func.func_entry(),
         Some(callee_instance),
     )?;
-    let (instance, mem0, mem0_len) = update_instance(instance, callee_instance, mem0, mem0_len);
-    Control::Continue((callee_ip, callee_sp, mem0, mem0_len, instance))
+    (args.instance, args.mem0_ptr, args.mem0_len) = update_instance(
+        args.instance,
+        callee_instance,
+        args.mem0_ptr,
+        args.mem0_len,
+    );
+    Control::Continue(())
 }

--- a/crates/wasmi/src/engine/resumable.rs
+++ b/crates/wasmi/src/engine/resumable.rs
@@ -102,8 +102,8 @@ impl ResumableOutOfFuelError {
         Self { required_fuel }
     }
 
-    /// Consumes `self` to return the underlying [`Error`].
-    pub(crate) fn required_fuel(self) -> u64 {
+    /// Returns the minimum required fuel to progress execution.
+    pub(crate) fn required_fuel(&self) -> u64 {
         self.required_fuel
     }
 }

--- a/crates/wasmi/src/error.rs
+++ b/crates/wasmi/src/error.rs
@@ -129,6 +129,14 @@ impl Error {
             .map(|boxed| *boxed)
     }
 
+    /// Returns the fuel required to make progress if `self` is a resumable out-of-fuel error.
+    pub(crate) fn resumable_required_fuel(&self) -> Option<u64> {
+        match self.kind() {
+            ErrorKind::ResumableOutOfFuel(error) => Some(error.required_fuel()),
+            _ => None,
+        }
+    }
+
     /// Returns `true` if the [`Error`] represents an out-of-fuel error.
     #[expect(unused)] // TODO: resolve unused API - used in resumable function calling
     pub(crate) fn is_out_of_fuel(&self) -> bool {

--- a/crates/wasmi/tests/integration/resumable_call.rs
+++ b/crates/wasmi/tests/integration/resumable_call.rs
@@ -395,3 +395,86 @@ fn run_test_typed(wasm_fn: Func, store: &mut Store<TestData>, wasm_trap: bool) {
         assert_eq!(call.unwrap_finished(), 4);
     }
 }
+
+/// A module whose `main` is small enough to translate but whose callee is not,
+/// so that fuel runs out while the callee is lazily translated.
+fn lazy_callee_wasm(call_op: &str) -> String {
+    let body = "(drop (i32.add (i32.const 1) (i32.const 1)))\n".repeat(2_000);
+    let call = match call_op {
+        "call" | "return_call" => format!("({call_op} $helper)"),
+        "call_indirect" | "return_call_indirect" => {
+            format!("(i32.const 0) ({call_op} (type $t))")
+        }
+        unknown => panic!("unknown call operator: {unknown}"),
+    };
+    format!(
+        r#"
+        (module
+            (type $t (func (result i32)))
+            (table 1 1 funcref)
+            (elem (i32.const 0) $helper)
+            (func $helper (type $t) {body} (i32.const 2))
+            (func (export "main") (result i32) {call})
+        )
+        "#
+    )
+}
+
+/// Runs `main` with too little fuel to translate the callee, then resumes it
+/// until it finishes, granting the fuel the engine asks for each time.
+fn assert_lazy_callee_resumes(call_op: &str) {
+    let mut config = Config::default();
+    config.wasm_tail_call(true);
+    config.consume_fuel(true);
+    config.compilation_mode(wasmi::CompilationMode::LazyTranslation);
+    let engine = Engine::new(&config);
+    let mut store = <Store<()>>::new(&engine, ());
+    store.set_fuel(10_000).unwrap();
+    let module = Module::new(&engine, &lazy_callee_wasm(call_op)).unwrap();
+    let instance = <Linker<()>>::new(&engine)
+        .instantiate_and_start(&mut store, &module)
+        .unwrap();
+    let main = instance.get_typed_func::<(), i32>(&store, "main").unwrap();
+
+    let mut call = main.call_resumable(&mut store, ()).unwrap();
+    let mut resumptions = 0;
+    loop {
+        match call {
+            TypedResumableCall::Finished(result) => {
+                assert_eq!(result, 2);
+                assert!(resumptions > 0, "expected at least one out of fuel pause");
+                return;
+            }
+            TypedResumableCall::OutOfFuel(invocation) => {
+                let required = invocation.required_fuel();
+                store
+                    .set_fuel(store.get_fuel().unwrap() + required)
+                    .unwrap();
+                call = invocation.resume(&mut store).unwrap();
+                resumptions += 1;
+                assert!(resumptions < 100, "too many resumptions");
+            }
+            TypedResumableCall::HostTrap(_) => panic!("unexpected host trap"),
+        }
+    }
+}
+
+#[test]
+fn resumable_out_of_fuel_translating_callee_of_call() {
+    assert_lazy_callee_resumes("call");
+}
+
+#[test]
+fn resumable_out_of_fuel_translating_callee_of_return_call() {
+    assert_lazy_callee_resumes("return_call");
+}
+
+#[test]
+fn resumable_out_of_fuel_translating_callee_of_call_indirect() {
+    assert_lazy_callee_resumes("call_indirect");
+}
+
+#[test]
+fn resumable_out_of_fuel_translating_callee_of_return_call_indirect() {
+    assert_lazy_callee_resumes("return_call_indirect");
+}

--- a/crates/wasmi/tests/integration/resumable_call.rs
+++ b/crates/wasmi/tests/integration/resumable_call.rs
@@ -430,7 +430,7 @@ fn assert_lazy_callee_resumes(call_op: &str) {
     let engine = Engine::new(&config);
     let mut store = <Store<()>>::new(&engine, ());
     store.set_fuel(10_000).unwrap();
-    let module = Module::new(&engine, &lazy_callee_wasm(call_op)).unwrap();
+    let module = Module::new(&engine, lazy_callee_wasm(call_op)).unwrap();
     let instance = <Linker<()>>::new(&engine)
         .instantiate_and_start(&mut store, &module)
         .unwrap();


### PR DESCRIPTION
`Func::call_resumable` cannot be resumed when fuel runs out while lazily translating a *callee* mid-execution, which is the default `CompilationMode::LazyTranslation`.

The root function translates and its instructions run, so side effects are already applied. Then translating the callee runs out of fuel and the call returns a plain `Err` rather than `Ok(ResumableCall::OutOfFuel(handle))`, even though the error already carries the correct `required_fuel`. The call is lost and only a full restart is possible.

```
LazyTranslation start=10000 -> Err(ran out of fuel while calling a resumable function: required_fuel=16849)
Eager           start=10000 -> ok [I32(2)] after 0 resumptions
Eager           start=0     -> ok [I32(2)] after 2 resumptions, granted=1207
```

Under `Eager` the identical fuel schedule resumes normally. All four call forms are affected: `call`, `return_call`, `call_indirect`, `return_call_indirect`.

This is not the case fixed by #1916 for #1859. That one is the *root* function's translation, which has no frame to resume into and is deliberately non-resumable. I checked that and left it as it is.

`code_map` builds a `ResumableOutOfFuelError`, but `From<Error> for ExecutionOutcome` folds it into `ExecutionOutcome::Error` and `compile_or_get_func_entry!` halts with `DoneReason::error(...)` instead of `DoneReason::OutOfFuel(...)`. This rewinds `ip` to the call operator and routes through the existing `out_of_fuel!` machinery, the same way `consume_fuel!` and `memory_copy_within` already do.

Found with a fuel self-oracle: a baseline run with metering off, compared against metered runs resumed at every out of fuel point, over 6 fuel schedules and 3 compilation modes, 1586 modules and 5948 calls. After the fix that oracle is clean. Four tests in `resumable_call.rs` fail 4/4 before and pass 4/4 after, and `cargo test --workspace` is green including the 642 spec tests.

## Performance, and where I would like your guidance

This regresses the call hot path and I would rather say so than have you find it.

`cargo bench --bench benches -- --baseline master`, on `execute/call`:

```
flat/0      -8.8%     nested/1    -10.8%     indirect/0  +7.2%
flat/1     -11.2%     nested/8     -6.2%     indirect/1  +8.0%
flat/8      -9.8%     nested/16    +1.3%     imported/1 +12.4%
flat/16     -7.9%                            imported/8  +1.7%
```

The `indirect/0` and `imported/1` regressions reproduced across three runs, including one at `--sample-size 200`, so they are real rather than noise. My machine was loaded, so treat the small numbers as unreliable, but not those two.

The cause is mine, not inherent: I changed `call_func_entry` and `return_call_func_entry` from returning `Control<(Ip, Sp), Break>` to taking `&mut Args` and writing `ip`/`sp` through it, so that the cold error branch can rewind `ip`. That cost is paid on every call to serve a path that almost never runs.

I did not want to guess at a cheaper shape in the executor without knowing your intent here. If you would prefer the error carried back to the handler in `exec.rs`, which already holds `args`, so the hot signatures stay scalar, I am happy to redo it that way. Or if you would rather just take the repro and fix it yourself, that is fine too.

I used Claude Code to build the differential harness and draft the patch, and I ran and reviewed everything above myself.
